### PR TITLE
fix(rc-mixer): show only AUX channels, not primary stick axes or mode switch

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -132,7 +132,7 @@ import {
   formatCurrent,
   formatRemaining
 } from './device-display'
-import { buildRcChannelDisplays } from './rc-channel-helpers'
+import { buildRcChannelDisplays, derivePrimaryAndModeChannels } from './rc-channel-helpers'
 import {
   connectButtonLabel,
   describeConnectFailure,
@@ -4760,9 +4760,10 @@ export function App() {
     () => buildRcMixerFunctionLookup(rcLogicFunctionCatalogMemo),
     [rcLogicFunctionCatalogMemo]
   )
+  const rcLogicExcludedChannels = useMemo(() => derivePrimaryAndModeChannels(snapshot), [snapshot])
   const rcLogicChannels = useMemo(
-    () => groupAssignmentsByChannel(rcLogicModel.assignments),
-    [rcLogicModel.assignments]
+    () => groupAssignmentsByChannel(rcLogicModel.assignments, 16, rcLogicExcludedChannels),
+    [rcLogicModel.assignments, rcLogicExcludedChannels]
   )
   function handleRcLogicAddAssignment(channel: number): void {
     const drafts = rcLogicAddDrafts(rcLogicModel, channel)

--- a/apps/web/src/hooks/use-rc-mixer.ts
+++ b/apps/web/src/hooks/use-rc-mixer.ts
@@ -7,6 +7,7 @@ import { useCallback, useMemo, useState } from 'react'
 
 import type { ConfiguratorSnapshot } from '@arduconfig/ardupilot-core'
 
+import { derivePrimaryAndModeChannels } from '../rc-channel-helpers'
 import {
   buildRcMixerFunctionLookup,
   createAssignment,
@@ -19,9 +20,10 @@ import {
 export function useRcMixer(snapshot: ConfiguratorSnapshot) {
   const [rcMixerState, setRcMixerState] = useState<RcMixerState>(createIdleRcMixerState)
   const rcMixerFunctionLookup = useMemo(() => buildRcMixerFunctionLookup(), [])
+  const excludedChannels = useMemo(() => derivePrimaryAndModeChannels(snapshot), [snapshot])
   const rcMixerChannels = useMemo(
-    () => groupAssignmentsByChannel(rcMixerState.assignments),
-    [rcMixerState.assignments]
+    () => groupAssignmentsByChannel(rcMixerState.assignments, 16, excludedChannels),
+    [rcMixerState.assignments, excludedChannels]
   )
   const rcMixerLivePwmByChannel = useMemo(() => {
     const map = new Map<number, number>()

--- a/apps/web/src/rc-channel-helpers.ts
+++ b/apps/web/src/rc-channel-helpers.ts
@@ -68,6 +68,22 @@ export function getModeChannelNumber(snapshot: ConfiguratorSnapshot): number | u
   return configuredChannel >= 1 && configuredChannel <= 16 ? configuredChannel : undefined
 }
 
+/**
+ * Channels reserved for the primary stick axes (RCMAP_ROLL/PITCH/THROTTLE/YAW)
+ * and the flight-mode switch. ArduPilot's RCn_OPTION / AP_RC_Logic AUX
+ * functions are never assigned to these in practice, so views that edit AUX
+ * functions only (e.g. the RC Mixer tab) exclude them rather than listing all
+ * 16 channels.
+ */
+export function derivePrimaryAndModeChannels(snapshot: ConfiguratorSnapshot): Set<number> {
+  const channels = new Set<number>(buildRcmapRoleByChannel(snapshot).keys())
+  const modeChannel = getModeChannelNumber(snapshot)
+  if (modeChannel !== undefined) {
+    channels.add(modeChannel)
+  }
+  return channels
+}
+
 export function buildRcChannelDisplays(snapshot: ConfiguratorSnapshot, visibleCount = 8): RcChannelDisplay[] {
   const modeChannelNumber = getModeChannelNumber(snapshot)
   const assignedRcOptionChannels = deriveAssignedRcOptionChannels(snapshot)

--- a/apps/web/src/view-models/rc-mixer.test.ts
+++ b/apps/web/src/view-models/rc-mixer.test.ts
@@ -58,4 +58,9 @@ describe('groupAssignmentsByChannel', () => {
     expect(groups).toHaveLength(4)
     expect(groups.every((group) => group.assignments.length === 0)).toBe(true)
   })
+
+  it('omits excluded channels (e.g. the primary stick axes) from the rows entirely', () => {
+    const groups = groupAssignmentsByChannel([assign(2)], 6, new Set([1, 2, 3, 4]))
+    expect(groups.map((group) => group.channel)).toEqual([5, 6])
+  })
 })

--- a/apps/web/src/view-models/rc-mixer.ts
+++ b/apps/web/src/view-models/rc-mixer.ts
@@ -106,14 +106,21 @@ export function buildRcMixerFunctionLookup(
 /**
  * Group assignments by channel for the channel-row layout. Channels with no
  * assignments are still surfaced so the UI can show "+ Add" affordances on
- * every channel in the 1..maxChannel range.
+ * every channel in the 1..maxChannel range — except those in `excludeChannels`
+ * (the primary stick axes and the flight-mode switch), which never get an AUX
+ * function assigned in practice and would otherwise clutter the mixer with
+ * rows nobody uses.
  */
 export function groupAssignmentsByChannel(
   assignments: readonly RcMixerAssignment[],
-  maxChannel = 16
+  maxChannel = 16,
+  excludeChannels?: ReadonlySet<number>
 ): Array<{ channel: number; assignments: RcMixerAssignment[] }> {
   const byChannel = new Map<number, RcMixerAssignment[]>()
   for (let channel = 1; channel <= maxChannel; channel += 1) {
+    if (excludeChannels?.has(channel)) {
+      continue
+    }
     byChannel.set(channel, [])
   }
   for (const assignment of assignments) {

--- a/tests/e2e/views.spec.ts
+++ b/tests/e2e/views.spec.ts
@@ -1532,6 +1532,29 @@ test.describe('Config view', () => {
   })
 })
 
+test.describe('RC Mixer view', () => {
+  test('shows only AUX channels, not the primary stick axes or the mode switch', async ({ page }) => {
+    // Demo Copter: RCMAP_ROLL/PITCH/THROTTLE/YAW = 1/2/3/4, FLTMODE_CH = 7,
+    // RCL_ENABLE = 1 with real range terms on ch5 (ArmDisarm) and ch6 (LAND).
+    // Channels 1-4 and 7 are stick axes / the mode switch, never AUX
+    // candidates in practice — the mixer should skip them entirely rather
+    // than listing all 16 channels.
+    await page.goto('/')
+    await page.getByTestId('transport-mode-select').selectOption('demo')
+    await page.getByTestId('connect-button').click()
+    await page.getByTestId('product-mode-expert').check()
+    await page.getByTestId('view-button-rc-mixer').click()
+
+    for (const channel of [1, 2, 3, 4, 7]) {
+      await expect(page.getByTestId(`rc-mixer-channel-${channel}`)).toHaveCount(0)
+    }
+    // AUX channels remain, including the ones with real assigned functions.
+    await expect(page.getByTestId('rc-mixer-channel-5')).toBeVisible()
+    await expect(page.getByTestId('rc-mixer-channel-6')).toBeVisible()
+    await expect(page.getByTestId('rc-mixer-channel-8')).toBeVisible()
+  })
+})
+
 // The receiver Bind (ELRS/CRSF) button is currently hidden in the UI
 // (SHOW_RECEIVER_BIND_BUTTON=false in ReceiverSection.tsx); the runtime
 // startReceiverBind path stays covered by tests/runtime.integration.test.mjs.


### PR DESCRIPTION
## Summary
- RC Mixer tab (both the preview scaffold and the real AP_RC_Logic editor) now only lists AUX-candidate channels — excludes RCMAP_ROLL/PITCH/THROTTLE/YAW and the flight-mode-switch channel, since ArduPilot never assigns AUX functions to those in practice.
- `groupAssignmentsByChannel()` gained an `excludeChannels` param; new `derivePrimaryAndModeChannels()` helper in `rc-channel-helpers.ts` computes the exclusion set from the live snapshot (RCMAP-aware, not a hardcoded 1-4), reusing the same detection the Receiver tab already relies on.

## ArduCopter byte-identical
UI-only — filters which channel rows render; no new writes, existing RCL_*/scaffold write paths unchanged.

## Test plan
- [x] `npm run typecheck`
- [x] `npm run test` (685 passed)
- [x] `npm run test:unit --workspace @arduconfig/web` (456 passed, incl. new groupAssignmentsByChannel exclude-set test)
- [x] `npx playwright test tests/e2e/views.spec.ts` — full suite, 144/144 passed (incl. new RC Mixer aux-channel test)