### PR TITLE
feat(snapshots): calibration exclusion, per-row Drop/Undo, overwrite-in-place, invalid wording parity

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -32,6 +32,7 @@ import {
   type MotorTestRequest,
   applyArducopter47CatalogOverrides,
   type ParameterBackupFile,
+  type ParameterBackupImportOptions,
   type ParameterBatchWriteProgress,
   type ParameterBatchWriteResult,
   type ParameterDraftEntry,
@@ -191,6 +192,7 @@ import { useReceiverAdditional } from './hooks/use-receiver-additional'
 import { useReceiverChannelDisplays } from './hooks/use-receiver-channel-displays'
 import { useReceiverSupportCatalog } from './hooks/use-receiver-support-catalog'
 import { useSelectedProfileDiff } from './hooks/use-selected-profile-diff'
+import { selectEntityDiff } from './selectors/entity-diff'
 import { useTuningCatalog } from './hooks/use-tuning-catalog'
 import { useTuningMasterPreview } from './hooks/use-tuning-master-preview'
 import { useTuningProfileSource } from './hooks/use-tuning-profile-source'
@@ -1727,24 +1729,72 @@ export function App() {
     const liveById = new Map(snapshot.parameters.map((parameter) => [parameter.id, parameter]))
     return buildParametersFromBackup(baseline.backup, liveById)
   }, [snapshotCompareBaselineId, savedSnapshots, snapshot.parameters])
+  // Snapshot restore curation: off-by-default calibration exclusion (restoring
+  // another unit's accel/gyro/compass calibration + AHRS trim onto different
+  // hardware is wrong by default) plus a per-row Drop so the operator can
+  // curate the diff before writing it — matching the Parameters tab's
+  // stage-then-write feel instead of committing the entire diff in one shot.
+  // Reuses the SAME opt-in 'calibration' exclusion category the Parameters
+  // tab's own backup-import toggles already use (parameter-backups.ts) rather
+  // than a second bespoke classifier.
+  const [snapshotImportCalibration, setSnapshotImportCalibration] = useState(false)
+  const [snapshotRestoreDroppedParamIds, setSnapshotRestoreDroppedParamIds] = useState<ReadonlySet<string>>(
+    () => new Set()
+  )
+  const snapshotRestoreImportOptions = useMemo<ParameterBackupImportOptions>(
+    () => ({ excludeCategories: snapshotImportCalibration ? [] : ['calibration'] }),
+    [snapshotImportCalibration]
+  )
   const {
     selectedProfile: selectedSnapshot,
-    restore: selectedSnapshotRestore,
-    diff: {
-      entries: selectedSnapshotDiffEntries,
-      groups: selectedSnapshotDiffGroups,
-      changed: selectedSnapshotChangedEntries,
-      invalid: selectedSnapshotInvalidEntries,
-      signature: selectedSnapshotDiffSignature
-    }
+    restore: selectedSnapshotRestore
   } = useSelectedProfileDiff({
     snapshotParameters: snapshotCompareBaselineParameters,
     savedProfiles: savedSnapshots,
     selectedProfileId: selectedSnapshotId,
-    resolveBackup: resolveSnapshotBackup
+    resolveBackup: resolveSnapshotBackup,
+    importOptions: snapshotRestoreImportOptions
   })
+  useEffect(() => {
+    setSnapshotRestoreDroppedParamIds(new Set())
+  }, [selectedSnapshot?.id])
+  function handleDropSnapshotRestoreEntry(paramId: string): void {
+    setSnapshotRestoreDroppedParamIds((current) => {
+      const next = new Set(current)
+      next.add(paramId)
+      return next
+    })
+  }
+  function handleClearSnapshotRestoreDrops(): void {
+    setSnapshotRestoreDroppedParamIds(new Set())
+  }
+  const snapshotRestoreExcludedCalibrationCount = selectedSnapshotRestore?.excludedCount ?? 0
+  const filteredSnapshotRestoreDraftValues = useMemo(() => {
+    const draftValues = selectedSnapshotRestore?.draftValues ?? {}
+    if (snapshotRestoreDroppedParamIds.size === 0) {
+      return draftValues
+    }
+    const result: Record<string, string> = {}
+    for (const [paramId, value] of Object.entries(draftValues)) {
+      if (!snapshotRestoreDroppedParamIds.has(paramId)) {
+        result[paramId] = value
+      }
+    }
+    return result
+  }, [selectedSnapshotRestore, snapshotRestoreDroppedParamIds])
+  const {
+    entries: selectedSnapshotDiffEntries,
+    groups: selectedSnapshotDiffGroups,
+    changed: selectedSnapshotChangedEntries,
+    invalid: selectedSnapshotInvalidEntries,
+    signature: selectedSnapshotDiffSignature
+  } = useMemo(
+    () => selectEntityDiff(snapshotCompareBaselineParameters, filteredSnapshotRestoreDraftValues),
+    [snapshotCompareBaselineParameters, filteredSnapshotRestoreDraftValues]
+  )
   const {
     handleCaptureLiveSnapshot,
+    handleOverwriteSelectedSnapshot,
     handleImportSnapshotFile,
     handleExportSnapshotLibrary,
     handleOpenDesktopSnapshotFile,
@@ -3085,12 +3135,12 @@ export function App() {
       return
     }
 
-    replaceDrafts(selectedSnapshotRestore.draftValues)
+    replaceDrafts(filteredSnapshotRestoreDraftValues)
     setSelectedParameterId(selectedSnapshotChangedEntries[0]?.id ?? selectedParameterId)
     setActiveViewId('parameters')
     setSnapshotNotice({
       tone: 'warning',
-      text: `Loaded ${selectedSnapshotRestore.changedCount} snapshot change(s) into the Expert parameter editor draft set.`
+      text: `Loaded ${selectedSnapshotChangedEntries.length} snapshot change(s) into the Expert parameter editor draft set.`
     })
   }
 
@@ -7238,6 +7288,9 @@ export function App() {
             selectedSnapshotChangedEntries,
             selectedSnapshotInvalidEntries,
             selectedSnapshotRebootSensitiveCount,
+            snapshotImportCalibration,
+            snapshotRestoreExcludedCalibrationCount,
+            snapshotRestoreDroppedParamIds,
             stagedProvisioningOverlayParameters,
             selectedProvisioningProfile,
             selectedProvisioningProfileRestore,
@@ -7256,6 +7309,10 @@ export function App() {
                 `Snapshot restore (single): ${entry.id}`
               ),
             handleCaptureLiveSnapshot,
+            handleOverwriteSelectedSnapshot,
+            handleDropSnapshotRestoreEntry,
+            handleClearSnapshotRestoreDrops,
+            setSnapshotImportCalibration,
             handleCreateProvisioningProfile,
             handleDeleteSelectedProvisioningProfile,
             handleDeleteSelectedSnapshot,

--- a/apps/web/src/hooks/use-selected-profile-diff.ts
+++ b/apps/web/src/hooks/use-selected-profile-diff.ts
@@ -16,6 +16,7 @@ import { useMemo } from 'react'
 
 import {
   type ParameterBackupFile,
+  type ParameterBackupImportOptions,
   type ParameterBackupImportResult,
   type ParameterState,
   deriveDraftValuesFromParameterBackup
@@ -45,8 +46,13 @@ export function useSelectedProfileDiff<TProfile extends { id: string }>(input: {
   savedProfiles: readonly TProfile[]
   selectedProfileId: string | undefined
   resolveBackup: (profile: TProfile) => ParameterBackupFile
+  /** Forwarded to deriveDraftValuesFromParameterBackup verbatim — lets a
+   *  caller (the Snapshot restore "Import calibrations" toggle) strip an
+   *  opt-in category before matched/changed/unknown are even tallied.
+   *  Omitted by every other call site, so their behavior is unchanged. */
+  importOptions?: ParameterBackupImportOptions
 }): UseSelectedProfileDiffResult<TProfile> {
-  const { snapshotParameters, savedProfiles, selectedProfileId, resolveBackup } = input
+  const { snapshotParameters, savedProfiles, selectedProfileId, resolveBackup, importOptions } = input
 
   const selectedProfile = useMemo<TProfile | undefined>(
     () => savedProfiles.find((profile) => profile.id === selectedProfileId) ?? savedProfiles[0],
@@ -57,8 +63,9 @@ export function useSelectedProfileDiff<TProfile extends { id: string }>(input: {
     [resolveBackup, selectedProfile]
   )
   const restore = useMemo<ParameterBackupImportResult | undefined>(
-    () => (selectedBackup ? deriveDraftValuesFromParameterBackup(snapshotParameters, selectedBackup) : undefined),
-    [selectedBackup, snapshotParameters]
+    () =>
+      selectedBackup ? deriveDraftValuesFromParameterBackup(snapshotParameters, selectedBackup, importOptions) : undefined,
+    [selectedBackup, snapshotParameters, importOptions]
   )
   const diff = useMemo<EntityDiff>(
     () => selectEntityDiff(snapshotParameters, restore?.draftValues),

--- a/apps/web/src/hooks/use-snapshot-library.ts
+++ b/apps/web/src/hooks/use-snapshot-library.ts
@@ -65,6 +65,7 @@ export interface UseSnapshotLibraryParams {
 
 export interface UseSnapshotLibraryResult {
   handleCaptureLiveSnapshot: () => void
+  handleOverwriteSelectedSnapshot: () => void
   handleImportSnapshotFile: (event: ChangeEvent<HTMLInputElement>) => Promise<void>
   handleExportSnapshotLibrary: () => void
   handleOpenDesktopSnapshotFile: () => Promise<void>
@@ -164,6 +165,50 @@ export function useSnapshotLibrary({
       text: `Saved snapshot "${savedSnapshot.label}" with ${backup.parameterCount} parameters.`
     })
     trackAppEvent('Snapshot Captured', {
+      parameterCount: backup.parameterCount,
+      protected: snapshotProtectedInput
+    })
+  }
+
+  // Refreshes the SELECTED snapshot's backup with the current live values
+  // in place — same id, so the selection and any references (compare
+  // baseline picker, exports) stay stable, unlike Capture which always
+  // creates a new entry. Metadata fields only change if the operator typed
+  // something into the form; blank fields keep the existing snapshot's
+  // values rather than clearing them.
+  function handleOverwriteSelectedSnapshot(): void {
+    if (!selectedSnapshot) {
+      return
+    }
+    if (snapshot.parameters.length === 0) {
+      setSnapshotNotice({
+        tone: 'warning',
+        text: 'Pull parameters before overwriting a snapshot.'
+      })
+      return
+    }
+
+    const backup = createParameterBackup(snapshot)
+    setSavedSnapshots((current) =>
+      updateSavedSnapshot(current, selectedSnapshot.id, (existing) => ({
+        ...existing,
+        label: snapshotLabelInput || existing.label,
+        capturedAt: backup.exportedAt,
+        note: snapshotNoteInput || existing.note,
+        tags: snapshotTagsInput ? parseSnapshotTags(snapshotTagsInput) : existing.tags,
+        protected: snapshotProtectedInput,
+        backup
+      }))
+    )
+    setSnapshotLabelInput('')
+    setSnapshotNoteInput('')
+    setSnapshotTagsInput('')
+    setSnapshotProtectedInput(false)
+    setSnapshotNotice({
+      tone: 'success',
+      text: `Overwrote snapshot "${snapshotLabelInput || selectedSnapshot.label}" with the current live values (${backup.parameterCount} parameters).`
+    })
+    trackAppEvent('Snapshot Overwritten', {
       parameterCount: backup.parameterCount,
       protected: snapshotProtectedInput
     })
@@ -337,6 +382,7 @@ export function useSnapshotLibrary({
 
   return {
     handleCaptureLiveSnapshot,
+    handleOverwriteSelectedSnapshot,
     handleImportSnapshotFile,
     handleExportSnapshotLibrary,
     handleOpenDesktopSnapshotFile,

--- a/apps/web/src/sections/SnapshotsSection.tsx
+++ b/apps/web/src/sections/SnapshotsSection.tsx
@@ -64,6 +64,15 @@ export interface SnapshotsSectionDerived {
   selectedSnapshotChangedEntries: readonly ParameterDraftEntry[]
   selectedSnapshotInvalidEntries: readonly ParameterDraftEntry[]
   selectedSnapshotRebootSensitiveCount: number
+  /** Off by default — restoring another unit's accel/compass/RC-trim
+   *  calibration onto different hardware is wrong by default. */
+  snapshotImportCalibration: boolean
+  /** How many calibration params the default filter is currently excluding
+   *  (informational note next to the checkbox). */
+  snapshotRestoreExcludedCalibrationCount: number
+  /** Param ids individually dropped from this restore via the per-row Drop
+   *  button — used to grey out/hide already-dropped rows. */
+  snapshotRestoreDroppedParamIds: ReadonlySet<string>
   stagedProvisioningOverlayParameters: readonly ParameterBackupEntry[]
   selectedProvisioningProfile: SavedProvisioningProfile | undefined
   selectedProvisioningProfileRestore: ParameterBackupImportResult | undefined
@@ -86,6 +95,16 @@ export interface SnapshotsSectionHandlers {
    *  gates it as the full restore. */
   handleApplySnapshotEntry: (entry: ParameterDraftEntry) => void | Promise<void>
   handleCaptureLiveSnapshot: () => void | Promise<void>
+  /** Refreshes the SELECTED snapshot's backup with current live values
+   *  in place (same id) instead of creating a new saved entry. */
+  handleOverwriteSelectedSnapshot: () => void | Promise<void>
+  /** Per-row Drop for the restore diff — like Parameters, excludes one
+   *  param from the restore without leaving this view. */
+  handleDropSnapshotRestoreEntry: (paramId: string) => void
+  /** Restores every row dropped via handleDropSnapshotRestoreEntry for the
+   *  selected snapshot. */
+  handleClearSnapshotRestoreDrops: () => void
+  setSnapshotImportCalibration: (value: boolean) => void
   handleCreateProvisioningProfile: () => void | Promise<void>
   handleDeleteSelectedProvisioningProfile: () => void | Promise<void>
   handleDeleteSelectedSnapshot: () => void | Promise<void>
@@ -213,6 +232,9 @@ export function SnapshotsSection(props: SnapshotsSectionProps): ReactElement {
     selectedSnapshotDiffGroups,
     selectedSnapshotChangedEntries,
     selectedSnapshotInvalidEntries,
+    snapshotImportCalibration,
+    snapshotRestoreExcludedCalibrationCount,
+    snapshotRestoreDroppedParamIds,
     stagedProvisioningOverlayParameters,
     selectedProvisioningProfile,
     selectedProvisioningProfileRestore,
@@ -241,6 +263,10 @@ export function SnapshotsSection(props: SnapshotsSectionProps): ReactElement {
     handleApplySelectedSnapshotRestore,
     handleApplySnapshotEntry,
     handleCaptureLiveSnapshot,
+    handleOverwriteSelectedSnapshot,
+    handleDropSnapshotRestoreEntry,
+    handleClearSnapshotRestoreDrops,
+    setSnapshotImportCalibration,
     handleCreateProvisioningProfile,
     handleDeleteSelectedProvisioningProfile,
     handleDeleteSelectedSnapshot,
@@ -375,6 +401,17 @@ export function SnapshotsSection(props: SnapshotsSectionProps): ReactElement {
                   >
                     Capture Live Snapshot
                   </button>
+                  {selectedSnapshot ? (
+                    <button
+                      data-testid="overwrite-selected-snapshot-button"
+                      className="snapshots-button snapshots-button--secondary"
+                      onClick={handleOverwriteSelectedSnapshot}
+                      disabled={busyAction !== undefined || snapshot.parameters.length === 0}
+                      title={`Replace "${selectedSnapshot.label}" with the current live values, keeping the same saved entry.`}
+                    >
+                      Overwrite Selected
+                    </button>
+                  ) : null}
                   <button
                     data-testid="import-snapshot-file-button"
                     className="snapshots-button snapshots-button--secondary"
@@ -738,6 +775,42 @@ export function SnapshotsSection(props: SnapshotsSectionProps): ReactElement {
                   </div>
                 ) : null}
 
+                {snapshotRestoreDroppedParamIds.size > 0 ? (
+                  <div className="snapshot-restore-dropped-note" data-testid="snapshot-restore-dropped-note">
+                    <span>
+                      {snapshotRestoreDroppedParamIds.size} row{snapshotRestoreDroppedParamIds.size === 1 ? '' : 's'} dropped
+                      from this restore.
+                    </span>
+                    <button
+                      type="button"
+                      style={buttonStyle()}
+                      data-testid="snapshot-restore-undo-drops"
+                      onClick={handleClearSnapshotRestoreDrops}
+                      disabled={busyAction !== undefined}
+                    >
+                      Undo drops
+                    </button>
+                  </div>
+                ) : null}
+
+                <label className="snapshot-restore-ack" data-testid="snapshot-import-calibration-toggle">
+                  <input
+                    data-testid="snapshot-import-calibration"
+                    type="checkbox"
+                    checked={snapshotImportCalibration}
+                    onChange={(event) => setSnapshotImportCalibration(event.target.checked)}
+                    disabled={busyAction !== undefined}
+                  />
+                  <span>
+                    Import calibrations (accelerometer/compass/RC-trim). Off by default — this data is
+                    specific to the unit it was captured from and is almost never meaningful on different
+                    hardware.
+                    {snapshotRestoreExcludedCalibrationCount > 0
+                      ? ` ${snapshotRestoreExcludedCalibrationCount} calibration value(s) are currently excluded.`
+                      : ''}
+                  </span>
+                </label>
+
                 {selectedSnapshotChangedEntries.length > 0 ? (
                   <div className="parameter-diff-grid">
                     {selectedSnapshotDiffGroups.map((group) => (
@@ -782,6 +855,19 @@ export function SnapshotsSection(props: SnapshotsSectionProps): ReactElement {
                             >
                               Apply
                             </button>
+                            {/* Per-row Drop — same contract as Parameters:
+                             *  excludes this param from the restore diff
+                             *  without leaving this view. */}
+                            <button
+                              type="button"
+                              style={buttonStyle()}
+                              data-testid={`snapshot-diff-drop-${draft.id}`}
+                              onClick={() => handleDropSnapshotRestoreEntry(draft.id)}
+                              disabled={busyAction !== undefined}
+                              title={`Drop the staged change to ${draft.id} (excludes it from this restore; keeps the live FC value as-is).`}
+                            >
+                              Drop
+                            </button>
                           </div>
                         ))}
                       </section>
@@ -798,15 +884,18 @@ export function SnapshotsSection(props: SnapshotsSectionProps): ReactElement {
                   <>
                     <div className="snapshots-detail-section-heading snapshots-detail-section-heading--compact">
                       <div>
-                        <h4>Review invalid restore entries</h4>
+                        <h4>
+                          {selectedSnapshotInvalidEntries.length} invalid draft{selectedSnapshotInvalidEntries.length === 1 ? '' : 's'} blocking
+                          restore
+                        </h4>
                       </div>
-                      <span className="snapshots-counter-chip is-danger">{selectedSnapshotInvalidEntries.length} blocked</span>
+                      <span className="snapshots-counter-chip is-danger">{selectedSnapshotInvalidEntries.length} invalid</span>
                     </div>
                   <div className="parameter-diff-grid parameter-diff-grid--invalid">
                     <section className="parameter-diff-group parameter-diff-group--invalid">
                       <header>
                         <strong>Invalid restore values</strong>
-                        <span>{selectedSnapshotInvalidEntries.length} blocked</span>
+                        <span>{selectedSnapshotInvalidEntries.length} invalid</span>
                       </header>
 
                       {selectedSnapshotInvalidEntries.map((draft) => (
@@ -817,6 +906,19 @@ export function SnapshotsSection(props: SnapshotsSectionProps): ReactElement {
                           </span>
                           <span className="parameter-diff-values">{draft.rawValue || 'Empty draft'}</span>
                           <span className="parameter-diff-delta">{draft.reason ?? 'Invalid value'}</span>
+                          {/* Every invalid row offers Drop — same contract
+                              as Parameters — so the operator can dismiss a
+                              bad restore value without first fixing it. */}
+                          <button
+                            type="button"
+                            style={buttonStyle()}
+                            data-testid={`snapshot-diff-drop-${draft.id}`}
+                            onClick={() => handleDropSnapshotRestoreEntry(draft.id)}
+                            disabled={busyAction !== undefined}
+                            title={`Drop the invalid restore value for ${draft.id} (excludes it from this restore).`}
+                          >
+                            Drop
+                          </button>
                         </div>
                       ))}
                     </section>

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -9919,6 +9919,15 @@ details.metadata-settings-section:not([open]) > summary::after {
   margin-top: 2px;
 }
 
+.snapshot-restore-dropped-note {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  color: var(--text-muted);
+  font-size: 11px;
+}
+
 .motor-test-card {
   display: grid;
   gap: 14px;

--- a/tests/e2e/views.spec.ts
+++ b/tests/e2e/views.spec.ts
@@ -3515,3 +3515,57 @@ test.describe('Inspectors (expert-only)', () => {
     await expect(page.getByTestId('dronecan-fwupdate-file-50')).toBeVisible()
   })
 })
+
+test.describe('Snapshot restore', () => {
+  test('captures a snapshot, shows a real diff after a live edit, drops/undoes a row, and overwrites in place', async ({ page }) => {
+    await page.goto('/')
+    await connectViaHeader(page)
+    // Capture must happen AFTER the full parameter sync — otherwise the
+    // backup only has whichever params had streamed in so far (a real race:
+    // BATT_LOW_VOLT missing from the backup entirely reads as "already
+    // matches", not as a diff, for the wrong reason).
+    await expectParameterSyncComplete(page)
+
+    // Capture a baseline while the live values are still untouched.
+    await page.getByTestId('view-button-snapshots').click()
+    await page.getByTestId('snapshot-label-input').fill('E2E baseline')
+    await page.getByTestId('capture-live-snapshot-button').click()
+    await expect(page.getByTestId('snapshot-import-calibration')).not.toBeChecked()
+
+    // Change a live value from a different tab so the snapshot now has
+    // something real to restore.
+    await page.getByTestId('product-mode-expert').check()
+    await page.getByTestId('view-button-parameters').click()
+    const search = page.getByTestId('parameter-search-input')
+    await search.fill('BATT_LOW_VOLT')
+    await page.locator('input[aria-label="BATT_LOW_VOLT value"]').fill('13.5')
+    await search.fill('')
+    await page.getByRole('button', { name: /^Apply All \(/ }).click()
+    await expect(page.getByRole('button', { name: /^Apply All \(0\)/ })).toBeVisible()
+
+    // Back in Snapshots, the captured baseline now diffs against the live
+    // (changed) value.
+    await page.getByTestId('view-button-snapshots').click()
+    await expect(page.getByTestId('snapshot-diff-drop-BATT_LOW_VOLT')).toBeVisible()
+
+    // Calibration is excluded by default (accel/gyro/compass/AHRS trim) —
+    // the note names how many were stripped from this restore.
+    await expect(page.getByTestId('snapshot-import-calibration-toggle')).toContainText('currently excluded')
+
+    // Drop the row — excludes it from the restore diff/count without
+    // leaving this view — then undo to restore it.
+    await page.getByTestId('snapshot-diff-drop-BATT_LOW_VOLT').click()
+    await expect(page.getByTestId('snapshot-diff-drop-BATT_LOW_VOLT')).toHaveCount(0)
+    await expect(page.getByTestId('snapshot-restore-dropped-note')).toContainText('1 row dropped')
+    await page.getByTestId('snapshot-restore-undo-drops').click()
+    await expect(page.getByTestId('snapshot-diff-drop-BATT_LOW_VOLT')).toBeVisible()
+    await expect(page.getByTestId('snapshot-restore-dropped-note')).toHaveCount(0)
+
+    // Overwrite Selected refreshes the SAME saved entry in place rather
+    // than creating a new one.
+    await page.getByTestId('overwrite-selected-snapshot-button').click()
+    await expect(page.getByText(/Overwrote snapshot/)).toBeVisible()
+    // The restore diff against the (now up to date) baseline is empty again.
+    await expect(page.getByTestId('snapshot-diff-drop-BATT_LOW_VOLT')).toHaveCount(0)
+  })
+})


### PR DESCRIPTION
## Summary
Snapshot restore's write path applied its entire diff in one shot with no way to curate individual rows — unlike Parameters' stage/drop/apply-staged flow. This closes that gap:

- **"Import calibrations" checkbox** (off by default): reuses the *existing* opt-in 'calibration' exclusion category already used by the Parameters tab's backup-import toggles (`deriveDraftValuesFromParameterBackup`'s `excludeCategories`) rather than a second bespoke classifier. `useSelectedProfileDiff` now threads an optional `importOptions` through — every other caller (provisioning, tuning) is unaffected.
- **Per-row Drop** on changed AND invalid restore entries, with Parameters' exact wording. An "Undo drops" affordance clears the per-snapshot drop set.
- **Invalid-entries wording** reworded to match Parameters' "N invalid draft(s) blocking Apply All" phrasing.
- **"Overwrite Selected"** refreshes the selected snapshot's backup with current live values in place (same id), instead of Capture always creating a new entry.

User confirmed the accel-calibration-flag handling is already correct and needs no changes.

## ArduCopter byte-identical
UI/draft-curation logic only; the underlying verified-write path (`handleApplyScopedParameterDrafts`) is untouched.

## Test plan
- [x] `npm run typecheck`
- [x] `npm run test` — 686 pass
- [x] `npm run test:unit --workspace @arduconfig/web` — 471 pass
- [x] `npx playwright test tests/e2e/views.spec.ts` — full suite, 148/148 pass (new end-to-end Snapshot restore test: capture → live edit → diff → drop/undo → overwrite-in-place)