### PR TITLE
fix(ai): detect truncated replies, add batched parameter lookup

### DIFF
--- a/apps/web/src/hooks/use-ai-assistant.ts
+++ b/apps/web/src/hooks/use-ai-assistant.ts
@@ -259,7 +259,7 @@ export function useAiAssistant(options: UseAiAssistantOptions): AiAssistantContr
         conversationRef.current = [...conversationRef.current, assistant]
         commit()
 
-        let stopReason: 'end' | 'tool-use' = 'end'
+        let stopReason: 'end' | 'tool-use' | 'length' = 'end'
         let streamError: string | undefined
 
         for await (const event of provider.send({
@@ -284,6 +284,12 @@ export function useAiAssistant(options: UseAiAssistantOptions): AiAssistantContr
 
         if (streamError) {
           setError(streamError)
+          break
+        }
+        if (stopReason === 'length') {
+          // The provider cut the reply off at its own output-token cap — tell
+          // the user rather than silently presenting a truncated answer as final.
+          setError('The response was cut off after reaching the model’s reply length limit. Ask it to continue.')
           break
         }
         if (stopReason !== 'tool-use' || (assistant.toolCalls?.length ?? 0) === 0) {

--- a/packages/ai-assistant/src/anthropic-provider.ts
+++ b/packages/ai-assistant/src/anthropic-provider.ts
@@ -11,7 +11,9 @@ import { iterateLines, sseData } from './stream.js'
 
 const DEFAULT_BASE_URL = 'https://api.anthropic.com'
 const ANTHROPIC_VERSION = '2023-06-01'
-const MAX_TOKENS = 4096
+// Generous enough that a verbose report after a long tool-investigation
+// (many parameters looked up) doesn't get cut off mid-sentence.
+const MAX_TOKENS = 8192
 
 interface AnthropicBlock {
   type: 'text' | 'tool_use' | 'tool_result'
@@ -101,7 +103,7 @@ export function createAnthropicProvider(options: { apiKey: string; baseUrl?: str
         )
       }
 
-      let stopReason: 'end' | 'tool-use' = 'end'
+      let stopReason: 'end' | 'tool-use' | 'length' = 'end'
       let toolId = ''
       let toolName = ''
       let toolJson = ''
@@ -146,6 +148,7 @@ export function createAnthropicProvider(options: { apiKey: string; baseUrl?: str
         } else if (type === 'message_delta') {
           const delta = event.delta as { stop_reason?: string }
           if (delta?.stop_reason === 'tool_use') stopReason = 'tool-use'
+          else if (delta?.stop_reason === 'max_tokens') stopReason = 'length'
         } else if (type === 'error') {
           const err = event.error as { message?: string }
           yield { type: 'error', message: err?.message ?? 'Anthropic stream error' }

--- a/packages/ai-assistant/src/ollama-provider.ts
+++ b/packages/ai-assistant/src/ollama-provider.ts
@@ -80,7 +80,7 @@ export function createOllamaProvider(options: { baseUrl?: string }): ChatProvide
         )
       }
 
-      let stopReason: 'end' | 'tool-use' = 'end'
+      let stopReason: 'end' | 'tool-use' | 'length' = 'end'
       let toolIndex = 0
 
       for await (const line of iterateLines(response)) {
@@ -90,6 +90,7 @@ export function createOllamaProvider(options: { baseUrl?: string }): ChatProvide
             tool_calls?: Array<{ function?: { name?: string; arguments?: Record<string, unknown> } }>
           }
           done?: boolean
+          done_reason?: string
           error?: string
         }
         try {
@@ -116,6 +117,7 @@ export function createOllamaProvider(options: { baseUrl?: string }): ChatProvide
             }
           }
         }
+        if (frame.done_reason === 'length') stopReason = 'length'
       }
       yield { type: 'done', stopReason }
     }

--- a/packages/ai-assistant/src/openai-provider.ts
+++ b/packages/ai-assistant/src/openai-provider.ts
@@ -94,7 +94,7 @@ export function createOpenAiProvider(options: { apiKey: string; baseUrl?: string
       }
 
       const pending = new Map<number, PendingToolCall>()
-      let stopReason: 'end' | 'tool-use' = 'end'
+      let stopReason: 'end' | 'tool-use' | 'length' = 'end'
 
       for await (const line of iterateLines(response)) {
         const data = sseData(line)
@@ -130,6 +130,7 @@ export function createOpenAiProvider(options: { apiKey: string; baseUrl?: string
           pending.set(toolDelta.index, existing)
         }
         if (choice.finish_reason === 'tool_calls') stopReason = 'tool-use'
+        else if (choice.finish_reason === 'length') stopReason = 'length'
       }
 
       if (stopReason === 'tool-use') {

--- a/packages/ai-assistant/src/provider.ts
+++ b/packages/ai-assistant/src/provider.ts
@@ -47,7 +47,11 @@ export interface ChatToolCall {
 export type ChatEvent =
   | { type: 'text-delta'; text: string }
   | { type: 'tool-call'; call: ChatToolCall }
-  | { type: 'done'; stopReason: 'end' | 'tool-use' }
+  // 'length' means the model's reply was cut off by the provider's own output
+  // token cap (Anthropic max_tokens, OpenAI finish_reason 'length', Ollama
+  // done_reason 'length') — distinct from a clean finish so the caller can tell
+  // the user the answer was truncated rather than silently treating it as done.
+  | { type: 'done'; stopReason: 'end' | 'tool-use' | 'length' }
   | { type: 'error'; message: string }
 
 export interface ChatRequest {

--- a/packages/ai-assistant/src/system-prompt.ts
+++ b/packages/ai-assistant/src/system-prompt.ts
@@ -59,7 +59,7 @@ export function buildSystemPrompt(inputs: SystemPromptInputs): string {
     'Ground rules:',
     '- Reply in plain conversational text. The chat UI renders your message as-is with no markdown formatting, so do NOT use markdown syntax (no **bold**, # headers, backtick code spans, or - / * bullet lists) — it will show up as literal asterisks and hashes. Use plain sentences and paragraphs; a short numbered list like "1. ... 2. ..." on its own lines is fine.',
     '- Prefer calling a tool to reading a value you are unsure of. Never invent a parameter id or a current value — look it up.',
-    '- ArduPilot parameter names are precise (e.g. ATC_RAT_PIT_P, INS_HNTCH_ENABLE). Use get_parameter or search_parameters to confirm exact ids and valid ranges before discussing them.',
+    '- ArduPilot parameter names are precise (e.g. ATC_RAT_PIT_P, INS_HNTCH_ENABLE). Use search_parameters or list_parameters to find candidate ids, then get_parameters (plural, batched) to confirm exact ranges/units for several of them in one call — do not call get_parameter one id at a time when you already know you need more than one; that wastes round trips.',
     '- Treat a connected flight controller as attached to a real aircraft. Be conservative: flag anything that affects flight safety (failsafe, battery, arming, tuning limits) and never encourage bypassing a pre-arm check.',
     '- Be concise and specific. Cite the parameter ids and values you looked up.',
     '',

--- a/packages/ai-assistant/src/tools.ts
+++ b/packages/ai-assistant/src/tools.ts
@@ -43,6 +43,9 @@ export type ToolResult =
  *  with a full ~1000-param dump. The model pages with offset/limit. */
 const DEFAULT_PARAM_PAGE = 100
 const MAX_PARAM_PAGE = 300
+/** Cap on how many ids get_parameters will detail in one call — keeps a single
+ *  batched lookup bounded even if the model asks for an unreasonably long list. */
+const MAX_BATCH_PARAMETERS = 50
 
 function asString(value: unknown): string | undefined {
   return typeof value === 'string' && value.length > 0 ? value : undefined
@@ -206,7 +209,7 @@ export const AI_ASSISTANT_TOOLS: ToolDefinition[] = [
   {
     name: 'get_parameter',
     description:
-      'Full detail for one parameter: current value plus its label, description, unit, valid range, enum options, and whether a reboot is required to apply. Use the exact parameter id (e.g. "ATC_RAT_PIT_P").',
+      'Full detail for ONE parameter: current value plus its label, description, unit, valid range, enum options, and whether a reboot is required to apply. Use the exact parameter id (e.g. "ATC_RAT_PIT_P"). If you need detail on more than one parameter, call get_parameters instead of calling this repeatedly — it returns the same detail for many ids in a single round trip.',
     parameters: {
       type: 'object',
       properties: { id: { type: 'string', description: 'Exact parameter id.' } },
@@ -215,9 +218,26 @@ export const AI_ASSISTANT_TOOLS: ToolDefinition[] = [
     }
   },
   {
+    name: 'get_parameters',
+    description:
+      `Full detail (value, label, description, unit, range, enum options) for MULTIPLE parameters in one call — the batched form of get_parameter. Always prefer this over several individual get_parameter calls when you already know which ids you need (e.g. after list_parameters or search_parameters). Unknown ids are reported separately rather than failing the whole call. Max ${MAX_BATCH_PARAMETERS} ids per call.`,
+    parameters: {
+      type: 'object',
+      properties: {
+        ids: {
+          type: 'array',
+          items: { type: 'string' },
+          description: `Exact parameter ids, max ${MAX_BATCH_PARAMETERS}.`
+        }
+      },
+      required: ['ids'],
+      additionalProperties: false
+    }
+  },
+  {
     name: 'search_parameters',
     description:
-      'Find parameters by fuzzy text across id, label, and description (e.g. "battery failsafe", "notch filter", "compass orientation"). Returns matching ids with their labels and current values so you can then get_parameter the relevant ones.',
+      'Find parameters by fuzzy text across id, label, and description (e.g. "battery failsafe", "notch filter", "compass orientation"). Returns matching ids with their labels and current values. Follow up with get_parameters (batched) for full detail on the ones you need — not one get_parameter call per id.',
     parameters: {
       type: 'object',
       properties: {
@@ -304,6 +324,31 @@ export function createToolExecutor(accessor: SnapshotAccessor): {
         const match = realParameters(snapshot).find((parameter) => parameter.id.toUpperCase() === id)
         if (!match) return { ok: false, error: `No parameter "${id}" on this vehicle.` }
         return { ok: true, data: detailParam(match) }
+      }
+      case 'get_parameters': {
+        const rawIds = args.ids
+        if (!Array.isArray(rawIds) || rawIds.length === 0) {
+          return { ok: false, error: 'Missing required non-empty "ids" array.' }
+        }
+        const ids = rawIds.filter((entry): entry is string => typeof entry === 'string' && entry.length > 0)
+        if (ids.length === 0) return { ok: false, error: '"ids" must contain at least one non-empty string.' }
+        const requested = ids.slice(0, MAX_BATCH_PARAMETERS).map((id) => id.toUpperCase())
+        const byId = new Map(realParameters(snapshot).map((parameter) => [parameter.id.toUpperCase(), parameter]))
+        const found: Record<string, unknown>[] = []
+        const notFound: string[] = []
+        for (const id of requested) {
+          const match = byId.get(id)
+          if (match) found.push(detailParam(match))
+          else notFound.push(id)
+        }
+        return {
+          ok: true,
+          data: {
+            parameters: found,
+            notFound,
+            truncated: ids.length > MAX_BATCH_PARAMETERS
+          }
+        }
       }
       case 'search_parameters': {
         const query = asString(args.query)?.toLowerCase()

--- a/tests/ai-assistant.test.mjs
+++ b/tests/ai-assistant.test.mjs
@@ -17,7 +17,10 @@ import {
   parseProposedChanges,
   PROPOSE_PARAM_CHANGES_TOOL,
   MAX_PROPOSED_CHANGES,
-  listModels
+  listModels,
+  createAnthropicProvider,
+  createOpenAiProvider,
+  createOllamaProvider
 } from '../packages/ai-assistant/dist/index.js'
 
 // A minimal ConfiguratorSnapshot with just the fields the read-only tools read.
@@ -77,6 +80,7 @@ test('tool definitions expose only read-only tools', () => {
   assert.deepEqual(names, [
     'get_can_nodes',
     'get_parameter',
+    'get_parameters',
     'get_prearm_status',
     'get_setup_status',
     'get_telemetry',
@@ -129,6 +133,30 @@ test('get_parameter returns full metadata and errors on unknown id', () => {
   assert.equal(ok.data.maximum, 0.6)
   const missing = execute('get_parameter', { id: 'NOPE' })
   assert.equal(missing.ok, false)
+})
+
+test('get_parameters batches full metadata for multiple ids and reports unknowns', () => {
+  const { execute } = createToolExecutor(accessorFor(makeSnapshot()))
+  const result = execute('get_parameters', { ids: ['atc_rat_pit_p', 'BATT_LOW_VOLT', 'NOPE'] })
+  assert.equal(result.ok, true)
+  assert.equal(result.data.parameters.length, 2)
+  assert.deepEqual(result.data.notFound, ['NOPE'])
+  const pitchP = result.data.parameters.find((p) => p.id === 'ATC_RAT_PIT_P')
+  assert.equal(pitchP.maximum, 0.6)
+})
+
+test('get_parameters rejects a missing or empty ids array', () => {
+  const { execute } = createToolExecutor(accessorFor(makeSnapshot()))
+  assert.equal(execute('get_parameters', {}).ok, false)
+  assert.equal(execute('get_parameters', { ids: [] }).ok, false)
+})
+
+test('get_parameters caps the batch size and reports truncation', () => {
+  const { execute } = createToolExecutor(accessorFor(makeSnapshot()))
+  const manyIds = Array.from({ length: 60 }, (_, i) => `PARAM_${i}`)
+  const result = execute('get_parameters', { ids: manyIds })
+  assert.equal(result.ok, true)
+  assert.equal(result.data.truncated, true)
 })
 
 test('search_parameters matches across id/label/description', () => {
@@ -301,6 +329,96 @@ function withStubbedFetch(handler, run) {
 }
 
 const jsonResponse = (body) => ({ ok: true, status: 200, json: async () => body, text: async () => '' })
+
+// A streaming Response whose body yields the given raw lines (SSE "data: ..."
+// frames or NDJSON, per-adapter) — enough for iterateLines() to parse.
+function streamResponse(lines) {
+  const encoder = new TextEncoder()
+  const body = new ReadableStream({
+    start(controller) {
+      for (const line of lines) controller.enqueue(encoder.encode(`${line}\n`))
+      controller.close()
+    }
+  })
+  return { ok: true, status: 200, body, text: async () => '' }
+}
+
+async function collectEvents(provider, request) {
+  const events = []
+  for await (const event of provider.send(request)) events.push(event)
+  return events
+}
+
+const baseRequest = { system: 'sys', messages: [{ role: 'user', content: 'hi' }], tools: [], model: 'm' }
+
+test('anthropic provider surfaces stop_reason max_tokens as a length done event', async () => {
+  await withStubbedFetch(
+    () =>
+      streamResponse([
+        'data: {"type":"content_block_start","content_block":{"type":"text"}}',
+        'data: {"type":"content_block_delta","delta":{"type":"text_delta","text":"cut off mid-"}}',
+        'data: {"type":"content_block_stop"}',
+        'data: {"type":"message_delta","delta":{"stop_reason":"max_tokens"}}'
+      ]),
+    async () => {
+      const provider = createAnthropicProvider({ apiKey: 'sk' })
+      const events = await collectEvents(provider, baseRequest)
+      const done = events.find((e) => e.type === 'done')
+      assert.equal(done.stopReason, 'length')
+    }
+  )
+})
+
+test('openai provider surfaces finish_reason length as a length done event', async () => {
+  await withStubbedFetch(
+    () =>
+      streamResponse([
+        'data: {"choices":[{"delta":{"content":"cut off mid-"}}]}',
+        'data: {"choices":[{"delta":{},"finish_reason":"length"}]}',
+        'data: [DONE]'
+      ]),
+    async () => {
+      const provider = createOpenAiProvider({ apiKey: 'sk' })
+      const events = await collectEvents(provider, baseRequest)
+      const done = events.find((e) => e.type === 'done')
+      assert.equal(done.stopReason, 'length')
+    }
+  )
+})
+
+test('ollama provider surfaces done_reason length as a length done event', async () => {
+  await withStubbedFetch(
+    () =>
+      streamResponse([
+        JSON.stringify({ message: { content: 'cut off mid-' } }),
+        JSON.stringify({ done: true, done_reason: 'length' })
+      ]),
+    async () => {
+      const provider = createOllamaProvider({})
+      const events = await collectEvents(provider, baseRequest)
+      const done = events.find((e) => e.type === 'done')
+      assert.equal(done.stopReason, 'length')
+    }
+  )
+})
+
+test('anthropic provider reports a clean end (not length) on a normal finish', async () => {
+  await withStubbedFetch(
+    () =>
+      streamResponse([
+        'data: {"type":"content_block_start","content_block":{"type":"text"}}',
+        'data: {"type":"content_block_delta","delta":{"type":"text_delta","text":"all done"}}',
+        'data: {"type":"content_block_stop"}',
+        'data: {"type":"message_delta","delta":{"stop_reason":"end_turn"}}'
+      ]),
+    async () => {
+      const provider = createAnthropicProvider({ apiKey: 'sk' })
+      const events = await collectEvents(provider, baseRequest)
+      const done = events.find((e) => e.type === 'done')
+      assert.equal(done.stopReason, 'end')
+    }
+  )
+})
 
 test('listModels(anthropic) returns sorted ids and sends the browser-access header', async () => {
   await withStubbedFetch(


### PR DESCRIPTION
Two problems from real-world use against a Cube with 1146 params: the model's answer got cut off mid-sentence with no indication, and it took many individual `get_parameter` calls to build a tuning report.

## Truncation
All three providers hard-coded or ignored the provider's own output-token cap:
- Anthropic: `max_tokens` raised 4096 -> 8192; `stop_reason: "max_tokens"` now detected.
- OpenAI: `finish_reason: "length"` now detected.
- Ollama: `done_reason: "length"` now detected.

`ChatEvent`'s `done.stopReason` gains a `'length'` variant; the hook stops the loop and tells the user the reply was cut off rather than silently presenting a truncated answer as final.

## Batched lookup
Adds `get_parameters` (plural) — full metadata for many ids in one call instead of one `get_parameter` call per id. Descriptions + the system prompt steer the model toward it. Deliberately **not** dumping the whole ~1100-param table into context — every turn resends the full conversation, so a big upfront dump gets re-billed every round trip and blows past small local-model context windows.

**ArduCopter byte-identical:** package + hook only; read-only tools; no runtime/transport edits.

**Validation:** typecheck clean; node --test 683 (+7); vitest 443; Playwright AI Assistant specs pass.