### PR TITLE
fix(ai): allow BYOK LLM hosts in CSP, model dropdown, correct stale copy

### DIFF
--- a/apps/web/public/_headers
+++ b/apps/web/public/_headers
@@ -9,6 +9,11 @@
 # three.js GLTF buffers fetched as data: URIs, the OpenStreetMap GPS-map iframe,
 # OpenStreetMap raster tiles for the no-GPS calibration map picker (img-src), and
 # inline <style> for dynamic widget sizing.
+# connect-src also allows https: and http://localhost for the AI Assistant's
+# bring-your-own-key model calls (Anthropic/OpenAI/OpenAI-compatible gateways over
+# https, a local Ollama over http://localhost). Consistent with the already-open
+# ws:/wss:; the public build ships no telemetry/beacon, so these are only ever the
+# user's own configured endpoints.
 # The service worker must never be cached, so browsers pick up the
 # self-destructing sw.js on the next visit and un-stick users promptly.
 /sw.js
@@ -18,4 +23,4 @@
   X-Frame-Options: DENY
   X-Content-Type-Options: nosniff
   Referrer-Policy: no-referrer
-  Content-Security-Policy: default-src 'self'; script-src 'self' 'sha256-ySvT2PEZeueHGC1y2crNuNTfphBynFPP7i+U21fEgX0='; connect-src 'self' ws: wss: data:; img-src 'self' data: blob: https://*.tile.openstreetmap.org; style-src 'self' 'unsafe-inline'; font-src 'self' data:; worker-src 'self'; manifest-src 'self'; frame-src https://www.openstreetmap.org; object-src 'none'; base-uri 'self'; frame-ancestors 'none'
+  Content-Security-Policy: default-src 'self'; script-src 'self' 'sha256-ySvT2PEZeueHGC1y2crNuNTfphBynFPP7i+U21fEgX0='; connect-src 'self' ws: wss: data: https: http://localhost:* http://127.0.0.1:*; img-src 'self' data: blob: https://*.tile.openstreetmap.org; style-src 'self' 'unsafe-inline'; font-src 'self' data:; worker-src 'self'; manifest-src 'self'; frame-src https://www.openstreetmap.org; object-src 'none'; base-uri 'self'; frame-ancestors 'none'

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -7566,6 +7566,10 @@ export function App() {
         apiKey={aiAssistant.apiKey}
         rememberKey={aiAssistant.settings.rememberKey}
         allowProposals={aiAssistant.settings.allowProposals}
+        availableModels={aiAssistant.availableModels}
+        modelsStatus={aiAssistant.modelsStatus}
+        modelsError={aiAssistant.modelsError}
+        onRefreshModels={aiAssistant.refreshModels}
         onProviderChange={aiAssistant.setProviderId}
         onModelChange={aiAssistant.setModel}
         onBaseUrlChange={aiAssistant.setBaseUrl}

--- a/apps/web/src/hooks/use-ai-assistant.ts
+++ b/apps/web/src/hooks/use-ai-assistant.ts
@@ -6,6 +6,7 @@ import {
   createProvider,
   createToolExecutor,
   isConnectionReady,
+  listModels,
   toolsFor,
   parseProposedChanges,
   ChatProviderError,
@@ -61,6 +62,11 @@ export interface AiAssistantController {
   status: 'idle' | 'streaming'
   error: string | undefined
   pendingProposal: PendingProposal | undefined
+  /** Models the configured key/endpoint exposes; empty until fetched. */
+  availableModels: string[]
+  modelsStatus: 'idle' | 'loading' | 'error'
+  modelsError: string | undefined
+  refreshModels: () => void
   setProviderId: (providerId: ChatProviderId) => void
   setModel: (model: string) => void
   setBaseUrl: (baseUrl: string) => void
@@ -111,6 +117,9 @@ export function useAiAssistant(options: UseAiAssistantOptions): AiAssistantContr
   const [status, setStatus] = useState<'idle' | 'streaming'>('idle')
   const [error, setError] = useState<string | undefined>(undefined)
   const [pendingProposal, setPendingProposal] = useState<PendingProposal | undefined>(undefined)
+  const [availableModels, setAvailableModels] = useState<string[]>([])
+  const [modelsStatus, setModelsStatus] = useState<'idle' | 'loading' | 'error'>('idle')
+  const [modelsError, setModelsError] = useState<string | undefined>(undefined)
 
   // Canonical provider-facing history; `messages` mirrors it for rendering.
   const conversationRef = useRef<ChatMessage[]>([])
@@ -131,6 +140,49 @@ export function useAiAssistant(options: UseAiAssistantOptions): AiAssistantContr
   )
 
   const configReady = isConnectionReady(connection)
+  // Cloud providers need a key before their model list can be fetched; Ollama
+  // just needs its endpoint; mock has no list to fetch.
+  const canFetchModels =
+    connection.providerId === 'ollama' ? true : connection.providerId === 'mock' ? false : Boolean(apiKey)
+
+  const connectionForModelsRef = useRef(connection)
+  connectionForModelsRef.current = connection
+  const modelsRequestRef = useRef(0)
+
+  const refreshModels = useCallback(() => {
+    const target = connectionForModelsRef.current
+    if (target.providerId !== 'ollama' && target.providerId !== 'mock' && !target.apiKey) return
+    const requestId = modelsRequestRef.current + 1
+    modelsRequestRef.current = requestId
+    setModelsStatus('loading')
+    setModelsError(undefined)
+    void listModels(target)
+      .then((models) => {
+        if (modelsRequestRef.current !== requestId) return // superseded
+        setAvailableModels(models)
+        setModelsStatus('idle')
+      })
+      .catch((caught: unknown) => {
+        if (modelsRequestRef.current !== requestId) return
+        setAvailableModels([])
+        setModelsStatus('error')
+        setModelsError(caught instanceof ChatProviderError ? caught.message : (caught as Error).message)
+      })
+  }, [])
+
+  // Auto-fetch the model list shortly after the key/endpoint settles, so the
+  // picker fills in without a manual step. Debounced so it doesn't fire on every
+  // keystroke while pasting a key.
+  useEffect(() => {
+    if (!canFetchModels) {
+      setAvailableModels([])
+      setModelsStatus('idle')
+      setModelsError(undefined)
+      return
+    }
+    const timer = setTimeout(refreshModels, 700)
+    return () => clearTimeout(timer)
+  }, [canFetchModels, connection.providerId, connection.apiKey, connection.baseUrl, refreshModels])
 
   // Refs so the async loop and follow-up runs read current values without
   // re-creating callbacks on every keystroke.
@@ -381,6 +433,10 @@ export function useAiAssistant(options: UseAiAssistantOptions): AiAssistantContr
     status,
     error,
     pendingProposal,
+    availableModels,
+    modelsStatus,
+    modelsError,
+    refreshModels,
     setProviderId,
     setModel,
     setBaseUrl,

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -14404,3 +14404,28 @@ button.mavlink-inspector__sent-row {
   display: flex;
   gap: 8px;
 }
+
+/* AI Assistant — model picker (dropdown fetched from the provider). */
+.ai-assistant__model-field {
+  position: relative;
+}
+.ai-assistant__model-actions {
+  display: flex;
+  gap: 10px;
+  margin-top: 4px;
+}
+.ai-assistant__linkbtn {
+  background: none;
+  border: none;
+  padding: 0;
+  color: var(--accent, #4fa3ff);
+  font-size: 0.78em;
+  cursor: pointer;
+  text-decoration: underline;
+}
+.ai-assistant__model-error {
+  display: block;
+  margin-top: 4px;
+  color: var(--warning, #ff6600);
+  font-size: 0.78em;
+}

--- a/apps/web/src/view-models/visible-app-views.ts
+++ b/apps/web/src/view-models/visible-app-views.ts
@@ -158,7 +158,7 @@ export function buildVisibleAppViews(inputs: VisibleAppViewsInputs): AppViewDesc
   const aiAssistantDescriptor: AppViewDescriptor = {
     id: 'ai-assistant',
     label: 'AI Assistant',
-    description: 'Bring your own model (Claude, GPT, or a local Ollama) to discuss your vehicle configuration. Read-only — it inspects parameters and telemetry but cannot change anything.',
+    description: 'Bring your own model (Claude, GPT, or a local Ollama) to discuss your vehicle and propose parameter changes you review and approve. No change is applied without your explicit confirmation.',
     badge: connectionKind === 'connected' ? 'live' : 'idle',
     tone: 'neutral'
   }

--- a/apps/web/src/views/AiAssistantView.tsx
+++ b/apps/web/src/views/AiAssistantView.tsx
@@ -31,6 +31,10 @@ export interface AiAssistantViewProps {
   apiKey: string
   rememberKey: boolean
   allowProposals: boolean
+  availableModels: string[]
+  modelsStatus: 'idle' | 'loading' | 'error'
+  modelsError?: string
+  onRefreshModels: () => void
   onProviderChange: (providerId: ChatProviderId) => void
   onModelChange: (model: string) => void
   onBaseUrlChange: (baseUrl: string) => void
@@ -54,6 +58,71 @@ function formatValue(value: number | undefined): string {
   return Number.isInteger(value) ? String(value) : Number(value.toFixed(4)).toString()
 }
 
+function ModelField(props: AiAssistantViewProps) {
+  const meta = providerMetadata(props.providerId)
+  const hasModels = props.availableModels.length > 0
+  const [useCustom, setUseCustom] = useState(false)
+  const showSelect = hasModels && !useCustom
+
+  // Ensure the current value is always selectable even if the fetched list
+  // doesn't include it (custom id, or a model not returned by /models).
+  const options = props.model && !props.availableModels.includes(props.model)
+    ? [props.model, ...props.availableModels]
+    : props.availableModels
+
+  return (
+    <label className="ai-assistant__model-field">
+      <span>
+        Model
+        {props.modelsStatus === 'loading' ? ' (loading…)' : hasModels ? ` (${props.availableModels.length})` : ''}
+      </span>
+      {showSelect ? (
+        <select
+          data-testid="ai-assistant-model-select"
+          value={props.model}
+          onChange={(event) => props.onModelChange(event.target.value)}
+        >
+          {options.map((id) => (
+            <option key={id} value={id}>
+              {id}
+            </option>
+          ))}
+        </select>
+      ) : (
+        <input
+          data-testid="ai-assistant-model-input"
+          type="text"
+          value={props.model}
+          placeholder={meta?.modelPlaceholder}
+          onChange={(event) => props.onModelChange(event.target.value)}
+        />
+      )}
+      <span className="ai-assistant__model-actions">
+        <button
+          type="button"
+          className="ai-assistant__linkbtn"
+          data-testid="ai-assistant-refresh-models"
+          onClick={props.onRefreshModels}
+        >
+          {props.modelsStatus === 'loading' ? 'Loading…' : 'Load models'}
+        </button>
+        {hasModels ? (
+          <button
+            type="button"
+            className="ai-assistant__linkbtn"
+            onClick={() => setUseCustom((prev) => !prev)}
+          >
+            {useCustom ? 'Pick from list' : 'Custom id'}
+          </button>
+        ) : null}
+      </span>
+      {props.modelsStatus === 'error' && props.modelsError ? (
+        <span className="ai-assistant__model-error">{props.modelsError}</span>
+      ) : null}
+    </label>
+  )
+}
+
 function SettingsForm(props: AiAssistantViewProps) {
   const meta = providerMetadata(props.providerId)
   return (
@@ -73,16 +142,7 @@ function SettingsForm(props: AiAssistantViewProps) {
             ))}
           </select>
         </label>
-        <label>
-          <span>Model</span>
-          <input
-            data-testid="ai-assistant-model-input"
-            type="text"
-            value={props.model}
-            placeholder={meta?.modelPlaceholder}
-            onChange={(event) => props.onModelChange(event.target.value)}
-          />
-        </label>
+        <ModelField {...props} />
         {meta?.needsApiKey ? (
           <label>
             <span>API key</span>
@@ -324,7 +384,7 @@ export function AiAssistantView(props: AiAssistantViewProps) {
   return (
     <Panel
       title="AI Assistant"
-      subtitle="Bring your own model (Claude, GPT, or a local Ollama) to discuss your vehicle’s current configuration. Read-only — the assistant can inspect parameters and telemetry but cannot change anything yet."
+      subtitle="Bring your own model (Claude, GPT, or a local Ollama) to discuss your vehicle’s configuration and propose parameter changes — every write is yours to review and approve, and nothing is applied without your explicit confirmation."
     >
       <div data-testid="ai-assistant-view" className="ai-assistant">
         <details className="ai-assistant__settings-disclosure" open={!props.configReady}>

--- a/packages/ai-assistant/src/index.ts
+++ b/packages/ai-assistant/src/index.ts
@@ -1,12 +1,15 @@
 // @arduconfig/ai-assistant — provider-agnostic, UI-agnostic tool-calling layer
-// for the AI Assistant tab. Read-only (slice 1): exposes the live vehicle state
-// to a chat model through MCP-style tools; the model cannot change anything.
+// for the AI Assistant tab. Exposes live vehicle state to a chat model through
+// MCP-style read tools, plus a propose_param_changes tool whose changes the
+// human reviews and approves. No autonomous writes — the propose tool only
+// stages a proposal; a write happens solely on explicit human confirmation.
 
 export * from './provider.js'
 export * from './tools.js'
 export * from './system-prompt.js'
 export * from './storage.js'
 export * from './create-provider.js'
+export * from './list-models.js'
 export { createAnthropicProvider } from './anthropic-provider.js'
 export { createOpenAiProvider } from './openai-provider.js'
 export { createOllamaProvider } from './ollama-provider.js'

--- a/packages/ai-assistant/src/list-models.ts
+++ b/packages/ai-assistant/src/list-models.ts
@@ -1,0 +1,102 @@
+// Fetch the models available to a configured provider/key, for the model picker.
+//
+// Each provider exposes a list endpoint: Anthropic GET /v1/models, OpenAI (and
+// OpenAI-compatible gateways) GET /v1/models, Ollama GET /api/tags. Returns a
+// sorted list of model ids; throws ChatProviderError on failure so the UI can
+// fall back to a free-text model field.
+
+import type { ProviderConnection } from './provider.js'
+import { ChatProviderError } from './provider.js'
+
+const ANTHROPIC_DEFAULT = 'https://api.anthropic.com'
+const OPENAI_DEFAULT = 'https://api.openai.com'
+const OLLAMA_DEFAULT = 'http://localhost:11434'
+const ANTHROPIC_VERSION = '2023-06-01'
+
+function trimBase(url: string | undefined, fallback: string): string {
+  return (url ?? fallback).replace(/\/$/, '')
+}
+
+export async function listModels(connection: ProviderConnection): Promise<string[]> {
+  switch (connection.providerId) {
+    case 'anthropic':
+      return listAnthropicModels(connection)
+    case 'openai':
+      return listOpenAiModels(connection)
+    case 'ollama':
+      return listOllamaModels(connection)
+    case 'mock':
+      return ['mock']
+    default:
+      return []
+  }
+}
+
+async function fetchJson(
+  url: string,
+  headers: Record<string, string>,
+  providerId: ProviderConnection['providerId']
+): Promise<unknown> {
+  let response: Response
+  try {
+    response = await fetch(url, { headers })
+  } catch (error) {
+    throw new ChatProviderError(`Could not reach the model list: ${(error as Error).message}`, providerId)
+  }
+  if (!response.ok) {
+    const detail = await response.text().catch(() => '')
+    throw new ChatProviderError(
+      `Model list error ${response.status}: ${detail.slice(0, 200)}`,
+      providerId,
+      response.status
+    )
+  }
+  return response.json()
+}
+
+async function listAnthropicModels(connection: ProviderConnection): Promise<string[]> {
+  if (!connection.apiKey) throw new ChatProviderError('An Anthropic API key is required.', 'anthropic')
+  const base = trimBase(connection.baseUrl, ANTHROPIC_DEFAULT)
+  const body = (await fetchJson(
+    `${base}/v1/models?limit=100`,
+    {
+      'x-api-key': connection.apiKey,
+      'anthropic-version': ANTHROPIC_VERSION,
+      'anthropic-dangerous-direct-browser-access': 'true'
+    },
+    'anthropic'
+  )) as { data?: Array<{ id?: string }> }
+  return sortIds((body.data ?? []).map((entry) => entry.id).filter(isNonEmpty))
+}
+
+async function listOpenAiModels(connection: ProviderConnection): Promise<string[]> {
+  if (!connection.apiKey) throw new ChatProviderError('An OpenAI API key is required.', 'openai')
+  const base = trimBase(connection.baseUrl, OPENAI_DEFAULT)
+  const body = (await fetchJson(
+    `${base}/v1/models`,
+    { authorization: `Bearer ${connection.apiKey}` },
+    'openai'
+  )) as { data?: Array<{ id?: string }> }
+  const ids = (body.data ?? []).map((entry) => entry.id).filter(isNonEmpty)
+  // Prefer chat-capable models when the endpoint is real OpenAI (it also lists
+  // embeddings/tts/whisper); keep everything if the filter would empty the list
+  // (OpenAI-compatible gateways name models differently).
+  const chat = ids.filter((id) => /gpt|^o\d|chatgpt/i.test(id))
+  return sortIds(chat.length > 0 ? chat : ids)
+}
+
+async function listOllamaModels(connection: ProviderConnection): Promise<string[]> {
+  const base = trimBase(connection.baseUrl, OLLAMA_DEFAULT)
+  const body = (await fetchJson(`${base}/api/tags`, {}, 'ollama')) as {
+    models?: Array<{ name?: string }>
+  }
+  return sortIds((body.models ?? []).map((entry) => entry.name).filter(isNonEmpty))
+}
+
+function isNonEmpty(value: string | undefined): value is string {
+  return typeof value === 'string' && value.length > 0
+}
+
+function sortIds(ids: string[]): string[] {
+  return [...new Set(ids)].sort((a, b) => a.localeCompare(b))
+}

--- a/tests/ai-assistant.test.mjs
+++ b/tests/ai-assistant.test.mjs
@@ -16,7 +16,8 @@ import {
   toolsFor,
   parseProposedChanges,
   PROPOSE_PARAM_CHANGES_TOOL,
-  MAX_PROPOSED_CHANGES
+  MAX_PROPOSED_CHANGES,
+  listModels
 } from '../packages/ai-assistant/dist/index.js'
 
 // A minimal ConfiguratorSnapshot with just the fields the read-only tools read.
@@ -284,6 +285,80 @@ test('system prompt switches framing when proposals are allowed', () => {
   const propose = buildSystemPrompt({ grounding: 'g', allowProposals: true })
   assert.match(propose, /propose_param_changes/)
   assert.match(propose, /human|user must|review and approve|review and apply/i)
+})
+
+// Stub global fetch for the listModels tests, capturing the request.
+function withStubbedFetch(handler, run) {
+  const original = globalThis.fetch
+  const calls = []
+  globalThis.fetch = async (url, init) => {
+    calls.push({ url, init })
+    return handler(url, init)
+  }
+  return Promise.resolve(run(calls)).finally(() => {
+    globalThis.fetch = original
+  })
+}
+
+const jsonResponse = (body) => ({ ok: true, status: 200, json: async () => body, text: async () => '' })
+
+test('listModels(anthropic) returns sorted ids and sends the browser-access header', async () => {
+  await withStubbedFetch(
+    () => jsonResponse({ data: [{ id: 'claude-sonnet-5' }, { id: 'claude-haiku-4-5' }] }),
+    async (calls) => {
+      const models = await listModels({ providerId: 'anthropic', model: '', apiKey: 'sk' })
+      assert.deepEqual(models, ['claude-haiku-4-5', 'claude-sonnet-5'])
+      assert.match(String(calls[0].url), /api\.anthropic\.com\/v1\/models/)
+      assert.equal(calls[0].init.headers['anthropic-dangerous-direct-browser-access'], 'true')
+      assert.equal(calls[0].init.headers['x-api-key'], 'sk')
+    }
+  )
+})
+
+test('listModels(anthropic) requires a key', async () => {
+  await assert.rejects(() => listModels({ providerId: 'anthropic', model: '' }), /key is required/i)
+})
+
+test('listModels(openai) filters to chat-capable models', async () => {
+  await withStubbedFetch(
+    () => jsonResponse({ data: [{ id: 'gpt-4o' }, { id: 'text-embedding-3-large' }, { id: 'o1' }, { id: 'whisper-1' }] }),
+    async () => {
+      const models = await listModels({ providerId: 'openai', model: '', apiKey: 'sk' })
+      assert.deepEqual(models, ['gpt-4o', 'o1'])
+    }
+  )
+})
+
+test('listModels(openai) keeps all ids when none match the chat filter (gateways)', async () => {
+  await withStubbedFetch(
+    () => jsonResponse({ data: [{ id: 'my-gateway-model' }, { id: 'another-model' }] }),
+    async () => {
+      const models = await listModels({ providerId: 'openai', model: '', apiKey: 'sk', baseUrl: 'https://gw.example.com' })
+      assert.deepEqual(models, ['another-model', 'my-gateway-model'])
+    }
+  )
+})
+
+test('listModels(ollama) returns installed model names from /api/tags', async () => {
+  await withStubbedFetch(
+    (url) => {
+      assert.match(String(url), /\/api\/tags$/)
+      return jsonResponse({ models: [{ name: 'llama3.1' }, { name: 'qwen2.5' }] })
+    },
+    async () => {
+      const models = await listModels({ providerId: 'ollama', model: '', baseUrl: 'http://localhost:11434' })
+      assert.deepEqual(models, ['llama3.1', 'qwen2.5'])
+    }
+  )
+})
+
+test('listModels throws ChatProviderError on a non-ok response', async () => {
+  await withStubbedFetch(
+    () => ({ ok: false, status: 401, json: async () => ({}), text: async () => 'unauthorized' }),
+    async () => {
+      await assert.rejects(() => listModels({ providerId: 'anthropic', model: '', apiKey: 'bad' }), /401/)
+    }
+  )
 })
 
 // In-memory Storage double for the persistence tests.


### PR DESCRIPTION
Follow-ups from prod testing of the AI Assistant tab.

## CSP (the blocker)
Prod `_headers` CSP shipped `connect-src 'self' ws: wss: data:`, which blocked every provider call (api.anthropic.com, api.openai.com, local Ollama) — the feature could not work in prod. Broaden `connect-src` with `https:` + `http://localhost:*`/`http://127.0.0.1:*` so BYOK endpoints (cloud providers, OpenAI-compatible gateways, local Ollama) are reachable. Consistent with the already-open ws:/wss:; the public build ships no telemetry/beacon, so these are only ever the user's own endpoints.

## Model picker
The Model field is now a dropdown populated from the provider's own model list — Anthropic/OpenAI `GET /v1/models` (keyed) and Ollama `GET /api/tags` — via a new `listModels()`. The hook auto-fetches (debounced) once the key/endpoint settles, with a Load-models refresh and a Custom-id escape hatch for unlisted models. Falls back to free-text when nothing is fetched.

## Copy
Subtitle + nav description still said 'read-only … cannot change anything' from slice 1; reworded to reflect the shipped propose → approve → write flow (nothing applied without explicit confirmation).

**ArduCopter byte-identical:** UI + package only; no runtime/transport edits.

**Validation:** typecheck clean; node --test 676; vitest 443 (+6 listModels); Playwright AI Assistant specs pass.