### PR TITLE
fix(osd,rc-mixer,firmware-flash): free-follow OSD drag, vehicle-aware RC Mixer functions, O(n) hex parsing

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -368,7 +368,6 @@ import {
   type AdditionalSettingsGroup
 } from './view-models/peripherals'
 import {
-  RC_MIXER_FUNCTION_CATALOG,
   buildRcMixerFunctionLookup,
   groupAssignmentsByChannel,
   type RcMixerAssignment
@@ -4640,6 +4639,7 @@ export function App() {
   )
   const {
     rcMixerChannels,
+    rcMixerFunctionCatalog,
     rcMixerFunctionLookup,
     rcMixerLivePwmByChannel,
     handleRcMixerAddAssignment,
@@ -7495,7 +7495,7 @@ export function App() {
       {activeViewId === 'rc-mixer' ? (
       <RcMixerView
         channels={hasRcLogicParams ? rcLogicChannels : rcMixerChannels}
-        functionCatalog={hasRcLogicParams ? rcLogicFunctionCatalogMemo : RC_MIXER_FUNCTION_CATALOG}
+        functionCatalog={hasRcLogicParams ? rcLogicFunctionCatalogMemo : rcMixerFunctionCatalog}
         functionLookup={hasRcLogicParams ? rcLogicFunctionLookup : rcMixerFunctionLookup}
         livePwmByChannel={rcMixerLivePwmByChannel}
         rcLinkLive={snapshot.liveVerification.rcInput.verified}

--- a/apps/web/src/hooks/use-rc-mixer.ts
+++ b/apps/web/src/hooks/use-rc-mixer.ts
@@ -12,14 +12,27 @@ import {
   buildRcMixerFunctionLookup,
   createAssignment,
   createIdleRcMixerState,
+  filterRcMixerFunctionCatalogForVehicle,
   groupAssignmentsByChannel,
+  RC_MIXER_FUNCTION_CATALOG,
   type RcMixerAssignment,
   type RcMixerState
 } from '../view-models/rc-mixer'
 
 export function useRcMixer(snapshot: ConfiguratorSnapshot) {
   const [rcMixerState, setRcMixerState] = useState<RcMixerState>(createIdleRcMixerState)
-  const rcMixerFunctionLookup = useMemo(() => buildRcMixerFunctionLookup(), [])
+  // Scaffold catalog covers all four vehicles' worth of BF-style AUX ideas;
+  // filter to what the connected firmware actually supports (AutoTune/LAND/
+  // parachutes/Precision Loiter/airmode aren't universal) rather than
+  // showing Rover a "Precision Loiter" entry it can never use.
+  const rcMixerFunctionCatalog = useMemo(
+    () => filterRcMixerFunctionCatalogForVehicle(RC_MIXER_FUNCTION_CATALOG, snapshot.vehicle?.vehicle),
+    [snapshot.vehicle?.vehicle]
+  )
+  const rcMixerFunctionLookup = useMemo(
+    () => buildRcMixerFunctionLookup(rcMixerFunctionCatalog),
+    [rcMixerFunctionCatalog]
+  )
   const excludedChannels = useMemo(() => derivePrimaryAndModeChannels(snapshot), [snapshot])
   const rcMixerChannels = useMemo(
     () => groupAssignmentsByChannel(rcMixerState.assignments, 16, excludedChannels),
@@ -54,6 +67,7 @@ export function useRcMixer(snapshot: ConfiguratorSnapshot) {
 
   return {
     rcMixerChannels,
+    rcMixerFunctionCatalog,
     rcMixerFunctionLookup,
     rcMixerLivePwmByChannel,
     handleRcMixerAddAssignment,

--- a/apps/web/src/view-models/rc-mixer.test.ts
+++ b/apps/web/src/view-models/rc-mixer.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from 'vitest'
 import {
   buildRcMixerFunctionLookup,
   createAssignment,
+  filterRcMixerFunctionCatalogForVehicle,
   groupAssignmentsByChannel,
   RC_MIXER_FUNCTION_CATALOG,
   type RcMixerAssignment,
@@ -62,5 +63,36 @@ describe('groupAssignmentsByChannel', () => {
   it('omits excluded channels (e.g. the primary stick axes) from the rows entirely', () => {
     const groups = groupAssignmentsByChannel([assign(2)], 6, new Set([1, 2, 3, 4]))
     expect(groups.map((group) => group.channel)).toEqual([5, 6])
+  })
+})
+
+describe('filterRcMixerFunctionCatalogForVehicle', () => {
+  const catalog: RcMixerFunctionDefinition[] = [
+    { id: 0, label: 'Do nothing', description: 'generic' },
+    { id: 16, label: 'AutoTune', description: 'copter+plane', vehicles: ['ArduCopter', 'ArduPlane'] },
+    { id: 66, label: 'Reverse throttle', description: 'rover only', vehicles: ['ArduRover'] }
+  ]
+
+  it('shows the full catalog when the vehicle kind is unknown or not yet connected', () => {
+    expect(filterRcMixerFunctionCatalogForVehicle(catalog, undefined)).toEqual(catalog)
+    expect(filterRcMixerFunctionCatalogForVehicle(catalog, 'Unknown')).toEqual(catalog)
+  })
+
+  it('drops entries scoped to vehicles other than the connected one', () => {
+    const rover = filterRcMixerFunctionCatalogForVehicle(catalog, 'ArduRover')
+    expect(rover.map((entry) => entry.id)).toEqual([0, 66])
+
+    const sub = filterRcMixerFunctionCatalogForVehicle(catalog, 'ArduSub')
+    expect(sub.map((entry) => entry.id)).toEqual([0])
+  })
+
+  it('keeps vehicle-untagged (generic) entries for every vehicle', () => {
+    const copter = filterRcMixerFunctionCatalogForVehicle(catalog, 'ArduCopter')
+    expect(copter.map((entry) => entry.id)).toEqual([0, 16])
+  })
+
+  it('the real catalog has at least one vehicle-restricted and one generic entry', () => {
+    expect(RC_MIXER_FUNCTION_CATALOG.some((entry) => entry.vehicles)).toBe(true)
+    expect(RC_MIXER_FUNCTION_CATALOG.some((entry) => !entry.vehicles)).toBe(true)
   })
 })

--- a/apps/web/src/view-models/rc-mixer.ts
+++ b/apps/web/src/view-models/rc-mixer.ts
@@ -9,6 +9,9 @@
 //   - We can wire the real protocol the day ArduPilot ships support
 //     without redoing the UI from scratch.
 
+/** ArduPilot's four vehicle firmwares — matches ConfiguratorSnapshot['vehicle']['vehicle']. */
+export type RcMixerVehicleKind = 'ArduCopter' | 'ArduPlane' | 'ArduRover' | 'ArduSub'
+
 export interface RcMixerFunctionDefinition {
   /** Numeric option value if/when ArduPilot adopts an enum. For the
    * scaffold this is a stable lookup key. */
@@ -22,6 +25,26 @@ export interface RcMixerFunctionDefinition {
    * narrates "active" — momentary functions describe the active range as
    * a trigger window, sustained ones as a hold window. */
   momentary?: boolean
+  /** Vehicle firmwares this function actually applies to. Undefined means
+   *  generic — every vehicle supports it (arm/disarm, RC override, scripting
+   *  flags, etc). Restrict this when the function is tied to a mode or
+   *  subsystem only some vehicles build (AutoTune, LAND, parachutes, Precision
+   *  Loiter, airmode). */
+  vehicles?: readonly RcMixerVehicleKind[]
+}
+
+/** Filters a function catalog down to entries the connected vehicle firmware
+ *  actually supports. `vehicleKind` undefined or `'Unknown'` (not yet
+ *  connected, or the FC hasn't reported a vehicle type) shows the full
+ *  catalog rather than guessing. */
+export function filterRcMixerFunctionCatalogForVehicle(
+  catalog: readonly RcMixerFunctionDefinition[],
+  vehicleKind: string | undefined
+): readonly RcMixerFunctionDefinition[] {
+  if (!vehicleKind || vehicleKind === 'Unknown') {
+    return catalog
+  }
+  return catalog.filter((definition) => !definition.vehicles || (definition.vehicles as readonly string[]).includes(vehicleKind))
 }
 
 export interface RcMixerAssignment {
@@ -54,19 +77,19 @@ export interface RcMixerState {
 export const RC_MIXER_FUNCTION_CATALOG: readonly RcMixerFunctionDefinition[] = [
   { id: 0, label: 'Do nothing', description: 'No assigned function — the channel is reserved or used by another mapping.' },
   { id: 9, label: 'Save waypoint', description: 'Records the current vehicle position into the active mission.', momentary: true },
-  { id: 16, label: 'AutoTune', description: 'Triggers ArduCopter\'s automatic tuning routine while the channel is high.' },
-  { id: 18, label: 'Land', description: 'Switches the vehicle into LAND immediately when this range is active.' },
-  { id: 22, label: 'Parachute release', description: 'Fires the chute servo when the channel enters the active range.', momentary: true },
+  { id: 16, label: 'AutoTune', description: 'Triggers the vehicle\'s automatic tuning routine while the channel is high.', vehicles: ['ArduCopter', 'ArduPlane'] },
+  { id: 18, label: 'Land', description: 'Switches the vehicle into LAND immediately when this range is active.', vehicles: ['ArduCopter', 'ArduPlane'] },
+  { id: 22, label: 'Parachute release', description: 'Fires the chute servo when the channel enters the active range.', momentary: true, vehicles: ['ArduCopter', 'ArduPlane'] },
   { id: 27, label: 'Arm / Disarm', description: 'Toggles the motor arm state. Most operators bind this to a sticky two-position switch.' },
   { id: 31, label: 'Motor emergency stop', description: 'Cuts power to the motors immediately. Wire to a guarded switch.', momentary: true },
-  { id: 41, label: 'RTL', description: 'Engages Return-to-Launch while the channel sits in the active range.' },
+  { id: 41, label: 'RTL', description: 'Engages Return-to-Launch while the channel sits in the active range.', vehicles: ['ArduCopter', 'ArduPlane', 'ArduRover'] },
   { id: 46, label: 'RC override enable', description: 'Lets a companion computer pilot via MAVLink while this range is held.' },
-  { id: 47, label: 'Gripper', description: 'Cycles the gripper open/closed on each pulse into the active range.', momentary: true },
-  { id: 51, label: 'Precision Loiter', description: 'Engages precision-loiter assistance (requires PrecLand sensor).' },
+  { id: 47, label: 'Gripper', description: 'Cycles the gripper open/closed on each pulse into the active range.', momentary: true, vehicles: ['ArduCopter', 'ArduRover'] },
+  { id: 51, label: 'Precision Loiter', description: 'Engages precision-loiter assistance (requires PrecLand sensor).', vehicles: ['ArduCopter'] },
   { id: 55, label: 'Guided', description: 'Switches the vehicle into GUIDED mode for the duration of the active range.' },
-  { id: 66, label: 'Reverse throttle', description: 'Inverts the throttle stick mapping while the channel sits in the active range.' },
+  { id: 66, label: 'Reverse throttle', description: 'Inverts the throttle stick mapping while the channel sits in the active range.', vehicles: ['ArduRover'] },
   { id: 77, label: 'Camera trigger', description: 'Fires the configured camera shutter / record line.', momentary: true },
-  { id: 83, label: 'Disable airmode', description: 'Forces airmode off while held; vehicle-dependent.' },
+  { id: 83, label: 'Disable airmode', description: 'Forces airmode off while held; vehicle-dependent.', vehicles: ['ArduCopter'] },
   { id: 153, label: 'Arm without safety', description: 'Arms even with safety switch active. Off-flight bench use only.' },
   { id: 300, label: 'Scripting 1', description: 'Triggers Lua script flag 1 (vehicle must run a script that reads it).' },
   { id: 301, label: 'Scripting 2', description: 'Triggers Lua script flag 2.' }

--- a/apps/web/src/views/Osd.tsx
+++ b/apps/web/src/views/Osd.tsx
@@ -235,6 +235,12 @@ export function OsdView(props: OsdViewProps) {
   const [analogLayout, setAnalogLayout] = useState<OsdAnalogLayout>('pal')
   const layout = OSD_ANALOG_LAYOUTS[analogLayout]
   const [draggingId, setDraggingId] = useState<string | undefined>(undefined)
+  // Continuous, un-quantized pixel offset from the grab point, updated on
+  // every pointermove — lets the element follow the cursor freely while
+  // dragging instead of jumping cell-to-cell (the committed column/row still
+  // only lands on whole character cells, matching ArduPilot's
+  // OSDn_ELEMENT_X/Y; only the mid-drag rendering is free).
+  const [dragOffsetPx, setDragOffsetPx] = useState<{ x: number; y: number } | undefined>(undefined)
   // Clicking an element's row in the left checklist (or the element itself in
   // the preview) highlights it on the other side and scrolls it into view —
   // so an operator can find "which row is this?" / "where did that land?"
@@ -308,6 +314,7 @@ export function OsdView(props: OsdViewProps) {
       lastRow: startRow
     }
     setDraggingId(element.id)
+    setDragOffsetPx({ x: 0, y: 0 })
   }
 
   function moveElementDrag(event: React.PointerEvent<HTMLSpanElement>): void {
@@ -327,12 +334,24 @@ export function OsdView(props: OsdViewProps) {
       maxColumn: layout.columns - 1,
       maxRow: layout.rows - 1
     })
-    if (nextColumn === state.lastColumn && nextRow === state.lastRow) {
-      return
+    if (nextColumn !== state.lastColumn || nextRow !== state.lastRow) {
+      state.lastColumn = nextColumn
+      state.lastRow = nextRow
+      onElementMove(state.elementId, nextColumn, nextRow)
     }
-    state.lastColumn = nextColumn
-    state.lastRow = nextRow
-    onElementMove(state.elementId, nextColumn, nextRow)
+    // Free-follow the raw pointer for the VISUAL position (clamped to the
+    // grid's edges, same bounds pointerDragToCell enforces for the committed
+    // cell) — decoupled from the quantized column/row above, so the element
+    // doesn't visually teleport cell-to-cell while the operator is still
+    // mid-drag.
+    const maxOffsetX = (layout.columns - 1 - state.startColumn) * state.cellWidth
+    const minOffsetX = -state.startColumn * state.cellWidth
+    const maxOffsetY = (layout.rows - 1 - state.startRow) * state.cellHeight
+    const minOffsetY = -state.startRow * state.cellHeight
+    setDragOffsetPx({
+      x: Math.max(minOffsetX, Math.min(maxOffsetX, event.clientX - state.pointerStartX)),
+      y: Math.max(minOffsetY, Math.min(maxOffsetY, event.clientY - state.pointerStartY))
+    })
   }
 
   function endElementDrag(event: React.PointerEvent<HTMLSpanElement>): void {
@@ -341,6 +360,7 @@ export function OsdView(props: OsdViewProps) {
     }
     dragStateRef.current = undefined
     setDraggingId(undefined)
+    setDragOffsetPx(undefined)
   }
 
   const dragEnabled = typeof onElementMove === 'function'
@@ -814,6 +834,15 @@ export function OsdView(props: OsdViewProps) {
                         // operator otherwise has no way to tell which element
                         // they're moving.
                         const friendlyLabel = matrixByElementId.get(element.id)?.label ?? element.id
+                        // While actively dragging THIS element, freeze its grid cell at
+                        // the drag-start position and slide it visually via a pixel
+                        // transform instead — the committed column/row still updates
+                        // (badge + drafts), but the DOM position only re-quantizes to
+                        // the new cell once the drag ends, so the box doesn't visually
+                        // teleport cell-to-cell while the pointer is still moving.
+                        const dragStart = isDragging ? dragStateRef.current : undefined
+                        const gridColumnStart = dragStart ? dragStart.startColumn + 1 : displayColumn + 1
+                        const gridRowStart = dragStart ? dragStart.startRow + 1 : displayRow + 1
                         return (
                           <span
                             key={element.id}
@@ -824,8 +853,12 @@ export function OsdView(props: OsdViewProps) {
                             className={className}
                             data-testid={`osd-preview-element-${element.id}`}
                             style={{
-                              gridColumnStart: displayColumn + 1,
-                              gridRowStart: displayRow + 1
+                              gridColumnStart,
+                              gridRowStart,
+                              transform:
+                                isDragging && dragOffsetPx
+                                  ? `translate(${dragOffsetPx.x}px, ${dragOffsetPx.y}px) scale(1.05)`
+                                  : undefined
                             }}
                             onPointerDown={dragEnabled ? (event) => startElementDrag(event, element) : undefined}
                             onPointerMove={dragEnabled ? moveElementDrag : undefined}

--- a/packages/firmware-flash/src/intel-hex.ts
+++ b/packages/firmware-flash/src/intel-hex.ts
@@ -128,30 +128,54 @@ function hexToBytes(hex: string, where: string): Uint8Array {
   return out
 }
 
-/** Sort writes by address and merge contiguous/overlapping runs into segments. */
+/** Sort writes by address and merge contiguous/overlapping runs into segments.
+ *
+ * A real ArduPilot .hex has one data record per 16-32 bytes, so a 1-2 MB
+ * image is tens of thousands of records. Allocating and copying the WHOLE
+ * accumulated segment on every contiguous record (the previous approach)
+ * is O(n^2) in the segment size — that quadratic blowup is exactly what made
+ * loading a large .hex file feel like it hung the browser. This does two
+ * O(n) passes instead: first group runs and total their length without
+ * touching any bytes, then allocate each final segment's buffer once and
+ * copy each run into its slot directly. */
 function coalesce(writes: IntelHexSegment[]): ParsedIntelHex {
   if (writes.length === 0) {
     return { segments: [], minAddress: 0, endAddress: 0, totalBytes: 0 }
   }
   const ordered = [...writes].sort((a, b) => a.address - b.address)
-  const segments: IntelHexSegment[] = []
+
+  interface PendingSegment {
+    address: number
+    length: number
+    runs: IntelHexSegment[]
+  }
+  const pending: PendingSegment[] = []
   for (const write of ordered) {
-    const last = segments[segments.length - 1]
-    if (last && write.address === last.address + last.data.length) {
-      // Contiguous — extend the current segment.
-      const merged = new Uint8Array(last.data.length + write.data.length)
-      merged.set(last.data)
-      merged.set(write.data, last.data.length)
-      last.data = merged
+    const current = pending[pending.length - 1]
+    const currentEnd = current ? current.address + current.length : undefined
+    if (current && write.address === currentEnd) {
+      current.length += write.data.length
+      current.runs.push(write)
       continue
     }
-    if (last && write.address < last.address + last.data.length) {
+    if (current && write.address < (currentEnd as number)) {
       throw new Error(
         `Invalid Intel HEX: overlapping data at 0x${write.address.toString(16)} — refusing to flash an ambiguous image`
       )
     }
-    segments.push({ address: write.address, data: write.data })
+    pending.push({ address: write.address, length: write.data.length, runs: [write] })
   }
+
+  const segments: IntelHexSegment[] = pending.map((segment) => {
+    const data = new Uint8Array(segment.length)
+    let offset = 0
+    for (const run of segment.runs) {
+      data.set(run.data, offset)
+      offset += run.data.length
+    }
+    return { address: segment.address, data }
+  })
+
   const minAddress = segments[0].address
   const lastSegment = segments[segments.length - 1]
   const endAddress = lastSegment.address + lastSegment.data.length

--- a/tests/e2e/views.spec.ts
+++ b/tests/e2e/views.spec.ts
@@ -1553,6 +1553,29 @@ test.describe('RC Mixer view', () => {
     await expect(page.getByTestId('rc-mixer-channel-6')).toBeVisible()
     await expect(page.getByTestId('rc-mixer-channel-8')).toBeVisible()
   })
+
+  test('function picker only offers functions the connected vehicle firmware actually supports', async ({ page }) => {
+    // Demo Plane doesn't report RCL_ENABLE, so the tab falls back to the
+    // scaffold catalog — which should now exclude Copter/Rover-only entries
+    // (Precision Loiter, Reverse throttle) while keeping Plane-applicable
+    // ones (Land) and vehicle-generic ones (Do nothing).
+    await page.goto('/')
+    await page.getByTestId('transport-mode-select').selectOption('demo-plane')
+    await page.getByTestId('connect-button').click()
+    await expect(page.getByTestId('session-vehicle-name')).toHaveText('ArduPlane', { timeout: VEHICLE_CONNECT_TIMEOUT })
+    await page.getByTestId('product-mode-expert').check()
+    await page.getByTestId('view-button-rc-mixer').click()
+
+    const channel5 = page.getByTestId('rc-mixer-channel-5')
+    await channel5.getByTestId('rc-mixer-add-channel-5').click()
+    const functionSelect = channel5.locator('select')
+    const optionLabels = await functionSelect.locator('option').allTextContents()
+
+    expect(optionLabels.some((label) => label.startsWith('Precision Loiter'))).toBe(false)
+    expect(optionLabels.some((label) => label.startsWith('Reverse throttle'))).toBe(false)
+    expect(optionLabels.some((label) => label.startsWith('Land'))).toBe(true)
+    expect(optionLabels.some((label) => label.startsWith('Do nothing'))).toBe(true)
+  })
 })
 
 // The receiver Bind (ELRS/CRSF) button is currently hidden in the UI
@@ -1941,6 +1964,52 @@ test.describe('OSD view preview', () => {
     const colAfter = Number(await batVolt.evaluate((el) => getComputedStyle(el).gridColumnStart))
     expect(colAfter).toBeGreaterThan(colBefore)
     await expect(page.getByTestId('osd-save')).not.toHaveText('Save OSD (0)')
+  })
+
+  test('OSD preview elements follow the pointer freely mid-drag instead of jumping cell-to-cell', async ({ page }) => {
+    // Regression guard: dragging used to re-quantize the DOM position (via
+    // gridColumnStart/gridRowStart) on every cell crossing, so the box visibly
+    // teleported in whole-cell jumps instead of tracking the cursor. The grid
+    // cell should now stay frozen at the drag-start position while a CSS
+    // transform slides the element smoothly; only on drop does it re-quantize.
+    await page.goto('/')
+    await page.getByTestId('transport-mode-select').selectOption('demo')
+    await page.getByTestId('connect-button').click()
+    await page.getByTestId('view-button-osd').click()
+
+    await expect(page.getByTestId('osd-preview-grid')).toBeVisible()
+    await page.getByTestId('osd-bf-preview-pane').scrollIntoViewIfNeeded()
+    const batVolt = page.getByTestId('osd-preview-element-BAT_VOLT')
+    await expect(batVolt).toBeVisible()
+
+    const gridBox = await page.getByTestId('osd-preview-grid').boundingBox()
+    const startBox = await batVolt.boundingBox()
+    if (!gridBox || !startBox) throw new Error('no bounding box for OSD preview grid or element')
+
+    const cellWidth = gridBox.width / 30
+    const startX = startBox.x + startBox.width / 2
+    const startY = startBox.y + startBox.height / 2
+    const colStart = await batVolt.evaluate((el) => getComputedStyle(el).gridColumnStart)
+
+    await page.mouse.move(startX, startY)
+    await page.mouse.down()
+    // Move less than a full cell — enough to produce a non-zero pixel offset
+    // but not enough to cross into the next character cell.
+    await page.mouse.move(startX + cellWidth * 0.4, startY, { steps: 4 })
+
+    // The grid cell hasn't re-quantized yet...
+    await expect(async () => {
+      const col = await batVolt.evaluate((el) => getComputedStyle(el).gridColumnStart)
+      expect(col).toBe(colStart)
+    }).toPass()
+    // ...but the element is visibly sliding via a translate transform, not
+    // sitting glued to its cell's static position.
+    await expect(async () => {
+      const transform = await batVolt.evaluate((el) => getComputedStyle(el).transform)
+      expect(transform).not.toBe('none')
+    }).toPass()
+
+    await page.mouse.up()
   })
 
   test('OSD preview-screen dropdown switches which screen the preview renders', async ({ page }) => {

--- a/tests/firmware-dfu.test.mjs
+++ b/tests/firmware-dfu.test.mjs
@@ -61,6 +61,45 @@ test('parseIntelHex: rejects an unknown record type', () => {
   assert.throws(() => parseIntelHex([record(0x06, 0x0000, [1]), EOF].join('\n')), /unsupported record type/i)
 })
 
+test('parseIntelHex: parses a large contiguous image in roughly linear time (no O(n^2) re-copy)', () => {
+  // Regression guard: coalesce() used to reallocate + copy the WHOLE
+  // accumulated segment on every single contiguous data record, which is
+  // O(n^2) in the segment size — a real ~1.5 MB ArduPilot .hex (tens of
+  // thousands of 16-byte records) made the browser feel hung just parsing
+  // the file. A real STM32F4 image is ~1-2 MB; use a representative size and
+  // assert it completes quickly, not just correctly.
+  const RECORD_BYTES = 16
+  const RECORD_COUNT = 100_000 // ~1.6 MB of contiguous data
+  const BASE_ADDRESS = 0x08000000
+  const lines = []
+  let lastUpper16 = -1
+  for (let i = 0; i < RECORD_COUNT; i += 1) {
+    const absoluteAddress = BASE_ADDRESS + i * RECORD_BYTES
+    const upper16 = (absoluteAddress / 0x10000) & 0xffff // record's ELA field: absoluteAddress = upper16 * 0x10000 + offset
+    if (upper16 !== lastUpper16) {
+      lines.push(record(0x04, 0x0000, [(upper16 >> 8) & 0xff, upper16 & 0xff]))
+      lastUpper16 = upper16
+    }
+    const data = Array.from({ length: RECORD_BYTES }, (_, b) => (i + b) & 0xff)
+    lines.push(record(0x00, absoluteAddress & 0xffff, data))
+  }
+  lines.push(EOF)
+  const hex = lines.join('\n')
+
+  const start = performance.now()
+  const parsed = parseIntelHex(hex)
+  const elapsedMs = performance.now() - start
+
+  assert.equal(parsed.segments.length, 1)
+  assert.equal(parsed.totalBytes, RECORD_COUNT * RECORD_BYTES)
+  assert.equal(parsed.segments[0].data[0], 0)
+  assert.equal(parsed.segments[0].data[RECORD_BYTES], 1 & 0xff)
+  // O(n^2) re-copying at this size took multiple seconds locally; O(n)
+  // finishes in well under a second. Generous ceiling so this doesn't flake
+  // on a slow CI runner while still catching a quadratic regression.
+  assert.ok(elapsedMs < 3000, `expected roughly-linear parse time, took ${elapsedMs.toFixed(0)}ms`)
+})
+
 test('parseDfuSeMemoryLayout: parses a mixed STM32F4 sector map', () => {
   const sectors = parseDfuSeMemoryLayout('@Internal Flash  /0x08000000/04*016Kg,01*016Kg,01*064Kg,07*128Kg')
   assert.equal(sectors.length, 4 + 1 + 1 + 7)


### PR DESCRIPTION
## Summary
- **OSD**: dragging a preview element used to re-quantize its DOM position on every cell crossing, so it visibly teleported cell-to-cell instead of tracking the cursor. Now freezes the grid cell at drag-start and slides visually via a clamped CSS transform; the committed column/row (badge + drafts) still updates continuously, and the DOM position only re-quantizes once the drag ends.
- **RC Mixer**: the function picker always showed all 18 scaffold functions regardless of connected vehicle (AutoTune/Precision Loiter/airmode on Rover, reverse-throttle on Copter, etc). Catalog entries now carry an optional `vehicles` tag; the picker narrows to what the connected firmware actually supports.
- **firmware-flash**: `parseIntelHex`'s `coalesce()` reallocated + copied the *whole* accumulated segment on every single contiguous data record — O(n²) in segment size. A real ~1.5 MB ArduPilot `.hex` is tens of thousands of 16-byte records, so loading a large `.hex` felt like it hung the browser before any USB traffic started. Rewritten as two O(n) passes.

## ArduCopter byte-identical
OSD/RC-Mixer changes are UI-only (render/filter logic, no new writes); the hex-parsing fix produces byte-identical parsed segments, only faster.

## Test plan
- [x] `npm run typecheck`
- [x] `npm run test` — 686 node tests pass (incl. new O(n) hex-parsing perf regression test)
- [x] `npm run test:unit --workspace @arduconfig/web` — 460 pass (incl. new RC Mixer vehicle-filter unit tests)
- [x] `npx playwright test tests/e2e/views.spec.ts` — full suite, 146/146 pass (incl. new OSD free-drag and RC Mixer vehicle-filter e2e tests)