### PR TITLE
fix(ai): don't discard investigation results when the tool-call budget runs out

### DIFF
--- a/apps/web/src/hooks/use-ai-assistant.ts
+++ b/apps/web/src/hooks/use-ai-assistant.ts
@@ -41,7 +41,11 @@ import {
 // model. A write happens only when the human ticks acknowledge and clicks Apply,
 // which delegates to the injected applyChanges (App owns the runtime + backup).
 
-const MAX_TOOL_ITERATIONS = 8
+// Number of assistant turns that may each request tools before a forced,
+// tool-free wrap-up turn (see hitIterationCap below) makes the model answer
+// with whatever it has gathered so far. Raised from 8 now that get_parameters
+// (batched) cuts down how many turns a deep parameter investigation needs.
+const MAX_TOOL_ITERATIONS = 12
 
 export interface AiAssistantSettings {
   providerId: ChatProviderId
@@ -253,7 +257,12 @@ export function useAiAssistant(options: UseAiAssistantOptions): AiAssistantContr
       })
       const tools = toolsFor({ allowProposals })
 
-      for (let iteration = 0; iteration < MAX_TOOL_ITERATIONS; iteration += 1) {
+      // Runs one assistant turn against `turnTools` (empty disallows further tool
+      // calls, used for the forced wrap-up below) and streams it into the
+      // conversation. Returns the terminal state; does not execute any tools.
+      async function runTurn(
+        turnTools: typeof tools
+      ): Promise<{ assistant: ChatMessage; stopReason: 'end' | 'tool-use' | 'length'; streamError?: string }> {
         const requestMessages = [...conversationRef.current]
         const assistant: ChatMessage = { role: 'assistant', content: '', toolCalls: [] }
         conversationRef.current = [...conversationRef.current, assistant]
@@ -265,7 +274,7 @@ export function useAiAssistant(options: UseAiAssistantOptions): AiAssistantContr
         for await (const event of provider.send({
           system,
           messages: requestMessages,
-          tools,
+          tools: turnTools,
           model: connectionRef.current.model,
           signal: controller.signal
         })) {
@@ -282,18 +291,26 @@ export function useAiAssistant(options: UseAiAssistantOptions): AiAssistantContr
           }
         }
 
+        return { assistant, stopReason, streamError }
+      }
+
+      let hitIterationCap = false
+
+      for (let iteration = 0; iteration < MAX_TOOL_ITERATIONS; iteration += 1) {
+        const { assistant, stopReason, streamError } = await runTurn(tools)
+
         if (streamError) {
           setError(streamError)
-          break
+          return
         }
         if (stopReason === 'length') {
           // The provider cut the reply off at its own output-token cap — tell
           // the user rather than silently presenting a truncated answer as final.
           setError('The response was cut off after reaching the model’s reply length limit. Ask it to continue.')
-          break
+          return
         }
         if (stopReason !== 'tool-use' || (assistant.toolCalls?.length ?? 0) === 0) {
-          break
+          return // Clean finish — the model answered without asking for another tool.
         }
 
         for (const call of assistant.toolCalls ?? []) {
@@ -309,7 +326,29 @@ export function useAiAssistant(options: UseAiAssistantOptions): AiAssistantContr
         commit()
 
         if (iteration === MAX_TOOL_ITERATIONS - 1) {
-          setError('Reached the tool-call limit for one turn. Ask a more specific question.')
+          hitIterationCap = true
+        }
+      }
+
+      if (hitIterationCap) {
+        // The model was still mid-investigation when the tool-call budget ran
+        // out. Rather than discarding everything it already gathered and
+        // showing a bare error, force one more turn with no tools offered so it
+        // MUST answer in prose from what it already has.
+        conversationRef.current = [
+          ...conversationRef.current,
+          {
+            role: 'user',
+            content:
+              '[Tool-call budget reached for this turn. Answer now using only the information already gathered above — no more tools are available this turn.]'
+          }
+        ]
+        commit()
+        const { streamError: wrapupError } = await runTurn([])
+        if (wrapupError) {
+          setError(wrapupError)
+        } else {
+          setError('Reached the tool-call limit for this turn — answered using what was already gathered. Ask a follow-up for more detail.')
         }
       }
 

--- a/packages/ai-assistant/src/mock-provider.ts
+++ b/packages/ai-assistant/src/mock-provider.ts
@@ -10,11 +10,36 @@ import type { ChatEvent, ChatProvider, ChatRequest } from './provider.js'
 
 const TOOL_CALL_ID = 'mock-call-1'
 
+/** Prompt marker that makes the mock keep requesting a tool forever as long as
+ *  tools are on offer — the e2e seam for exercising the hook's tool-iteration
+ *  cap and its forced, tool-free wrap-up turn deterministically. */
+const LOOP_FOREVER_MARKER = 'LOOP_TEST_MARKER'
+
 export function createMockProvider(): ChatProvider {
   return {
     id: 'mock',
     async *send(request: ChatRequest): AsyncIterable<ChatEvent> {
       const last = request.messages[request.messages.length - 1]
+
+      // No tools on offer — this is the hook's forced wrap-up turn after
+      // hitting its tool-call budget (or any tool-free call). A real provider
+      // physically cannot request a tool here, so the mock must answer in
+      // prose too, exercising the same "synthesize from what's gathered" path.
+      if (request.tools.length === 0) {
+        yield { type: 'text-delta', text: 'Summarizing from everything gathered so far.' }
+        yield { type: 'done', stopReason: 'end' }
+        return
+      }
+
+      // Deterministic infinite-tool-use seam: keeps requesting the same
+      // read-only tool on every turn for as long as tools remain on offer, so
+      // e2e can drive the hook into its iteration cap without depending on
+      // real model behavior.
+      if (request.messages.some((message) => message.role === 'user' && message.content.includes(LOOP_FOREVER_MARKER))) {
+        yield { type: 'tool-call', call: { id: `mock-loop-${request.messages.length}`, name: 'get_vehicle_info', arguments: {} } }
+        yield { type: 'done', stopReason: 'tool-use' }
+        return
+      }
 
       // A write-intent prompt (and the propose tool is on offer) → stage a
       // proposal. Used by e2e to exercise the propose→approve→apply flow.

--- a/tests/ai-assistant.test.mjs
+++ b/tests/ai-assistant.test.mjs
@@ -307,6 +307,39 @@ test('mock provider does NOT propose when the propose tool is not offered', asyn
   assert.ok(!names.includes('propose_param_changes'))
 })
 
+test('mock provider answers in prose (never a tool call) when no tools are offered', async () => {
+  const provider = createProvider({ providerId: 'mock', model: 'mock' })
+  const request = {
+    system: 'sys',
+    messages: [{ role: 'user', content: 'anything' }],
+    tools: [],
+    model: 'mock'
+  }
+  const events = []
+  for await (const event of provider.send(request)) events.push(event)
+  assert.ok(!events.some((e) => e.type === 'tool-call'))
+  assert.ok(events.some((e) => e.type === 'text-delta'))
+  assert.equal(events.find((e) => e.type === 'done').stopReason, 'end')
+})
+
+test('mock provider keeps requesting a tool when the loop-test marker is present', async () => {
+  const provider = createProvider({ providerId: 'mock', model: 'mock' })
+  const request = {
+    system: 'sys',
+    messages: [
+      { role: 'user', content: 'LOOP_TEST_MARKER investigate everything' },
+      { role: 'assistant', content: '', toolCalls: [{ id: 'x', name: 'get_vehicle_info', arguments: {} }] },
+      { role: 'tool', content: '{"ok":true}', toolCallId: 'x' }
+    ],
+    tools: [{ name: 'get_vehicle_info', description: '', parameters: { type: 'object', properties: {} } }],
+    model: 'mock'
+  }
+  const events = []
+  for await (const event of provider.send(request)) events.push(event)
+  assert.equal(events.find((e) => e.type === 'tool-call').call.name, 'get_vehicle_info')
+  assert.equal(events.find((e) => e.type === 'done').stopReason, 'tool-use')
+})
+
 test('system prompt switches framing when proposals are allowed', () => {
   const readOnly = buildSystemPrompt({ grounding: 'g' })
   assert.match(readOnly, /READ-ONLY/)

--- a/tests/e2e/views.spec.ts
+++ b/tests/e2e/views.spec.ts
@@ -464,6 +464,31 @@ test.describe('AI Assistant view (Expert, offline mock provider)', () => {
     await expect(page.getByTestId('ai-assistant-proposal-result')).toContainText('1 verified', { timeout: 20000 })
     await expect(page.getByTestId('ai-assistant-proposal-result')).toContainText('backup was saved')
   })
+
+  test('still answers after hitting the tool-call budget instead of leaving the user with a bare error', async ({ page }) => {
+    await page.goto('/?aiProvider=mock')
+    await page.getByTestId('transport-mode-select').selectOption('demo')
+    await page.getByTestId('connect-button').click()
+    await expect(page.getByTestId('session-vehicle-name')).toHaveText('ArduCopter', { timeout: VEHICLE_CONNECT_TIMEOUT })
+    await expectParameterSyncComplete(page)
+
+    await page.getByTestId('product-mode-expert').check()
+    await page.getByTestId('view-button-ai-assistant').click()
+    await expect(page.getByTestId('ai-assistant-view')).toBeVisible()
+
+    // LOOP_TEST_MARKER makes the mock provider request a tool on every turn,
+    // deterministically driving the hook into its tool-iteration cap.
+    await page.getByTestId('ai-assistant-input').fill('LOOP_TEST_MARKER investigate everything')
+    await page.getByTestId('ai-assistant-send').click()
+
+    // The forced, tool-free wrap-up turn still produces a final answer — the
+    // conversation isn't left with nothing but an error after all that work.
+    await expect(page.getByTestId('ai-assistant-transcript')).toContainText('Summarizing from everything gathered', {
+      timeout: 20000
+    })
+    // The user is told the budget was hit, without it replacing the answer.
+    await expect(page.getByTestId('ai-assistant-error')).toContainText(/tool-call limit/i)
+  })
 })
 
 test.describe('connection transports', () => {


### PR DESCRIPTION
Hitting the tool-iteration cap ("Reached the tool-call limit for one turn. Ask a more specific question.") discarded everything the model had already gathered — the loop just aborted with a bare error, after a long useful investigation.

**Root cause:** the loop executed the final permitted round's tool calls, set the cap error, then exited without ever giving the model a turn to use those results.

**Fix:** when the budget runs out mid-investigation, force one more turn with no tools offered, so the model must synthesize a prose answer from everything already gathered — the cap notice becomes a footnote alongside the answer, not a replacement for it. Also raises the budget 8 -> 12 turns now that the batched `get_parameters` lookup (previous fix) needs fewer round trips per investigation.

**Test seam:** the mock provider gained a deterministic "keep requesting a tool forever" mode plus a no-tools-offered branch that always answers in prose, so a new Playwright test drives the real hook into the cap and asserts the wrap-up answer actually renders.

**ArduCopter byte-identical:** hook + package only; no runtime/transport edits.

**Validation:** typecheck clean; node --test 685 (+2); vitest 443; Playwright AI Assistant specs 3/3 (incl. the new cap/wrap-up test).