### PR TITLE
fix(receiver): correct reversed pitch preview; fix flaky param-id-hint e2e test

### DIFF
--- a/apps/web/src/preview-components.tsx
+++ b/apps/web/src/preview-components.tsx
@@ -158,16 +158,23 @@ export function StickCraftPreview({
   return (
     // display:contents wrapper exposes the live attitude for tests without
     // affecting layout (e.g. asserting a centred yaw holds heading).
+    //
+    // rollNorm/pitchNorm are ArduPilot's own norm_input() convention (verified
+    // against rc_input_to_roll_pitch_rad + its unit test in AP_Math): positive
+    // norm_input -> positive target angle -> roll-right / pitch-up. FlightDeckPreview's
+    // rollDeg/pitchDeg use that same positive-is-up/right convention directly
+    // (confirmed by the other FlightDeckPreview call site, which feeds real
+    // ATTITUDE.pitch/roll unmodified) — neither axis needs a sign flip here.
     <div
       style={{ display: 'contents' }}
       data-testid="receiver-stick-attitude"
       data-yaw-heading={Math.round(yawHeading)}
       data-roll-deg={Math.round(rollNorm * 35)}
-      data-pitch-deg={Math.round(-pitchNorm * 35)}
+      data-pitch-deg={Math.round(pitchNorm * 35)}
     >
       <FlightDeckPreview
         rollDeg={rollNorm * 35}
-        pitchDeg={-pitchNorm * 35}
+        pitchDeg={pitchNorm * 35}
         yawDeg={yawHeading}
         captionLabel={verified ? '' : 'Waiting on live RC input'}
         flightMode="Stick preview"

--- a/tests/e2e/views.spec.ts
+++ b/tests/e2e/views.spec.ts
@@ -1509,21 +1509,26 @@ test.describe('Config view', () => {
   test('an editable field shows the raw ArduPilot parameter name under its label', async ({ page }) => {
     // Reported gap: friendly labels alone don't tell the operator what to
     // search the wiki/Parameters tab for. Centralized in ScopedField's shared
-    // components, so any editable field is representative — Main loop rate
-    // (SCHED_LOOP_RATE) in the system-rates section.
+    // components, so any editable field is representative — Fast sampling
+    // (INS_FAST_SAMPLE) in the system-rates section. NOTE: not Main loop rate
+    // (SCHED_LOOP_RATE) — that one has <= 8 enum options and Config.tsx
+    // renders it via the chip-grid layout (ScopedOptionChipsField), which is
+    // a role="radiogroup" of buttons with no single labelled control for
+    // getByLabel to match. INS_FAST_SAMPLE has no enum options, so it goes
+    // through ScopedNumberField's plain aria-label'd <input> instead.
     await page.goto('/')
     await page.getByTestId('transport-mode-select').selectOption('demo')
     await page.getByTestId('connect-button').click()
     await page.getByTestId('view-button-config').click()
 
     const rates = page.getByTestId('config-section-system-rates')
-    const field = rates.locator('.scoped-editor-field', { hasText: 'Main loop rate' })
-    await expect(field.locator('.scoped-editor-field__param-id')).toHaveText('SCHED_LOOP_RATE')
+    const field = rates.locator('.scoped-editor-field', { hasText: 'Fast sampling' })
+    await expect(field.locator('.scoped-editor-field__param-id')).toHaveText('INS_FAST_SAMPLE')
 
     // Regression guard: the id hint must not pollute the control's accessible
     // name (a <label> concatenates ALL its text by default) — an exact
     // getByLabel query on the friendly label alone must still resolve.
-    await expect(field.getByLabel('Main loop rate', { exact: true })).toBeVisible()
+    await expect(field.getByLabel('Fast sampling (IMU mask)', { exact: true })).toBeVisible()
   })
 })
 


### PR DESCRIPTION
## Summary
- Fixes reversed pitch detection in the Receiver Endpoints stick-driven craft preview (`StickCraftPreview`) — an erroneous sign flip was applied to pitch only, inverting nose-up/down relative to ArduPilot's own `rc_input_to_roll_pitch_rad` convention. Verified against `AP_Math/control.cpp` + its unit test, and against the sibling `FlightDeckPreview` call site that renders real ATTITUDE telemetry unmodified.
- Fixes an e2e test (`an editable field shows the raw ArduPilot parameter name under its label`, from PR #9) that was failing intermittently under full-suite load and in CI. Root cause: it targeted "Main loop rate" (`SCHED_LOOP_RATE`), which `Config.tsx` renders via the chip-grid layout (`ScopedOptionChipsField`, a `role="radiogroup"` of buttons) since it has <= 8 enum options — there was never a genuinely labelled single control there for `getByLabel(exact)` to match. Retargeted to `INS_FAST_SAMPLE` ("Fast sampling"), which has no enum options and renders through `ScopedNumberField`'s plain `aria-label`'d `<input>`.

## ArduCopter byte-identical
UI/test-only — preview-component render math and an e2e test target. No runtime, transport, or param-metadata changes.

## Test plan
- [x] `npm run typecheck`
- [x] `npm run test` (node suite)
- [x] `npm run build`
- [x] `npx playwright test tests/e2e/views.spec.ts` — full suite, 143/143 passed
- [x] Targeted re-run of the fixed test with `--repeat-each=3` — stable