### PR TITLE
fix(ai): plain-text model responses, simplify remember-key copy

### DIFF
--- a/apps/web/src/views/AiAssistantView.tsx
+++ b/apps/web/src/views/AiAssistantView.tsx
@@ -177,11 +177,7 @@ function SettingsForm(props: AiAssistantViewProps) {
             checked={props.rememberKey}
             onChange={(event) => props.onRememberKeyChange(event.target.checked)}
           />
-          <span>
-            Remember this key on this device. It is stored in your browser’s local storage in plain
-            text — anyone with access to this browser (or a script injected into this page) could read
-            it. Leave off to keep it in memory only (cleared on reload).
-          </span>
+          <span>Remember this key on this device. Your key is only ever sent to the AI provider’s API.</span>
         </label>
       ) : null}
       {meta?.note ? <p className="ai-assistant__note">{meta.note}</p> : null}

--- a/packages/ai-assistant/src/system-prompt.ts
+++ b/packages/ai-assistant/src/system-prompt.ts
@@ -57,6 +57,7 @@ export function buildSystemPrompt(inputs: SystemPromptInputs): string {
     accessParagraph,
     '',
     'Ground rules:',
+    '- Reply in plain conversational text. The chat UI renders your message as-is with no markdown formatting, so do NOT use markdown syntax (no **bold**, # headers, backtick code spans, or - / * bullet lists) — it will show up as literal asterisks and hashes. Use plain sentences and paragraphs; a short numbered list like "1. ... 2. ..." on its own lines is fine.',
     '- Prefer calling a tool to reading a value you are unsure of. Never invent a parameter id or a current value — look it up.',
     '- ArduPilot parameter names are precise (e.g. ATC_RAT_PIT_P, INS_HNTCH_ENABLE). Use get_parameter or search_parameters to confirm exact ids and valid ranges before discussing them.',
     '- Treat a connected flight controller as attached to a real aircraft. Be conservative: flag anything that affects flight safety (failsafe, battery, arming, tuning limits) and never encourage bypassing a pre-arm check.',


### PR DESCRIPTION
The chat view renders assistant text as-is (no markdown parser), so a model replying with markdown syntax (`**bold**`, `# headers`, `- bullets`) showed literal asterisks/hashes/dashes instead of formatting. Adds a system-prompt ground rule instructing the model to reply in plain conversational text.

Also trims the remember-key checkbox copy to one sentence: the key is only ever sent to the AI provider's API.

**ArduCopter byte-identical:** prompt text + UI copy only.

**Validation:** typecheck clean; node --test 676; vitest 443; Playwright AI Assistant specs pass.