### PR TITLE
feat(ux): OSD click-to-highlight, Show-changes scroll, simplified export, custom flight-mode entry

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -5443,6 +5443,20 @@ export function App() {
     setActiveViewId('setup')
   }, [activeViewId, isExpertMode])
 
+  // "Show changes" (global draft bar) switches to Parameters AND bumps this so
+  // ParametersSection scrolls to the diff grid — a plain boolean can't refire
+  // on a second click while already on the tab. Reset to 0 the instant the
+  // operator leaves Parameters, so the counter is only ever nonzero in the
+  // exact render where Show Changes caused the switch; a later unrelated
+  // manual nav back into Parameters (remounting the section) sees 0 and
+  // doesn't auto-scroll.
+  const [showChangesRequestId, setShowChangesRequestId] = useState(0)
+  useEffect(() => {
+    if (activeViewId !== 'parameters') {
+      setShowChangesRequestId(0)
+    }
+  }, [activeViewId])
+
   function handleSetupFlowAction(action: SetupFlowActionDescriptor): void {
     if (action.disabled) {
       return
@@ -5827,7 +5841,10 @@ export function App() {
           canApplyAllDraftParameters={canApplyAllDraftParameters}
           applyAllBusyLabel={applyAllBusyLabel}
           rebootPending={Boolean(parameterFollowUp?.requiresReboot)}
-          onShowChanges={() => setActiveViewId('parameters')}
+          onShowChanges={() => {
+            setActiveViewId('parameters')
+            setShowChangesRequestId((n) => n + 1)
+          }}
           onWriteAll={() => void handleApplyAllParameterDrafts()}
           onDiscard={clearAllDrafts}
           onRequestReboot={() => void handleGuidedAction('reboot-autopilot')}
@@ -7767,6 +7784,7 @@ export function App() {
           editedValues={editedValues}
           parameterNotice={parameterNotice}
           parameterFollowUp={parameterFollowUp}
+          scrollToChangesRequestId={showChangesRequestId}
           formatCategoryLabel={formatCategoryLabel}
           parameterSearch={parameterSearch}
           setParameterSearch={setParameterSearch}

--- a/apps/web/src/sections/ParametersSection.tsx
+++ b/apps/web/src/sections/ParametersSection.tsx
@@ -34,6 +34,11 @@ export interface ParametersSectionProps {
   editedValues: Record<string, string>
   parameterNotice: ParameterNotice | undefined
   parameterFollowUp: ParameterFollowUp | undefined
+  /** Bumped by the global draft bar's "Show changes" button — a plain
+   *  boolean can't refire on a second click while already on this tab, so
+   *  App increments a counter instead. Any change scrolls the diff grid
+   *  into view (invalid rows first, since those block Apply All). */
+  scrollToChangesRequestId: number
   formatCategoryLabel: (categoryId: string | undefined) => string
   parameterSearch: string
   setParameterSearch: Dispatch<SetStateAction<string>>
@@ -100,6 +105,7 @@ export function ParametersSection(props: ParametersSectionProps): ReactElement {
     editedValues,
     parameterNotice,
     parameterFollowUp,
+    scrollToChangesRequestId,
     formatCategoryLabel,
     parameterSearch,
     setParameterSearch,
@@ -156,6 +162,19 @@ export function ParametersSection(props: ParametersSectionProps): ReactElement {
       rebootFollowUpRef.current?.scrollIntoView({ behavior: 'smooth', block: 'center' })
     }
   }, [followUpRequiresReboot])
+  // "Show changes" (the global draft bar) switches to this tab but previously
+  // dropped the operator wherever they last scrolled, leaving the diff grid
+  // to hunt for — the reported bug. Scroll to it on every request; invalid
+  // rows first since those block Apply All, matching the existing "jump to
+  // them" anchor link below. Runs on mount too (a fresh tab switch), since a
+  // dependency changing on the very first render still fires the effect.
+  const stagedDiffGridRef = useRef<HTMLDivElement>(null)
+  const invalidDiffGridRef = useRef<HTMLDivElement>(null)
+  useEffect(() => {
+    if (scrollToChangesRequestId === 0) return
+    const target = invalidDiffGridRef.current ?? stagedDiffGridRef.current
+    target?.scrollIntoView({ behavior: 'smooth', block: 'start' })
+  }, [scrollToChangesRequestId])
   // The search box filters the staged review too: filtering only the
   // table while the review list (where you look mid-import) ignores it
   // makes wildcard search appear broken. Selection, Select all, and Drop
@@ -353,31 +372,38 @@ export function ParametersSection(props: ParametersSectionProps): ReactElement {
             <div className="button-row">
               <button
                 data-testid="export-parameter-backup"
-                style={buttonStyle()}
+                style={buttonStyle('primary')}
                 onClick={handleExportParameterBackup}
                 disabled={busyAction !== undefined || snapshot.parameters.length === 0}
-                title="ArduConfigurator JSON backup with full metadata; round-trips through Import Backup."
+                title="ArduConfigurator JSON backup with full metadata; round-trips through Import Backup. Use this unless another tool specifically needs a legacy format."
               >
-                Export JSON
+                Export
               </button>
-              <button
-                data-testid="export-parameter-backup-parm"
+              {/* A third export format ("why do these exist?") collapsed into
+               *  one control: pick a legacy ground-station format here only
+               *  when you specifically need to hand the file to Mission
+               *  Planner or QGroundControl. Resets to the placeholder after
+               *  each export so it reads as a one-shot action, not a
+               *  persistent mode toggle. */}
+              <select
+                data-testid="export-parameter-backup-legacy"
+                className="export-legacy-select"
                 style={buttonStyle()}
-                onClick={handleExportParameterBackupAsParm}
+                value=""
                 disabled={busyAction !== undefined || snapshot.parameters.length === 0}
-                title="Mission Planner .parm — NAME,VALUE per line, header metadata in # comments."
+                title="Export in a legacy ground-station format for a specific tool, instead of ArduConfigurator's own JSON."
+                onChange={(event) => {
+                  const format = event.target.value
+                  if (format === 'parm') handleExportParameterBackupAsParm()
+                  else if (format === 'params') handleExportParameterBackupAsParams()
+                }}
               >
-                Export .parm
-              </button>
-              <button
-                data-testid="export-parameter-backup-params"
-                style={buttonStyle()}
-                onClick={handleExportParameterBackupAsParams}
-                disabled={busyAction !== undefined || snapshot.parameters.length === 0}
-                title="QGroundControl .params — tab-separated vid/cid/NAME/VALUE/type."
-              >
-                Export .params
-              </button>
+                <option value="" disabled>
+                  Export Legacy…
+                </option>
+                <option value="parm">Mission Planner (.parm)</option>
+                <option value="params">QGroundControl (.params)</option>
+              </select>
               <fieldset className="parameter-import-exclusions" data-testid="parameter-export-exclusions">
                 <legend>Skip on export</legend>
                 {([
@@ -558,7 +584,7 @@ export function ParametersSection(props: ParametersSectionProps): ReactElement {
           ) : null}
 
           {visibleStagedGroups.length > 0 ? (
-            <div className="parameter-diff-grid" id="parameter-diff-grid" data-testid="parameter-diff-grid">
+            <div ref={stagedDiffGridRef} className="parameter-diff-grid" id="parameter-diff-grid" data-testid="parameter-diff-grid">
               {visibleStagedGroups.map((group) => (
                 <section key={group.category} className="parameter-diff-group">
                   <header>
@@ -658,7 +684,7 @@ export function ParametersSection(props: ParametersSectionProps): ReactElement {
           ) : null}
 
           {invalidParameterGroups.length > 0 ? (
-            <div className="parameter-diff-grid parameter-diff-grid--invalid" id="parameter-invalid-grid">
+            <div ref={invalidDiffGridRef} className="parameter-diff-grid parameter-diff-grid--invalid" id="parameter-invalid-grid">
               {invalidParameterGroups.map((group) => (
                 <section key={`invalid:${group.category}`} className="parameter-diff-group parameter-diff-group--invalid">
                   <header>

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -6911,6 +6911,22 @@ textarea:focus {
   border: 1px solid rgba(var(--edge-rgb), 0.035);
   background: linear-gradient(180deg, rgba(var(--fill-rgb), 0.96), rgba(var(--fill-rgb), 0.98));
 }
+/* ScopedSelectField's opt-in "Custom…" mode: the select stays full-width
+ * until Custom… is picked, then a plain number input appears alongside it
+ * for typing an unlisted value directly (e.g. a scripting-defined flight
+ * mode number) instead of only ever showing an inert "N (unlisted)" label. */
+.scoped-select-with-custom {
+  display: flex;
+  gap: 6px;
+}
+.scoped-select-with-custom select {
+  flex: 1;
+  min-width: 0;
+}
+.scoped-select-with-custom__input {
+  width: 5.5em;
+  flex: 0 0 auto;
+}
 /* Dotted-quad IPv4 editor: four small octet inputs separated by dots. */
 .ip-address-field__octets {
   display: flex;
@@ -11840,6 +11856,15 @@ details.metadata-settings-section:not([open]) > summary::after {
   z-index: 2;
 }
 
+/* Clicked from the checklist (or clicked directly in the preview) — a
+ * persistent highlight, distinct from the transient is-dragging state, so an
+ * operator can see "this is the one I selected" without holding a drag. */
+.osd-preview-screen__element.is-highlighted {
+  background: rgba(97, 218, 251, 0.16);
+  outline-color: rgba(97, 218, 251, 0.85);
+  z-index: 2;
+}
+
 /* Live cell-coordinate badge shown above an element while it's being dragged,
  * so the operator gets snap feedback (which character cell it will land on).
  * Self-contained amber pill with dark ink — legible on both the dark video
@@ -12841,6 +12866,22 @@ details.bf-gui-box:not([open]) > summary::after {
 .osd-matrix__row:not(.osd-matrix__row--head):hover {
   background: var(--surface-200);
 }
+.osd-matrix__row.is-highlighted {
+  background: rgba(97, 218, 251, 0.1);
+  outline: 1px solid rgba(97, 218, 251, 0.5);
+  outline-offset: -1px;
+}
+.osd-matrix__label--clickable {
+  cursor: pointer;
+  border-radius: 4px;
+}
+.osd-matrix__label--clickable:hover {
+  background: var(--surface-200);
+}
+.osd-matrix__label--clickable:focus-visible {
+  outline: 2px solid var(--accent, #61dafb);
+  outline-offset: 1px;
+}
 .osd-matrix__col {
   text-align: center;
   font-size: 10px;
@@ -13260,11 +13301,10 @@ details.bf-gui-box:not([open]) > summary::after {
   }
 
   /* Exporting a backup file is a desktop task; on a phone keep Import Backup
-   * (used for cross-vehicle migration) plus Apply/Discard, and drop the three
-   * export buttons so the review card stops dominating the screen. */
+   * (used for cross-vehicle migration) plus Apply/Discard, and drop the
+   * export controls so the review card stops dominating the screen. */
   [data-testid="export-parameter-backup"],
-  [data-testid="export-parameter-backup-parm"],
-  [data-testid="export-parameter-backup-params"] {
+  [data-testid="export-parameter-backup-legacy"] {
     display: none;
   }
 

--- a/apps/web/src/views/Modes.tsx
+++ b/apps/web/src/views/Modes.tsx
@@ -138,6 +138,7 @@ export function ModesView(props: ModesViewProps) {
                       editedValues={editedValues!}
                       onChange={onChangeSlot!}
                       draftStatusById={draftStatusById!}
+                      allowCustomValue
                     />
                   ) : (
                     slot.modeLabel

--- a/apps/web/src/views/Osd.tsx
+++ b/apps/web/src/views/Osd.tsx
@@ -1,4 +1,4 @@
-import { useRef, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 
 import { Panel, StatusBadge, buttonStyle } from '@arduconfig/ui-kit'
 import type { ParameterState } from '@arduconfig/ardupilot-core'
@@ -235,6 +235,22 @@ export function OsdView(props: OsdViewProps) {
   const [analogLayout, setAnalogLayout] = useState<OsdAnalogLayout>('pal')
   const layout = OSD_ANALOG_LAYOUTS[analogLayout]
   const [draggingId, setDraggingId] = useState<string | undefined>(undefined)
+  // Clicking an element's row in the left checklist (or the element itself in
+  // the preview) highlights it on the other side and scrolls it into view —
+  // so an operator can find "which row is this?" / "where did that land?"
+  // without hunting. Click again to clear. Purely presentational; not backed
+  // by any FC state.
+  const [highlightedElementId, setHighlightedElementId] = useState<string | undefined>(undefined)
+  const previewElementRefs = useRef(new Map<string, HTMLSpanElement>())
+  const matrixRowRefs = useRef(new Map<string, HTMLDivElement>())
+  function toggleHighlightedElement(elementId: string): void {
+    setHighlightedElementId((current) => (current === elementId ? undefined : elementId))
+  }
+  useEffect(() => {
+    if (!highlightedElementId) return
+    previewElementRefs.current.get(highlightedElementId)?.scrollIntoView({ block: 'nearest', inline: 'nearest' })
+    matrixRowRefs.current.get(highlightedElementId)?.scrollIntoView({ block: 'nearest', inline: 'nearest' })
+  }, [highlightedElementId])
   const dragStateRef = useRef<{
     elementId: string
     pointerStartX: number
@@ -572,9 +588,30 @@ export function OsdView(props: OsdViewProps) {
                             const placed = previewById.get(row.elementId)
                             const enabledOnPreview = row.cells.some((cell) => cell.screen === activeScreen && matrixCellChecked(cell))
                             const showAlign = enabledOnPreview && dragEnabled && placed !== undefined && onElementMove !== undefined
+                            const isHighlighted = highlightedElementId === row.elementId
                             return (
-                              <div key={row.elementId} className="osd-matrix__row" data-testid={`osd-element-row-${row.elementId}`}>
-                                <span className="osd-matrix__label">
+                              <div
+                                key={row.elementId}
+                                ref={(node) => {
+                                  if (node) matrixRowRefs.current.set(row.elementId, node)
+                                  else matrixRowRefs.current.delete(row.elementId)
+                                }}
+                                className={`osd-matrix__row${isHighlighted ? ' is-highlighted' : ''}`}
+                                data-testid={`osd-element-row-${row.elementId}`}
+                              >
+                                <span
+                                  className="osd-matrix__label osd-matrix__label--clickable"
+                                  role="button"
+                                  tabIndex={0}
+                                  data-testid={`osd-element-row-label-${row.elementId}`}
+                                  onClick={() => toggleHighlightedElement(row.elementId)}
+                                  onKeyDown={(event) => {
+                                    if (event.key === 'Enter' || event.key === ' ') {
+                                      event.preventDefault()
+                                      toggleHighlightedElement(row.elementId)
+                                    }
+                                  }}
+                                >
                                   <strong>{row.label}</strong>
                                   <small>{row.elementId}</small>
                                 </span>
@@ -758,6 +795,7 @@ export function OsdView(props: OsdViewProps) {
                     >
                       {previewElements.map((element) => {
                         const isDragging = draggingId === element.id
+                        const isHighlighted = highlightedElementId === element.id
                         // Render at the element's position AS IT LANDS on the
                         // active layout. The raw param can sit beyond this grid
                         // (a 60-col HD layout viewed as 30-col PAL), so clamp to
@@ -767,11 +805,22 @@ export function OsdView(props: OsdViewProps) {
                         const className = [
                           'osd-preview-screen__element',
                           dragEnabled ? 'osd-preview-screen__element--draggable' : '',
-                          isDragging ? 'is-dragging' : ''
+                          isDragging ? 'is-dragging' : '',
+                          isHighlighted ? 'is-highlighted' : ''
                         ].filter(Boolean).join(' ')
+                        // Friendly name shown while dragging (or highlighted) —
+                        // element.text is the OSD-glyph preview string (e.g. the
+                        // dashes for HORIZON), not a readable name, so the
+                        // operator otherwise has no way to tell which element
+                        // they're moving.
+                        const friendlyLabel = matrixByElementId.get(element.id)?.label ?? element.id
                         return (
                           <span
                             key={element.id}
+                            ref={(node) => {
+                              if (node) previewElementRefs.current.set(element.id, node)
+                              else previewElementRefs.current.delete(element.id)
+                            }}
                             className={className}
                             data-testid={`osd-preview-element-${element.id}`}
                             style={{
@@ -782,11 +831,13 @@ export function OsdView(props: OsdViewProps) {
                             onPointerMove={dragEnabled ? moveElementDrag : undefined}
                             onPointerUp={dragEnabled ? endElementDrag : undefined}
                             onPointerCancel={dragEnabled ? endElementDrag : undefined}
+                            onClick={() => toggleHighlightedElement(element.id)}
                           >
                             {element.text}
-                            {isDragging ? (
-                              <span className="osd-preview-screen__element-pos" aria-hidden="true">
-                                {displayColumn},{displayRow}
+                            {isDragging || isHighlighted ? (
+                              <span className="osd-preview-screen__element-pos" aria-hidden="true" data-testid={`osd-preview-element-label-${element.id}`}>
+                                {friendlyLabel}
+                                {isDragging ? ` ${displayColumn},${displayRow}` : ''}
                               </span>
                             ) : null}
                           </span>

--- a/apps/web/src/views/ScopedField.tsx
+++ b/apps/web/src/views/ScopedField.tsx
@@ -1,4 +1,4 @@
-import type { ReactElement, ReactNode } from 'react'
+import { useState, type ReactElement, type ReactNode } from 'react'
 import type { ParameterState } from '@arduconfig/ardupilot-core'
 import { formatParamNumber, formatParamNumberInput } from '@arduconfig/param-metadata'
 
@@ -98,22 +98,82 @@ interface ScopedSelectFieldProps extends CommonScopedFieldProps {
    *  the option count is small enough; otherwise falls back to the native
    *  dropdown. Defaults to `'select'` (native dropdown). */
   layout?: 'select' | 'chips'
+  /** When true, an explicit "Custom…" option reveals a plain number input so
+   *  an unlisted enum value (e.g. a custom FLTMODEn, like scripting-defined
+   *  mode 29) can be typed directly instead of only ever showing as an
+   *  inert "N (unlisted)" label with no way to change it to another number.
+   *  Opt-in — every other ScopedSelectField usage is unaffected. */
+  allowCustomValue?: boolean
 }
 
+const CUSTOM_VALUE_SENTINEL = '__custom__'
+
 export function ScopedSelectField(props: ScopedSelectFieldProps) {
-  const { parameter, liveValue, editedValues, draftStatusById, onChange, compact = true, layout = 'select' } = props
+  const { parameter, liveValue, editedValues, draftStatusById, onChange, compact = true, layout = 'select', allowCustomValue = false } = props
   const options = parameter.definition?.options ?? []
   if (layout === 'chips' && shouldRenderOptionChips(options.length)) {
     return <ScopedOptionChipsField {...props} />
   }
   const status = statusModifier(draftStatusById, parameter.id)
   const currentValue = editedValues[parameter.id] ?? String(liveValue ?? '')
+  const matchesKnownOption = options.some((option) => String(option.value) === currentValue)
+  // Sticky "I picked Custom…" flag — without it, typing e.g. "6" (a real
+  // FLTMODE value) into the number input would make matchesKnownOption true
+  // again and the custom input would vanish out from under the operator's
+  // cursor mid-edit.
+  const [customModeForced, setCustomModeForced] = useState(false)
+  const showCustomInput = allowCustomValue && (customModeForced || (currentValue !== '' && !matchesKnownOption))
+
+  if (allowCustomValue) {
+    return (
+      <label className={fieldClassName(draftStatusById, parameter.id, compact)}>
+        <span>{parameter.definition?.label ?? parameter.id}</span>
+        <span className="scoped-select-with-custom">
+          <select
+            data-testid={`scoped-select-${parameter.id}`}
+            value={showCustomInput ? CUSTOM_VALUE_SENTINEL : currentValue}
+            onChange={(event) => {
+              if (event.target.value === CUSTOM_VALUE_SENTINEL) {
+                setCustomModeForced(true)
+              } else {
+                setCustomModeForced(false)
+                onChange(parameter.id, event.target.value)
+              }
+            }}
+          >
+            {options.map((option) => (
+              <option key={`${parameter.id}:${option.value}`} value={String(option.value)}>
+                {option.label}
+              </option>
+            ))}
+            <option value={CUSTOM_VALUE_SENTINEL}>Custom…</option>
+          </select>
+          {showCustomInput ? (
+            <input
+              type="number"
+              data-testid={`scoped-select-custom-${parameter.id}`}
+              className="scoped-select-with-custom__input"
+              value={currentValue}
+              aria-label={`Custom ${parameter.definition?.label ?? parameter.id} value`}
+              onChange={(event) => onChange(parameter.id, event.target.value)}
+            />
+          ) : null}
+        </span>
+        <StagedWasLine
+          status={status}
+          liveValue={liveValue}
+          options={parameter.definition?.options}
+        />
+      </label>
+    )
+  }
+
   // Surface a value that isn't one of the listed options as its own option, so a
   // native <select> shows the real value instead of silently falling back to the
   // first option (which misreads e.g. an unlisted pin as "Disabled").
   const currentNumber = Number(currentValue)
   const renderedOptions =
-    currentValue !== '' && Number.isFinite(currentNumber) && !options.some((option) => String(option.value) === currentValue)
+    currentValue !== '' && Number.isFinite(currentNumber) && !matchesKnownOption
       ? [...options, { value: currentNumber, label: `${currentValue} (unlisted)` }]
       : options
   return (

--- a/tests/e2e/views.spec.ts
+++ b/tests/e2e/views.spec.ts
@@ -267,6 +267,53 @@ test.describe('Parameters tab (expert-only)', () => {
     await search.fill('')
     expect(await dataRows.count()).toBeGreaterThan(10)
   })
+
+  test('global "Show changes" scrolls to the diff grid after switching tabs', async ({ page }) => {
+    // The reported bug: clicking Show changes from another tab switched to
+    // Parameters but dropped the operator wherever they last scrolled,
+    // leaving the diff grid to hunt for.
+    await page.goto('/')
+    await connectViaHeader(page)
+    await page.getByTestId('product-mode-expert').click()
+    await page.getByTestId('view-button-parameters').click()
+
+    const search = page.getByTestId('parameter-search-input')
+    await search.fill('BATT_LOW_VOLT')
+    await page.locator('input[aria-label="BATT_LOW_VOLT value"]').fill('13.5')
+    await search.fill('')
+
+    // Navigate away — the global draft bar should follow across tabs.
+    await page.getByTestId('view-button-config').click()
+    await expect(page.getByTestId('global-draft-bar')).toBeVisible()
+
+    await page.getByTestId('global-draft-show').click()
+    await expect(page.getByTestId('workspace-view-title')).toHaveText('Parameters')
+    await expect(page.getByTestId('parameter-diff-grid')).toBeInViewport()
+  })
+
+  test('Export collapses to one primary button + an Export Legacy format picker', async ({ page }) => {
+    // Was three buttons (Export JSON / .parm / .params) with no explanation of
+    // why they exist. Now: one primary Export (native JSON) plus a legacy
+    // select for the two ground-station formats, used only when a specific
+    // tool needs them.
+    await page.goto('/')
+    await connectViaHeader(page)
+    await page.getByTestId('product-mode-expert').click()
+    await page.getByTestId('view-button-parameters').click()
+
+    await expect(page.getByTestId('export-parameter-backup')).toHaveText('Export')
+    const legacySelect = page.getByTestId('export-parameter-backup-legacy')
+    await expect(legacySelect).toHaveValue('')
+    const optionLabels = await legacySelect.locator('option').allTextContents()
+    expect(optionLabels).toEqual(['Export Legacy…', 'Mission Planner (.parm)', 'QGroundControl (.params)'])
+
+    // Picking a format triggers its export and resets to the placeholder —
+    // reads as a one-shot action, not a persistent mode.
+    const download = page.waitForEvent('download')
+    await legacySelect.selectOption('parm')
+    await download
+    await expect(legacySelect).toHaveValue('')
+  })
 })
 
 test.describe('tab order', () => {
@@ -1568,6 +1615,30 @@ test.describe('Receiver flight-mode labels', () => {
     // for the previously unset 4..6 slots (was: "Mode <n>" placeholders).
     await expect(table.locator('[data-testid^="modes-slot-"]')).toHaveCount(6)
   })
+
+  test('flight-mode slot supports typing an unlisted mode number via Custom…', async ({ page }) => {
+    // Reported gap: an unlisted mode number (e.g. a scripting-defined 29) only
+    // ever showed as an inert "29 (unlisted)" label with no way to type a
+    // different raw number without leaving for the raw Parameters tab.
+    await page.goto('/')
+    await connectViaHeader(page)
+    await openView(page, 'modes')
+    const table = page.getByTestId('modes-slot-table')
+    const slot5 = table.getByTestId('modes-slot-5')
+    const select = slot5.locator('select')
+    await expect(select).toHaveValue('16') // PosHold
+
+    await select.selectOption('__custom__')
+    const customInput = slot5.locator('input[type="number"]')
+    await expect(customInput).toBeVisible()
+    await customInput.fill('29')
+    await expect(page.getByTestId('global-draft-bar')).toBeVisible()
+
+    // Picking a named mode again returns to the plain dropdown.
+    await select.selectOption('9') // Land
+    await expect(slot5.locator('input[type="number"]')).toHaveCount(0)
+    await expect(select).toHaveValue('9')
+  })
 })
 
 test.describe('Receiver RSSI', () => {
@@ -1695,6 +1766,35 @@ test.describe('OSD view preview', () => {
     await expect(page.getByTestId('osd-preview-element-GSPEED')).toHaveCount(0)
     await expect(page.getByTestId('osd-preview-element-HOME')).toHaveCount(0)
     await expect(page.getByTestId('osd-preview-element-HORIZON')).toHaveCount(0)
+  })
+
+  test('clicking a checklist row highlights the element in the preview, and vice versa', async ({ page }) => {
+    await page.goto('/')
+    await connectViaHeader(page)
+    await openView(page, 'osd')
+
+    const row = page.getByTestId('osd-element-row-BAT_VOLT')
+    const rowLabel = page.getByTestId('osd-element-row-label-BAT_VOLT')
+    const previewElement = page.getByTestId('osd-preview-element-BAT_VOLT')
+    await expect(previewElement).toBeVisible()
+    await expect(row).not.toHaveClass(/is-highlighted/)
+    await expect(previewElement).not.toHaveClass(/is-highlighted/)
+
+    // Clicking the checklist row highlights the corresponding preview element.
+    await rowLabel.click()
+    await expect(row).toHaveClass(/is-highlighted/)
+    await expect(previewElement).toHaveClass(/is-highlighted/)
+    await expect(page.getByTestId('osd-preview-element-label-BAT_VOLT')).toBeVisible()
+
+    // Clicking it again clears the highlight.
+    await rowLabel.click()
+    await expect(row).not.toHaveClass(/is-highlighted/)
+    await expect(previewElement).not.toHaveClass(/is-highlighted/)
+
+    // Clicking the preview element itself highlights the checklist row too.
+    await previewElement.click()
+    await expect(row).toHaveClass(/is-highlighted/)
+    await expect(previewElement).toHaveClass(/is-highlighted/)
   })
 
   test('enabling an element with no live-telemetry text still adds it to the preview', async ({ page }) => {


### PR DESCRIPTION
Four usability fixes from a round of live UX feedback.

**OSD editor** — clicking an element in the checklist highlights it in the preview and scrolls it into view (and vice versa). Dragging/highlighting an element now shows its friendly name, not just an X,Y coordinate.

**Parameters "Show changes"** — now scrolls the diff grid (invalid rows first) into view instead of leaving the operator wherever they last scrolled. A request-id counter resets whenever the operator leaves the tab, so an unrelated manual nav back to Parameters doesn't trigger an unwanted auto-scroll.

**Export buttons** — collapses `Export JSON / .parm / .params` into one primary **Export** button (native JSON) plus an **Export Legacy** select revealing the Mission Planner / QGroundControl sub-choice.

**Flight Modes** — `ScopedSelectField` gains an opt-in `allowCustomValue` prop; picking "Custom…" reveals a number input for typing an unlisted mode value directly. Opt-in, so every other usage of the shared field elsewhere is unaffected — only enabled on the flight-mode slot editor.

**ArduCopter byte-identical:** presentational/UI only; no runtime/transport/param-metadata edits.

**Validation:** typecheck clean; node --test 685; vitest 455; Playwright 142 (+4).