### PR TITLE
feat(receiver,rc-mixer): real arm-switch (RCn_OPTION) control; condense RC Mixer tab

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -380,6 +380,7 @@ import {
   rcLogicTermFromAssignmentId,
   rcLogicUpdateDrafts
 } from './view-models/rc-logic'
+import { armSwitchAssignmentDrafts, deriveArmSwitchAssignment } from './view-models/arm-switch'
 import { type StatusTone } from './status-tone'
 import {
   createSavedSnapshot,
@@ -1078,6 +1079,10 @@ export function App() {
   const compassSetupAvailability = deriveCompassSetupAvailability(snapshot)
   const boardOrientation = readRoundedParameter(snapshot, 'AHRS_ORIENTATION')
   const configuredModeChannel = readRoundedParameter(snapshot, 'FLTMODE_CH') ?? readRoundedParameter(snapshot, 'MODE_CH')
+  // Arm switch: RC5_OPTION existing proves this firmware's RCn_OPTION metadata
+  // is synced at all, so the control gates on that rather than assuming.
+  const armSwitchAvailable = selectParameterById(snapshot, 'RC5_OPTION') !== undefined
+  const armSwitchAssignment = deriveArmSwitchAssignment(snapshot, editedValues)
   const rssiType = readRoundedParameter(snapshot, 'RSSI_TYPE')
   const rssiChannel = readRoundedParameter(snapshot, 'RSSI_CHANNEL')
   const rssiChannelLow = readRoundedParameter(snapshot, 'RSSI_CHAN_LOW')
@@ -4797,6 +4802,14 @@ export function App() {
   function handleRcLogicToggleEngine(enabled: boolean): void {
     setDraft('RCL_ENABLE', enabled ? '1' : '0')
   }
+  // Arm switch: writes plain RCn_OPTION directly (153, or 154 for the
+  // AirMode variant) — independent of the AP_RC_Logic engine above, so it
+  // works on every ArduPilot vehicle/firmware, not just the fork that ships
+  // RCL_*. channel 0 means "None" (clear the current assignment).
+  function handleSetArmSwitchChannel(channel: number, airmode: boolean): void {
+    const targetChannel = channel === 0 ? undefined : channel
+    mergeDrafts(armSwitchAssignmentDrafts(armSwitchAssignment, targetChannel, airmode))
+  }
   // DroneNet: the Networking tab embeds a NET_-filtered DroneCAN node editor so a
   // peripheral's network settings are configurable without the CAN tab. Filtering
   // at the state level means the node list, param count, staged changes, and the
@@ -6909,7 +6922,9 @@ export function App() {
             receiverWorkflowInvalidCount,
             receiverAdvancedDraftCount,
             receiverAdvancedInvalidCount,
-            receiverHasPendingReview
+            receiverHasPendingReview,
+            armSwitchAvailable,
+            armSwitchAssignment
           }}
           handlers={{
             handleStartRcMappingExercise,
@@ -6930,7 +6945,8 @@ export function App() {
             handleDiscardScopedParameterDrafts,
             renderAdditionalSettingsCard,
             setDraft,
-            setReceiverTaskOverride
+            setReceiverTaskOverride,
+            handleSetArmSwitchChannel
           }}
         />
         ) : null}

--- a/apps/web/src/param-groups.ts
+++ b/apps/web/src/param-groups.ts
@@ -55,7 +55,9 @@ export const RECEIVER_SUPPORT_PARAM_IDS = ['FLTMODE_CH', 'MODE_CH', 'RSSI_TYPE',
 // list — the Relays tab pulls every RELAYx_* the controller reports. RCn_OPTION
 // is included so the tab's "RC Channel" control (which binds a relay's aux
 // function to an RC switch by writing RCn_OPTION) stages + applies in the same
-// scope; RCn_OPTION isn't product-edited anywhere else.
+// scope. RCn_OPTION is also in isReceiverReviewParamId's scope below (the
+// Receiver tab's arm-switch control writes it too) — a param can legitimately
+// belong to more than one tab's review scope; either Apply button commits it.
 export function isRelayParamId(parameterId: string): boolean {
   return /^RELAY\d+_(FUNCTION|PIN|DEFAULT|INVERTED)$/.test(parameterId) || /^RC\d+_OPTION$/.test(parameterId)
 }

--- a/apps/web/src/param-review.ts
+++ b/apps/web/src/param-review.ts
@@ -31,7 +31,10 @@ function makeParamIdPredicate<Id extends string>(
 export function isReceiverReviewParamId(paramId: string): boolean {
   return (
     paramId.startsWith('RCMAP_') ||
-    /^RC\d+_(MIN|MAX|TRIM)$/.test(paramId) ||
+    // MIN/MAX/TRIM from calibration; OPTION from the arm-switch control
+    // (also in the Relay tab's scope — a channel's OPTION can legitimately
+    // be edited from either place).
+    /^RC\d+_(MIN|MAX|TRIM|OPTION)$/.test(paramId) ||
     /^FLTMODE\d+$/.test(paramId) ||
     RECEIVER_SUPPORT_PARAM_IDS.includes(paramId as (typeof RECEIVER_SUPPORT_PARAM_IDS)[number])
   )

--- a/apps/web/src/sections/ReceiverSection.tsx
+++ b/apps/web/src/sections/ReceiverSection.tsx
@@ -26,6 +26,7 @@ import {
 import { formatArducopterFlightModeChannel, formatArducopterRssiType } from '@arduconfig/param-metadata'
 import { StatusBadge, buttonStyle } from '@arduconfig/ui-kit'
 
+import { armSwitchChannelOptions, type ArmSwitchAssignment } from '../view-models/arm-switch'
 import type { useModeSwitchDerivations } from '../hooks/use-mode-switch-derivations'
 import type { useRcCalibrationDerivations } from '../hooks/use-rc-calibration-derivations'
 import type { useRcExercises } from '../hooks/use-rc-exercises'
@@ -79,6 +80,10 @@ export interface ReceiverSectionDerived {
   receiverAdvancedDraftCount: number
   receiverAdvancedInvalidCount: number
   receiverHasPendingReview: boolean
+  /** True once RC5_OPTION metadata is synced — proves this firmware exposes
+   *  RCn_OPTION at all, so the Arm switch card has something to bind to. */
+  armSwitchAvailable: boolean
+  armSwitchAssignment: ArmSwitchAssignment
 }
 
 export interface ReceiverSectionHandlers {
@@ -115,6 +120,7 @@ export interface ReceiverSectionHandlers {
   ) => ReactNode
   setDraft: (paramId: string, value: string) => void
   setReceiverTaskOverride: (taskId: import('../views/Receiver').ReceiverTaskId) => void
+  handleSetArmSwitchChannel: (channel: number, airmode: boolean) => void
 }
 
 export interface ReceiverSectionProps {
@@ -254,7 +260,9 @@ export function ReceiverSection(props: ReceiverSectionProps): ReactElement {
     receiverWorkflowInvalidCount,
     receiverAdvancedDraftCount,
     receiverAdvancedInvalidCount,
-    receiverHasPendingReview
+    receiverHasPendingReview,
+    armSwitchAvailable,
+    armSwitchAssignment
   } = derived
 
   const {
@@ -270,7 +278,8 @@ export function ReceiverSection(props: ReceiverSectionProps): ReactElement {
     handleDiscardScopedParameterDrafts,
     renderAdditionalSettingsCard,
     setDraft,
-    setReceiverTaskOverride
+    setReceiverTaskOverride,
+    handleSetArmSwitchChannel
   } = handlers
 
   return (
@@ -894,6 +903,52 @@ export function ReceiverSection(props: ReceiverSectionProps): ReactElement {
                             draftStatusById={parameterDraftById}
                             layout="chips"
                           />
+                        </div>
+                      ) : null}
+
+                      {armSwitchAvailable ? (
+                        <div className="scoped-review-card scoped-review-card--compact" data-testid="receiver-arm-switch">
+                          <div className="switch-exercise-card__header">
+                            <div>
+                              <strong>Arm switch</strong>
+                              <p>Assign a channel to arm/disarm the vehicle from a physical switch (writes RCn_OPTION directly).</p>
+                            </div>
+                            <StatusBadge tone={armSwitchAssignment.channel !== undefined ? 'success' : 'neutral'}>
+                              {armSwitchAssignment.channel !== undefined
+                                ? `CH${armSwitchAssignment.channel}${armSwitchAssignment.airmode ? ' + AirMode' : ''}`
+                                : 'not assigned'}
+                            </StatusBadge>
+                          </div>
+
+                          <label className="receiver-arm-switch__field">
+                            <span>Channel</span>
+                            <select
+                              data-testid="receiver-arm-switch-channel"
+                              value={String(armSwitchAssignment.channel ?? 0)}
+                              onChange={(event) =>
+                                handleSetArmSwitchChannel(Number(event.target.value), armSwitchAssignment.airmode)
+                              }
+                            >
+                              {armSwitchChannelOptions().map((option) => (
+                                <option key={option.value} value={option.value}>
+                                  {option.label}
+                                </option>
+                              ))}
+                            </select>
+                          </label>
+
+                          <label className="receiver-arm-switch__checkbox">
+                            <input
+                              type="checkbox"
+                              data-testid="receiver-arm-switch-airmode"
+                              checked={armSwitchAssignment.airmode}
+                              disabled={armSwitchAssignment.channel === undefined}
+                              onChange={(event) =>
+                                handleSetArmSwitchChannel(armSwitchAssignment.channel ?? 0, event.target.checked)
+                              }
+                            />
+                            <span>Also enable AirMode when armed via this switch</span>
+                          </label>
                         </div>
                       ) : null}
 

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -6822,6 +6822,37 @@ textarea:focus {
   background: var(--bg-panel-raised);
 }
 
+.receiver-arm-switch__field {
+  display: grid;
+  gap: 4px;
+  font-size: 12px;
+  color: var(--text-muted);
+}
+
+.receiver-arm-switch__field select {
+  font: inherit;
+  font-family: var(--font-data);
+  background: var(--surface-300);
+  color: var(--text);
+  border: 1px solid var(--surface-400);
+  border-radius: 5px;
+  padding: 4px 6px;
+}
+
+.receiver-arm-switch__checkbox {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 12px;
+  color: var(--text-muted);
+  cursor: pointer;
+}
+
+.receiver-arm-switch__checkbox:has(input:disabled) {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
 .scoped-review-card__disclosure {
   display: flex;
   align-items: center;
@@ -7708,7 +7739,7 @@ details.metadata-settings-section:not([open]) > summary::after {
 
 .rc-mixer-stack {
   display: grid;
-  gap: 8px;
+  gap: 6px;
 }
 
 /* AP_RC_Logic engine controls (shown when the firmware supports RCL_*). */
@@ -7730,6 +7761,19 @@ details.metadata-settings-section:not([open]) > summary::after {
 
 .rc-mixer-track {
   padding: 2px 0 12px;
+}
+
+/* No assignments to visualize yet — shrink to a slim cursor-only rail
+ * (still shows where the live channel sits, useful for picking the right
+ * channel to add a function to) instead of the full band-height track. */
+.rc-mixer-track--empty {
+  padding: 2px 0 4px;
+}
+.rc-mixer-track--empty .rc-mixer-track__rail {
+  height: 14px;
+}
+.rc-mixer-track--empty .rc-mixer-track__tick em {
+  display: none;
 }
 
 .rc-mixer-track__rail {
@@ -7849,8 +7893,8 @@ details.metadata-settings-section:not([open]) > summary::after {
 
 .rc-mixer-channel {
   display: grid;
-  gap: 6px;
-  padding: 8px 10px;
+  gap: 4px;
+  padding: 6px 10px;
   border-radius: var(--radius-md);
   border: 1px solid var(--border);
   background: var(--bg-panel);
@@ -7880,12 +7924,6 @@ details.metadata-settings-section:not([open]) > summary::after {
   display: flex;
   align-items: center;
   gap: 6px;
-}
-
-.rc-mixer-channel__empty {
-  margin: 0;
-  color: var(--text-muted);
-  font-size: 11px;
 }
 
 .rc-mixer-channel__assignments {

--- a/apps/web/src/view-models/arm-switch.test.ts
+++ b/apps/web/src/view-models/arm-switch.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  ARM_SWITCH_AIRMODE_OPTION_VALUE,
+  ARM_SWITCH_OPTION_VALUE,
+  armSwitchAssignmentDrafts,
+  armSwitchChannelOptions,
+  deriveArmSwitchAssignment
+} from './arm-switch'
+
+function snapshotWith(params: Record<string, number>): any {
+  return {
+    parameters: Object.entries(params).map(([id, value]) => ({ id, value, definition: undefined }))
+  }
+}
+
+describe('deriveArmSwitchAssignment', () => {
+  it('reports no assignment when nothing is set', () => {
+    expect(deriveArmSwitchAssignment(snapshotWith({}), {})).toEqual({ channel: undefined, airmode: false })
+  })
+
+  it('finds a plain Arm/Disarm assignment from the live snapshot', () => {
+    const snapshot = snapshotWith({ RC7_OPTION: ARM_SWITCH_OPTION_VALUE })
+    expect(deriveArmSwitchAssignment(snapshot, {})).toEqual({ channel: 7, airmode: false })
+  })
+
+  it('finds the AirMode variant', () => {
+    const snapshot = snapshotWith({ RC9_OPTION: ARM_SWITCH_AIRMODE_OPTION_VALUE })
+    expect(deriveArmSwitchAssignment(snapshot, {})).toEqual({ channel: 9, airmode: true })
+  })
+
+  it('prefers a staged edit over the live value', () => {
+    const snapshot = snapshotWith({ RC6_OPTION: 0 })
+    const edited = { RC6_OPTION: String(ARM_SWITCH_OPTION_VALUE) }
+    expect(deriveArmSwitchAssignment(snapshot, edited)).toEqual({ channel: 6, airmode: false })
+  })
+
+  it('ignores channels outside the 5..16 AUX range', () => {
+    const snapshot = snapshotWith({ RC1_OPTION: ARM_SWITCH_OPTION_VALUE })
+    expect(deriveArmSwitchAssignment(snapshot, {})).toEqual({ channel: undefined, airmode: false })
+  })
+})
+
+describe('armSwitchAssignmentDrafts', () => {
+  it('assigns a fresh channel with no prior assignment', () => {
+    const drafts = armSwitchAssignmentDrafts({ channel: undefined, airmode: false }, 8, false)
+    expect(drafts).toEqual({ RC8_OPTION: String(ARM_SWITCH_OPTION_VALUE) })
+  })
+
+  it('writes the AirMode variant when requested', () => {
+    const drafts = armSwitchAssignmentDrafts({ channel: undefined, airmode: false }, 8, true)
+    expect(drafts).toEqual({ RC8_OPTION: String(ARM_SWITCH_AIRMODE_OPTION_VALUE) })
+  })
+
+  it('clears the previous channel when moving to a new one', () => {
+    const drafts = armSwitchAssignmentDrafts({ channel: 6, airmode: false }, 10, false)
+    expect(drafts).toEqual({ RC6_OPTION: '0', RC10_OPTION: String(ARM_SWITCH_OPTION_VALUE) })
+  })
+
+  it('clears the current channel when the target is undefined ("None")', () => {
+    const drafts = armSwitchAssignmentDrafts({ channel: 6, airmode: false }, undefined, false)
+    expect(drafts).toEqual({ RC6_OPTION: '0' })
+  })
+
+  it('toggling airmode on the SAME channel only rewrites that channel', () => {
+    const drafts = armSwitchAssignmentDrafts({ channel: 6, airmode: false }, 6, true)
+    expect(drafts).toEqual({ RC6_OPTION: String(ARM_SWITCH_AIRMODE_OPTION_VALUE) })
+  })
+})
+
+describe('armSwitchChannelOptions', () => {
+  it('starts with "None" followed by every AUX channel 5..16', () => {
+    const options = armSwitchChannelOptions()
+    expect(options[0]).toEqual({ value: 0, label: 'None' })
+    expect(options).toHaveLength(1 + (16 - 5 + 1))
+    expect(options[1]).toEqual({ value: 5, label: 'Channel 5' })
+    expect(options[options.length - 1]).toEqual({ value: 16, label: 'Channel 16' })
+  })
+})

--- a/apps/web/src/view-models/arm-switch.ts
+++ b/apps/web/src/view-models/arm-switch.ts
@@ -1,0 +1,107 @@
+// Pure builder for the Receiver tab's "Arm switch" control — confirmed gap:
+// no UI in this app wrote a real RCn_OPTION Arm/Disarm value to a channel
+// (the RC Mixer tab's own "Arm/Disarm" entry either does nothing without the
+// RCL_* engine, or writes RCL_FUNC, a different subsystem, when it is
+// present). This binds directly to the plain RCn_OPTION parameter every
+// ArduPilot vehicle exposes, independent of AP_RC_Logic.
+
+import type { ConfiguratorSnapshot } from '@arduconfig/ardupilot-core'
+
+import { readRoundedParameter } from '../selectors/parameter-read'
+
+/** RCn_OPTION value for a plain Arm/Disarm switch (firmware 4.2+; ArduPilot
+ *  keeps the old value 41 recognized for 4.1-and-earlier compatibility, but
+ *  153 is what current firmware documents and what this control writes). */
+export const ARM_SWITCH_OPTION_VALUE = 153
+/** RCn_OPTION value for Arm/Disarm bundled with AirMode-on-arm. */
+export const ARM_SWITCH_AIRMODE_OPTION_VALUE = 154
+
+// RCn_OPTION only makes sense on AUX channels — the primary stick axes and
+// the mode-switch channel are excluded elsewhere in the app (see
+// derivePrimaryAndModeChannels) and by convention start no earlier than
+// channel 5.
+export const ARM_SWITCH_MIN_CHANNEL = 5
+export const ARM_SWITCH_MAX_CHANNEL = 16
+
+export interface ArmSwitchAssignment {
+  /** The channel currently carrying an Arm/Disarm RCn_OPTION value, or
+   *  undefined if none does. */
+  channel: number | undefined
+  /** True when the assigned channel uses the AirMode variant (154) rather
+   *  than the plain one (153). Meaningless when channel is undefined. */
+  airmode: boolean
+}
+
+/** Reads a param honoring an in-progress staged edit over the live value —
+ *  same effective-value convention used by rc-logic.ts, so the control
+ *  reflects a just-made selection immediately, before Apply. */
+function effectiveOptionValue(
+  snapshot: ConfiguratorSnapshot,
+  editedValues: Record<string, string>,
+  channel: number
+): number | undefined {
+  const paramId = `RC${channel}_OPTION`
+  const staged = editedValues[paramId]
+  if (staged !== undefined && staged !== '') {
+    const parsed = Number(staged)
+    return Number.isFinite(parsed) ? parsed : undefined
+  }
+  return readRoundedParameter(snapshot, paramId)
+}
+
+/** Scans RC5_OPTION..RC16_OPTION for an existing Arm/Disarm assignment. Only
+ *  the first match is reported — if more than one channel somehow carries
+ *  it (hand-edited via raw Parameters), this is the one the control treats
+ *  as "current" and will move away from a re-assignment. */
+export function deriveArmSwitchAssignment(
+  snapshot: ConfiguratorSnapshot,
+  editedValues: Record<string, string>
+): ArmSwitchAssignment {
+  for (let channel = ARM_SWITCH_MIN_CHANNEL; channel <= ARM_SWITCH_MAX_CHANNEL; channel += 1) {
+    const value = effectiveOptionValue(snapshot, editedValues, channel)
+    if (value === ARM_SWITCH_OPTION_VALUE) {
+      return { channel, airmode: false }
+    }
+    if (value === ARM_SWITCH_AIRMODE_OPTION_VALUE) {
+      return { channel, airmode: true }
+    }
+  }
+  return { channel: undefined, airmode: false }
+}
+
+/** Drafts to move (or clear) the arm-switch assignment. `targetChannel`
+ *  undefined clears whichever channel currently holds it (sets its
+ *  RCn_OPTION to 0). Moving to a new channel also clears the previous one —
+ *  ArduPilot doesn't reject two live arm switches, but that's a footgun this
+ *  control shouldn't invite; exactly one channel is ever assigned at a time. */
+export function armSwitchAssignmentDrafts(
+  current: ArmSwitchAssignment,
+  targetChannel: number | undefined,
+  airmode: boolean
+): Record<string, string> {
+  const drafts: Record<string, string> = {}
+  if (current.channel !== undefined && current.channel !== targetChannel) {
+    drafts[`RC${current.channel}_OPTION`] = '0'
+  }
+  if (targetChannel !== undefined) {
+    drafts[`RC${targetChannel}_OPTION`] = String(
+      airmode ? ARM_SWITCH_AIRMODE_OPTION_VALUE : ARM_SWITCH_OPTION_VALUE
+    )
+  }
+  return drafts
+}
+
+export interface ArmSwitchChannelOption {
+  value: number
+  label: string
+}
+
+/** Channel picker options: 0 = "None" (clears the assignment), then every
+ *  AUX channel in range. */
+export function armSwitchChannelOptions(): readonly ArmSwitchChannelOption[] {
+  const options: ArmSwitchChannelOption[] = [{ value: 0, label: 'None' }]
+  for (let channel = ARM_SWITCH_MIN_CHANNEL; channel <= ARM_SWITCH_MAX_CHANNEL; channel += 1) {
+    options.push({ value: channel, label: `Channel ${channel}` })
+  }
+  return options
+}

--- a/apps/web/src/views/RcMixer.tsx
+++ b/apps/web/src/views/RcMixer.tsx
@@ -263,7 +263,10 @@ export function RcMixerView(props: RcMixerViewProps) {
                   </div>
                 </header>
 
-                <div className="rc-mixer-track" data-testid={`rc-mixer-track-${channel}`}>
+                <div
+                  className={`rc-mixer-track${assignments.length === 0 ? ' rc-mixer-track--empty' : ''}`}
+                  data-testid={`rc-mixer-track-${channel}`}
+                >
                   <div className="rc-mixer-track__rail">
                     {TRACK_TICKS.map((tick) => {
                       const pct = ((tick - RC_MIXER_TRACK_MIN_PWM) / (RC_MIXER_TRACK_MAX_PWM - RC_MIXER_TRACK_MIN_PWM)) * 100
@@ -370,9 +373,7 @@ export function RcMixerView(props: RcMixerViewProps) {
                   </div>
                 </div>
 
-                {assignments.length === 0 ? (
-                  <p className="rc-mixer-channel__empty">No functions assigned to this channel.</p>
-                ) : (
+                {assignments.length === 0 ? null : (
                   <ul className="rc-mixer-channel__assignments">
                     {assignments.map((assignment) => {
                       const definition = functionLookup.byId.get(assignment.functionId)

--- a/tests/e2e/views.spec.ts
+++ b/tests/e2e/views.spec.ts
@@ -1662,6 +1662,47 @@ test.describe('Receiver RC options', () => {
   })
 })
 
+test.describe('Receiver arm switch', () => {
+  test('assigns RCn_OPTION to a channel, moves it, adds AirMode, and clears it', async ({ page }) => {
+    await page.goto('/')
+    await connectViaHeader(page)
+    await openView(page, 'receiver')
+    await page.getByTestId('receiver-task-nav').getByRole('button', { name: 'Flight Modes' }).click()
+    const card = page.getByTestId('receiver-arm-switch')
+    await card.scrollIntoViewIfNeeded()
+    await expect(card).toBeVisible()
+
+    // Demo seeds every RCn_OPTION at 0 — starts unassigned.
+    await expect(card).toContainText('not assigned')
+    const channelSelect = page.getByTestId('receiver-arm-switch-channel')
+    const airmodeCheckbox = page.getByTestId('receiver-arm-switch-airmode')
+    await expect(channelSelect).toHaveValue('0')
+    await expect(airmodeCheckbox).toBeDisabled()
+
+    // Assign channel 6 — stages RC6_OPTION=153 and the card reflects it.
+    await channelSelect.selectOption('6')
+    await expect(card).toContainText('CH6')
+    await expect(airmodeCheckbox).toBeEnabled()
+    await expect(page.getByTestId('receiver-apply-button')).not.toHaveText('Apply Receiver Changes (0)')
+
+    // Enable AirMode on the same channel — rewrites RC6_OPTION to 154, no
+    // second channel touched.
+    await airmodeCheckbox.check()
+    await expect(card).toContainText('CH6 + AirMode')
+
+    // Move to channel 9 — clears RC6_OPTION and assigns RC9_OPTION, keeping
+    // exactly one live arm switch.
+    await channelSelect.selectOption('9')
+    await expect(card).toContainText('CH9')
+    await expect(card).not.toContainText('CH6')
+
+    // Clear the assignment entirely.
+    await channelSelect.selectOption('0')
+    await expect(card).toContainText('not assigned')
+    await expect(airmodeCheckbox).toBeDisabled()
+  })
+})
+
 test.describe('Receiver flight-mode labels', () => {
   test('flight-mode slots render known mode names (no "Mode N" placeholders)', async ({ page }) => {
     await page.goto('/')


### PR DESCRIPTION
## Summary
- **Receiver — Arm switch**: confirmed genuine gap (no UI wrote a real `RCn_OPTION` Arm/Disarm value to any channel). New "Arm switch" card in the Flight Modes task: a channel picker that writes `RCn_OPTION=153` (or `154` with an AirMode checkbox), always clearing the previous channel when moving so exactly one switch is ever assigned. Gated on `RC5_OPTION` being synced.
- **RC Mixer — condense**: channels with no assignments now render a slim cursor-only rail instead of the full PWM track, and the redundant "No functions assigned" paragraph (duplicating the header's own "No assignments" text) is gone. Tightened gaps/padding across the tab.

## ArduCopter byte-identical
`RCn_OPTION` is a real write, but gated behind an explicit operator action and the same staged-draft/verified-write path as every other Receiver control. RC Mixer changes are presentation-only.

## Test plan
- [x] `npm run typecheck`
- [x] `npm run test` — 686 pass
- [x] `npm run test:unit --workspace @arduconfig/web` — 471 pass (11 new arm-switch unit tests)
- [x] `npx playwright test tests/e2e/views.spec.ts` — full suite, 147/147 pass (new arm-switch e2e test)