### PR TITLE
fix(motors): surface SERVO_DSHOT_ESC as the real gate for DShot reverse

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -2238,7 +2238,7 @@ export function App() {
   // operator can Apply + Reboot from inside the popout instead of closing,
   // applying from the Outputs view, refreshing, and reopening.
   const motorReorderDialogParamIds = useMemo(() => {
-    const ids = new Set<string>(['SERVO_BLH_RVMASK'])
+    const ids = new Set<string>(['SERVO_BLH_RVMASK', 'SERVO_DSHOT_ESC'])
     effectiveMotorOutputs.forEach((output) => ids.add(output.paramId))
     return ids
   }, [effectiveMotorOutputs])

--- a/apps/web/src/hooks/use-config-sections.ts
+++ b/apps/web/src/hooks/use-config-sections.ts
@@ -76,10 +76,11 @@ export function useConfigSections(snapshot: ConfiguratorSnapshot) {
     {
       id: 'esc-dshot',
       title: 'ESC & DShot',
-      description: 'Output protocol and DShot/BLHeli behavior — set this before motor testing. Bidirectional DShot needs a DShot protocol; check it on the first 4 outputs (some boards do 8) and enable BLHeli auto. Reverse a motor here instead of swapping wires.',
+      description: 'Output protocol and DShot/BLHeli behavior — set this before motor testing. Bidirectional DShot needs a DShot protocol; check it on the first 4 outputs (some boards do 8) and enable BLHeli auto. ESC type must be set (not "None") for reverse/3D DShot commands to be sent at all. Reverse a motor here instead of swapping wires.',
       fields: [
         { paramId: 'MOT_PWM_TYPE', label: 'ESC protocol', digits: 0 },
         { paramId: 'SERVO_DSHOT_RATE', label: 'DShot rate', digits: 0 },
+        { paramId: 'SERVO_DSHOT_ESC', label: 'ESC type', digits: 0 },
         { paramId: 'SERVO_BLH_AUTO', label: 'BLHeli auto', digits: 0 },
         { paramId: 'SERVO_BLH_POLES', label: 'Motor poles', digits: 0 },
         { paramId: 'SERVO_BLH_BDMASK', label: 'Bidirectional DShot outputs', digits: 0 },

--- a/apps/web/src/sections/MotorReorderDialog.tsx
+++ b/apps/web/src/sections/MotorReorderDialog.tsx
@@ -17,6 +17,7 @@ import { normalizeBitmaskValue } from '../parameter-format'
 import { hasBitmaskFlag, toggleBitmaskFlag } from '../selectors/bitmask'
 import { readRoundedParameter, selectParameterById } from '../selectors/parameter-read'
 import type { MotorPreviewNode } from '../view-models/motor-preview'
+import { resolveMotorReverseEligibility } from '../view-models/motor-reverse'
 import { motorSpinArcPath } from '../views/motor-spin-arc'
 import type { MotorReorderRow } from '../hooks/use-motor-reorder'
 
@@ -508,7 +509,13 @@ export function MotorReorderDialog({
                 const motPwmType = Math.round(
                   Number(editedValues.MOT_PWM_TYPE ?? readRoundedParameter(snapshot, 'MOT_PWM_TYPE') ?? 0)
                 )
-                const isDShot = motPwmType >= 4 && motPwmType <= 7
+                const dshotEscParam = selectParameterById(snapshot, 'SERVO_DSHOT_ESC')
+                const dshotEscType =
+                  editedValues.SERVO_DSHOT_ESC !== undefined
+                    ? Math.round(Number(editedValues.SERVO_DSHOT_ESC))
+                    : dshotEscParam?.value
+                const eligibility = resolveMotorReverseEligibility({ motPwmType, dshotEscType })
+                const escOptions = dshotEscParam?.definition?.options ?? []
                 return (
                   <div className="motor-reverse-card" data-testid="motor-reorder-direction-reverse">
                     <div className="switch-exercise-card__header">
@@ -516,10 +523,29 @@ export function MotorReorderDialog({
                         <strong>Reverse motor direction</strong>
                         <p>
                           If the right motor spins the wrong way, reverse it here over DShot (BLHeli/AM32) instead
-                          of swapping wires. {isDShot ? 'Takes effect on the next reboot/redetect.' : 'Requires a DShot ESC protocol — set MOT_PWM_TYPE to a DShot value (4-7) first.'}
+                          of swapping wires. {eligibility.canReverse ? 'Takes effect on the next reboot/redetect.' : eligibility.blockedReason}
                         </p>
                       </div>
                     </div>
+                    {dshotEscParam && eligibility.isDShotProtocol ? (
+                      <label
+                        className={`motor-reverse-esctype${eligibility.escTypeConfigured ? '' : ' motor-reverse-esctype--warning'}`}
+                        data-testid="motor-reorder-direction-esctype"
+                      >
+                        <span>ESC type (SERVO_DSHOT_ESC)</span>
+                        <select
+                          value={String(dshotEscType ?? 0)}
+                          disabled={busyAction !== undefined}
+                          onChange={(event) => setDraft('SERVO_DSHOT_ESC', event.target.value)}
+                        >
+                          {escOptions.map((option) => (
+                            <option key={`servo-dshot-esc:${option.value}`} value={String(option.value)}>
+                              {option.label}
+                            </option>
+                          ))}
+                        </select>
+                      </label>
+                    ) : null}
                     <div className="motor-reverse-grid">
                       {effectiveMotorOutputs.map((output) => {
                         const bit = output.channelNumber - 1
@@ -533,7 +559,7 @@ export function MotorReorderDialog({
                             <input
                               type="checkbox"
                               checked={reversed}
-                              disabled={!isDShot || busyAction !== undefined}
+                              disabled={!eligibility.canReverse || busyAction !== undefined}
                               onChange={(event) =>
                                 setDraft(rvmaskParam.id, String(toggleBitmaskFlag(currentMask, bit, event.target.checked)))
                               }

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -13149,6 +13149,28 @@ details.bf-gui-box:not([open]) > summary::after {
   border-color: var(--accent, #61dafb);
   background: rgba(97, 218, 251, 0.08);
 }
+.motor-reverse-esctype {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-top: 10px;
+  padding: 8px 10px;
+  border-radius: 8px;
+  border: 1px solid transparent;
+  font-size: 12px;
+}
+.motor-reverse-esctype span {
+  color: var(--text-muted);
+  white-space: nowrap;
+}
+.motor-reverse-esctype select {
+  flex: 1;
+  min-width: 0;
+}
+.motor-reverse-esctype--warning {
+  border-color: var(--warning, #ff6600);
+  background: rgba(255, 102, 0, 0.08);
+}
 
 .calibration-card--danger {
   border-color: var(--danger, #e2123f);

--- a/apps/web/src/view-models/motor-reverse.test.ts
+++ b/apps/web/src/view-models/motor-reverse.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest'
+
+import { resolveMotorReverseEligibility } from './motor-reverse'
+
+describe('resolveMotorReverseEligibility', () => {
+  it('blocks on a non-DShot protocol regardless of ESC type', () => {
+    const result = resolveMotorReverseEligibility({ motPwmType: 0, dshotEscType: 1 })
+    expect(result.isDShotProtocol).toBe(false)
+    expect(result.canReverse).toBe(false)
+    expect(result.blockedReason).toMatch(/DShot/i)
+  })
+
+  it('blocks on DShot protocol but SERVO_DSHOT_ESC = None (0)', () => {
+    const result = resolveMotorReverseEligibility({ motPwmType: 6, dshotEscType: 0 })
+    expect(result.isDShotProtocol).toBe(true)
+    expect(result.escTypeConfigured).toBe(false)
+    expect(result.canReverse).toBe(false)
+    expect(result.blockedReason).toMatch(/SERVO_DSHOT_ESC/)
+  })
+
+  it('blocks the same way when SERVO_DSHOT_ESC is undefined (param not synced)', () => {
+    const result = resolveMotorReverseEligibility({ motPwmType: 6, dshotEscType: undefined })
+    expect(result.canReverse).toBe(false)
+    expect(result.escTypeConfigured).toBe(false)
+  })
+
+  it('allows reversing once both a DShot protocol and a real ESC type are set', () => {
+    const result = resolveMotorReverseEligibility({ motPwmType: 6, dshotEscType: 1 })
+    expect(result.isDShotProtocol).toBe(true)
+    expect(result.escTypeConfigured).toBe(true)
+    expect(result.canReverse).toBe(true)
+    expect(result.blockedReason).toBeUndefined()
+  })
+
+  it.each([4, 5, 6, 7])('treats MOT_PWM_TYPE=%i as a DShot protocol', (motPwmType) => {
+    expect(resolveMotorReverseEligibility({ motPwmType, dshotEscType: 1 }).isDShotProtocol).toBe(true)
+  })
+
+  it.each([1, 2, 3, 8])('does not treat MOT_PWM_TYPE=%i as DShot', (motPwmType) => {
+    expect(resolveMotorReverseEligibility({ motPwmType, dshotEscType: 1 }).isDShotProtocol).toBe(false)
+  })
+})

--- a/apps/web/src/view-models/motor-reverse.ts
+++ b/apps/web/src/view-models/motor-reverse.ts
@@ -1,0 +1,54 @@
+// Pure eligibility/copy logic for the Motor Reorder dialog's "Reverse
+// direction" card, extracted so the two real prerequisites for DShot reverse
+// to actually work are unit-tested rather than only inline JSX conditionals.
+//
+// Hardware-verified (real Cube + iFlight Blitz Mini E55/AM32, 2026-07-08):
+// the reverse checkbox writes SERVO_BLH_RVMASK, but that mask is only ever
+// acted on by ArduPilot's RCOutput driver when SERVO_DSHOT_ESC names a real
+// ESC type — with SERVO_DSHOT_ESC = 0 ("None"), the reverse (and 3D) DShot
+// command is silently never sent, regardless of RVMASK or a reboot. Both
+// SERVO_BLH_RVMASK and SERVO_DSHOT_ESC also only take effect on the next
+// reboot (AP_BLHeli::init() / RCOutput::set_dshot_esc_type are only pushed at
+// ESC-subsystem startup), which the Motor Reorder dialog's Apply button
+// already forces regardless of this check.
+
+export interface MotorReverseEligibility {
+  isDShotProtocol: boolean
+  escTypeConfigured: boolean
+  canReverse: boolean
+  /** Present iff canReverse is false — shown in place of the toggle grid. */
+  blockedReason?: string
+}
+
+/** DShot MOT_PWM_TYPE values (ArduCopter enum): 4=DShot150 .. 7=DShot1200. */
+function isDShotPwmType(motPwmType: number): boolean {
+  return motPwmType >= 4 && motPwmType <= 7
+}
+
+export function resolveMotorReverseEligibility(inputs: {
+  motPwmType: number
+  /** SERVO_DSHOT_ESC value; undefined when the param isn't in the synced set. */
+  dshotEscType: number | undefined
+}): MotorReverseEligibility {
+  const isDShotProtocol = isDShotPwmType(inputs.motPwmType)
+  const escTypeConfigured = (inputs.dshotEscType ?? 0) > 0
+
+  if (!isDShotProtocol) {
+    return {
+      isDShotProtocol,
+      escTypeConfigured,
+      canReverse: false,
+      blockedReason: 'Requires a DShot ESC protocol — set MOT_PWM_TYPE to a DShot value (4-7) first.'
+    }
+  }
+  if (!escTypeConfigured) {
+    return {
+      isDShotProtocol,
+      escTypeConfigured,
+      canReverse: false,
+      blockedReason:
+        'Set your ESC type below first — with SERVO_DSHOT_ESC set to "None", no DShot commands are ever sent, including reverse.'
+    }
+  }
+  return { isDShotProtocol, escTypeConfigured, canReverse: true }
+}

--- a/packages/param-metadata/src/arducopter-enums.ts
+++ b/packages/param-metadata/src/arducopter-enums.ts
@@ -527,6 +527,18 @@ export const ARDUCOPTER_BLH_AUTO_LABELS: Record<number, string> = {
   1: 'Enabled (all DShot outputs)'
 }
 
+// SERVO_DSHOT_ESC — which DShot command set/bit-width the ESC firmware
+// understands. 'None' (0) disables ALL DShot commands, including the
+// SERVO_BLH_RVMASK reverse-direction command and 3D mode — hardware-verified
+// on a real board where reverse silently did nothing until this was set.
+export const ARDUCOPTER_DSHOT_ESC_TYPE_LABELS: Record<number, string> = {
+  0: 'None (no DShot commands sent)',
+  1: 'BLHeli32 / KISS / AM32',
+  2: 'BLHeli_S / BlueJay',
+  3: 'BLHeli32 / AM32 / KISS + Extended DShot Telemetry',
+  4: 'BLHeli_S / BlueJay + Extended DShot Telemetry'
+}
+
 // Per-output channel bit labels for the BLHeli bidirectional-DShot
 // (SERVO_BLH_BDMASK) and reverse (SERVO_BLH_RVMASK) masks. Bit 0 = output 1.
 // Most boards support bidirectional DShot on the first 4 outputs only.

--- a/packages/param-metadata/src/arducopter.ts
+++ b/packages/param-metadata/src/arducopter.ts
@@ -30,6 +30,7 @@ import {
   ARDUCOPTER_OSD_SWITCH_METHOD_LABELS,
   ARDUCOPTER_OSD_TYPE_LABELS,
   ARDUCOPTER_DSHOT_RATE_LABELS,
+  ARDUCOPTER_DSHOT_ESC_TYPE_LABELS,
   ARDUCOPTER_BLH_AUTO_LABELS,
   ARDUCOPTER_OUTPUT_CHANNEL_BIT_LABELS,
   ARDUCOPTER_RC_OPTIONS_BIT_LABELS,
@@ -3055,6 +3056,20 @@ export const arducopterMetadata: FirmwareMetadataBundle = {
       rebootRequired: true,
       options: enumOptions(ARDUCOPTER_DSHOT_RATE_LABELS)
     },
+    SERVO_DSHOT_ESC: {
+      id: 'SERVO_DSHOT_ESC',
+      label: 'ESC type (DShot commands)',
+      // Hardware-verified: with this at "None", SERVO_BLH_RVMASK (reverse) and
+      // 3D-mode commands are never sent at all — ArduPilot's own RCOutput driver
+      // only sends DShot special commands for the listed ESC types, and silently
+      // does nothing for "None". Must be set correctly before reverse works.
+      description: 'Which DShot command set/bit-width your ESC firmware understands. "None" disables ALL DShot special commands — including SERVO_BLH_RVMASK reverse-direction and 3D mode — even if those are otherwise configured. Only enable the "+ Extended DShot Telemetry" variants if your ESC firmware build actually supports EDT.',
+      category: 'outputs',
+      minimum: 0,
+      maximum: 4,
+      rebootRequired: true,
+      options: enumOptions(ARDUCOPTER_DSHOT_ESC_TYPE_LABELS)
+    },
     SERVO_BLH_AUTO: {
       id: 'SERVO_BLH_AUTO',
       label: 'BLHeli auto-enable',
@@ -3090,10 +3105,16 @@ export const arducopterMetadata: FirmwareMetadataBundle = {
     SERVO_BLH_RVMASK: {
       id: 'SERVO_BLH_RVMASK',
       label: 'Reverse motor direction (per output)',
-      description: 'Per-output bitmask: check an output to reverse that motor’s spin direction via DShot (BLHeli/AM32) without swapping wires. Takes effect immediately on DShot ESCs.',
+      // Hardware-verified: the reversed mask is only pushed into the RCOutput
+      // driver from AP_BLHeli::init(), which runs once at ESC-subsystem startup
+      // — a live param change does nothing until the FC reboots. Also requires
+      // SERVO_DSHOT_ESC to be set to a real ESC type (not "None"); with "None"
+      // this mask is accepted but no reverse command is ever sent.
+      description: 'Per-output bitmask: check an output to reverse that motor’s spin direction via DShot (BLHeli/AM32) without swapping wires. Requires SERVO_DSHOT_ESC set to your ESC type (not "None"), and a reboot after changing, to take effect.',
       category: 'outputs',
       minimum: 0,
       maximum: 255,
+      rebootRequired: true,
       bitmask: true,
       options: enumOptions(ARDUCOPTER_OUTPUT_CHANNEL_BIT_LABELS)
     },

--- a/packages/protocol-mavlink/src/mock-scenario.ts
+++ b/packages/protocol-mavlink/src/mock-scenario.ts
@@ -410,6 +410,7 @@ const mockParameters: ParameterState = {
   MOT_PWM_TYPE: 5,
   ESC_CALIBRATION: 0,
   SERVO_DSHOT_RATE: 0,
+  SERVO_DSHOT_ESC: 1,
   SERVO_BLH_AUTO: 0,
   SERVO_BLH_BDMASK: 0,
   SERVO_BLH_RVMASK: 0,

--- a/tests/e2e/views.spec.ts
+++ b/tests/e2e/views.spec.ts
@@ -651,6 +651,37 @@ test.describe('Motors direction test', () => {
     // Staging the mask enables the panel's Apply and reboot with a count.
     await expect(page.getByTestId('motor-reorder-apply')).toContainText('Apply and reboot (1)')
   })
+
+  test('reverse toggles are disabled when SERVO_DSHOT_ESC is "None" — the actual DShot-command gate', async ({ page }) => {
+    // Hardware-verified root cause (2026-07-08, real Cube + AM32 ESC): RVMASK
+    // alone does nothing unless SERVO_DSHOT_ESC names a real ESC type. This
+    // covers the live reactivity of the fix: the ESC-type selector added to
+    // the Direction tab, and toggles disabling/re-enabling as it changes.
+    await page.goto('/')
+    await connectViaHeader(page)
+    await openView(page, 'motors')
+    await page.getByTestId('outputs-summary-motor-setup').click()
+    await page.getByTestId('motor-reorder-lightbox-tab-direction').click()
+
+    const m1 = page.getByTestId('motor-reorder-direction-reverse-1').locator('input')
+    const escSelect = page.getByTestId('motor-reorder-direction-esctype').locator('select')
+    await expect(escSelect).toBeVisible()
+    await expect(m1).toBeEnabled()
+
+    await m1.check()
+    await expect(m1).toBeChecked()
+
+    // Switching the ESC type to "None" disables the toggles — matches the
+    // real firmware behavior where SERVO_DSHOT_ESC=0 silently drops every
+    // DShot special command, including reverse.
+    await escSelect.selectOption('0')
+    await expect(m1).toBeDisabled()
+
+    // Switching back re-enables it, and the staged reverse bit persisted.
+    await escSelect.selectOption('1')
+    await expect(m1).toBeEnabled()
+    await expect(m1).toBeChecked()
+  })
 })
 
 test.describe('Calibration tab — motor-spin (ESC)', () => {

--- a/tests/transport.test.mjs
+++ b/tests/transport.test.mjs
@@ -714,8 +714,8 @@ test('MockTransport serializes chunked inbound frames so demo parameter sync com
     const stats = await runtime.waitForParameterSync({ timeoutMs: 120000 })
 
     assert.equal(stats.status, 'complete')
-    assert.equal(stats.downloaded, 1151)
-    assert.equal(stats.total, 1151)
+    assert.equal(stats.downloaded, 1152)
+    assert.equal(stats.total, 1152)
     assert.equal(runtime.getSnapshot().parameters.find((parameter) => parameter.id === 'FRAME_CLASS')?.value, 1)
     assert.equal(runtime.getSnapshot().parameters.find((parameter) => parameter.id === 'FRAME_TYPE')?.value, 1)
   } finally {
@@ -846,7 +846,7 @@ test('Bundled WebSocket bridge can drive runtime heartbeat and parameter sync fr
     assert.equal(runtime.getSnapshot().connection.kind, 'connected')
     assert.equal(runtime.getSnapshot().vehicle?.vehicle, 'ArduCopter')
     assert.equal(stats.status, 'complete')
-    assert.equal(stats.downloaded, 1151)
+    assert.equal(stats.downloaded, 1152)
     assert.equal(runtime.getSnapshot().parameters.find((parameter) => parameter.id === 'FRAME_CLASS')?.value, 1)
   } finally {
     await runtime.disconnect().catch(() => {})


### PR DESCRIPTION
Hardware-verified on a real Cube + iFlight Blitz Mini E55 (AM32): the Motor Reorder dialog's "Reverse direction" toggles write `SERVO_BLH_RVMASK`, but that mask is only ever acted on when `SERVO_DSHOT_ESC` names a real ESC type. Traced in ArduPilot's own source (`RCOutput_serial.cpp`'s `update_channel_masks()`): the DShot reverse/3D command send is a switch on ESC type with a bare `default: break;` for "None" (0) — with `SERVO_DSHOT_ESC` unset, the reverse command is silently never transmitted, regardless of RVMASK, regardless of rebooting. This app never surfaced that param at all.

## What changed

- **param-metadata**: adds the `SERVO_DSHOT_ESC` definition (was entirely missing) with its real enum, and fixes `SERVO_BLH_RVMASK`'s metadata — `rebootRequired` was false and its description claimed "takes effect immediately", both wrong (`AP_BLHeli::init()` only pushes the reversed mask at ESC-subsystem startup). Every apply path now correctly prompts for a reboot.
- **apps/web**: the Direction tab's reverse card checks `SERVO_DSHOT_ESC` via a new pure `resolveMotorReverseEligibility()` helper, blocks the toggles with a clear reason when the ESC type is "None", and adds an inline ESC-type selector right there. Also added to the general ESC & DShot config section.
- Demo mock seeds `SERVO_DSHOT_ESC=1` so the existing demo/e2e happy path is unaffected; a new e2e test covers the "None" blocked state and live toggle reactivity.

**ArduCopter byte-identical:** metadata + UI only; no runtime/transport edits.

**Validation:** typecheck clean; node --test 685; vitest 455 (+12); Playwright 138 (+2, incl. the new gating test).