### PR TITLE
feat(ui): show the real ArduPilot parameter name under every field's label

### DIFF
--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -7047,6 +7047,19 @@ textarea:focus {
   text-transform: none;
 }
 
+/* The raw ArduPilot parameter name shown under every friendly label (e.g.
+ * "Vertical speed" / VSPEED) — muted and monospace so it reads as metadata,
+ * not as a second label competing with the one above it. */
+.scoped-editor-field__param-id {
+  display: block;
+  margin-top: 1px;
+  color: var(--text-dim, var(--text-muted));
+  font-family: var(--font-data);
+  font-size: 10px;
+  letter-spacing: 0.02em;
+  text-transform: none;
+}
+
 .scoped-editor-field input,
 .scoped-editor-field select,
 .scoped-editor-field textarea {
@@ -11766,6 +11779,11 @@ details.metadata-settings-section:not([open]) > summary::after {
 .modes-table__row span {
   font-size: 13px;
   color: var(--text);
+}
+
+.modes-table__mode-readonly {
+  display: flex;
+  flex-direction: column;
 }
 
 .modes-table__row--head span {

--- a/apps/web/src/views/Failsafe.tsx
+++ b/apps/web/src/views/Failsafe.tsx
@@ -93,7 +93,6 @@ export function FailsafeView(props: FailsafeViewProps) {
               >
                 <div className="config-section__header">
                   <span className="config-section__kicker">{row.source}</span>
-                  <code>{row.paramId}</code>
                 </div>
                 {row.parameter ? (
                   <ScopedField

--- a/apps/web/src/views/Modes.tsx
+++ b/apps/web/src/views/Modes.tsx
@@ -141,7 +141,12 @@ export function ModesView(props: ModesViewProps) {
                       allowCustomValue
                     />
                   ) : (
-                    slot.modeLabel
+                    <span className="modes-table__mode-readonly">
+                      {slot.modeLabel}
+                      {slot.parameter ? (
+                        <small className="scoped-editor-field__param-id">{slot.parameter.id}</small>
+                      ) : null}
+                    </span>
                   )}
                 </span>
                 <span role="cell">

--- a/apps/web/src/views/ScopedField.tsx
+++ b/apps/web/src/views/ScopedField.tsx
@@ -26,6 +26,27 @@ function fieldClassName(map: ScopedFieldDraftMap, paramId: string, compact: bool
 }
 
 /**
+ * Small always-visible line showing the raw ArduPilot parameter name next to
+ * its friendly label (e.g. "Vertical speed" / "VSPEED") — the label alone
+ * doesn't tell an operator what to search the wiki or the raw Parameters tab
+ * for. Skipped when there's no friendly label: in that case `parameter.id` IS
+ * already the label text, so showing it again would be a plain duplicate.
+ */
+function ParamIdHint({ parameter }: { parameter: ParameterState }): ReactElement | null {
+  if (!parameter.definition?.label) return null
+  // aria-hidden: purely decorative metadata, and — since several of these
+  // components wrap their control in a <label> — without it the browser
+  // folds this text into the <label>'s accessible name (e.g. "Roll Angle P"
+  // becomes "Roll Angle PATC_ANG_RLL_P"), breaking any getByLabel(exact) query
+  // and any screen-reader announcement of the control.
+  return (
+    <small className="scoped-editor-field__param-id" aria-hidden="true">
+      {parameter.id}
+    </small>
+  )
+}
+
+/**
  * Render "was: X" small text below a staged editor so the operator can
  * see the live-snapshot value that's about to be overwritten. Returns
  * null for unchanged / invalid fields — only show on actually-staged
@@ -125,12 +146,15 @@ export function ScopedSelectField(props: ScopedSelectFieldProps) {
   const showCustomInput = allowCustomValue && (customModeForced || (currentValue !== '' && !matchesKnownOption))
 
   if (allowCustomValue) {
+    const fieldLabel = parameter.definition?.label ?? parameter.id
     return (
       <label className={fieldClassName(draftStatusById, parameter.id, compact)}>
-        <span>{parameter.definition?.label ?? parameter.id}</span>
+        <span>{fieldLabel}</span>
+        <ParamIdHint parameter={parameter} />
         <span className="scoped-select-with-custom">
           <select
             data-testid={`scoped-select-${parameter.id}`}
+            aria-label={fieldLabel}
             value={showCustomInput ? CUSTOM_VALUE_SENTINEL : currentValue}
             onChange={(event) => {
               if (event.target.value === CUSTOM_VALUE_SENTINEL) {
@@ -154,7 +178,7 @@ export function ScopedSelectField(props: ScopedSelectFieldProps) {
               data-testid={`scoped-select-custom-${parameter.id}`}
               className="scoped-select-with-custom__input"
               value={currentValue}
-              aria-label={`Custom ${parameter.definition?.label ?? parameter.id} value`}
+              aria-label={`Custom ${fieldLabel} value`}
               onChange={(event) => onChange(parameter.id, event.target.value)}
             />
           ) : null}
@@ -176,10 +200,12 @@ export function ScopedSelectField(props: ScopedSelectFieldProps) {
     currentValue !== '' && Number.isFinite(currentNumber) && !matchesKnownOption
       ? [...options, { value: currentNumber, label: `${currentValue} (unlisted)` }]
       : options
+  const fieldLabel = parameter.definition?.label ?? parameter.id
   return (
     <label className={fieldClassName(draftStatusById, parameter.id, compact)}>
-      <span>{parameter.definition?.label ?? parameter.id}</span>
-      <select value={currentValue} onChange={(event) => onChange(parameter.id, event.target.value)}>
+      <span>{fieldLabel}</span>
+      <ParamIdHint parameter={parameter} />
+      <select aria-label={fieldLabel} value={currentValue} onChange={(event) => onChange(parameter.id, event.target.value)}>
         {renderedOptions.map((valueOption) => (
           <option key={`${parameter.id}:${valueOption.value}`} value={String(valueOption.value)}>
             {valueOption.label}
@@ -234,14 +260,17 @@ export function ScopedNumberField(props: ScopedNumberFieldProps) {
   const step =
     parameter.definition?.step ??
     inferStep(parameter.definition?.minimum, parameter.definition?.maximum, stepFallback)
+  const fieldLabel = parameter.definition?.label ?? parameter.id
   return (
     <label className={fieldClassName(draftStatusById, parameter.id, compact)}>
       <span>
-        {parameter.definition?.label ?? parameter.id}
+        {fieldLabel}
         {unit ? <small className="scoped-editor-field__unit"> ({unit})</small> : null}
       </span>
+      <ParamIdHint parameter={parameter} />
       <input
         type="number"
+        aria-label={fieldLabel}
         min={parameter.definition?.minimum}
         max={parameter.definition?.maximum}
         step={step}
@@ -299,6 +328,7 @@ export function ScopedBitmaskField(props: CommonScopedFieldProps) {
       data-testid={`scoped-bitmask-${parameter.id}`}
     >
       <span>{parameter.definition?.label ?? parameter.id}</span>
+      <ParamIdHint parameter={parameter} />
       <div className="scoped-bitmask-bits">
         {options.map((option) => {
           const bit = option.value
@@ -345,6 +375,7 @@ export function ScopedOptionChipsField(props: CommonScopedFieldProps) {
       data-testid={`scoped-chips-${parameter.id}`}
     >
       <span>{parameter.definition?.label ?? parameter.id}</span>
+      <ParamIdHint parameter={parameter} />
       <div className="scoped-option-chips" role="radiogroup">
         {options.map((option) => {
           const selected = String(option.value) === current

--- a/apps/web/src/views/ServoFunctionMapping.tsx
+++ b/apps/web/src/views/ServoFunctionMapping.tsx
@@ -112,7 +112,6 @@ export function ServoFunctionMappingView(props: ServoFunctionMappingViewProps) {
                   >
                     <th scope="row" className="servo-mapping__channel">
                       <strong>SERVO{channel}</strong>
-                      <small>{row.parameter.id}</small>
                     </th>
                     <td className="servo-mapping__function">
                       <ScopedSelectField

--- a/tests/e2e/views.spec.ts
+++ b/tests/e2e/views.spec.ts
@@ -1505,6 +1505,26 @@ test.describe('Config view', () => {
     // than the ambiguous "Primary GPS" substring shared by both.
     await expect(gps.getByText('Primary GPS Select')).toBeVisible()
   })
+
+  test('an editable field shows the raw ArduPilot parameter name under its label', async ({ page }) => {
+    // Reported gap: friendly labels alone don't tell the operator what to
+    // search the wiki/Parameters tab for. Centralized in ScopedField's shared
+    // components, so any editable field is representative — Main loop rate
+    // (SCHED_LOOP_RATE) in the system-rates section.
+    await page.goto('/')
+    await page.getByTestId('transport-mode-select').selectOption('demo')
+    await page.getByTestId('connect-button').click()
+    await page.getByTestId('view-button-config').click()
+
+    const rates = page.getByTestId('config-section-system-rates')
+    const field = rates.locator('.scoped-editor-field', { hasText: 'Main loop rate' })
+    await expect(field.locator('.scoped-editor-field__param-id')).toHaveText('SCHED_LOOP_RATE')
+
+    // Regression guard: the id hint must not pollute the control's accessible
+    // name (a <label> concatenates ALL its text by default) — an exact
+    // getByLabel query on the friendly label alone must still resolve.
+    await expect(field.getByLabel('Main loop rate', { exact: true })).toBeVisible()
+  })
 })
 
 // The receiver Bind (ELRS/CRSF) button is currently hidden in the UI


### PR DESCRIPTION
Centralizes a UI feedback item ("might be interesting to have an 'i' that tells you the actual param name in most spots") by fixing it once in the shared field components, rather than editing dozens of views individually.

## What changed

Traced first: a handful of views (Failsafe, ServoFunctionMapping, Config's read-only rows, Ports, OSD) already show the raw param id next to the label — just inconsistently. Root cause: **21 files** render editable fields through the shared `ScopedSelectField`/`ScopedNumberField`/`ScopedBitmaskField`/`ScopedOptionChipsField` family in `ScopedField.tsx`, and none of them ever show `parameter.id` as a distinct element.

Adds a `ParamIdHint` helper, rendered after the label in all five shared components — propagating to the large majority of the 21 call sites at once. Confirmed with the user: always-visible small text matching the existing convention, not a new hover tooltip.

Also: `Modes.tsx`'s read-only flight-mode-slot fallback (outside the shared components) gains the same hint; `Failsafe.tsx`/`ServoFunctionMapping.tsx` had their own now-redundant id displays removed.

## Caught during validation

A `<label>` concatenates **all** its text into the wrapped control's accessible name by default, so the new hint broke an existing `getByLabel(exact)` e2e query. Fixed by pinning each control's accessible name via an explicit `aria-label` — a correctness fix (screen readers would've announced the id too), not just a test workaround. A new e2e assertion guards against regressing this class of bug again.

**ArduCopter byte-identical:** presentational only; no runtime/transport/param-metadata changes.

**Validation:** typecheck clean; node --test 685; vitest 455; Playwright 143 (+2 new).