### PR TITLE
fix(osd): render HORIZON/CRSSHAIR/SIDEBARS as line-art glyphs, not text

### DIFF
--- a/apps/web/src/hooks/use-osd-editor.ts
+++ b/apps/web/src/hooks/use-osd-editor.ts
@@ -166,7 +166,15 @@ export function useOsdEditor({
       HOME: 'HOME',
       HOMEDIST: 'HDIST',
       HOMEDIR: 'HDIR',
-      HORIZON: '[H]',
+      // These three are line-art OSD elements (an artificial-horizon ladder
+      // bar, a center reticle, and left/right scale bars), not text readouts —
+      // real MAX7456-style OSD fonts render them as runs of dash/line glyphs.
+      // A single preview cell can't reproduce the multi-row bars exactly, but
+      // dashes read as "a line", where a raw label or the old '[H]' read as
+      // stray text.
+      HORIZON: '- - - -',
+      CRSSHAIR: '- + -',
+      SIDEBARS: '¦',
       SATS: 'SAT',
       HDOP: 'HDOP',
       WAYPOINT: 'WP',


### PR DESCRIPTION
The OSD preview showed a stray "[H]" for the artificial-horizon element and the raw element id ("CRSSHAIR"/"SIDEBARS") for the other two — all three are line-art elements on a real MAX7456-style OSD font (a horizon ladder bar, a center reticle, and left/right scale bars), not text readouts, and had no dash-based preview at all.

Gives each a short dash/line glyph in the preview's `elementTexts` map instead — reads as "a line" the way the real OSD does, rather than a random text placeholder.

**ArduCopter byte-identical:** OSD preview text only, no runtime/param edits.

**Validation:** typecheck clean; node --test 685; vitest 455; Playwright OSD specs 17/17.