### PR TITLE
feat(ai): AI Assistant tab — BYOK chat that reads state and proposes param changes

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -13,6 +13,7 @@
     "test:unit": "vitest run --config vitest.config.ts"
   },
   "dependencies": {
+    "@arduconfig/ai-assistant": "1.1.1",
     "@arduconfig/ardupilot-core": "1.1.1",
     "@arduconfig/firmware-flash": "1.1.1",
     "@arduconfig/param-metadata": "1.1.1",

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -32,10 +32,13 @@ import {
   type MotorTestRequest,
   applyArducopter47CatalogOverrides,
   type ParameterBackupFile,
+  type ParameterBatchWriteProgress,
+  type ParameterBatchWriteResult,
   type ParameterDraftEntry,
   type ParameterImportCategory,
   type ParameterState,
   type ParameterUnconfirmedWrite,
+  type ParameterWriteRequest,
   type RcAxisId,
   type RcMappingCandidate,
 } from '@arduconfig/ardupilot-core'
@@ -139,7 +142,7 @@ import {
 import { detectMavlinkPort } from './serial-autodetect'
 import { canApplyParameterChanges, parameterApplyBlockedReason } from './apply-gate'
 import { ALL_MOTOR_TEST_OUTPUT, ALL_MOTOR_TEST_OUTPUT_SIMULTANEOUS, buildMotorTestRequest } from './motor-test-helpers'
-import { isExpertOnlyView, readGuidedSetupShortcutSectionId } from './guided-setup-shortcut'
+import { canUseGuidedSetupTestingShortcut, isExpertOnlyView, readGuidedSetupShortcutSectionId } from './guided-setup-shortcut'
 import { actionLabels, type GuidedActionId } from './guided-action-labels'
 import {
   canRunGuidedAction
@@ -287,6 +290,10 @@ import {
   LUA_SCRIPTS_DIR
 } from './view-models/lua-scripts'
 import { LUA_APPLET_CONTENTS } from './lua-applets'
+import { AiAssistantView } from './views/AiAssistantView'
+import { useAiAssistant } from './hooks/use-ai-assistant'
+import { buildTranscript } from './view-models/ai-assistant'
+import { resolveWriteBlockReason } from './view-models/ai-assistant-proposal'
 import { IpAddressField } from './views/IpAddressField'
 import { PassthroughEditor } from './views/PassthroughEditor'
 import { availablePassthroughEndpoints, groupPassthroughBlocks } from './view-models/passthrough'
@@ -4681,6 +4688,59 @@ export function App() {
       }).cards,
     [snapshot.parameters, luaScripts.installed]
   )
+  // AI Assistant controller. Reads live vehicle state through a snapshot
+  // accessor (never the runtime directly), so its read-only tools always see the
+  // current snapshot. e2e forces the offline 'mock' provider via ?aiProvider=mock
+  // (dev/localhost only) so the tab can be exercised with no key and no network.
+  const aiAssistantAccessor = useMemo(() => ({ getSnapshot: () => runtime.getSnapshot() }), [runtime])
+  const aiForcedProvider = useMemo(() => {
+    if (!canUseGuidedSetupTestingShortcut()) return undefined
+    try {
+      return new URLSearchParams(window.location.search).get('aiProvider') === 'mock'
+        ? ('mock' as const)
+        : undefined
+    } catch {
+      return undefined
+    }
+  }, [])
+  // Applies an AI-proposed, human-approved batch of parameter changes. Mirrors
+  // the preset apply path: auto-backup to Snapshots first (undo safety net),
+  // then the verified batch write with rollback. The model can never call this —
+  // it only runs from an explicit human click behind the acknowledge gate.
+  const handleAiApplyProposal = useCallback(
+    async (
+      requests: ParameterWriteRequest[],
+      onProgress?: (progress: ParameterBatchWriteProgress) => void
+    ): Promise<ParameterBatchWriteResult> => {
+      const backupSnapshot = runtime.getSnapshot()
+      const autoBackup = createSavedSnapshot(createParameterBackup(backupSnapshot), 'Before AI-assisted changes', 'captured', {
+        note: 'Auto-saved before applying AI Assistant proposed parameter changes.',
+        tags: ['auto-backup', 'ai-assistant']
+      })
+      setSavedSnapshots((current) => [autoBackup, ...current.filter((entry) => entry.id !== autoBackup.id)])
+      const result = await runtime.setParameters(requests, UI_PARAMETER_WRITE_OPTIONS, onProgress)
+      if (result.applied.length > 0) {
+        void runtime.requestParameterList().then(() => runtime.waitForParameterSync()).catch(() => undefined)
+      }
+      return result
+    },
+    [runtime, setSavedSnapshots]
+  )
+  const aiAssistant = useAiAssistant({
+    accessor: aiAssistantAccessor,
+    applyChanges: handleAiApplyProposal,
+    forcedProviderId: aiForcedProvider
+  })
+  const aiTranscript = useMemo(() => buildTranscript(aiAssistant.messages), [aiAssistant.messages])
+  const aiWriteBlockReason = useMemo(
+    () =>
+      resolveWriteBlockReason({
+        connectionKind: snapshot.connection.kind,
+        armed: snapshot.vehicle?.armed ?? false,
+        syncStatus: snapshot.parameterStats.status
+      }),
+    [snapshot.connection.kind, snapshot.vehicle?.armed, snapshot.parameterStats.status]
+  )
   // RCL_ENABLE is the AP_RC_Logic engine sentinel — present only on firmware that
   // compiled the RC logic / range-function engine. Its presence unlocks the real
   // RC Mixer editor; otherwise the tab stays a preview.
@@ -7490,6 +7550,35 @@ export function App() {
         onInstall={luaScripts.install}
         onRemove={luaScripts.remove}
         onUpload={luaScripts.upload}
+      />
+      ) : null}
+
+      {activeViewId === 'ai-assistant' ? (
+      <AiAssistantView
+        connected={snapshot.connection.kind === 'connected'}
+        configReady={aiAssistant.configReady}
+        status={aiAssistant.status}
+        error={aiAssistant.error}
+        transcript={aiTranscript}
+        providerId={aiAssistant.settings.providerId}
+        model={aiAssistant.settings.model}
+        baseUrl={aiAssistant.settings.baseUrl}
+        apiKey={aiAssistant.apiKey}
+        rememberKey={aiAssistant.settings.rememberKey}
+        allowProposals={aiAssistant.settings.allowProposals}
+        onProviderChange={aiAssistant.setProviderId}
+        onModelChange={aiAssistant.setModel}
+        onBaseUrlChange={aiAssistant.setBaseUrl}
+        onApiKeyChange={aiAssistant.setApiKey}
+        onRememberKeyChange={aiAssistant.setRememberKey}
+        onAllowProposalsChange={aiAssistant.setAllowProposals}
+        proposal={aiAssistant.pendingProposal}
+        writeBlockReason={aiWriteBlockReason}
+        onApplyProposal={aiAssistant.applyProposal}
+        onDiscardProposal={aiAssistant.discardProposal}
+        onSend={aiAssistant.send}
+        onStop={aiAssistant.stop}
+        onClear={aiAssistant.clear}
       />
       ) : null}
 

--- a/apps/web/src/ai-assistant-storage.ts
+++ b/apps/web/src/ai-assistant-storage.ts
@@ -1,0 +1,48 @@
+// Thin browser binding over @arduconfig/ai-assistant's pure storage module.
+//
+// Splits persistence by sensitivity (the FirmwareFlasher precedent): the
+// non-secret provider config always persists; the API key is written only when
+// the user opts into "remember on this device". Everything is guarded so a
+// storage-less / private-mode context degrades to in-memory-only, never a crash.
+
+import {
+  loadProviderConfig,
+  saveProviderConfig,
+  loadPersistedApiKey,
+  persistApiKey,
+  clearPersistedApiKey,
+  type PersistedProviderConfig
+} from '@arduconfig/ai-assistant'
+
+function storage(): Storage | undefined {
+  try {
+    return typeof window === 'undefined' ? undefined : window.localStorage
+  } catch {
+    return undefined
+  }
+}
+
+export function loadAiAssistantConfig(): PersistedProviderConfig | undefined {
+  const store = storage()
+  return store ? loadProviderConfig(store) : undefined
+}
+
+export function saveAiAssistantConfig(config: PersistedProviderConfig): void {
+  const store = storage()
+  if (store) saveProviderConfig(store, config)
+}
+
+export function loadAiAssistantKey(): string | undefined {
+  const store = storage()
+  return store ? loadPersistedApiKey(store) : undefined
+}
+
+export function persistAiAssistantKey(apiKey: string): void {
+  const store = storage()
+  if (store) persistApiKey(store, apiKey)
+}
+
+export function clearAiAssistantKey(): void {
+  const store = storage()
+  if (store) clearPersistedApiKey(store)
+}

--- a/apps/web/src/guided-setup-shortcut.ts
+++ b/apps/web/src/guided-setup-shortcut.ts
@@ -23,7 +23,8 @@ export function isExpertOnlyView(viewId: AppViewId): boolean {
     viewId === 'mavlink-inspector' ||
     viewId === 'dronecan-inspector' ||
     viewId === 'networking' ||
-    viewId === 'lua'
+    viewId === 'lua' ||
+    viewId === 'ai-assistant'
   )
 }
 

--- a/apps/web/src/hooks/use-ai-assistant.ts
+++ b/apps/web/src/hooks/use-ai-assistant.ts
@@ -1,0 +1,396 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+
+import {
+  buildSystemPrompt,
+  buildVehicleGroundingSummary,
+  createProvider,
+  createToolExecutor,
+  isConnectionReady,
+  toolsFor,
+  parseProposedChanges,
+  ChatProviderError,
+  type ChatMessage,
+  type ChatProviderId,
+  type ProviderConnection,
+  type SnapshotAccessor
+} from '@arduconfig/ai-assistant'
+import type {
+  ParameterBatchWriteProgress,
+  ParameterBatchWriteResult,
+  ParameterWriteRequest
+} from '@arduconfig/ardupilot-core'
+
+import { defaultModelFor } from '../view-models/ai-assistant'
+import { buildProposalReview, type PendingProposal } from '../view-models/ai-assistant-proposal'
+import {
+  loadAiAssistantConfig,
+  saveAiAssistantConfig,
+  loadAiAssistantKey,
+  persistAiAssistantKey,
+  clearAiAssistantKey
+} from '../ai-assistant-storage'
+
+// Stateful controller for the AI Assistant tab. Owns the conversation, the
+// provider config, the in-memory API key, the streaming send loop, and — in
+// slice 2 — a human-gated parameter-change proposal. This is the ONLY place the
+// app makes outbound calls to a third-party LLM endpoint.
+//
+// SAFETY: the propose_param_changes tool never writes. When the model calls it,
+// the loop validates + stages a proposal and returns "awaiting approval" to the
+// model. A write happens only when the human ticks acknowledge and clicks Apply,
+// which delegates to the injected applyChanges (App owns the runtime + backup).
+
+const MAX_TOOL_ITERATIONS = 8
+
+export interface AiAssistantSettings {
+  providerId: ChatProviderId
+  model: string
+  baseUrl: string
+  rememberKey: boolean
+  /** Offer the propose_param_changes tool (still human-approved). */
+  allowProposals: boolean
+}
+
+export type { PendingProposal }
+
+export interface AiAssistantController {
+  settings: AiAssistantSettings
+  apiKey: string
+  configReady: boolean
+  messages: ChatMessage[]
+  status: 'idle' | 'streaming'
+  error: string | undefined
+  pendingProposal: PendingProposal | undefined
+  setProviderId: (providerId: ChatProviderId) => void
+  setModel: (model: string) => void
+  setBaseUrl: (baseUrl: string) => void
+  setApiKey: (apiKey: string) => void
+  setRememberKey: (remember: boolean) => void
+  setAllowProposals: (allow: boolean) => void
+  send: (text: string) => void
+  applyProposal: () => void
+  discardProposal: () => void
+  stop: () => void
+  clear: () => void
+}
+
+export interface UseAiAssistantOptions {
+  /** Live vehicle-state accessor, e.g. { getSnapshot: () => runtime.getSnapshot() }. */
+  accessor: SnapshotAccessor
+  /** Applies approved changes through the runtime (App owns backup + setParameters). */
+  applyChanges?: (
+    requests: ParameterWriteRequest[],
+    onProgress?: (progress: ParameterBatchWriteProgress) => void
+  ) => Promise<ParameterBatchWriteResult>
+  /** Overrides the default provider — e2e passes 'mock' to run offline. */
+  forcedProviderId?: ChatProviderId
+}
+
+function initialSettings(forcedProviderId?: ChatProviderId): AiAssistantSettings {
+  const stored = loadAiAssistantConfig()
+  const providerId = forcedProviderId ?? stored?.providerId ?? 'anthropic'
+  return {
+    providerId,
+    // Fall back to the provider id itself when there is no catalog default
+    // (the offline 'mock' provider has no metadata but still needs a model).
+    model: stored?.model ?? (defaultModelFor(providerId) || providerId),
+    baseUrl: stored?.baseUrl ?? '',
+    rememberKey: stored?.rememberKey ?? false,
+    allowProposals: stored?.allowProposals ?? true
+  }
+}
+
+export function useAiAssistant(options: UseAiAssistantOptions): AiAssistantController {
+  const { accessor, applyChanges, forcedProviderId } = options
+
+  const [settings, setSettings] = useState<AiAssistantSettings>(() => initialSettings(forcedProviderId))
+  const [apiKey, setApiKeyState] = useState<string>(() =>
+    settings.rememberKey ? loadAiAssistantKey() ?? '' : ''
+  )
+  const [messages, setMessages] = useState<ChatMessage[]>([])
+  const [status, setStatus] = useState<'idle' | 'streaming'>('idle')
+  const [error, setError] = useState<string | undefined>(undefined)
+  const [pendingProposal, setPendingProposal] = useState<PendingProposal | undefined>(undefined)
+
+  // Canonical provider-facing history; `messages` mirrors it for rendering.
+  const conversationRef = useRef<ChatMessage[]>([])
+  const abortRef = useRef<AbortController | undefined>(undefined)
+
+  const commit = useCallback(() => {
+    setMessages([...conversationRef.current])
+  }, [])
+
+  const connection: ProviderConnection = useMemo(
+    () => ({
+      providerId: settings.providerId,
+      model: settings.model,
+      apiKey: apiKey || undefined,
+      baseUrl: settings.baseUrl || undefined
+    }),
+    [settings.providerId, settings.model, settings.baseUrl, apiKey]
+  )
+
+  const configReady = isConnectionReady(connection)
+
+  // Refs so the async loop and follow-up runs read current values without
+  // re-creating callbacks on every keystroke.
+  const connectionRef = useRef(connection)
+  connectionRef.current = connection
+  const allowProposalsRef = useRef(settings.allowProposals)
+  allowProposalsRef.current = settings.allowProposals
+  const applyChangesRef = useRef(applyChanges)
+  applyChangesRef.current = applyChanges
+  const pendingProposalRef = useRef<PendingProposal | undefined>(undefined)
+  pendingProposalRef.current = pendingProposal
+  const statusRef = useRef(status)
+  statusRef.current = status
+
+  // Persist non-secret config whenever it changes.
+  useEffect(() => {
+    saveAiAssistantConfig({
+      providerId: settings.providerId,
+      model: settings.model,
+      baseUrl: settings.baseUrl || undefined,
+      rememberKey: settings.rememberKey,
+      allowProposals: settings.allowProposals
+    })
+  }, [settings.providerId, settings.model, settings.baseUrl, settings.rememberKey, settings.allowProposals])
+
+  const setProviderId = useCallback((providerId: ChatProviderId) => {
+    setSettings((prev) => ({ ...prev, providerId, model: defaultModelFor(providerId) }))
+  }, [])
+  const setModel = useCallback((model: string) => setSettings((prev) => ({ ...prev, model })), [])
+  const setBaseUrl = useCallback((baseUrl: string) => setSettings((prev) => ({ ...prev, baseUrl })), [])
+  const setAllowProposals = useCallback((allow: boolean) => setSettings((prev) => ({ ...prev, allowProposals: allow })), [])
+
+  const setApiKey = useCallback((nextKey: string) => {
+    setApiKeyState(nextKey)
+    // Only persist when the user opted in; otherwise the key lives in memory.
+    setSettings((prev) => {
+      if (prev.rememberKey) {
+        if (nextKey) persistAiAssistantKey(nextKey)
+        else clearAiAssistantKey()
+      }
+      return prev
+    })
+  }, [])
+
+  const setRememberKey = useCallback(
+    (remember: boolean) => {
+      setSettings((prev) => ({ ...prev, rememberKey: remember }))
+      if (remember) {
+        if (apiKey) persistAiAssistantKey(apiKey)
+      } else {
+        clearAiAssistantKey()
+      }
+    },
+    [apiKey]
+  )
+
+  // The provider conversation loop: runs turns until the model stops asking for
+  // tools. Read-only tools execute inline; propose_param_changes is intercepted
+  // and staged (never written). Does NOT manage status/abort — startRun does.
+  const driveConversation = useCallback(
+    async (controller: AbortController) => {
+      const provider = createProvider(connectionRef.current)
+      const executor = createToolExecutor(accessor)
+      const allowProposals = allowProposalsRef.current
+      const system = buildSystemPrompt({
+        grounding: buildVehicleGroundingSummary(accessor.getSnapshot()),
+        allowProposals
+      })
+      const tools = toolsFor({ allowProposals })
+
+      for (let iteration = 0; iteration < MAX_TOOL_ITERATIONS; iteration += 1) {
+        const requestMessages = [...conversationRef.current]
+        const assistant: ChatMessage = { role: 'assistant', content: '', toolCalls: [] }
+        conversationRef.current = [...conversationRef.current, assistant]
+        commit()
+
+        let stopReason: 'end' | 'tool-use' = 'end'
+        let streamError: string | undefined
+
+        for await (const event of provider.send({
+          system,
+          messages: requestMessages,
+          tools,
+          model: connectionRef.current.model,
+          signal: controller.signal
+        })) {
+          if (event.type === 'text-delta') {
+            assistant.content += event.text
+            commit()
+          } else if (event.type === 'tool-call') {
+            assistant.toolCalls = [...(assistant.toolCalls ?? []), event.call]
+            commit()
+          } else if (event.type === 'done') {
+            stopReason = event.stopReason
+          } else if (event.type === 'error') {
+            streamError = event.message
+          }
+        }
+
+        if (streamError) {
+          setError(streamError)
+          break
+        }
+        if (stopReason !== 'tool-use' || (assistant.toolCalls?.length ?? 0) === 0) {
+          break
+        }
+
+        for (const call of assistant.toolCalls ?? []) {
+          const result =
+            call.name === 'propose_param_changes'
+              ? stageProposal(call.arguments)
+              : executor.execute(call.name, call.arguments)
+          conversationRef.current = [
+            ...conversationRef.current,
+            { role: 'tool', content: JSON.stringify(result), toolCallId: call.id }
+          ]
+        }
+        commit()
+
+        if (iteration === MAX_TOOL_ITERATIONS - 1) {
+          setError('Reached the tool-call limit for one turn. Ask a more specific question.')
+        }
+      }
+
+      // Validate + stage a proposal for human approval. NEVER writes.
+      function stageProposal(args: Record<string, unknown>): unknown {
+        const parsed = parseProposedChanges(args)
+        if ('error' in parsed) {
+          return { ok: false, error: parsed.error }
+        }
+        const review = buildProposalReview(accessor.getSnapshot().parameters, parsed.proposal.changes)
+        setPendingProposal({ summary: parsed.proposal.summary, changes: parsed.proposal.changes, review, status: 'pending' })
+        return {
+          ok: true,
+          staged: true,
+          message: `Proposal staged for the user to review and approve: ${review.stagedCount} change(s) ready to apply, ${review.invalidCount} invalid, ${review.unchangedCount} already at target. Await the user's explicit Apply — you cannot apply changes yourself.`
+        }
+      }
+    },
+    [accessor, commit]
+  )
+
+  // Wrap an async run with controller + status/abort lifecycle.
+  const startRun = useCallback((seed: (controller: AbortController) => Promise<void>) => {
+    const controller = new AbortController()
+    abortRef.current = controller
+    setStatus('streaming')
+    void (async () => {
+      try {
+        await seed(controller)
+      } catch (caught) {
+        if (controller.signal.aborted) return
+        const message =
+          caught instanceof ChatProviderError ? caught.message : `Assistant error: ${(caught as Error).message}`
+        setError(message)
+      } finally {
+        if (abortRef.current === controller) abortRef.current = undefined
+        setStatus('idle')
+      }
+    })()
+  }, [])
+
+  const stop = useCallback(() => {
+    abortRef.current?.abort()
+    abortRef.current = undefined
+    setStatus('idle')
+  }, [])
+
+  const clear = useCallback(() => {
+    stop()
+    conversationRef.current = []
+    setError(undefined)
+    setPendingProposal(undefined)
+    commit()
+  }, [stop, commit])
+
+  const send = useCallback(
+    (text: string) => {
+      const trimmed = text.trim()
+      if (!trimmed || statusRef.current === 'streaming' || !configReady) return
+      setError(undefined)
+      conversationRef.current = [...conversationRef.current, { role: 'user', content: trimmed }]
+      commit()
+      startRun((controller) => driveConversation(controller))
+    },
+    [configReady, commit, startRun, driveConversation]
+  )
+
+  const discardProposal = useCallback(() => setPendingProposal(undefined), [])
+
+  const applyProposal = useCallback(() => {
+    const proposal = pendingProposalRef.current
+    const apply = applyChangesRef.current
+    if (!proposal || proposal.status !== 'pending' || !proposal.review.canApply || !apply) return
+    if (statusRef.current === 'streaming') return
+
+    const requests: ParameterWriteRequest[] = proposal.review.entries
+      .filter((entry) => entry.status === 'staged' && entry.nextValue !== undefined)
+      .map((entry) => ({ paramId: entry.id, paramValue: entry.nextValue as number }))
+    if (requests.length === 0) return
+
+    setError(undefined)
+    setPendingProposal((prev) =>
+      prev ? { ...prev, status: 'applying', progress: { completed: 0, total: requests.length, paramId: '' } } : prev
+    )
+
+    startRun(async (controller) => {
+      let result: ParameterBatchWriteResult
+      try {
+        result = await apply(requests, (progress) =>
+          setPendingProposal((prev) => (prev ? { ...prev, progress } : prev))
+        )
+      } catch (caught) {
+        const message = `Failed to apply changes: ${(caught as Error).message}`
+        setPendingProposal((prev) => (prev ? { ...prev, status: 'error', error: message, progress: undefined } : prev))
+        setError(message)
+        return
+      }
+
+      const summary = {
+        applied: result.applied.length,
+        unconfirmed: result.unconfirmed.length,
+        rolledBack: result.rolledBack.length
+      }
+      setPendingProposal((prev) => (prev ? { ...prev, status: 'applied', result: summary, progress: undefined } : prev))
+
+      // Let the model see the outcome so it can confirm conversationally.
+      conversationRef.current = [
+        ...conversationRef.current,
+        {
+          role: 'user',
+          content: `[The user reviewed and applied your proposed changes. Result: ${summary.applied} verified, ${summary.unconfirmed} unconfirmed, ${summary.rolledBack} rolled back.]`
+        }
+      ]
+      commit()
+      await driveConversation(controller)
+    })
+  }, [startRun, driveConversation, commit])
+
+  // Abort any in-flight request on unmount.
+  useEffect(() => () => abortRef.current?.abort(), [])
+
+  return {
+    settings,
+    apiKey,
+    configReady,
+    messages,
+    status,
+    error,
+    pendingProposal,
+    setProviderId,
+    setModel,
+    setBaseUrl,
+    setApiKey,
+    setRememberKey,
+    setAllowProposals,
+    send,
+    applyProposal,
+    discardProposal,
+    stop,
+    clear
+  }
+}

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -14196,3 +14196,211 @@ button.mavlink-inspector__sent-row {
   font-size: 0.82em;
   line-height: 1.5;
 }
+
+/* AI Assistant tab. Chat transcript + a bring-your-own-model settings form.
+   Read-only surface (no apply/confirm affordances). Reuses shared tokens so it
+   inherits both light and dark themes. */
+.ai-assistant {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+.ai-assistant__settings-disclosure > summary {
+  cursor: pointer;
+  color: var(--text-muted);
+  font-size: 0.85em;
+  padding: 4px 0;
+}
+.ai-assistant__settings-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 12px;
+}
+.ai-assistant__settings-grid label,
+.ai-assistant__remember {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  font-size: 0.82em;
+  color: var(--text-muted);
+}
+.ai-assistant__settings-grid input,
+.ai-assistant__settings-grid select {
+  min-width: 0;
+}
+.ai-assistant__remember {
+  flex-direction: row;
+  align-items: flex-start;
+  gap: 8px;
+  margin-top: 12px;
+  line-height: 1.45;
+}
+.ai-assistant__remember input {
+  margin-top: 2px;
+  flex: 0 0 auto;
+}
+.ai-assistant__note {
+  margin: 10px 0 0;
+  color: var(--text-dim, var(--text-muted));
+  font-size: 0.8em;
+  line-height: 1.5;
+}
+.ai-assistant__transcript {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  min-height: 140px;
+  max-height: 52vh;
+  overflow-y: auto;
+  padding: 4px;
+}
+.ai-assistant__empty {
+  color: var(--text-muted);
+  font-size: 0.88em;
+  line-height: 1.55;
+  margin: auto 0;
+}
+.ai-assistant__turn {
+  border-radius: 10px;
+  padding: 10px 12px;
+  max-width: 90%;
+  line-height: 1.55;
+  font-size: 0.9em;
+}
+.ai-assistant__turn-text {
+  margin: 0;
+  white-space: pre-wrap;
+}
+.ai-assistant__turn--user {
+  align-self: flex-end;
+  background: var(--accent-weak, var(--bg-panel-soft));
+  border: 1px solid var(--border-subtle, var(--border));
+}
+.ai-assistant__turn--assistant {
+  align-self: flex-start;
+  background: var(--bg-panel-raised);
+  border: 1px solid var(--border-subtle, var(--border));
+}
+.ai-assistant__tool-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin-top: 8px;
+}
+.ai-assistant__tool-chip {
+  font-family: var(--font-mono, monospace);
+  font-size: 0.75em;
+  padding: 2px 7px;
+  border-radius: 999px;
+  border: 1px solid var(--border-subtle, var(--border));
+  color: var(--text-muted);
+  background: var(--bg-panel-soft);
+}
+.ai-assistant__tool-chip--done {
+  color: var(--success, var(--primary-action));
+  border-color: var(--success, var(--primary-action));
+}
+.ai-assistant__composer {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+.ai-assistant__composer textarea {
+  width: 100%;
+  resize: vertical;
+  font: inherit;
+}
+.ai-assistant__composer-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+}
+.ai-assistant__hint {
+  margin: 0;
+  color: var(--text-muted);
+  font-size: 0.78em;
+}
+
+/* AI Assistant — parameter-change proposal card (slice 2). Read-and-approve
+   surface rendered inline in the chat; deliberately calm, with colour reserved
+   for invalid rows and the applied/error result. */
+.ai-assistant__proposal {
+  border: 1px solid var(--border-strong, var(--border));
+  border-radius: 10px;
+  padding: 12px;
+  background: var(--bg-panel-raised);
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+.ai-assistant__proposal-header {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  gap: 8px;
+}
+.ai-assistant__proposal-summary {
+  color: var(--text-muted);
+  font-size: 0.85em;
+}
+.ai-assistant__proposal-rows {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+.ai-assistant__proposal-row {
+  border: 1px solid var(--border-subtle, var(--border));
+  border-radius: 8px;
+  padding: 8px 10px;
+  background: var(--bg-panel-soft);
+}
+.ai-assistant__proposal-row--invalid {
+  border-color: var(--warning, #ff6600);
+}
+.ai-assistant__proposal-row-head {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 8px;
+}
+.ai-assistant__proposal-row-head code {
+  font-family: var(--font-mono, monospace);
+  font-size: 0.85em;
+}
+.ai-assistant__proposal-change {
+  font-variant-numeric: tabular-nums;
+  font-size: 0.9em;
+}
+.ai-assistant__proposal-label {
+  margin: 4px 0 0;
+  color: var(--text-muted);
+  font-size: 0.8em;
+}
+.ai-assistant__proposal-why {
+  margin: 4px 0 0;
+  color: var(--text-dim, var(--text-muted));
+  font-size: 0.8em;
+  line-height: 1.45;
+}
+.ai-assistant__proposal-invalid {
+  margin: 4px 0 0;
+  color: var(--warning, #ff6600);
+  font-size: 0.8em;
+}
+.ai-assistant__proposal-ack {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+  font-size: 0.82em;
+  color: var(--text-muted);
+  line-height: 1.45;
+}
+.ai-assistant__proposal-ack input {
+  margin-top: 2px;
+  flex: 0 0 auto;
+}
+.ai-assistant__proposal-actions {
+  display: flex;
+  gap: 8px;
+}

--- a/apps/web/src/view-models/ai-assistant-proposal.test.ts
+++ b/apps/web/src/view-models/ai-assistant-proposal.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from 'vitest'
+
+import type { ParameterState } from '@arduconfig/ardupilot-core'
+import { buildProposalReview, resolveWriteBlockReason } from './ai-assistant-proposal'
+
+const param = (id: string, value: number, definition?: Partial<ParameterState['definition']>): ParameterState => ({
+  id,
+  value,
+  index: 0,
+  count: 1,
+  definition: definition ? { id, label: id, description: '', category: 'tuning', ...definition } : undefined
+})
+
+const params: ParameterState[] = [
+  param('ATC_RAT_PIT_P', 0.135, { label: 'Pitch P Gain', minimum: 0, maximum: 1.5 }),
+  param('BATT_LOW_VOLT', 14.0, { label: 'Low battery voltage', unit: 'V', minimum: 0, maximum: 60 }),
+  param('COMPASS_USE', 1, { label: 'Use compass', options: [{ value: 0, label: 'Off' }, { value: 1, label: 'On' }] })
+]
+
+describe('buildProposalReview', () => {
+  it('stages an in-range change with its delta and the model reason', () => {
+    const review = buildProposalReview(params, [{ paramId: 'ATC_RAT_PIT_P', value: 0.145, reason: 'crisper pitch' }])
+    expect(review.stagedCount).toBe(1)
+    expect(review.invalidCount).toBe(0)
+    expect(review.canApply).toBe(true)
+    const entry = review.entries[0]
+    expect(entry.currentValue).toBe(0.135)
+    expect(entry.nextValue).toBe(0.145)
+    expect(entry.why).toBe('crisper pitch')
+    expect(entry.unit).toBeUndefined()
+  })
+
+  it('flags an out-of-range change invalid and blocks apply', () => {
+    const review = buildProposalReview(params, [{ paramId: 'ATC_RAT_PIT_P', value: 9.9 }])
+    expect(review.invalidCount).toBe(1)
+    expect(review.canApply).toBe(false)
+    expect(review.entries[0].status).toBe('invalid')
+    expect(review.entries[0].reason).toMatch(/maximum/i)
+  })
+
+  it('flags an unknown parameter invalid', () => {
+    const review = buildProposalReview(params, [{ paramId: 'NOPE_PARAM', value: 1 }])
+    expect(review.invalidCount).toBe(1)
+    expect(review.canApply).toBe(false)
+    expect(review.entries[0].reason).toMatch(/not present/i)
+  })
+
+  it('flags an enum-mismatch invalid', () => {
+    const review = buildProposalReview(params, [{ paramId: 'COMPASS_USE', value: 5 }])
+    expect(review.invalidCount).toBe(1)
+    expect(review.canApply).toBe(false)
+  })
+
+  it('marks a no-op change unchanged and does not allow apply on it alone', () => {
+    const review = buildProposalReview(params, [{ paramId: 'BATT_LOW_VOLT', value: 14.0 }])
+    expect(review.unchangedCount).toBe(1)
+    expect(review.stagedCount).toBe(0)
+    expect(review.canApply).toBe(false)
+  })
+
+  it('blocks apply if any single change is invalid, even alongside valid ones', () => {
+    const review = buildProposalReview(params, [
+      { paramId: 'ATC_RAT_PIT_P', value: 0.145 },
+      { paramId: 'BATT_LOW_VOLT', value: 999 }
+    ])
+    expect(review.stagedCount).toBe(1)
+    expect(review.invalidCount).toBe(1)
+    expect(review.canApply).toBe(false)
+  })
+
+  it('carries the unit through for display', () => {
+    const review = buildProposalReview(params, [{ paramId: 'BATT_LOW_VOLT', value: 13.5 }])
+    expect(review.entries[0].unit).toBe('V')
+  })
+})
+
+describe('resolveWriteBlockReason', () => {
+  it('blocks when disconnected', () => {
+    expect(resolveWriteBlockReason({ connectionKind: 'disconnected', armed: false, syncStatus: 'complete' })).toMatch(/Connect/)
+  })
+  it('blocks when armed', () => {
+    expect(resolveWriteBlockReason({ connectionKind: 'connected', armed: true, syncStatus: 'complete' })).toMatch(/disarm/i)
+  })
+  it('blocks when sync incomplete', () => {
+    expect(resolveWriteBlockReason({ connectionKind: 'connected', armed: false, syncStatus: 'streaming' })).toMatch(/download/i)
+  })
+  it('allows when connected, disarmed, and synced', () => {
+    expect(resolveWriteBlockReason({ connectionKind: 'connected', armed: false, syncStatus: 'complete' })).toBeUndefined()
+  })
+})

--- a/apps/web/src/view-models/ai-assistant-proposal.ts
+++ b/apps/web/src/view-models/ai-assistant-proposal.ts
@@ -1,0 +1,111 @@
+// Pure builder for the AI Assistant's parameter-change proposal card.
+//
+// Reuses the exact validation the manual Parameters diff grid uses
+// (deriveParameterDraftEntries): each proposed value is fed through the same
+// range / enum / not-present / no-op checks, so an AI proposal is held to the
+// identical bar as a hand-typed edit. The model's per-change `reason` is merged
+// in for display. No React, no runtime — unit-tested directly.
+
+import type {
+  ConfiguratorSnapshot,
+  ParameterBatchWriteProgress,
+  ParameterState
+} from '@arduconfig/ardupilot-core'
+import { deriveParameterDraftEntries, type ParameterDraftStatus } from '@arduconfig/ardupilot-core'
+import type { ProposedChange } from '@arduconfig/ai-assistant'
+
+export interface ProposalReviewEntry {
+  id: string
+  label: string
+  unit?: string
+  currentValue?: number
+  nextValue?: number
+  delta?: number
+  status: ParameterDraftStatus
+  /** Validation reason from the draft engine (why invalid / unchanged). */
+  reason?: string
+  /** The model's justification for this change, shown to the human. */
+  why?: string
+}
+
+export interface ProposalReview {
+  entries: ProposalReviewEntry[]
+  stagedCount: number
+  invalidCount: number
+  unchangedCount: number
+  /** True when there is at least one real change and nothing invalid — the
+   *  same rule the manual grid uses (canApplyAllDraftParameters). */
+  canApply: boolean
+}
+
+/** Validate + shape an AI proposal for display and apply-gating. */
+export function buildProposalReview(
+  parameters: readonly ParameterState[],
+  changes: readonly ProposedChange[]
+): ProposalReview {
+  // Last write wins if the model lists a param twice; also carries the reason.
+  const draftValues: Record<string, string> = {}
+  const reasonById = new Map<string, string>()
+  for (const change of changes) {
+    draftValues[change.paramId] = String(change.value)
+    if (change.reason) reasonById.set(change.paramId, change.reason)
+  }
+
+  const draftEntries = deriveParameterDraftEntries([...parameters], draftValues)
+  const entries: ProposalReviewEntry[] = draftEntries.map((entry) => ({
+    id: entry.id,
+    label: entry.label,
+    unit: entry.definition?.unit,
+    currentValue: entry.currentValue,
+    nextValue: entry.nextValue,
+    delta: entry.delta,
+    status: entry.status,
+    reason: entry.reason,
+    why: reasonById.get(entry.id)
+  }))
+
+  const stagedCount = entries.filter((entry) => entry.status === 'staged').length
+  const invalidCount = entries.filter((entry) => entry.status === 'invalid').length
+  const unchangedCount = entries.filter((entry) => entry.status === 'unchanged').length
+
+  return {
+    entries,
+    stagedCount,
+    invalidCount,
+    unchangedCount,
+    canApply: stagedCount > 0 && invalidCount === 0
+  }
+}
+
+/** A staged proposal through its lifecycle, owned by the hook and rendered by
+ *  the view. Lives here (not in the hook) so the presentational view can consume
+ *  it without importing the stateful hook. */
+export interface PendingProposal {
+  summary?: string
+  changes: ProposedChange[]
+  review: ProposalReview
+  status: 'pending' | 'applying' | 'applied' | 'error'
+  progress?: ParameterBatchWriteProgress
+  result?: { applied: number; unconfirmed: number; rolledBack: number }
+  error?: string
+}
+
+/** Why a write can't happen right now, independent of the proposal's validity.
+ *  Mirrors the runtime's own preconditions so Apply is disabled proactively
+ *  (runtime.setParameters also enforces these and we catch+report). */
+export function resolveWriteBlockReason(inputs: {
+  connectionKind: ConfiguratorSnapshot['connection']['kind']
+  armed: boolean
+  syncStatus: ConfiguratorSnapshot['parameterStats']['status']
+}): string | undefined {
+  if (inputs.connectionKind !== 'connected') {
+    return 'Connect a vehicle before applying changes.'
+  }
+  if (inputs.armed) {
+    return 'Vehicle is armed — disarm before applying parameter changes.'
+  }
+  if (inputs.syncStatus !== 'complete') {
+    return 'Wait for the parameter download to finish before applying.'
+  }
+  return undefined
+}

--- a/apps/web/src/view-models/ai-assistant.test.ts
+++ b/apps/web/src/view-models/ai-assistant.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from 'vitest'
+
+import type { ChatMessage } from '@arduconfig/ai-assistant'
+import {
+  buildTranscript,
+  defaultModelFor,
+  providerMetadata,
+  resolveComposerState,
+  PROVIDER_METADATA
+} from './ai-assistant'
+
+describe('provider metadata', () => {
+  it('exposes the three user-facing providers and no mock', () => {
+    const ids = PROVIDER_METADATA.map((entry) => entry.id)
+    expect(ids).toEqual(['anthropic', 'openai', 'ollama'])
+    expect(ids).not.toContain('mock')
+  })
+
+  it('marks cloud providers as needing a key and ollama as not', () => {
+    expect(providerMetadata('anthropic')?.needsApiKey).toBe(true)
+    expect(providerMetadata('openai')?.needsApiKey).toBe(true)
+    expect(providerMetadata('ollama')?.needsApiKey).toBe(false)
+  })
+
+  it('provides a default model per provider', () => {
+    expect(defaultModelFor('anthropic')).toBe('claude-sonnet-5')
+    expect(defaultModelFor('ollama')).toBe('llama3.1')
+  })
+})
+
+describe('resolveComposerState', () => {
+  it('blocks when config is not ready', () => {
+    const state = resolveComposerState({ connected: true, configReady: false, streaming: false, draftIsEmpty: false })
+    expect(state.canSend).toBe(false)
+    expect(state.hint).toMatch(/Settings/)
+  })
+
+  it('blocks while streaming', () => {
+    const state = resolveComposerState({ connected: true, configReady: true, streaming: true, draftIsEmpty: false })
+    expect(state.canSend).toBe(false)
+  })
+
+  it('allows sending offline but hints to connect', () => {
+    const state = resolveComposerState({ connected: false, configReady: true, streaming: false, draftIsEmpty: false })
+    expect(state.canSend).toBe(true)
+    expect(state.hint).toMatch(/connect a vehicle/i)
+  })
+
+  it('is ready with no hint when connected and configured', () => {
+    const state = resolveComposerState({ connected: true, configReady: true, streaming: false, draftIsEmpty: false })
+    expect(state).toEqual({ canSend: true, hint: '' })
+  })
+
+  it('cannot send an empty draft', () => {
+    const state = resolveComposerState({ connected: true, configReady: true, streaming: false, draftIsEmpty: true })
+    expect(state.canSend).toBe(false)
+  })
+})
+
+describe('buildTranscript', () => {
+  it('folds tool results into their assistant turn and marks calls done', () => {
+    const messages: ChatMessage[] = [
+      { role: 'user', content: 'What am I connected to?' },
+      { role: 'assistant', content: 'Let me check.', toolCalls: [{ id: 'c1', name: 'get_vehicle_info', arguments: {} }] },
+      { role: 'tool', content: '{"ok":true}', toolCallId: 'c1' },
+      { role: 'assistant', content: 'You are on an ArduCopter.' }
+    ]
+    const turns = buildTranscript(messages)
+    expect(turns.map((turn) => turn.role)).toEqual(['user', 'assistant', 'assistant'])
+    expect(turns[1].toolCalls).toEqual([{ id: 'c1', name: 'get_vehicle_info', done: true }])
+    expect(turns[2].text).toMatch(/ArduCopter/)
+  })
+
+  it('marks an unresolved tool call as not done', () => {
+    const messages: ChatMessage[] = [
+      { role: 'user', content: 'hi' },
+      { role: 'assistant', content: '', toolCalls: [{ id: 'pending', name: 'get_telemetry', arguments: {} }] }
+    ]
+    const turns = buildTranscript(messages)
+    expect(turns[1].toolCalls[0].done).toBe(false)
+  })
+})

--- a/apps/web/src/view-models/ai-assistant.ts
+++ b/apps/web/src/view-models/ai-assistant.ts
@@ -1,0 +1,137 @@
+// Pure view-model helpers for the AI Assistant tab.
+//
+// No React, no runtime, no network — presentation-shaping logic only, so it is
+// unit-tested directly (see ai-assistant.test.ts). The provider send loop and
+// tool execution live in the hook (use-ai-assistant); the actual tool/provider
+// definitions live in @arduconfig/ai-assistant.
+
+import type { ChatMessage, ChatProviderId } from '@arduconfig/ai-assistant'
+
+export interface ProviderMetadata {
+  id: ChatProviderId
+  label: string
+  /** Cloud key required before the model can be reached. */
+  needsApiKey: boolean
+  /** Sensible default model id for a fresh config. */
+  defaultModel: string
+  modelPlaceholder: string
+  /** Shown when the provider needs an endpoint (Ollama) or supports an override. */
+  baseUrlPlaceholder?: string
+  /** One-line setup note surfaced under the settings form. */
+  note?: string
+}
+
+// 'mock' is intentionally omitted from the user-facing picker — it is the
+// offline test seam, selected only by e2e via a query flag.
+export const PROVIDER_METADATA: readonly ProviderMetadata[] = [
+  {
+    id: 'anthropic',
+    label: 'Anthropic (Claude)',
+    needsApiKey: true,
+    defaultModel: 'claude-sonnet-5',
+    modelPlaceholder: 'claude-sonnet-5',
+    note: 'Your key is sent only to api.anthropic.com. Direct browser access is enabled for you.'
+  },
+  {
+    id: 'openai',
+    label: 'OpenAI (GPT)',
+    needsApiKey: true,
+    defaultModel: 'gpt-4o',
+    modelPlaceholder: 'gpt-4o',
+    note: 'Your key is sent only to api.openai.com (or your custom base URL).'
+  },
+  {
+    id: 'ollama',
+    label: 'Ollama (local)',
+    needsApiKey: false,
+    defaultModel: 'llama3.1',
+    modelPlaceholder: 'llama3.1',
+    baseUrlPlaceholder: 'http://localhost:11434',
+    note: 'Runs fully on your machine. Start Ollama with OLLAMA_ORIGINS set to allow this page.'
+  }
+]
+
+export function providerMetadata(id: ChatProviderId): ProviderMetadata | undefined {
+  return PROVIDER_METADATA.find((entry) => entry.id === id)
+}
+
+/** Default model for a provider when the user switches providers. */
+export function defaultModelFor(id: ChatProviderId): string {
+  return providerMetadata(id)?.defaultModel ?? ''
+}
+
+export interface ComposerState {
+  canSend: boolean
+  /** Why sending is blocked, for the composer's disabled hint. Empty when ready. */
+  hint: string
+}
+
+/** Decide whether the composer can send and, if not, why. */
+export function resolveComposerState(inputs: {
+  connected: boolean
+  configReady: boolean
+  streaming: boolean
+  draftIsEmpty: boolean
+}): ComposerState {
+  if (!inputs.configReady) {
+    return { canSend: false, hint: 'Add your model provider and key in Settings to start.' }
+  }
+  if (inputs.streaming) {
+    return { canSend: false, hint: 'Waiting for the model…' }
+  }
+  if (!inputs.connected) {
+    // Still allowed — the model can answer general ArduPilot questions offline —
+    // but nudge the user that live-state questions need a vehicle.
+    return { canSend: !inputs.draftIsEmpty, hint: 'Not connected — connect a vehicle to ask about live state.' }
+  }
+  return { canSend: !inputs.draftIsEmpty, hint: '' }
+}
+
+export interface RenderToolCall {
+  id: string
+  name: string
+  /** True once a matching tool-result message has been recorded. */
+  done: boolean
+}
+
+export interface RenderTurn {
+  key: string
+  role: 'user' | 'assistant'
+  text: string
+  toolCalls: RenderToolCall[]
+}
+
+/**
+ * Project the canonical ChatMessage[] conversation into renderable turns:
+ * user and assistant turns become bubbles; tool-result messages are folded
+ * into their originating assistant turn's tool-call chips (marking them done).
+ */
+export function buildTranscript(messages: readonly ChatMessage[]): RenderTurn[] {
+  const resolvedToolCallIds = new Set<string>()
+  for (const message of messages) {
+    if (message.role === 'tool' && message.toolCallId) {
+      resolvedToolCallIds.add(message.toolCallId)
+    }
+  }
+
+  const turns: RenderTurn[] = []
+  let index = 0
+  for (const message of messages) {
+    if (message.role === 'tool') {
+      index += 1
+      continue
+    }
+    turns.push({
+      key: `${message.role}-${index}`,
+      role: message.role,
+      text: message.content,
+      toolCalls: (message.toolCalls ?? []).map((call) => ({
+        id: call.id,
+        name: call.name,
+        done: resolvedToolCallIds.has(call.id)
+      }))
+    })
+    index += 1
+  }
+  return turns
+}

--- a/apps/web/src/view-models/visible-app-views.test.ts
+++ b/apps/web/src/view-models/visible-app-views.test.ts
@@ -63,6 +63,13 @@ describe('buildVisibleAppViews', () => {
     expect(ids(buildVisibleAppViews(baseInputs({ isExpertMode: true, hasNetworkingParams: false })))).not.toContain('networking')
   })
 
+  it('gates the AI Assistant view behind Expert mode alone (no FC capability)', () => {
+    // Unlike Networking/Lua it needs no capability flag — Expert mode is the
+    // only gate, since it is useful even before a vehicle is connected.
+    expect(ids(buildVisibleAppViews(baseInputs({ isExpertMode: true })))).toContain('ai-assistant')
+    expect(ids(buildVisibleAppViews(baseInputs({ isExpertMode: false })))).not.toContain('ai-assistant')
+  })
+
   it('shows Lua Scripts only in Expert mode AND when the FC reports SCR_ params', () => {
     expect(ids(buildVisibleAppViews(baseInputs({ isExpertMode: true, hasScriptingParams: true })))).toContain('lua')
     expect(ids(buildVisibleAppViews(baseInputs({ isExpertMode: false, hasScriptingParams: true })))).not.toContain('lua')

--- a/apps/web/src/view-models/visible-app-views.ts
+++ b/apps/web/src/view-models/visible-app-views.ts
@@ -151,6 +151,17 @@ export function buildVisibleAppViews(inputs: VisibleAppViewsInputs): AppViewDesc
     badge: connectionKind === 'connected' ? 'live' : 'idle',
     tone: 'neutral'
   }
+  // AI Assistant (bring-your-own-key chat over Anthropic/OpenAI/Ollama). Expert-
+  // only, but — unlike Networking/Lua — gated on no FC capability: it is useful
+  // for general ArduPilot questions even before a vehicle is connected, and its
+  // read-only tools simply return "not connected" until a link is up.
+  const aiAssistantDescriptor: AppViewDescriptor = {
+    id: 'ai-assistant',
+    label: 'AI Assistant',
+    description: 'Bring your own model (Claude, GPT, or a local Ollama) to discuss your vehicle configuration. Read-only — it inspects parameters and telemetry but cannot change anything.',
+    badge: connectionKind === 'connected' ? 'live' : 'idle',
+    tone: 'neutral'
+  }
   // Canonical tab order (single source of truth). The Setup tab is the
   // health/status/info dashboard, so it leads and is relabelled; the rest
   // follow a setup -> tuning -> tools flow. Views not listed fall to the
@@ -159,7 +170,7 @@ export function buildVisibleAppViews(inputs: VisibleAppViewsInputs): AppViewDesc
     'setup', 'calibration', 'config', 'ports', 'receiver', 'modes', 'motors',
     'servos', 'power', 'failsafe', 'vtx', 'osd', 'tuning', 'presets',
     'snapshots', 'logs', 'parameters', 'can', 'networking', 'files', 'lua', 'flash', 'rc-mixer',
-    'mavlink-inspector', 'dronecan-inspector'
+    'mavlink-inspector', 'dronecan-inspector', 'ai-assistant'
   ]
   const relabelled = base.map((view) =>
     view.id === 'setup'
@@ -177,7 +188,9 @@ export function buildVisibleAppViews(inputs: VisibleAppViewsInputs): AppViewDesc
     // Lua Scripts — Expert-only AND only when the FC advertises scripting (SCR_).
     ...(isExpertMode && hasScriptingParams ? [luaDescriptor] : []),
     // Expert-only views — only surfaced when Expert mode is on.
-    ...(isExpertMode ? [rcMixerDescriptor, mavlinkInspectorDescriptor, dronecanInspectorDescriptor] : [])
+    ...(isExpertMode
+      ? [rcMixerDescriptor, mavlinkInspectorDescriptor, dronecanInspectorDescriptor, aiAssistantDescriptor]
+      : [])
   ]
   const rankOf = (id: string): number => {
     const index = CANONICAL_VIEW_ORDER.indexOf(id)

--- a/apps/web/src/views/AiAssistantView.tsx
+++ b/apps/web/src/views/AiAssistantView.tsx
@@ -1,0 +1,395 @@
+import { useState } from 'react'
+import { Panel, buttonStyle } from '@arduconfig/ui-kit'
+
+import type { ChatProviderId } from '@arduconfig/ai-assistant'
+import {
+  PROVIDER_METADATA,
+  providerMetadata,
+  resolveComposerState,
+  type RenderTurn
+} from '../view-models/ai-assistant'
+import type { PendingProposal, ProposalReviewEntry } from '../view-models/ai-assistant-proposal'
+
+// Presentational AI Assistant tab. App owns the conversation, provider config,
+// and the send loop (via useAiAssistant); this view only renders and dispatches
+// callbacks. No runtime / transport / MAVLink imports, per the "Adding a View"
+// pattern. The composer's draft text is local UI state — nothing more.
+//
+// Read-only slice: the model can inspect the vehicle but cannot change it, so
+// the surface is a chat + a settings form, with no apply/confirm affordances.
+
+export interface AiAssistantViewProps {
+  connected: boolean
+  configReady: boolean
+  status: 'idle' | 'streaming'
+  error?: string
+  transcript: readonly RenderTurn[]
+  // Settings (controlled).
+  providerId: ChatProviderId
+  model: string
+  baseUrl: string
+  apiKey: string
+  rememberKey: boolean
+  allowProposals: boolean
+  onProviderChange: (providerId: ChatProviderId) => void
+  onModelChange: (model: string) => void
+  onBaseUrlChange: (baseUrl: string) => void
+  onApiKeyChange: (apiKey: string) => void
+  onRememberKeyChange: (remember: boolean) => void
+  onAllowProposalsChange: (allow: boolean) => void
+  // Proposal (slice 2). Present only when the model has staged a change.
+  proposal?: PendingProposal
+  /** Why applying is blocked right now (armed/disconnected/syncing), if at all. */
+  writeBlockReason?: string
+  onApplyProposal: () => void
+  onDiscardProposal: () => void
+  // Conversation actions.
+  onSend: (text: string) => void
+  onStop: () => void
+  onClear: () => void
+}
+
+function formatValue(value: number | undefined): string {
+  if (value === undefined) return '—'
+  return Number.isInteger(value) ? String(value) : Number(value.toFixed(4)).toString()
+}
+
+function SettingsForm(props: AiAssistantViewProps) {
+  const meta = providerMetadata(props.providerId)
+  return (
+    <div className="bf-note" data-testid="ai-assistant-settings">
+      <div className="ai-assistant__settings-grid">
+        <label>
+          <span>Provider</span>
+          <select
+            data-testid="ai-assistant-provider-select"
+            value={props.providerId}
+            onChange={(event) => props.onProviderChange(event.target.value as ChatProviderId)}
+          >
+            {PROVIDER_METADATA.map((entry) => (
+              <option key={entry.id} value={entry.id}>
+                {entry.label}
+              </option>
+            ))}
+          </select>
+        </label>
+        <label>
+          <span>Model</span>
+          <input
+            data-testid="ai-assistant-model-input"
+            type="text"
+            value={props.model}
+            placeholder={meta?.modelPlaceholder}
+            onChange={(event) => props.onModelChange(event.target.value)}
+          />
+        </label>
+        {meta?.needsApiKey ? (
+          <label>
+            <span>API key</span>
+            <input
+              data-testid="ai-assistant-key-input"
+              type="password"
+              autoComplete="off"
+              value={props.apiKey}
+              placeholder="Paste your key"
+              onChange={(event) => props.onApiKeyChange(event.target.value)}
+            />
+          </label>
+        ) : null}
+        {meta?.baseUrlPlaceholder !== undefined || !meta?.needsApiKey ? (
+          <label>
+            <span>Base URL{meta?.needsApiKey ? ' (optional)' : ''}</span>
+            <input
+              data-testid="ai-assistant-baseurl-input"
+              type="text"
+              value={props.baseUrl}
+              placeholder={meta?.baseUrlPlaceholder ?? 'Default'}
+              onChange={(event) => props.onBaseUrlChange(event.target.value)}
+            />
+          </label>
+        ) : null}
+      </div>
+      {meta?.needsApiKey ? (
+        <label className="ai-assistant__remember">
+          <input
+            data-testid="ai-assistant-remember-key"
+            type="checkbox"
+            checked={props.rememberKey}
+            onChange={(event) => props.onRememberKeyChange(event.target.checked)}
+          />
+          <span>
+            Remember this key on this device. It is stored in your browser’s local storage in plain
+            text — anyone with access to this browser (or a script injected into this page) could read
+            it. Leave off to keep it in memory only (cleared on reload).
+          </span>
+        </label>
+      ) : null}
+      {meta?.note ? <p className="ai-assistant__note">{meta.note}</p> : null}
+      <label className="ai-assistant__remember">
+        <input
+          data-testid="ai-assistant-allow-proposals"
+          type="checkbox"
+          checked={props.allowProposals}
+          onChange={(event) => props.onAllowProposalsChange(event.target.checked)}
+        />
+        <span>
+          Let the assistant propose parameter changes. Proposals are never applied automatically —
+          you review a diff and approve each apply. Turn off for read-only Q&amp;A.
+        </span>
+      </label>
+    </div>
+  )
+}
+
+function ProposalRow(props: { entry: ProposalReviewEntry }) {
+  const { entry } = props
+  const invalid = entry.status === 'invalid'
+  const unchanged = entry.status === 'unchanged'
+  return (
+    <div
+      className={`ai-assistant__proposal-row${invalid ? ' ai-assistant__proposal-row--invalid' : ''}`}
+      data-testid={`ai-assistant-proposal-row-${entry.id}`}
+      data-status={entry.status}
+    >
+      <div className="ai-assistant__proposal-row-head">
+        <code>{entry.id}</code>
+        <span className="ai-assistant__proposal-change">
+          {formatValue(entry.currentValue)} → <strong>{formatValue(entry.nextValue ?? entry.currentValue)}</strong>
+          {entry.unit ? ` ${entry.unit}` : ''}
+        </span>
+      </div>
+      {entry.label ? <p className="ai-assistant__proposal-label">{entry.label}</p> : null}
+      {entry.why ? <p className="ai-assistant__proposal-why">{entry.why}</p> : null}
+      {invalid && entry.reason ? <p className="ai-assistant__proposal-invalid">{entry.reason}</p> : null}
+      {unchanged ? <p className="ai-assistant__proposal-invalid">Already at this value.</p> : null}
+    </div>
+  )
+}
+
+function ProposalCard(props: {
+  proposal: PendingProposal
+  writeBlockReason?: string
+  onApply: () => void
+  onDiscard: () => void
+}) {
+  const { proposal, writeBlockReason, onApply, onDiscard } = props
+  const { review, status } = proposal
+  const [acknowledged, setAcknowledged] = useState(false)
+  const applying = status === 'applying'
+  const applied = status === 'applied'
+  const canApply = review.canApply && !writeBlockReason && acknowledged && !applying && !applied
+
+  return (
+    <div className="ai-assistant__proposal" data-testid="ai-assistant-proposal" data-status={status}>
+      <div className="ai-assistant__proposal-header">
+        <strong>Proposed change{review.stagedCount === 1 ? '' : 's'}</strong>
+        {proposal.summary ? <span className="ai-assistant__proposal-summary">{proposal.summary}</span> : null}
+      </div>
+
+      <div className="ai-assistant__proposal-rows">
+        {review.entries.map((entry) => (
+          <ProposalRow key={entry.id} entry={entry} />
+        ))}
+      </div>
+
+      {applied && proposal.result ? (
+        <div className="bf-note bf-note--success" data-testid="ai-assistant-proposal-result">
+          <p>
+            Applied: {proposal.result.applied} verified
+            {proposal.result.unconfirmed > 0 ? `, ${proposal.result.unconfirmed} unconfirmed` : ''}
+            {proposal.result.rolledBack > 0 ? `, ${proposal.result.rolledBack} rolled back` : ''}. A backup was
+            saved to Snapshots before the write.
+          </p>
+        </div>
+      ) : proposal.status === 'error' && proposal.error ? (
+        <div className="bf-note bf-note--warning" data-testid="ai-assistant-proposal-result">
+          <p>{proposal.error}</p>
+        </div>
+      ) : (
+        <>
+          {review.invalidCount > 0 ? (
+            <p className="ai-assistant__hint">
+              {review.invalidCount} change{review.invalidCount === 1 ? '' : 's'} can’t be applied (invalid or out of
+              range) — fix or ask the assistant to revise before applying.
+            </p>
+          ) : null}
+          {writeBlockReason ? <p className="ai-assistant__hint">{writeBlockReason}</p> : null}
+          {review.canApply && !writeBlockReason ? (
+            <label className="ai-assistant__proposal-ack">
+              <input
+                data-testid="ai-assistant-proposal-ack"
+                type="checkbox"
+                checked={acknowledged}
+                disabled={applying}
+                onChange={(event) => setAcknowledged(event.target.checked)}
+              />
+              <span>I’ve reviewed these changes and want to write them to the flight controller.</span>
+            </label>
+          ) : null}
+          <div className="ai-assistant__proposal-actions">
+            <button
+              type="button"
+              style={buttonStyle('primary')}
+              data-testid="ai-assistant-proposal-apply"
+              disabled={!canApply}
+              onClick={onApply}
+            >
+              {applying
+                ? `Applying… (${proposal.progress?.completed ?? 0}/${proposal.progress?.total ?? review.stagedCount})`
+                : `Apply ${review.stagedCount} change${review.stagedCount === 1 ? '' : 's'}`}
+            </button>
+            <button
+              type="button"
+              style={buttonStyle('secondary')}
+              data-testid="ai-assistant-proposal-discard"
+              disabled={applying}
+              onClick={onDiscard}
+            >
+              Discard
+            </button>
+          </div>
+        </>
+      )}
+    </div>
+  )
+}
+
+function ToolChip(props: { name: string; done: boolean }) {
+  return (
+    <span
+      className={`ai-assistant__tool-chip${props.done ? ' ai-assistant__tool-chip--done' : ''}`}
+      data-testid="ai-assistant-tool-chip"
+      data-tool={props.name}
+      data-done={props.done ? 'true' : 'false'}
+    >
+      {props.done ? '✓' : '…'} {props.name}
+    </span>
+  )
+}
+
+function Composer(props: { view: AiAssistantViewProps }) {
+  const { view } = props
+  const [draft, setDraft] = useState('')
+  const composer = resolveComposerState({
+    connected: view.connected,
+    configReady: view.configReady,
+    streaming: view.status === 'streaming',
+    draftIsEmpty: draft.trim().length === 0
+  })
+
+  const submit = () => {
+    if (!composer.canSend) return
+    view.onSend(draft)
+    setDraft('')
+  }
+
+  return (
+    <div className="ai-assistant__composer">
+      <textarea
+        data-testid="ai-assistant-input"
+        rows={2}
+        value={draft}
+        placeholder="Ask about your vehicle’s configuration…"
+        onChange={(event) => setDraft(event.target.value)}
+        onKeyDown={(event) => {
+          if (event.key === 'Enter' && !event.shiftKey) {
+            event.preventDefault()
+            submit()
+          }
+        }}
+      />
+      <div className="ai-assistant__composer-actions">
+        {view.status === 'streaming' ? (
+          <button type="button" style={buttonStyle('secondary')} data-testid="ai-assistant-stop" onClick={view.onStop}>
+            Stop
+          </button>
+        ) : (
+          <button
+            type="button"
+            style={buttonStyle('primary')}
+            data-testid="ai-assistant-send"
+            disabled={!composer.canSend}
+            onClick={submit}
+          >
+            Send
+          </button>
+        )}
+      </div>
+      {composer.hint ? <p className="ai-assistant__hint">{composer.hint}</p> : null}
+    </div>
+  )
+}
+
+export function AiAssistantView(props: AiAssistantViewProps) {
+  return (
+    <Panel
+      title="AI Assistant"
+      subtitle="Bring your own model (Claude, GPT, or a local Ollama) to discuss your vehicle’s current configuration. Read-only — the assistant can inspect parameters and telemetry but cannot change anything yet."
+    >
+      <div data-testid="ai-assistant-view" className="ai-assistant">
+        <details className="ai-assistant__settings-disclosure" open={!props.configReady}>
+          <summary>Model &amp; provider settings</summary>
+          <SettingsForm {...props} />
+        </details>
+
+        {props.error ? (
+          <div className="bf-note bf-note--warning" data-testid="ai-assistant-error">
+            <p>{props.error}</p>
+          </div>
+        ) : null}
+
+        <div className="ai-assistant__transcript" data-testid="ai-assistant-transcript">
+          {props.transcript.length === 0 ? (
+            <p className="ai-assistant__empty" data-testid="ai-assistant-empty">
+              {props.configReady
+                ? props.connected
+                  ? 'Ask a question about your connected vehicle — for example, “Why won’t it arm?” or “Is my battery failsafe set up?”'
+                  : 'Configured. Connect a vehicle to ask about its live state, or ask a general ArduPilot question.'
+                : 'Add your model provider and key above to get started.'}
+            </p>
+          ) : (
+            props.transcript.map((turn) => (
+              <div
+                key={turn.key}
+                className={`ai-assistant__turn ai-assistant__turn--${turn.role}`}
+                data-testid="ai-assistant-message"
+                data-role={turn.role}
+              >
+                {turn.text ? <p className="ai-assistant__turn-text">{turn.text}</p> : null}
+                {turn.toolCalls.length > 0 ? (
+                  <div className="ai-assistant__tool-chips">
+                    {turn.toolCalls.map((call) => (
+                      <ToolChip key={call.id} name={call.name} done={call.done} />
+                    ))}
+                  </div>
+                ) : null}
+              </div>
+            ))
+          )}
+        </div>
+
+        {props.proposal ? (
+          <ProposalCard
+            proposal={props.proposal}
+            writeBlockReason={props.writeBlockReason}
+            onApply={props.onApplyProposal}
+            onDiscard={props.onDiscardProposal}
+          />
+        ) : null}
+
+        <Composer view={props} />
+
+        {props.transcript.length > 0 ? (
+          <button
+            type="button"
+            style={buttonStyle('secondary')}
+            data-testid="ai-assistant-clear"
+            onClick={props.onClear}
+          >
+            Clear conversation
+          </button>
+        ) : null}
+      </div>
+    </Panel>
+  )
+}

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -20,6 +20,7 @@ export default defineConfig({
       pkg('@arduconfig/protocol-mavlink', 'protocol-mavlink/src/index.ts'),
       pkg('@arduconfig/ardupilot-core', 'ardupilot-core/src/index.ts'),
       pkg('@arduconfig/param-metadata', 'param-metadata/src/index.ts'),
+      pkg('@arduconfig/ai-assistant', 'ai-assistant/src/index.ts'),
       pkg('@arduconfig/ui-kit', 'ui-kit/src/index.tsx')
     ])
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
     },
     "apps/desktop": {
       "name": "@arduconfig/desktop",
-      "version": "1.2.0",
+      "version": "1.3.0",
       "license": "GPL-3.0-only",
       "dependencies": {
         "@arduconfig/firmware-flash": "1.1.1",
@@ -40,9 +40,10 @@
     },
     "apps/web": {
       "name": "@arduconfig/web",
-      "version": "1.2.0",
+      "version": "1.3.0",
       "license": "GPL-3.0-only",
       "dependencies": {
+        "@arduconfig/ai-assistant": "1.1.1",
         "@arduconfig/ardupilot-core": "1.1.1",
         "@arduconfig/firmware-flash": "1.1.1",
         "@arduconfig/param-metadata": "1.1.1",
@@ -62,6 +63,10 @@
         "wbn": "^0.0.9",
         "wbn-sign": "^0.3.1"
       }
+    },
+    "node_modules/@arduconfig/ai-assistant": {
+      "resolved": "packages/ai-assistant",
+      "link": true
     },
     "node_modules/@arduconfig/ardupilot-core": {
       "resolved": "packages/ardupilot-core",
@@ -6798,6 +6803,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "packages/ai-assistant": {
+      "name": "@arduconfig/ai-assistant",
+      "version": "1.1.1",
+      "license": "GPL-3.0-only",
+      "dependencies": {
+        "@arduconfig/ardupilot-core": "*",
+        "@arduconfig/param-metadata": "*"
       }
     },
     "packages/ardupilot-core": {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   ],
   "scripts": {
     "build": "npm run build --workspace @arduconfig/firmware-flash && npm run build --workspace @arduconfig/mock-sitl && npm run build --workspace @arduconfig/sitl-harness && npm run build --workspace @arduconfig/web && npm run build --workspace @arduconfig/desktop",
-    "typecheck": "npm run typecheck --workspace @arduconfig/transport && npm run typecheck --workspace @arduconfig/firmware-flash && npm run typecheck --workspace @arduconfig/protocol-mavlink && npm run typecheck --workspace @arduconfig/param-metadata && npm run typecheck --workspace @arduconfig/ardupilot-core && npm run typecheck --workspace @arduconfig/mock-sitl && npm run typecheck --workspace @arduconfig/sitl-harness && npm run typecheck --workspace @arduconfig/web && npm run typecheck --workspace @arduconfig/desktop",
+    "typecheck": "npm run typecheck --workspace @arduconfig/transport && npm run typecheck --workspace @arduconfig/firmware-flash && npm run typecheck --workspace @arduconfig/protocol-mavlink && npm run typecheck --workspace @arduconfig/param-metadata && npm run typecheck --workspace @arduconfig/ardupilot-core && npm run typecheck --workspace @arduconfig/ai-assistant && npm run typecheck --workspace @arduconfig/mock-sitl && npm run typecheck --workspace @arduconfig/sitl-harness && npm run typecheck --workspace @arduconfig/web && npm run typecheck --workspace @arduconfig/desktop",
     "test": "npm run build && node --test tests/*.test.mjs",
     "test:e2e": "npm run build && playwright test",
     "test:e2e:headed": "npm run build && playwright test --headed",

--- a/packages/ai-assistant/package.json
+++ b/packages/ai-assistant/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@arduconfig/ai-assistant",
+  "version": "1.1.1",
+  "private": true,
+  "license": "GPL-3.0-only",
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "scripts": {
+    "build": "tsc -b tsconfig.json",
+    "typecheck": "tsc -b tsconfig.json --pretty false"
+  },
+  "dependencies": {
+    "@arduconfig/ardupilot-core": "*",
+    "@arduconfig/param-metadata": "*"
+  }
+}

--- a/packages/ai-assistant/src/anthropic-provider.ts
+++ b/packages/ai-assistant/src/anthropic-provider.ts
@@ -1,0 +1,158 @@
+// Anthropic Messages API adapter (browser BYOK).
+//
+// Direct-from-browser calls require the anthropic-dangerous-direct-browser-access
+// header; the x-api-key is the user's own key, held in memory (or opt-in
+// localStorage) and sent only to api.anthropic.com (or a user-set base URL).
+
+import type { ChatEvent, ChatMessage, ChatProvider, ChatRequest } from './provider.js'
+import { ChatProviderError } from './provider.js'
+import type { ToolDefinition } from './tools.js'
+import { iterateLines, sseData } from './stream.js'
+
+const DEFAULT_BASE_URL = 'https://api.anthropic.com'
+const ANTHROPIC_VERSION = '2023-06-01'
+const MAX_TOKENS = 4096
+
+interface AnthropicBlock {
+  type: 'text' | 'tool_use' | 'tool_result'
+  text?: string
+  id?: string
+  name?: string
+  input?: Record<string, unknown>
+  tool_use_id?: string
+  content?: string
+}
+
+interface AnthropicMessage {
+  role: 'user' | 'assistant'
+  content: AnthropicBlock[]
+}
+
+function toAnthropicMessages(messages: ChatMessage[]): AnthropicMessage[] {
+  const out: AnthropicMessage[] = []
+  for (const message of messages) {
+    if (message.role === 'assistant') {
+      const content: AnthropicBlock[] = []
+      if (message.content) content.push({ type: 'text', text: message.content })
+      for (const call of message.toolCalls ?? []) {
+        content.push({ type: 'tool_use', id: call.id, name: call.name, input: call.arguments })
+      }
+      out.push({ role: 'assistant', content })
+      continue
+    }
+    // user + tool both map to a user turn; merge consecutive ones so tool
+    // results ride in a single user message, as the API expects.
+    const block: AnthropicBlock =
+      message.role === 'tool'
+        ? { type: 'tool_result', tool_use_id: message.toolCallId, content: message.content }
+        : { type: 'text', text: message.content }
+    const previous = out[out.length - 1]
+    if (previous && previous.role === 'user') previous.content.push(block)
+    else out.push({ role: 'user', content: [block] })
+  }
+  return out
+}
+
+function toAnthropicTools(tools: ToolDefinition[]): unknown[] {
+  return tools.map((tool) => ({
+    name: tool.name,
+    description: tool.description,
+    input_schema: tool.parameters
+  }))
+}
+
+export function createAnthropicProvider(options: { apiKey: string; baseUrl?: string }): ChatProvider {
+  const baseUrl = (options.baseUrl ?? DEFAULT_BASE_URL).replace(/\/$/, '')
+  return {
+    id: 'anthropic',
+    async *send(request: ChatRequest): AsyncIterable<ChatEvent> {
+      let response: Response
+      try {
+        response = await fetch(`${baseUrl}/v1/messages`, {
+          method: 'POST',
+          headers: {
+            'content-type': 'application/json',
+            'x-api-key': options.apiKey,
+            'anthropic-version': ANTHROPIC_VERSION,
+            'anthropic-dangerous-direct-browser-access': 'true'
+          },
+          body: JSON.stringify({
+            model: request.model,
+            max_tokens: MAX_TOKENS,
+            system: request.system,
+            messages: toAnthropicMessages(request.messages),
+            tools: toAnthropicTools(request.tools),
+            stream: true
+          }),
+          signal: request.signal
+        })
+      } catch (error) {
+        throw new ChatProviderError(
+          `Could not reach Anthropic: ${(error as Error).message}`,
+          'anthropic'
+        )
+      }
+      if (!response.ok) {
+        const detail = await response.text().catch(() => '')
+        throw new ChatProviderError(
+          `Anthropic API error ${response.status}: ${detail.slice(0, 300)}`,
+          'anthropic',
+          response.status
+        )
+      }
+
+      let stopReason: 'end' | 'tool-use' = 'end'
+      let toolId = ''
+      let toolName = ''
+      let toolJson = ''
+      let inToolBlock = false
+
+      for await (const line of iterateLines(response)) {
+        const data = sseData(line)
+        if (!data) continue
+        let event: Record<string, unknown>
+        try {
+          event = JSON.parse(data) as Record<string, unknown>
+        } catch {
+          continue
+        }
+        const type = event.type as string
+        if (type === 'content_block_start') {
+          const block = event.content_block as AnthropicBlock
+          if (block?.type === 'tool_use') {
+            inToolBlock = true
+            toolId = block.id ?? ''
+            toolName = block.name ?? ''
+            toolJson = ''
+          }
+        } else if (type === 'content_block_delta') {
+          const delta = event.delta as { type?: string; text?: string; partial_json?: string }
+          if (delta?.type === 'text_delta' && delta.text) {
+            yield { type: 'text-delta', text: delta.text }
+          } else if (delta?.type === 'input_json_delta' && delta.partial_json) {
+            toolJson += delta.partial_json
+          }
+        } else if (type === 'content_block_stop') {
+          if (inToolBlock) {
+            inToolBlock = false
+            let args: Record<string, unknown> = {}
+            try {
+              args = toolJson ? (JSON.parse(toolJson) as Record<string, unknown>) : {}
+            } catch {
+              args = {}
+            }
+            yield { type: 'tool-call', call: { id: toolId, name: toolName, arguments: args } }
+          }
+        } else if (type === 'message_delta') {
+          const delta = event.delta as { stop_reason?: string }
+          if (delta?.stop_reason === 'tool_use') stopReason = 'tool-use'
+        } else if (type === 'error') {
+          const err = event.error as { message?: string }
+          yield { type: 'error', message: err?.message ?? 'Anthropic stream error' }
+          return
+        }
+      }
+      yield { type: 'done', stopReason }
+    }
+  }
+}

--- a/packages/ai-assistant/src/create-provider.ts
+++ b/packages/ai-assistant/src/create-provider.ts
@@ -1,0 +1,40 @@
+// Resolve a configured ProviderConnection into a concrete ChatProvider.
+
+import type { ChatProvider, ProviderConnection } from './provider.js'
+import { ChatProviderError } from './provider.js'
+import { createAnthropicProvider } from './anthropic-provider.js'
+import { createOpenAiProvider } from './openai-provider.js'
+import { createOllamaProvider } from './ollama-provider.js'
+import { createMockProvider } from './mock-provider.js'
+
+export function createProvider(connection: ProviderConnection): ChatProvider {
+  switch (connection.providerId) {
+    case 'anthropic':
+      if (!connection.apiKey) throw new ChatProviderError('An Anthropic API key is required.', 'anthropic')
+      return createAnthropicProvider({ apiKey: connection.apiKey, baseUrl: connection.baseUrl })
+    case 'openai':
+      if (!connection.apiKey) throw new ChatProviderError('An OpenAI API key is required.', 'openai')
+      return createOpenAiProvider({ apiKey: connection.apiKey, baseUrl: connection.baseUrl })
+    case 'ollama':
+      return createOllamaProvider({ baseUrl: connection.baseUrl })
+    case 'mock':
+      return createMockProvider()
+    default:
+      throw new ChatProviderError(`Unknown provider "${connection.providerId}".`, connection.providerId)
+  }
+}
+
+/** Whether a connection has everything it needs to send (used to gate the UI). */
+export function isConnectionReady(connection: ProviderConnection): boolean {
+  if (!connection.model) return false
+  switch (connection.providerId) {
+    case 'anthropic':
+    case 'openai':
+      return Boolean(connection.apiKey)
+    case 'ollama':
+    case 'mock':
+      return true
+    default:
+      return false
+  }
+}

--- a/packages/ai-assistant/src/index.ts
+++ b/packages/ai-assistant/src/index.ts
@@ -1,0 +1,13 @@
+// @arduconfig/ai-assistant — provider-agnostic, UI-agnostic tool-calling layer
+// for the AI Assistant tab. Read-only (slice 1): exposes the live vehicle state
+// to a chat model through MCP-style tools; the model cannot change anything.
+
+export * from './provider.js'
+export * from './tools.js'
+export * from './system-prompt.js'
+export * from './storage.js'
+export * from './create-provider.js'
+export { createAnthropicProvider } from './anthropic-provider.js'
+export { createOpenAiProvider } from './openai-provider.js'
+export { createOllamaProvider } from './ollama-provider.js'
+export { createMockProvider } from './mock-provider.js'

--- a/packages/ai-assistant/src/mock-provider.ts
+++ b/packages/ai-assistant/src/mock-provider.ts
@@ -1,0 +1,73 @@
+// Deterministic mock provider — the offline test seam.
+//
+// Mirrors how the demo transport lets the whole app run with no hardware: the
+// mock provider lets the AI Assistant run with no API key and no network, so
+// unit tests and Playwright e2e can exercise the full send loop (user turn ->
+// tool call -> app executes the read-only tool -> tool result -> assistant
+// text) with a stable, assertable script.
+
+import type { ChatEvent, ChatProvider, ChatRequest } from './provider.js'
+
+const TOOL_CALL_ID = 'mock-call-1'
+
+export function createMockProvider(): ChatProvider {
+  return {
+    id: 'mock',
+    async *send(request: ChatRequest): AsyncIterable<ChatEvent> {
+      const last = request.messages[request.messages.length - 1]
+
+      // A write-intent prompt (and the propose tool is on offer) → stage a
+      // proposal. Used by e2e to exercise the propose→approve→apply flow.
+      const proposeOffered = request.tools.some((tool) => tool.name === 'propose_param_changes')
+      if (
+        last?.role === 'user' &&
+        // Ignore synthetic bracketed system notes (e.g. the post-apply outcome
+        // the hook injects) so we only propose in response to a real prompt.
+        !last.content.startsWith('[') &&
+        proposeOffered &&
+        /propose|raise|increase|bump|tune/i.test(last.content)
+      ) {
+        yield { type: 'text-delta', text: 'Here is a proposed change for you to review. ' }
+        yield {
+          type: 'tool-call',
+          call: {
+            id: 'mock-propose-1',
+            name: 'propose_param_changes',
+            arguments: {
+              summary: 'Nudge pitch-axis rate P gain up slightly.',
+              changes: [
+                { paramId: 'ATC_RAT_PIT_P', value: 0.145, reason: 'Small increase for crisper pitch response.' }
+              ]
+            }
+          }
+        }
+        yield { type: 'done', stopReason: 'tool-use' }
+        return
+      }
+
+      // After a tool result comes back, produce a final text answer.
+      if (last?.role === 'tool') {
+        let vehicle = 'the connected vehicle'
+        try {
+          const parsed = JSON.parse(last.content) as { data?: { vehicle?: string } }
+          if (parsed.data?.vehicle) vehicle = parsed.data.vehicle
+        } catch {
+          // Non-JSON tool result — fall back to the generic phrasing.
+        }
+        for (const chunk of ['Based on ', 'get_vehicle_info, this is ', `${vehicle}.`]) {
+          yield { type: 'text-delta', text: chunk }
+        }
+        yield { type: 'done', stopReason: 'end' }
+        return
+      }
+
+      // First assistant turn: call a read-only tool to demonstrate the loop.
+      yield { type: 'text-delta', text: 'Let me check the vehicle. ' }
+      yield {
+        type: 'tool-call',
+        call: { id: TOOL_CALL_ID, name: 'get_vehicle_info', arguments: {} }
+      }
+      yield { type: 'done', stopReason: 'tool-use' }
+    }
+  }
+}

--- a/packages/ai-assistant/src/ollama-provider.ts
+++ b/packages/ai-assistant/src/ollama-provider.ts
@@ -1,0 +1,123 @@
+// Ollama adapter — a local model over the /api/chat endpoint (NDJSON stream).
+//
+// No API key. baseUrl defaults to http://localhost:11434 and is user-editable.
+// For the browser to reach a local Ollama across origins the user must start it
+// with OLLAMA_ORIGINS set to allow the app origin — the settings UI notes this.
+
+import type { ChatEvent, ChatMessage, ChatProvider, ChatRequest } from './provider.js'
+import { ChatProviderError } from './provider.js'
+import type { ToolDefinition } from './tools.js'
+import { iterateLines } from './stream.js'
+
+const DEFAULT_BASE_URL = 'http://localhost:11434'
+
+interface OllamaMessage {
+  role: 'system' | 'user' | 'assistant' | 'tool'
+  content: string
+  tool_calls?: Array<{ function: { name: string; arguments: Record<string, unknown> } }>
+}
+
+function toOllamaMessages(system: string, messages: ChatMessage[]): OllamaMessage[] {
+  const out: OllamaMessage[] = [{ role: 'system', content: system }]
+  for (const message of messages) {
+    if (message.role === 'assistant') {
+      out.push({
+        role: 'assistant',
+        content: message.content,
+        tool_calls:
+          message.toolCalls && message.toolCalls.length > 0
+            ? message.toolCalls.map((call) => ({
+                function: { name: call.name, arguments: call.arguments }
+              }))
+            : undefined
+      })
+    } else if (message.role === 'tool') {
+      out.push({ role: 'tool', content: message.content })
+    } else {
+      out.push({ role: 'user', content: message.content })
+    }
+  }
+  return out
+}
+
+function toOllamaTools(tools: ToolDefinition[]): unknown[] {
+  return tools.map((tool) => ({
+    type: 'function',
+    function: { name: tool.name, description: tool.description, parameters: tool.parameters }
+  }))
+}
+
+export function createOllamaProvider(options: { baseUrl?: string }): ChatProvider {
+  const baseUrl = (options.baseUrl ?? DEFAULT_BASE_URL).replace(/\/$/, '')
+  return {
+    id: 'ollama',
+    async *send(request: ChatRequest): AsyncIterable<ChatEvent> {
+      let response: Response
+      try {
+        response = await fetch(`${baseUrl}/api/chat`, {
+          method: 'POST',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({
+            model: request.model,
+            messages: toOllamaMessages(request.system, request.messages),
+            tools: toOllamaTools(request.tools),
+            stream: true
+          }),
+          signal: request.signal
+        })
+      } catch (error) {
+        throw new ChatProviderError(
+          `Could not reach Ollama at ${baseUrl}: ${(error as Error).message}. Is it running, and is OLLAMA_ORIGINS set to allow this page?`,
+          'ollama'
+        )
+      }
+      if (!response.ok) {
+        const detail = await response.text().catch(() => '')
+        throw new ChatProviderError(
+          `Ollama error ${response.status}: ${detail.slice(0, 300)}`,
+          'ollama',
+          response.status
+        )
+      }
+
+      let stopReason: 'end' | 'tool-use' = 'end'
+      let toolIndex = 0
+
+      for await (const line of iterateLines(response)) {
+        let frame: {
+          message?: {
+            content?: string
+            tool_calls?: Array<{ function?: { name?: string; arguments?: Record<string, unknown> } }>
+          }
+          done?: boolean
+          error?: string
+        }
+        try {
+          frame = JSON.parse(line)
+        } catch {
+          continue
+        }
+        if (frame.error) {
+          yield { type: 'error', message: `Ollama: ${frame.error}` }
+          return
+        }
+        if (frame.message?.content) {
+          yield { type: 'text-delta', text: frame.message.content }
+        }
+        for (const call of frame.message?.tool_calls ?? []) {
+          if (!call.function?.name) continue
+          stopReason = 'tool-use'
+          yield {
+            type: 'tool-call',
+            call: {
+              id: `ollama-tool-${toolIndex++}`,
+              name: call.function.name,
+              arguments: call.function.arguments ?? {}
+            }
+          }
+        }
+      }
+      yield { type: 'done', stopReason }
+    }
+  }
+}

--- a/packages/ai-assistant/src/openai-provider.ts
+++ b/packages/ai-assistant/src/openai-provider.ts
@@ -1,0 +1,149 @@
+// OpenAI Chat Completions adapter (browser BYOK).
+//
+// Uses the streaming chat/completions endpoint with function/tool calling.
+// baseUrl is overridable so OpenAI-compatible gateways (Azure/OpenRouter/etc.)
+// work by pointing at their /v1.
+
+import type { ChatEvent, ChatMessage, ChatProvider, ChatRequest } from './provider.js'
+import { ChatProviderError } from './provider.js'
+import type { ToolDefinition } from './tools.js'
+import { iterateLines, sseData } from './stream.js'
+
+const DEFAULT_BASE_URL = 'https://api.openai.com'
+
+interface OpenAiMessage {
+  role: 'system' | 'user' | 'assistant' | 'tool'
+  content: string | null
+  tool_call_id?: string
+  tool_calls?: Array<{
+    id: string
+    type: 'function'
+    function: { name: string; arguments: string }
+  }>
+}
+
+function toOpenAiMessages(system: string, messages: ChatMessage[]): OpenAiMessage[] {
+  const out: OpenAiMessage[] = [{ role: 'system', content: system }]
+  for (const message of messages) {
+    if (message.role === 'assistant') {
+      out.push({
+        role: 'assistant',
+        content: message.content || null,
+        tool_calls:
+          message.toolCalls && message.toolCalls.length > 0
+            ? message.toolCalls.map((call) => ({
+                id: call.id,
+                type: 'function' as const,
+                function: { name: call.name, arguments: JSON.stringify(call.arguments) }
+              }))
+            : undefined
+      })
+    } else if (message.role === 'tool') {
+      out.push({ role: 'tool', content: message.content, tool_call_id: message.toolCallId })
+    } else {
+      out.push({ role: 'user', content: message.content })
+    }
+  }
+  return out
+}
+
+function toOpenAiTools(tools: ToolDefinition[]): unknown[] {
+  return tools.map((tool) => ({
+    type: 'function',
+    function: { name: tool.name, description: tool.description, parameters: tool.parameters }
+  }))
+}
+
+interface PendingToolCall {
+  id: string
+  name: string
+  args: string
+}
+
+export function createOpenAiProvider(options: { apiKey: string; baseUrl?: string }): ChatProvider {
+  const baseUrl = (options.baseUrl ?? DEFAULT_BASE_URL).replace(/\/$/, '')
+  return {
+    id: 'openai',
+    async *send(request: ChatRequest): AsyncIterable<ChatEvent> {
+      let response: Response
+      try {
+        response = await fetch(`${baseUrl}/v1/chat/completions`, {
+          method: 'POST',
+          headers: {
+            'content-type': 'application/json',
+            authorization: `Bearer ${options.apiKey}`
+          },
+          body: JSON.stringify({
+            model: request.model,
+            messages: toOpenAiMessages(request.system, request.messages),
+            tools: toOpenAiTools(request.tools),
+            stream: true
+          }),
+          signal: request.signal
+        })
+      } catch (error) {
+        throw new ChatProviderError(`Could not reach OpenAI: ${(error as Error).message}`, 'openai')
+      }
+      if (!response.ok) {
+        const detail = await response.text().catch(() => '')
+        throw new ChatProviderError(
+          `OpenAI API error ${response.status}: ${detail.slice(0, 300)}`,
+          'openai',
+          response.status
+        )
+      }
+
+      const pending = new Map<number, PendingToolCall>()
+      let stopReason: 'end' | 'tool-use' = 'end'
+
+      for await (const line of iterateLines(response)) {
+        const data = sseData(line)
+        if (!data || data === '[DONE]') continue
+        let chunk: {
+          choices?: Array<{
+            delta?: {
+              content?: string
+              tool_calls?: Array<{
+                index: number
+                id?: string
+                function?: { name?: string; arguments?: string }
+              }>
+            }
+            finish_reason?: string
+          }>
+        }
+        try {
+          chunk = JSON.parse(data)
+        } catch {
+          continue
+        }
+        const choice = chunk.choices?.[0]
+        if (!choice) continue
+        if (choice.delta?.content) {
+          yield { type: 'text-delta', text: choice.delta.content }
+        }
+        for (const toolDelta of choice.delta?.tool_calls ?? []) {
+          const existing = pending.get(toolDelta.index) ?? { id: '', name: '', args: '' }
+          if (toolDelta.id) existing.id = toolDelta.id
+          if (toolDelta.function?.name) existing.name = toolDelta.function.name
+          if (toolDelta.function?.arguments) existing.args += toolDelta.function.arguments
+          pending.set(toolDelta.index, existing)
+        }
+        if (choice.finish_reason === 'tool_calls') stopReason = 'tool-use'
+      }
+
+      if (stopReason === 'tool-use') {
+        for (const call of pending.values()) {
+          let args: Record<string, unknown> = {}
+          try {
+            args = call.args ? (JSON.parse(call.args) as Record<string, unknown>) : {}
+          } catch {
+            args = {}
+          }
+          yield { type: 'tool-call', call: { id: call.id, name: call.name, arguments: args } }
+        }
+      }
+      yield { type: 'done', stopReason }
+    }
+  }
+}

--- a/packages/ai-assistant/src/provider.ts
+++ b/packages/ai-assistant/src/provider.ts
@@ -1,0 +1,89 @@
+// Normalized chat-provider abstraction for the AI Assistant.
+//
+// Three real backends (Anthropic Messages, OpenAI Chat Completions, and a
+// local Ollama server) plus a deterministic mock all implement one interface,
+// so the app-side send loop is provider-agnostic: it feeds a conversation and
+// the read-only tool schemas in, and consumes a single normalized event
+// stream out. The MCP-style tool *shapes* (see ./tools) are provider-neutral;
+// each adapter is the thin translation layer to that vendor's tool-calling
+// wire format.
+//
+// This module is browser-first (adapters call `fetch` directly, BYOK) and has
+// no React/runtime/transport dependencies — vehicle state reaches the tools
+// through an injected accessor, never through this layer.
+
+import type { ToolDefinition } from './tools.js'
+
+/** Provider identifiers the app can configure. */
+export type ChatProviderId = 'anthropic' | 'openai' | 'ollama' | 'mock'
+
+/** One turn in the conversation, normalized across providers. */
+export interface ChatMessage {
+  role: 'user' | 'assistant' | 'tool'
+  /** Assistant/user free text. Empty string for a pure tool-call assistant turn. */
+  content: string
+  /**
+   * Tool calls the assistant requested on this turn (role === 'assistant').
+   * The app executes each and appends role === 'tool' messages carrying the
+   * matching `toolCallId` + JSON result.
+   */
+  toolCalls?: ChatToolCall[]
+  /** Set on role === 'tool' messages — the id of the call this result answers. */
+  toolCallId?: string
+}
+
+export interface ChatToolCall {
+  /** Provider-assigned id, echoed back on the tool-result message. */
+  id: string
+  name: string
+  /** Parsed JSON arguments; `{}` when the tool takes none. */
+  arguments: Record<string, unknown>
+}
+
+/**
+ * Normalized streaming event. Adapters translate each vendor's SSE/NDJSON
+ * frames into this small union so the send loop never sees wire specifics.
+ */
+export type ChatEvent =
+  | { type: 'text-delta'; text: string }
+  | { type: 'tool-call'; call: ChatToolCall }
+  | { type: 'done'; stopReason: 'end' | 'tool-use' }
+  | { type: 'error'; message: string }
+
+export interface ChatRequest {
+  system: string
+  messages: ChatMessage[]
+  tools: ToolDefinition[]
+  /** Provider model id (e.g. 'claude-sonnet-5', 'gpt-4o', 'llama3.1'). */
+  model: string
+  signal?: AbortSignal
+}
+
+/** The one interface every backend implements. */
+export interface ChatProvider {
+  readonly id: ChatProviderId
+  send(request: ChatRequest): AsyncIterable<ChatEvent>
+}
+
+/** Config the app persists (non-secret) + the in-memory key. */
+export interface ProviderConnection {
+  providerId: ChatProviderId
+  model: string
+  /** API key (cloud providers). Never persisted unless the user opts in. */
+  apiKey?: string
+  /** Endpoint override — required for Ollama, optional proxy for cloud. */
+  baseUrl?: string
+}
+
+/** Thrown by adapters for a non-2xx or transport failure; carries a
+ *  human-readable, provider-attributed message the UI surfaces verbatim. */
+export class ChatProviderError extends Error {
+  constructor(
+    message: string,
+    readonly providerId: ChatProviderId,
+    readonly status?: number
+  ) {
+    super(message)
+    this.name = 'ChatProviderError'
+  }
+}

--- a/packages/ai-assistant/src/storage.ts
+++ b/packages/ai-assistant/src/storage.ts
@@ -1,0 +1,106 @@
+// Persistence for the AI Assistant provider config.
+//
+// Split by sensitivity, mirroring the FirmwareFlasher precedent (persist the
+// non-secret connection config; keep the secret in memory unless the user
+// explicitly opts in):
+//   - Non-secret config (provider, model, base URL, rememberKey flag) is always
+//     persisted so the tab reopens preconfigured.
+//   - The API key is written ONLY when rememberKey is true, under its own key,
+//     with a visible XSS-risk warning in the UI. By default it stays in memory
+//     and is gone on reload.
+//
+// Storage is injectable (Pick<Storage,...>) so tests run without a real DOM,
+// and every access is try/catch-guarded — storage can throw in private-mode /
+// embedded contexts and must never crash the app.
+
+import type { ChatProviderId } from './provider.js'
+
+export type WritableStorage = Pick<Storage, 'getItem' | 'setItem' | 'removeItem'>
+
+const CONFIG_KEY = 'arduconfig:ai-assistant:config'
+const API_KEY_KEY = 'arduconfig:ai-assistant:key'
+const SCHEMA_VERSION = 1
+
+export interface PersistedProviderConfig {
+  providerId: ChatProviderId
+  model: string
+  baseUrl?: string
+  /** When true, the API key is persisted alongside this config (opt-in). */
+  rememberKey: boolean
+  /** When true (default), the model is offered the propose_param_changes tool.
+   *  Off = read-only Q&A. Optional for backward compatibility with slice-1
+   *  configs that predate it. */
+  allowProposals?: boolean
+}
+
+interface StoredConfigEnvelope {
+  version: number
+  config: PersistedProviderConfig
+}
+
+const VALID_PROVIDERS: ReadonlySet<string> = new Set(['anthropic', 'openai', 'ollama', 'mock'])
+
+function isPersistedConfig(value: unknown): value is PersistedProviderConfig {
+  if (typeof value !== 'object' || value === null) return false
+  const candidate = value as Record<string, unknown>
+  return (
+    typeof candidate.providerId === 'string' &&
+    VALID_PROVIDERS.has(candidate.providerId) &&
+    typeof candidate.model === 'string' &&
+    (candidate.baseUrl === undefined || typeof candidate.baseUrl === 'string') &&
+    typeof candidate.rememberKey === 'boolean' &&
+    (candidate.allowProposals === undefined || typeof candidate.allowProposals === 'boolean')
+  )
+}
+
+/** Load persisted non-secret config, or undefined if absent/corrupt. */
+export function loadProviderConfig(storage: WritableStorage): PersistedProviderConfig | undefined {
+  try {
+    const raw = storage.getItem(CONFIG_KEY)
+    if (!raw) return undefined
+    const parsed = JSON.parse(raw) as StoredConfigEnvelope
+    if (parsed.version !== SCHEMA_VERSION || !isPersistedConfig(parsed.config)) {
+      return undefined
+    }
+    return parsed.config
+  } catch {
+    return undefined
+  }
+}
+
+/** Persist non-secret config. Never writes the API key — see persistApiKey. */
+export function saveProviderConfig(storage: WritableStorage, config: PersistedProviderConfig): void {
+  try {
+    const envelope: StoredConfigEnvelope = { version: SCHEMA_VERSION, config }
+    storage.setItem(CONFIG_KEY, JSON.stringify(envelope))
+  } catch {
+    // Storage unavailable (private mode / embedded) — config just won't persist.
+  }
+}
+
+/** Load a persisted API key, if the user opted into remembering it. */
+export function loadPersistedApiKey(storage: WritableStorage): string | undefined {
+  try {
+    return storage.getItem(API_KEY_KEY) ?? undefined
+  } catch {
+    return undefined
+  }
+}
+
+/** Persist the API key (only ever call this when rememberKey is true). */
+export function persistApiKey(storage: WritableStorage, apiKey: string): void {
+  try {
+    storage.setItem(API_KEY_KEY, apiKey)
+  } catch {
+    // Ignore — key simply stays in memory only.
+  }
+}
+
+/** Remove any persisted API key (called when the user turns rememberKey off). */
+export function clearPersistedApiKey(storage: WritableStorage): void {
+  try {
+    storage.removeItem(API_KEY_KEY)
+  } catch {
+    // Ignore.
+  }
+}

--- a/packages/ai-assistant/src/stream.ts
+++ b/packages/ai-assistant/src/stream.ts
@@ -1,0 +1,40 @@
+// Shared streaming helpers for the HTTP provider adapters.
+//
+// All three real backends stream line-oriented bodies — Anthropic and OpenAI
+// as Server-Sent Events (`data: {json}` lines), Ollama as NDJSON (one JSON
+// object per line). `iterateLines` turns a fetch Response body into an async
+// line iterator; each adapter parses those lines per its own wire format.
+
+/** Yield the response body as decoded, newline-delimited lines (no trailing
+ *  empties). Works for both SSE and NDJSON since both are line-based. */
+export async function* iterateLines(response: Response): AsyncGenerator<string> {
+  const body = response.body
+  if (!body) return
+  const reader = body.getReader()
+  const decoder = new TextDecoder()
+  let buffer = ''
+  try {
+    for (;;) {
+      const { done, value } = await reader.read()
+      if (done) break
+      buffer += decoder.decode(value, { stream: true })
+      let newlineIndex = buffer.indexOf('\n')
+      while (newlineIndex !== -1) {
+        const line = buffer.slice(0, newlineIndex).replace(/\r$/, '')
+        buffer = buffer.slice(newlineIndex + 1)
+        if (line.length > 0) yield line
+        newlineIndex = buffer.indexOf('\n')
+      }
+    }
+    const tail = buffer.trim()
+    if (tail.length > 0) yield tail
+  } finally {
+    reader.releaseLock()
+  }
+}
+
+/** Strip the leading `data:` (and optional space) from an SSE data line. */
+export function sseData(line: string): string | undefined {
+  if (!line.startsWith('data:')) return undefined
+  return line.slice(5).trimStart()
+}

--- a/packages/ai-assistant/src/system-prompt.ts
+++ b/packages/ai-assistant/src/system-prompt.ts
@@ -1,0 +1,68 @@
+// System prompt + vehicle grounding summary for the AI Assistant.
+//
+// The grounding summary is a compact, plain-text snapshot of the connected
+// vehicle injected into the system prompt each turn, so the model has the
+// essential context (what's connected, is it armed, is it healthy, how many
+// params) without spending a mandatory first tool call to discover it — the
+// MCP "resource" idea, inlined. The model still drills into detail through the
+// read-only tools.
+
+import type { ConfiguratorSnapshot } from '@arduconfig/ardupilot-core'
+
+/** Compact plain-text vehicle state for the system prompt. Pure; safe to call
+ *  on a disconnected snapshot (returns a "not connected" line). */
+export function buildVehicleGroundingSummary(snapshot: ConfiguratorSnapshot): string {
+  if (snapshot.connection.kind !== 'connected') {
+    return 'No flight controller is currently connected. Answer general ArduPilot questions, and tell the user to connect a vehicle before asking about live state.'
+  }
+
+  const vehicle = snapshot.vehicle
+  const board = snapshot.hardware.board
+  const prearm = snapshot.preArmStatus
+  const lines: string[] = []
+
+  lines.push(`Vehicle: ${vehicle?.vehicle ?? 'Unknown'} (${vehicle?.firmware ?? 'Unknown'} firmware${
+    board?.firmwareVersion ? `, ${board.firmwareVersion}` : ''
+  })`)
+  lines.push(`State: ${vehicle?.armed ? 'ARMED' : 'disarmed'}, mode ${vehicle?.flightMode ?? 'unknown'}, system ${vehicle?.systemStatus ?? 'unknown'}`)
+  lines.push(`Parameters: ${snapshot.parameterStats.downloaded} downloaded (sync ${snapshot.parameterStats.status})`)
+  lines.push(
+    prearm.healthy
+      ? 'Pre-arm: passing.'
+      : `Pre-arm: ${prearm.issues.length} outstanding issue(s). Use get_prearm_status for detail.`
+  )
+  if (snapshot.canNodes.length > 0) {
+    lines.push(`DroneCAN: ${snapshot.canNodes.length} node(s) on the bus.`)
+  }
+
+  return lines.join('\n')
+}
+
+export interface SystemPromptInputs {
+  /** Output of buildVehicleGroundingSummary for the current snapshot. */
+  grounding: string
+  /** When true, the propose_param_changes tool is available (still human-gated). */
+  allowProposals?: boolean
+}
+
+/** Build the full system prompt. The access framing switches on whether the
+ *  propose tool is offered — but a write is ALWAYS human-approved either way. */
+export function buildSystemPrompt(inputs: SystemPromptInputs): string {
+  const accessParagraph = inputs.allowProposals
+    ? 'You can inspect parameters, telemetry, pre-arm status, DroneCAN nodes, and setup progress through the read tools. You can also PROPOSE parameter changes with the propose_param_changes tool — but proposing does NOT apply anything: it stages a diff the user must explicitly review and approve. You cannot apply changes yourself and must never claim to have changed a parameter. When you propose changes, use exact parameter ids and values within each parameter\'s valid range, give a short reason per change, and briefly tell the user to review and apply the proposal.'
+    : 'You have READ-ONLY access this session. You can inspect parameters, telemetry, pre-arm status, DroneCAN nodes, and setup progress through the provided tools, but you CANNOT change any parameter or command the vehicle. When the user asks you to change something, explain exactly which parameters you would change and to what values — do not claim to have changed anything.'
+  return [
+    'You are the ArduConfigurator AI Assistant, an expert copilot for setting up and tuning ArduPilot vehicles (primarily ArduCopter FPV builds). You help the user understand the current state of their connected flight controller and reason about its configuration.',
+    '',
+    accessParagraph,
+    '',
+    'Ground rules:',
+    '- Prefer calling a tool to reading a value you are unsure of. Never invent a parameter id or a current value — look it up.',
+    '- ArduPilot parameter names are precise (e.g. ATC_RAT_PIT_P, INS_HNTCH_ENABLE). Use get_parameter or search_parameters to confirm exact ids and valid ranges before discussing them.',
+    '- Treat a connected flight controller as attached to a real aircraft. Be conservative: flag anything that affects flight safety (failsafe, battery, arming, tuning limits) and never encourage bypassing a pre-arm check.',
+    '- Be concise and specific. Cite the parameter ids and values you looked up.',
+    '',
+    'Current vehicle context:',
+    inputs.grounding
+  ].join('\n')
+}

--- a/packages/ai-assistant/src/tools.ts
+++ b/packages/ai-assistant/src/tools.ts
@@ -1,0 +1,430 @@
+// Read-only tool definitions + executor for the AI Assistant (slice 1).
+//
+// These are MCP-style tools: each has a name, a description, and a JSON-schema
+// input contract, and each resolves purely from the live ConfiguratorSnapshot
+// via an injected accessor. The schemas are deliberately provider-neutral and
+// MCP-portable, so a future desktop-hosted MCP server can expose the exact same
+// contract.
+//
+// SLICE 1 IS READ-ONLY. No tool here mutates a parameter or issues a vehicle
+// command — the model physically cannot change the aircraft. The write path
+// (propose -> human approves -> runtime.setParameters) is a separate later
+// slice. Keeping writes out also keeps prompt-injection (e.g. via STATUSTEXT
+// the model reads through get_telemetry / get_prearm_status) inert.
+
+import type { ConfiguratorSnapshot, ParameterState } from '@arduconfig/ardupilot-core'
+
+/** Minimal JSON-schema shape for a tool's input contract. */
+export interface ToolInputSchema {
+  type: 'object'
+  properties: Record<string, unknown>
+  required?: string[]
+  additionalProperties?: boolean
+}
+
+export interface ToolDefinition {
+  name: string
+  description: string
+  parameters: ToolInputSchema
+}
+
+/** The single seam through which tools read live vehicle state. Injected by the
+ *  app with `() => runtime.getSnapshot()`; the package never touches the runtime
+ *  instance directly, keeping it UI/transport-agnostic. */
+export interface SnapshotAccessor {
+  getSnapshot(): ConfiguratorSnapshot
+}
+
+export type ToolResult =
+  | { ok: true; data: unknown }
+  | { ok: false; error: string }
+
+/** Hard cap so a single list/search call can never blow the model's context
+ *  with a full ~1000-param dump. The model pages with offset/limit. */
+const DEFAULT_PARAM_PAGE = 100
+const MAX_PARAM_PAGE = 300
+
+function asString(value: unknown): string | undefined {
+  return typeof value === 'string' && value.length > 0 ? value : undefined
+}
+
+function asPositiveInt(value: unknown, fallback: number, max: number): number {
+  if (typeof value !== 'number' || !Number.isFinite(value)) return fallback
+  const rounded = Math.floor(value)
+  if (rounded < 0) return fallback
+  return Math.min(rounded, max)
+}
+
+/** Real (non-alias-mirror) params only — mirrors would double-count. */
+function realParameters(snapshot: ConfiguratorSnapshot): ParameterState[] {
+  return snapshot.parameters.filter((parameter) => parameter.aliasedFrom === undefined)
+}
+
+/** Compact {id, value} projection for list/search — no metadata, so the model
+ *  can scan hundreds cheaply, then drill in with get_parameter. */
+function compactParam(parameter: ParameterState): { id: string; value: number } {
+  return { id: parameter.id, value: parameter.value }
+}
+
+/** Full metadata projection for a single param the model asked about. */
+function detailParam(parameter: ParameterState): Record<string, unknown> {
+  const definition = parameter.definition
+  return {
+    id: parameter.id,
+    value: parameter.value,
+    unit: definition?.unit,
+    label: definition?.label,
+    description: definition?.description,
+    minimum: definition?.minimum,
+    maximum: definition?.maximum,
+    rebootRequired: definition?.rebootRequired ?? false,
+    options: definition?.options?.map((option) => ({
+      value: option.value,
+      label: option.label
+    })),
+    bitmask: definition?.bitmask ?? undefined
+  }
+}
+
+/** One parameter change the model proposes. `reason` is shown to the human on
+ *  the approval card. Semantic validation (range/enum/exists) happens web-side
+ *  against the live snapshot — this is just the wire shape. */
+export interface ProposedChange {
+  paramId: string
+  value: number
+  reason?: string
+}
+
+/** Upper bound on a single proposal, so a runaway response cannot stage a huge
+ *  batch. Enforced by parseProposedChanges. */
+export const MAX_PROPOSED_CHANGES = 40
+
+// The one WRITE-INTENT tool. It does NOT write — the app dispatches it specially,
+// validates it against the live snapshot, and stages it for explicit human
+// approval. Only a human click applies it. Kept out of createToolExecutor (which
+// stays strictly read-only) precisely so it can never execute a write here.
+export const PROPOSE_PARAM_CHANGES_TOOL: ToolDefinition = {
+  name: 'propose_param_changes',
+  description:
+    'Propose one or more parameter changes for the USER to review and approve. This does NOT apply anything — it stages a diff the user must explicitly approve and apply. Use exact parameter ids and values within each parameter\'s valid range. Give a short reason per change. Never claim you have applied changes; you can only propose them.',
+  parameters: {
+    type: 'object',
+    properties: {
+      summary: { type: 'string', description: 'One-sentence summary of what this set of changes accomplishes.' },
+      changes: {
+        type: 'array',
+        description: `The proposed changes (max ${MAX_PROPOSED_CHANGES}).`,
+        items: {
+          type: 'object',
+          properties: {
+            paramId: { type: 'string', description: 'Exact parameter id, e.g. "ATC_RAT_PIT_P".' },
+            value: { type: 'number', description: 'The proposed new value.' },
+            reason: { type: 'string', description: 'Why this change (shown to the user).' }
+          },
+          required: ['paramId', 'value']
+        }
+      }
+    },
+    required: ['changes'],
+    additionalProperties: false
+  }
+}
+
+export interface ParsedProposal {
+  summary?: string
+  changes: ProposedChange[]
+}
+
+/** Validate + normalize raw propose_param_changes arguments (shape + cap only).
+ *  Returns the parsed proposal or a human-readable error. */
+export function parseProposedChanges(
+  args: Record<string, unknown>,
+  maxChanges: number = MAX_PROPOSED_CHANGES
+): { proposal: ParsedProposal } | { error: string } {
+  const rawChanges = args.changes
+  if (!Array.isArray(rawChanges) || rawChanges.length === 0) {
+    return { error: 'Proposal must include a non-empty "changes" array.' }
+  }
+  if (rawChanges.length > maxChanges) {
+    return { error: `Too many changes (${rawChanges.length}); propose at most ${maxChanges} at once.` }
+  }
+  const changes: ProposedChange[] = []
+  for (const raw of rawChanges) {
+    if (typeof raw !== 'object' || raw === null) {
+      return { error: 'Each change must be an object with paramId and value.' }
+    }
+    const candidate = raw as Record<string, unknown>
+    const paramId = candidate.paramId
+    const value = candidate.value
+    if (typeof paramId !== 'string' || paramId.length === 0) {
+      return { error: 'Each change needs a non-empty string "paramId".' }
+    }
+    if (typeof value !== 'number' || !Number.isFinite(value)) {
+      return { error: `Change for "${paramId}" needs a finite numeric "value".` }
+    }
+    changes.push({
+      paramId,
+      value,
+      reason: typeof candidate.reason === 'string' ? candidate.reason : undefined
+    })
+  }
+  return {
+    proposal: {
+      summary: typeof args.summary === 'string' ? args.summary : undefined,
+      changes
+    }
+  }
+}
+
+/** The tool set offered to the provider. Read-only always; the propose tool is
+ *  added only when the user has left proposals enabled. */
+export function toolsFor(options: { allowProposals: boolean }): ToolDefinition[] {
+  return options.allowProposals ? [...AI_ASSISTANT_TOOLS, PROPOSE_PARAM_CHANGES_TOOL] : [...AI_ASSISTANT_TOOLS]
+}
+
+export const AI_ASSISTANT_TOOLS: ToolDefinition[] = [
+  {
+    name: 'get_vehicle_info',
+    description:
+      'Identity and live status of the connected flight controller: firmware, vehicle type (ArduCopter/Plane/Rover/Sub), armed state, current flight mode, decoded system status, board type, and firmware version. Call this first to ground your understanding of what is connected.',
+    parameters: { type: 'object', properties: {}, additionalProperties: false }
+  },
+  {
+    name: 'list_parameters',
+    description:
+      'List parameter ids and current values (compact — no metadata). There can be ~1000+ params, so results are paged. Use `prefix` to scope to a family (e.g. "INS_", "ATC_", "SERVO"). Use get_parameter or search_parameters to get labels/units/ranges for specific ids.',
+    parameters: {
+      type: 'object',
+      properties: {
+        prefix: { type: 'string', description: 'Only return ids starting with this (case-insensitive).' },
+        offset: { type: 'number', description: 'Skip this many matches (paging). Default 0.' },
+        limit: { type: 'number', description: `Max results, capped at ${MAX_PARAM_PAGE}. Default ${DEFAULT_PARAM_PAGE}.` }
+      },
+      additionalProperties: false
+    }
+  },
+  {
+    name: 'get_parameter',
+    description:
+      'Full detail for one parameter: current value plus its label, description, unit, valid range, enum options, and whether a reboot is required to apply. Use the exact parameter id (e.g. "ATC_RAT_PIT_P").',
+    parameters: {
+      type: 'object',
+      properties: { id: { type: 'string', description: 'Exact parameter id.' } },
+      required: ['id'],
+      additionalProperties: false
+    }
+  },
+  {
+    name: 'search_parameters',
+    description:
+      'Find parameters by fuzzy text across id, label, and description (e.g. "battery failsafe", "notch filter", "compass orientation"). Returns matching ids with their labels and current values so you can then get_parameter the relevant ones.',
+    parameters: {
+      type: 'object',
+      properties: {
+        query: { type: 'string', description: 'Free-text query.' },
+        limit: { type: 'number', description: `Max results, capped at ${MAX_PARAM_PAGE}. Default 25.` }
+      },
+      required: ['query'],
+      additionalProperties: false
+    }
+  },
+  {
+    name: 'get_telemetry',
+    description:
+      'Live telemetry snapshot: RC input channels, battery voltage/current, attitude (roll/pitch/yaw), GPS/position, and sensor health bits (baro, gyro, accel, mag, GPS, optical flow) from SYS_STATUS. Values may be undefined on a bench FC with no fix.',
+    parameters: { type: 'object', properties: {}, additionalProperties: false }
+  },
+  {
+    name: 'get_prearm_status',
+    description:
+      'Current pre-arm check status: whether the vehicle would allow arming, and the list of outstanding pre-arm failure messages the firmware is reporting. Use this to explain why a vehicle will not arm.',
+    parameters: { type: 'object', properties: {}, additionalProperties: false }
+  },
+  {
+    name: 'get_can_nodes',
+    description:
+      'DroneCAN peripherals discovered on the bus (GPS, compass, ESCs, power modules, etc.): node name, health, mode, and hardware/software versions. Empty when no CAN bus is active or no nodes are present.',
+    parameters: { type: 'object', properties: {}, additionalProperties: false }
+  },
+  {
+    name: 'get_setup_status',
+    description:
+      'Guided-setup checklist state: each setup section (radio, sensors, outputs, failsafe, etc.) with its completion status and notes, plus the state of guided actions (calibrations, reboot). Use this to see what setup steps still need attention.',
+    parameters: { type: 'object', properties: {}, additionalProperties: false }
+  }
+]
+
+/** Build a pure, read-only tool executor over an injected snapshot accessor. */
+export function createToolExecutor(accessor: SnapshotAccessor): {
+  definitions: ToolDefinition[]
+  execute(name: string, args: Record<string, unknown>): ToolResult
+} {
+  function execute(name: string, args: Record<string, unknown>): ToolResult {
+    const snapshot = accessor.getSnapshot()
+    switch (name) {
+      case 'get_vehicle_info': {
+        const board = snapshot.hardware.board
+        return {
+          ok: true,
+          data: {
+            connection: snapshot.connection.kind,
+            firmware: snapshot.vehicle?.firmware ?? 'Unknown',
+            vehicle: snapshot.vehicle?.vehicle ?? 'Unknown',
+            armed: snapshot.vehicle?.armed ?? false,
+            flightMode: snapshot.vehicle?.flightMode,
+            systemStatus: snapshot.vehicle?.systemStatus,
+            firmwareVersion: board?.firmwareVersion,
+            boardType: board?.boardType,
+            parametersDownloaded: snapshot.parameterStats.downloaded,
+            parameterSyncStatus: snapshot.parameterStats.status
+          }
+        }
+      }
+      case 'list_parameters': {
+        const prefix = asString(args.prefix)?.toUpperCase()
+        const offset = asPositiveInt(args.offset, 0, Number.MAX_SAFE_INTEGER)
+        const limit = asPositiveInt(args.limit, DEFAULT_PARAM_PAGE, MAX_PARAM_PAGE) || DEFAULT_PARAM_PAGE
+        const all = realParameters(snapshot)
+          .filter((parameter) => (prefix ? parameter.id.toUpperCase().startsWith(prefix) : true))
+          .sort((left, right) => left.id.localeCompare(right.id))
+        const page = all.slice(offset, offset + limit)
+        return {
+          ok: true,
+          data: {
+            total: all.length,
+            offset,
+            returned: page.length,
+            parameters: page.map(compactParam)
+          }
+        }
+      }
+      case 'get_parameter': {
+        const id = asString(args.id)?.toUpperCase()
+        if (!id) return { ok: false, error: 'Missing required "id".' }
+        const match = realParameters(snapshot).find((parameter) => parameter.id.toUpperCase() === id)
+        if (!match) return { ok: false, error: `No parameter "${id}" on this vehicle.` }
+        return { ok: true, data: detailParam(match) }
+      }
+      case 'search_parameters': {
+        const query = asString(args.query)?.toLowerCase()
+        if (!query) return { ok: false, error: 'Missing required "query".' }
+        const limit = asPositiveInt(args.limit, 25, MAX_PARAM_PAGE) || 25
+        const terms = query.split(/\s+/).filter(Boolean)
+        const scored = realParameters(snapshot)
+          .map((parameter) => {
+            const haystack = [
+              parameter.id,
+              parameter.definition?.label ?? '',
+              parameter.definition?.description ?? ''
+            ]
+              .join(' ')
+              .toLowerCase()
+            const score = terms.reduce((sum, term) => (haystack.includes(term) ? sum + 1 : sum), 0)
+            return { parameter, score }
+          })
+          .filter((entry) => entry.score === terms.length)
+          .slice(0, limit)
+        return {
+          ok: true,
+          data: {
+            query,
+            returned: scored.length,
+            parameters: scored.map((entry) => ({
+              id: entry.parameter.id,
+              label: entry.parameter.definition?.label,
+              value: entry.parameter.value
+            }))
+          }
+        }
+      }
+      case 'get_telemetry': {
+        const live = snapshot.liveVerification
+        const sensor = (state: { present: boolean; healthy: boolean }): string =>
+          state.healthy ? 'healthy' : state.present ? 'present-unhealthy' : 'absent'
+        return {
+          ok: true,
+          data: {
+            rc: {
+              verified: live.rcInput.verified,
+              channelCount: live.rcInput.channelCount,
+              channels: live.rcInput.channels
+            },
+            battery: {
+              voltageV: live.batteryTelemetry.voltageV,
+              currentA: live.batteryTelemetry.currentA,
+              remainingPercent: live.batteryTelemetry.remainingPercent
+            },
+            attitude: {
+              rollDeg: live.attitudeTelemetry.rollDeg,
+              pitchDeg: live.attitudeTelemetry.pitchDeg,
+              yawDeg: live.attitudeTelemetry.yawDeg
+            },
+            position: {
+              latitudeDeg: live.globalPosition.latitudeDeg,
+              longitudeDeg: live.globalPosition.longitudeDeg,
+              relativeAltitudeM: live.globalPosition.relativeAltitudeM
+            },
+            sensors: {
+              baro: sensor(live.baroSensor),
+              gyro: sensor(live.gyroSensor),
+              accel: sensor(live.accelSensor),
+              mag: sensor(live.magSensor),
+              gps: sensor(live.gpsSensor),
+              opticalFlow: live.opticalFlow.verified ? 'active' : 'idle'
+            }
+          }
+        }
+      }
+      case 'get_prearm_status': {
+        return {
+          ok: true,
+          data: {
+            healthy: snapshot.preArmStatus.healthy,
+            issues: snapshot.preArmStatus.issues.map((issue) => ({
+              text: issue.text,
+              severity: issue.severity
+            }))
+          }
+        }
+      }
+      case 'get_can_nodes': {
+        return {
+          ok: true,
+          data: {
+            busStatus: snapshot.canBus.status,
+            nodes: snapshot.canNodes.map((node) => ({
+              componentId: node.componentId,
+              name: node.name,
+              health: node.health,
+              mode: node.mode,
+              uptimeSec: node.uptimeSec,
+              swVersion: node.swVersion
+            }))
+          }
+        }
+      }
+      case 'get_setup_status': {
+        return {
+          ok: true,
+          data: {
+            sections: snapshot.setupSections.map((section) => ({
+              id: section.id,
+              title: section.title,
+              status: section.status,
+              notes: section.notes
+            })),
+            guidedActions: Object.values(snapshot.guidedActions).map((action) => ({
+              actionId: action.actionId,
+              status: action.status,
+              summary: action.summary
+            }))
+          }
+        }
+      }
+      default:
+        return { ok: false, error: `Unknown tool "${name}".` }
+    }
+  }
+
+  return { definitions: AI_ASSISTANT_TOOLS, execute }
+}

--- a/packages/ai-assistant/tsconfig.json
+++ b/packages/ai-assistant/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "composite": true,
+    "declaration": true,
+    "declarationMap": true,
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "rootDir": "src",
+    "outDir": "dist",
+    "lib": ["ES2022", "DOM", "DOM.Iterable"]
+  },
+  "include": ["src"],
+  "references": [
+    { "path": "../param-metadata" },
+    { "path": "../ardupilot-core" }
+  ]
+}

--- a/packages/param-metadata/src/types.ts
+++ b/packages/param-metadata/src/types.ts
@@ -80,6 +80,12 @@ export type AppViewId =
   // at render time; shown only when the FC reports scripting support
   // (SCR_ENABLE present, i.e. the build has the Lua VM compiled in).
   | 'lua'
+  // 'ai-assistant' is the Expert-only AI Assistant surface — bring-your-own-key
+  // chat (Anthropic/OpenAI/Ollama) that inspects live vehicle state through
+  // read-only tools. Injected at render time; shown whenever Expert mode is on
+  // (it needs no specific FC capability, only a configured model + optionally a
+  // connected vehicle to discuss). Read-only: no parameter writes this slice.
+  | 'ai-assistant'
 
 export interface ParameterValueOption {
   value: number

--- a/tests/ai-assistant.test.mjs
+++ b/tests/ai-assistant.test.mjs
@@ -1,0 +1,323 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import {
+  createToolExecutor,
+  AI_ASSISTANT_TOOLS,
+  buildVehicleGroundingSummary,
+  buildSystemPrompt,
+  createProvider,
+  isConnectionReady,
+  loadProviderConfig,
+  saveProviderConfig,
+  loadPersistedApiKey,
+  persistApiKey,
+  clearPersistedApiKey,
+  toolsFor,
+  parseProposedChanges,
+  PROPOSE_PARAM_CHANGES_TOOL,
+  MAX_PROPOSED_CHANGES
+} from '../packages/ai-assistant/dist/index.js'
+
+// A minimal ConfiguratorSnapshot with just the fields the read-only tools read.
+function makeSnapshot(overrides = {}) {
+  return {
+    connection: { kind: 'connected' },
+    vehicle: {
+      firmware: 'ArduPilot',
+      vehicle: 'ArduCopter',
+      systemId: 1,
+      componentId: 1,
+      armed: false,
+      flightMode: 'STABILIZE',
+      systemStatus: 'standby'
+    },
+    hardware: { board: { firmwareVersion: '4.5.7 (official)', boardType: 9 }, uartsFile: {} },
+    parameterStats: { downloaded: 3, total: 3, duplicateFrames: 0, status: 'complete', progress: 1 },
+    parameters: [
+      { id: 'ATC_RAT_PIT_P', value: 0.135, index: 0, count: 3, definition: { id: 'ATC_RAT_PIT_P', label: 'Pitch axis rate controller P gain', description: 'Pitch P', category: 'tuning', minimum: 0, maximum: 0.6 } },
+      { id: 'BATT_LOW_VOLT', value: 14.0, index: 1, count: 3, definition: { id: 'BATT_LOW_VOLT', label: 'Low battery voltage', description: 'Failsafe low voltage', category: 'power', unit: 'V' } },
+      { id: 'ATC_MIR', value: 5, index: 2, count: 3, aliasedFrom: 'ATC_RAT_PIT_P' }
+    ],
+    setupSections: [
+      { id: 'radio', title: 'Radio', description: '', status: 'complete', notes: [], actions: [], parameters: [] }
+    ],
+    guidedActions: {
+      'calibrate-compass': { actionId: 'calibrate-compass', status: 'idle', summary: 'Compass', instructions: [], statusTexts: [] }
+    },
+    motorTest: {},
+    liveVerification: {
+      satisfiedSignals: [],
+      rcInput: { verified: true, channelCount: 8, channels: [1500, 1500, 1000, 1500, 1000, 1000, 1000, 1000] },
+      batteryTelemetry: { verified: true, voltageV: 16.4, currentA: 2.1, remainingPercent: 88 },
+      attitudeTelemetry: { verified: true, rollDeg: 0.2, pitchDeg: -0.1, yawDeg: 90 },
+      globalPosition: { verified: false },
+      baroSensor: { verified: true, present: true, healthy: true },
+      gyroSensor: { verified: true, present: true, healthy: true },
+      accelSensor: { verified: true, present: true, healthy: true },
+      magSensor: { verified: false, present: true, healthy: false },
+      gpsSensor: { verified: false, present: false, healthy: false },
+      opticalFlow: { verified: false }
+    },
+    preArmStatus: { healthy: false, issues: [{ text: 'Compass not calibrated', severity: 'error', firstSeenAtMs: 0, lastSeenAtMs: 0 }] },
+    statusTexts: [],
+    canNodes: [
+      { componentId: 125, name: 'org.ardupilot.gps', health: 'ok', mode: 'operational', uptimeSec: 42, firstSeenAtMs: 0, lastSeenAtMs: 0, lastSeenSource: 'uavcan-node-status' }
+    ],
+    canBus: { status: 'active', bus: 1, framesReceived: 10, nodes: [], escTelemetry: [] },
+    ...overrides
+  }
+}
+
+const accessorFor = (snapshot) => ({ getSnapshot: () => snapshot })
+
+test('tool definitions expose only read-only tools', () => {
+  const names = AI_ASSISTANT_TOOLS.map((t) => t.name).sort()
+  assert.deepEqual(names, [
+    'get_can_nodes',
+    'get_parameter',
+    'get_prearm_status',
+    'get_setup_status',
+    'get_telemetry',
+    'get_vehicle_info',
+    'list_parameters',
+    'search_parameters'
+  ])
+  // Every tool name starts with a read verb — none implies a mutation.
+  for (const name of names) {
+    assert.ok(/^(get|list|search)_/.test(name), `${name} must be a read-only accessor`)
+  }
+})
+
+test('get_vehicle_info returns identity and status', () => {
+  const { execute } = createToolExecutor(accessorFor(makeSnapshot()))
+  const result = execute('get_vehicle_info', {})
+  assert.equal(result.ok, true)
+  assert.equal(result.data.vehicle, 'ArduCopter')
+  assert.equal(result.data.armed, false)
+  assert.equal(result.data.firmwareVersion, '4.5.7 (official)')
+})
+
+test('list_parameters is compact, prefix-filtered, and excludes alias mirrors', () => {
+  const { execute } = createToolExecutor(accessorFor(makeSnapshot()))
+  const all = execute('list_parameters', {})
+  // ATC_MIR is an alias mirror -> excluded; 2 real params remain.
+  assert.equal(all.data.total, 2)
+  assert.deepEqual(all.data.parameters, [
+    { id: 'ATC_RAT_PIT_P', value: 0.135 },
+    { id: 'BATT_LOW_VOLT', value: 14 }
+  ])
+  const scoped = execute('list_parameters', { prefix: 'batt' })
+  assert.equal(scoped.data.total, 1)
+  assert.equal(scoped.data.parameters[0].id, 'BATT_LOW_VOLT')
+})
+
+test('list_parameters caps limit and honors offset', () => {
+  const { execute } = createToolExecutor(accessorFor(makeSnapshot()))
+  const page = execute('list_parameters', { limit: 1, offset: 1 })
+  assert.equal(page.data.returned, 1)
+  assert.equal(page.data.offset, 1)
+  assert.equal(page.data.parameters[0].id, 'BATT_LOW_VOLT')
+})
+
+test('get_parameter returns full metadata and errors on unknown id', () => {
+  const { execute } = createToolExecutor(accessorFor(makeSnapshot()))
+  const ok = execute('get_parameter', { id: 'atc_rat_pit_p' })
+  assert.equal(ok.ok, true)
+  assert.equal(ok.data.label, 'Pitch axis rate controller P gain')
+  assert.equal(ok.data.maximum, 0.6)
+  const missing = execute('get_parameter', { id: 'NOPE' })
+  assert.equal(missing.ok, false)
+})
+
+test('search_parameters matches across id/label/description', () => {
+  const { execute } = createToolExecutor(accessorFor(makeSnapshot()))
+  const hits = execute('search_parameters', { query: 'battery voltage' })
+  assert.equal(hits.ok, true)
+  assert.equal(hits.data.parameters[0].id, 'BATT_LOW_VOLT')
+})
+
+test('get_telemetry summarizes sensor health bits', () => {
+  const { execute } = createToolExecutor(accessorFor(makeSnapshot()))
+  const t = execute('get_telemetry', {})
+  assert.equal(t.data.sensors.baro, 'healthy')
+  assert.equal(t.data.sensors.mag, 'present-unhealthy')
+  assert.equal(t.data.sensors.gps, 'absent')
+  assert.equal(t.data.battery.voltageV, 16.4)
+})
+
+test('get_prearm_status surfaces outstanding issues', () => {
+  const { execute } = createToolExecutor(accessorFor(makeSnapshot()))
+  const p = execute('get_prearm_status', {})
+  assert.equal(p.data.healthy, false)
+  assert.equal(p.data.issues[0].text, 'Compass not calibrated')
+})
+
+test('unknown tool returns an error result, never throws', () => {
+  const { execute } = createToolExecutor(accessorFor(makeSnapshot()))
+  const r = execute('do_something_dangerous', {})
+  assert.equal(r.ok, false)
+})
+
+test('grounding summary reflects connected vs disconnected', () => {
+  assert.match(buildVehicleGroundingSummary(makeSnapshot()), /ArduCopter/)
+  assert.match(buildVehicleGroundingSummary(makeSnapshot()), /1 outstanding issue/)
+  const offline = buildVehicleGroundingSummary(makeSnapshot({ connection: { kind: 'disconnected' } }))
+  assert.match(offline, /No flight controller/)
+})
+
+test('system prompt states the read-only constraint and embeds grounding', () => {
+  const prompt = buildSystemPrompt({ grounding: 'GROUNDING-MARKER' })
+  assert.match(prompt, /READ-ONLY/)
+  assert.match(prompt, /cannot/i)
+  assert.match(prompt, /GROUNDING-MARKER/)
+})
+
+test('isConnectionReady gates on key for cloud, not for ollama/mock', () => {
+  assert.equal(isConnectionReady({ providerId: 'anthropic', model: 'claude-sonnet-5' }), false)
+  assert.equal(isConnectionReady({ providerId: 'anthropic', model: 'claude-sonnet-5', apiKey: 'sk' }), true)
+  assert.equal(isConnectionReady({ providerId: 'ollama', model: 'llama3.1' }), true)
+  assert.equal(isConnectionReady({ providerId: 'mock', model: 'mock' }), true)
+  assert.equal(isConnectionReady({ providerId: 'anthropic', model: '' }), false)
+})
+
+test('mock provider drives the full tool loop against the executor', async () => {
+  const snapshot = makeSnapshot()
+  const { execute } = createToolExecutor(accessorFor(snapshot))
+  const provider = createProvider({ providerId: 'mock', model: 'mock' })
+
+  const messages = [{ role: 'user', content: 'What am I connected to?' }]
+  const request = { system: 'sys', messages, tools: AI_ASSISTANT_TOOLS, model: 'mock' }
+
+  // First pass: expect a tool call.
+  let toolCall
+  let firstText = ''
+  for await (const event of provider.send(request)) {
+    if (event.type === 'text-delta') firstText += event.text
+    if (event.type === 'tool-call') toolCall = event.call
+  }
+  assert.ok(firstText.length > 0)
+  assert.ok(toolCall)
+  assert.equal(toolCall.name, 'get_vehicle_info')
+
+  // Execute the tool and feed the result back.
+  const toolResult = execute(toolCall.name, toolCall.arguments)
+  messages.push({ role: 'assistant', content: firstText, toolCalls: [toolCall] })
+  messages.push({ role: 'tool', content: JSON.stringify(toolResult), toolCallId: toolCall.id })
+
+  // Second pass: expect a final text answer referencing the vehicle.
+  let finalText = ''
+  for await (const event of provider.send({ ...request, messages })) {
+    if (event.type === 'text-delta') finalText += event.text
+  }
+  assert.match(finalText, /ArduCopter/)
+})
+
+test('toolsFor gates the propose tool behind allowProposals', () => {
+  const readOnly = toolsFor({ allowProposals: false }).map((t) => t.name)
+  assert.ok(!readOnly.includes('propose_param_changes'))
+  assert.equal(readOnly.length, AI_ASSISTANT_TOOLS.length)
+  const withWrite = toolsFor({ allowProposals: true }).map((t) => t.name)
+  assert.ok(withWrite.includes('propose_param_changes'))
+})
+
+test('propose tool schema requires changes', () => {
+  assert.equal(PROPOSE_PARAM_CHANGES_TOOL.name, 'propose_param_changes')
+  assert.deepEqual(PROPOSE_PARAM_CHANGES_TOOL.parameters.required, ['changes'])
+})
+
+test('parseProposedChanges normalizes a valid proposal', () => {
+  const parsed = parseProposedChanges({
+    summary: 'tune pitch',
+    changes: [{ paramId: 'ATC_RAT_PIT_P', value: 0.145, reason: 'crisper' }]
+  })
+  assert.ok('proposal' in parsed)
+  assert.equal(parsed.proposal.summary, 'tune pitch')
+  assert.deepEqual(parsed.proposal.changes[0], { paramId: 'ATC_RAT_PIT_P', value: 0.145, reason: 'crisper' })
+})
+
+test('parseProposedChanges rejects malformed input and enforces the cap', () => {
+  assert.ok('error' in parseProposedChanges({ changes: [] }))
+  assert.ok('error' in parseProposedChanges({ changes: 'nope' }))
+  assert.ok('error' in parseProposedChanges({ changes: [{ paramId: '', value: 1 }] }))
+  assert.ok('error' in parseProposedChanges({ changes: [{ paramId: 'X', value: 'high' }] }))
+  assert.ok('error' in parseProposedChanges({ changes: [{ paramId: 'X', value: NaN }] }))
+  const tooMany = { changes: Array.from({ length: MAX_PROPOSED_CHANGES + 1 }, (_, i) => ({ paramId: `P${i}`, value: i })) }
+  assert.ok('error' in parseProposedChanges(tooMany))
+})
+
+test('mock provider stages a proposal on a write-intent prompt when the tool is offered', async () => {
+  const provider = createProvider({ providerId: 'mock', model: 'mock' })
+  const request = {
+    system: 'sys',
+    messages: [{ role: 'user', content: 'please raise my pitch P a little' }],
+    tools: toolsFor({ allowProposals: true }),
+    model: 'mock'
+  }
+  let proposeCall
+  for await (const event of provider.send(request)) {
+    if (event.type === 'tool-call') proposeCall = event.call
+  }
+  assert.ok(proposeCall)
+  assert.equal(proposeCall.name, 'propose_param_changes')
+  assert.equal(proposeCall.arguments.changes[0].paramId, 'ATC_RAT_PIT_P')
+})
+
+test('mock provider does NOT propose when the propose tool is not offered', async () => {
+  const provider = createProvider({ providerId: 'mock', model: 'mock' })
+  const request = {
+    system: 'sys',
+    messages: [{ role: 'user', content: 'please raise my pitch P a little' }],
+    tools: toolsFor({ allowProposals: false }),
+    model: 'mock'
+  }
+  const names = []
+  for await (const event of provider.send(request)) {
+    if (event.type === 'tool-call') names.push(event.call.name)
+  }
+  assert.ok(!names.includes('propose_param_changes'))
+})
+
+test('system prompt switches framing when proposals are allowed', () => {
+  const readOnly = buildSystemPrompt({ grounding: 'g' })
+  assert.match(readOnly, /READ-ONLY/)
+  const propose = buildSystemPrompt({ grounding: 'g', allowProposals: true })
+  assert.match(propose, /propose_param_changes/)
+  assert.match(propose, /human|user must|review and approve|review and apply/i)
+})
+
+// In-memory Storage double for the persistence tests.
+function memoryStorage() {
+  const map = new Map()
+  return {
+    getItem: (k) => (map.has(k) ? map.get(k) : null),
+    setItem: (k, v) => map.set(k, String(v)),
+    removeItem: (k) => map.delete(k),
+    _map: map
+  }
+}
+
+test('provider config round-trips and rejects corrupt data', () => {
+  const storage = memoryStorage()
+  assert.equal(loadProviderConfig(storage), undefined)
+  saveProviderConfig(storage, { providerId: 'openai', model: 'gpt-4o', rememberKey: false })
+  const loaded = loadProviderConfig(storage)
+  assert.equal(loaded.providerId, 'openai')
+  assert.equal(loaded.model, 'gpt-4o')
+  assert.equal(loaded.rememberKey, false)
+  storage.setItem('arduconfig:ai-assistant:config', '{not json')
+  assert.equal(loadProviderConfig(storage), undefined)
+})
+
+test('config persistence never writes the api key', () => {
+  const storage = memoryStorage()
+  saveProviderConfig(storage, { providerId: 'anthropic', model: 'claude-sonnet-5', rememberKey: true })
+  const serialized = JSON.stringify([...storage._map.entries()])
+  assert.ok(!serialized.includes('sk-'), 'saveProviderConfig must not persist a key')
+  // Only the explicit key API writes it.
+  assert.equal(loadPersistedApiKey(storage), undefined)
+  persistApiKey(storage, 'sk-secret')
+  assert.equal(loadPersistedApiKey(storage), 'sk-secret')
+  clearPersistedApiKey(storage)
+  assert.equal(loadPersistedApiKey(storage), undefined)
+})

--- a/tests/e2e/views.spec.ts
+++ b/tests/e2e/views.spec.ts
@@ -399,6 +399,73 @@ test.describe('Lua Scripts view (Expert + scripting-capable FC)', () => {
   })
 })
 
+test.describe('AI Assistant view (Expert, offline mock provider)', () => {
+  test('appears only in Expert mode and drives a read-only tool loop against the demo vehicle', async ({ page }) => {
+    // ?aiProvider=mock forces the offline mock provider (dev/localhost only), so
+    // the whole send loop runs with no API key and no network.
+    await page.goto('/?aiProvider=mock')
+    await page.getByTestId('transport-mode-select').selectOption('demo')
+    await page.getByTestId('connect-button').click()
+    await expect(page.getByTestId('session-vehicle-name')).toHaveText('ArduCopter', { timeout: VEHICLE_CONNECT_TIMEOUT })
+    await expectParameterSyncComplete(page)
+
+    // Basic mode: no AI Assistant tab (Expert-only surface).
+    await expect(page.getByTestId('view-button-ai-assistant')).toHaveCount(0)
+
+    // Expert mode: the tab appears (gated on Expert alone, no FC capability).
+    await page.getByTestId('product-mode-expert').check()
+    await expect(page.getByTestId('view-button-ai-assistant')).toBeVisible()
+    await page.getByTestId('view-button-ai-assistant').click()
+    await expect(page.getByTestId('ai-assistant-view')).toBeVisible()
+
+    // The mock provider needs no key, so the composer is ready. Ask a question.
+    await page.getByTestId('ai-assistant-input').fill('What am I connected to?')
+    await page.getByTestId('ai-assistant-send').click()
+
+    // The user turn renders, the model calls the read-only get_vehicle_info tool,
+    // the app executes it, and the final answer reflects the demo vehicle.
+    await expect(page.getByTestId('ai-assistant-message').first()).toContainText('What am I connected to?')
+    const toolChip = page.getByTestId('ai-assistant-tool-chip').filter({ hasText: 'get_vehicle_info' })
+    await expect(toolChip).toHaveAttribute('data-done', 'true', { timeout: 15000 })
+    await expect(page.getByTestId('ai-assistant-transcript')).toContainText('ArduCopter')
+  })
+
+  test('proposes a parameter change that the human reviews, acknowledges, and applies', async ({ page }) => {
+    await page.goto('/?aiProvider=mock')
+    await page.getByTestId('transport-mode-select').selectOption('demo')
+    await page.getByTestId('connect-button').click()
+    await expect(page.getByTestId('session-vehicle-name')).toHaveText('ArduCopter', { timeout: VEHICLE_CONNECT_TIMEOUT })
+    await expectParameterSyncComplete(page)
+
+    await page.getByTestId('product-mode-expert').check()
+    await page.getByTestId('view-button-ai-assistant').click()
+    await expect(page.getByTestId('ai-assistant-view')).toBeVisible()
+
+    // A write-intent prompt makes the mock provider stage a proposal (never auto-applies).
+    await page.getByTestId('ai-assistant-input').fill('please raise my pitch P a little')
+    await page.getByTestId('ai-assistant-send').click()
+
+    // The proposal card renders the diff current → proposed for ATC_RAT_PIT_P.
+    const proposal = page.getByTestId('ai-assistant-proposal')
+    await expect(proposal).toBeVisible({ timeout: 15000 })
+    const row = page.getByTestId('ai-assistant-proposal-row-ATC_RAT_PIT_P')
+    await expect(row).toBeVisible()
+    await expect(row).toHaveAttribute('data-status', 'staged')
+    await expect(row).toContainText('0.145')
+
+    // Apply is gated: disabled until the acknowledge checkbox is ticked.
+    const applyButton = page.getByTestId('ai-assistant-proposal-apply')
+    await expect(applyButton).toBeDisabled()
+    await page.getByTestId('ai-assistant-proposal-ack').check()
+    await expect(applyButton).toBeEnabled()
+
+    // Apply → verified batch write against the demo FC → success result.
+    await applyButton.click()
+    await expect(page.getByTestId('ai-assistant-proposal-result')).toContainText('1 verified', { timeout: 20000 })
+    await expect(page.getByTestId('ai-assistant-proposal-result')).toContainText('backup was saved')
+  })
+})
+
 test.describe('connection transports', () => {
   test('WebSocket transport reveals the bridge endpoint URL input', async ({ page }) => {
     await page.goto('/')

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -21,6 +21,7 @@
       "@arduconfig/mock-sitl": ["./packages/mock-sitl/src/index.ts"],
       "@arduconfig/sitl-harness": ["./packages/sitl-harness/src/index.ts"],
       "@arduconfig/param-metadata": ["./packages/param-metadata/src/index.ts"],
+      "@arduconfig/ai-assistant": ["./packages/ai-assistant/src/index.ts"],
       "@arduconfig/ui-kit": ["./packages/ui-kit/src/index.tsx"]
     }
   }


### PR DESCRIPTION
## What

Adds an Expert-gated **AI Assistant** tab: bring your own model (Anthropic, OpenAI, or a local Ollama) to discuss the connected vehicle and, with explicit approval, apply parameter changes.

Shipped in two slices:
- **Slice 1 — read-only Q&A.** The model inspects parameters, telemetry, pre-arm status, DroneCAN nodes, and setup progress through MCP-style read tools.
- **Slice 2 — propose → human-approve → write.** The model calls `propose_param_changes`; the app validates it and renders an inline diff card; a write happens only after the human ticks acknowledge and clicks Apply.

## How

New UI/transport-agnostic package **`@arduconfig/ai-assistant`**:
- Normalized `ChatProvider` over hand-rolled `fetch` adapters (Anthropic Messages, OpenAI Chat Completions, Ollama) plus a deterministic mock (offline test seam). No SDK deps.
- MCP-style, provider-portable tools resolved from the live `ConfiguratorSnapshot` via an injected accessor. `propose_param_changes` is the one write-intent tool and it **never writes**.
- Versioned config storage; API key in-memory by default, opt-in localStorage.

`apps/web`: presentational `AiAssistantView`, pure view-models (co-located tests), and the stateful `useAiAssistant` hook (the only outbound LLM calls in the app).

## Safety (no autonomous writes)

- The propose tool is dispatched specially and only *stages* a proposal; the read-only executor never handles it.
- Reuses `deriveParameterDraftEntries` for validation (out-of-range / unknown / enum / no-op block Apply), `createParameterBackup` for an auto pre-apply undo snapshot, and `runtime.setParameters` batch-with-rollback for the verified write.
- Apply is gated on connected + disarmed + synced; an opt-out toggle drops back to read-only.
- No telemetry/beacon; key and proposals stay local.

## ArduCopter byte-identical

Additive UI + a new package + App-level wiring only. Writes go through `runtime.setParameters` **unchanged** — no runtime/transport/protocol edits — so all vehicles are byte-identical.

## Validation ladder

- Typecheck clean
- `node --test`: 670 pass
- vitest: 443 pass
- Playwright: 136 pass (incl. propose → acknowledge-gated Apply → verified write on the demo FC)
- **Rung 5 (live FC):** verified on a real Cube (ArduCopter 4.7.0 beta) — live read-only Q&A over the real pre-arm state, plus a proposed `NTF_LED_BRIGHT` write applied (verified) and restored to its original value.
