### PR TITLE
feat(osd): named video-system dropdown auto-sets the character grid

### DIFF
--- a/apps/web/src/views/Osd.tsx
+++ b/apps/web/src/views/Osd.tsx
@@ -23,6 +23,27 @@ const OSD_ANALOG_LAYOUTS = {
 } as const
 type OsdAnalogLayout = keyof typeof OSD_ANALOG_LAYOUTS
 
+// Named video-system picker — the operator names the goggles/VRX they
+// actually have instead of guessing a raw grid size. `layout` is fixed for
+// every digital system (each digital standard only ever runs one character
+// grid); `analog` has none here because analog is either PAL or NTSC
+// depending on the camera/goggles, picked via the secondary selector.
+// Grid sizes verified against ArduPilot's own DisplayPort OSD documentation
+// (HDZero: ardupilot.org/copter/docs/common-displayport.html, explicit
+// "set OSDx_TXT_RES to 0 or 1") and hardware specs (Walksnail Avatar HD
+// defaults to 60x22; the whole DJI HD family — O3 Air Unit, Goggles 2,
+// Goggles V2, Goggles 3 — shares the same 810p/60x22 grid).
+const OSD_VIDEO_SYSTEMS = {
+  analog: { label: 'Analog', layout: undefined },
+  hdzero: { label: 'HDZero', layout: 'hd_50x18' },
+  walksnail: { label: 'Walksnail Avatar', layout: 'hd_60x22' },
+  dji_o3: { label: 'DJI O3 Air Unit', layout: 'hd_60x22' },
+  dji_goggles_2: { label: 'DJI Goggles 2', layout: 'hd_60x22' },
+  dji_goggles_v: { label: 'DJI Goggles V2', layout: 'hd_60x22' },
+  dji_goggles_3: { label: 'DJI Goggles 3', layout: 'hd_60x22' }
+} as const satisfies Record<string, { label: string; layout: OsdAnalogLayout | undefined }>
+type OsdVideoSystem = keyof typeof OSD_VIDEO_SYSTEMS
+
 // BF-style element category groupings. Each id below maps a per-element
 // OsdElementToggle (keyed on elementId — BAT_VOLT / GSPEED / etc.) into a
 // logical group operators recognize from BF's OSD configuration page.
@@ -232,7 +253,12 @@ export function OsdView(props: OsdViewProps) {
   // boundary, so the preview reflects each cell change as it happens
   // — no separate "commit on drop" step.
   const gridRef = useRef<HTMLDivElement | null>(null)
-  const [analogLayout, setAnalogLayout] = useState<OsdAnalogLayout>('pal')
+  // Default NTSC, not PAL — an arbitrary-but-deliberate choice away from the
+  // old hardcoded PAL default (field feedback). Digital systems don't need a
+  // sub-choice since each one only ever runs a single fixed grid.
+  const [videoSystem, setVideoSystem] = useState<OsdVideoSystem>('analog')
+  const [analogSubMode, setAnalogSubMode] = useState<'pal' | 'ntsc'>('ntsc')
+  const analogLayout: OsdAnalogLayout = OSD_VIDEO_SYSTEMS[videoSystem].layout ?? analogSubMode
   const layout = OSD_ANALOG_LAYOUTS[analogLayout]
   const [draggingId, setDraggingId] = useState<string | undefined>(undefined)
   // Continuous, un-quantized pixel offset from the grab point, updated on
@@ -897,19 +923,43 @@ export function OsdView(props: OsdViewProps) {
                     {dragEnabled ? 'editable · drag to reposition' : 'live preview'}
                   </StatusBadge>
                   <label className="osd-preview-footer__layout" data-testid="osd-analog-layout">
-                    <span>Video layout</span>
+                    <span>Video system</span>
                     <select
-                      value={analogLayout}
-                      onChange={(event) => setAnalogLayout(event.target.value as OsdAnalogLayout)}
-                      aria-label="OSD video layout"
+                      value={videoSystem}
+                      onChange={(event) => setVideoSystem(event.target.value as OsdVideoSystem)}
+                      aria-label="OSD video system"
                     >
-                      {(Object.keys(OSD_ANALOG_LAYOUTS) as OsdAnalogLayout[]).map((key) => (
-                        <option key={key} value={key}>
-                          {OSD_ANALOG_LAYOUTS[key].label} ({OSD_ANALOG_LAYOUTS[key].columns}×{OSD_ANALOG_LAYOUTS[key].rows})
-                        </option>
-                      ))}
+                      {(Object.keys(OSD_VIDEO_SYSTEMS) as OsdVideoSystem[]).map((key) => {
+                        const system = OSD_VIDEO_SYSTEMS[key]
+                        const gridSuffix = system.layout
+                          ? ` (${OSD_ANALOG_LAYOUTS[system.layout].columns}×${OSD_ANALOG_LAYOUTS[system.layout].rows})`
+                          : ''
+                        return (
+                          <option key={key} value={key}>
+                            {system.label}
+                            {gridSuffix}
+                          </option>
+                        )
+                      })}
                     </select>
                   </label>
+                  {videoSystem === 'analog' ? (
+                    <label className="osd-preview-footer__layout" data-testid="osd-analog-submode">
+                      <span>Analog standard</span>
+                      <select
+                        value={analogSubMode}
+                        onChange={(event) => setAnalogSubMode(event.target.value as 'pal' | 'ntsc')}
+                        aria-label="OSD analog standard"
+                      >
+                        <option value="ntsc">NTSC ({OSD_ANALOG_LAYOUTS.ntsc.columns}×{OSD_ANALOG_LAYOUTS.ntsc.rows})</option>
+                        <option value="pal">PAL ({OSD_ANALOG_LAYOUTS.pal.columns}×{OSD_ANALOG_LAYOUTS.pal.rows})</option>
+                      </select>
+                    </label>
+                  ) : null}
+                  <p className="osd-preview-footer__match-note">
+                    The goggles/VRX, camera, and FC OSD settings must all agree on the same video system — a
+                    mismatch here is a preview-only aid and won&apos;t fix a mismatch on the real hardware.
+                  </p>
                   <p>
                     Element positions read from the OSD{activeScreen}_*_X/Y catalog values. Live telemetry feeds the
                     displayed numbers. Video layout is a preview aid (PAL/NTSC/HD canvas) and doesn’t change FC params.

--- a/tests/e2e/views.spec.ts
+++ b/tests/e2e/views.spec.ts
@@ -1838,24 +1838,42 @@ test.describe('OSD view preview', () => {
     await expect(units).toContainText('globally')
   })
 
-  test('analog/HD layout selector switches the preview canvas (PAL/NTSC/HD)', async ({ page }) => {
+  test('named video-system selector switches the preview canvas (Analog/HDZero/Walksnail/DJI)', async ({ page }) => {
     await page.goto('/')
     await connectViaHeader(page)
     await openView(page, 'osd')
 
+    // Default is Analog + NTSC (not PAL — field feedback), 30 columns.
     const screen = page.locator('.osd-preview-screen').first()
-    await expect(screen).toHaveAttribute('data-osd-layout', 'pal')
+    await expect(page.getByTestId('osd-analog-layout').locator('select')).toHaveValue('analog')
+    await expect(page.getByTestId('osd-analog-submode').locator('select')).toHaveValue('ntsc')
+    await expect(screen).toHaveAttribute('data-osd-layout', 'ntsc')
     const grid = page.getByTestId('osd-preview-grid')
     const columnCount = () =>
       grid.evaluate((el) => getComputedStyle(el).gridTemplateColumns.split(' ').length)
-    // PAL is 30 columns; the two HD grids are 50x18 and 60x22.
     expect(await columnCount()).toBe(30)
-    await page.getByTestId('osd-analog-layout').locator('select').selectOption('hd_50x18')
+
+    // Switching to a named digital system auto-sets its fixed grid and hides
+    // the analog PAL/NTSC sub-picker (a digital standard has no such choice).
+    await page.getByTestId('osd-analog-layout').locator('select').selectOption('hdzero')
     await expect(screen).toHaveAttribute('data-osd-layout', 'hd_50x18')
     expect(await columnCount()).toBe(50)
-    await page.getByTestId('osd-analog-layout').locator('select').selectOption('hd_60x22')
+    await expect(page.getByTestId('osd-analog-submode')).toHaveCount(0)
+
+    await page.getByTestId('osd-analog-layout').locator('select').selectOption('walksnail')
     await expect(screen).toHaveAttribute('data-osd-layout', 'hd_60x22')
     expect(await columnCount()).toBe(60)
+
+    await page.getByTestId('osd-analog-layout').locator('select').selectOption('dji_o3')
+    await expect(screen).toHaveAttribute('data-osd-layout', 'hd_60x22')
+    expect(await columnCount()).toBe(60)
+
+    // Back to Analog, PAL this time.
+    await page.getByTestId('osd-analog-layout').locator('select').selectOption('analog')
+    await expect(page.getByTestId('osd-analog-submode')).toBeVisible()
+    await page.getByTestId('osd-analog-submode').locator('select').selectOption('pal')
+    await expect(screen).toHaveAttribute('data-osd-layout', 'pal')
+    expect(await columnCount()).toBe(30)
   })
 
   test('renders the per-element preview from the OSD1_*_EN/X/Y catalog values', async ({ page }) => {
@@ -1934,7 +1952,7 @@ test.describe('OSD view preview', () => {
     // Switch to the 60x22 HD grid (DJI/Walksnail-class DisplayPort). A column
     // beyond the analog 29 ceiling must render at that column, not be clamped
     // back into the 30x16 box the way the fixed 29/15 clamp did.
-    await page.getByTestId('osd-analog-layout').locator('select').selectOption('hd_60x22')
+    await page.getByTestId('osd-analog-layout').locator('select').selectOption('dji_o3')
     const align = page.getByTestId('osd-element-align-BAT_VOLT')
     await align.scrollIntoViewIfNeeded()
     const xInput = align.locator('input[type="number"]').first()
@@ -1984,8 +2002,9 @@ test.describe('OSD view preview', () => {
     const startBox = await batVolt.boundingBox()
     if (!gridBox || !startBox) throw new Error('no bounding box for OSD preview grid or element')
 
+    // Default video system is Analog/NTSC (30x13) — not PAL (30x16).
     const cellWidth = gridBox.width / 30
-    const cellHeight = gridBox.height / 16
+    const cellHeight = gridBox.height / 13
     const startX = startBox.x + startBox.width / 2
     const startY = startBox.y + startBox.height / 2
     const colBefore = Number(await batVolt.evaluate((el) => getComputedStyle(el).gridColumnStart))


### PR DESCRIPTION
## Summary
Replaced the raw "video layout" size picker with a named video-system picker: Analog, HDZero, Walksnail Avatar, DJI O3 Air Unit, DJI Goggles 2/V2/3. Digital systems auto-set their fixed grid:
- HDZero → 50x18 (per ArduPilot's own DisplayPort docs, which explicitly recommend `OSDx_TXT_RES` 0 or 1 for HDZero)
- Walksnail Avatar and the whole DJI HD family (O3/Goggles 2/V2/3) → 60x22 (their native 810p grid, confirmed via Walksnail's own wiki + DJI FPV system specs)

Analog reveals a secondary PAL/NTSC selector since analog genuinely is either. Default changed from PAL to Analog/NTSC (explicit field feedback). Added a standing note that goggles/VRX, camera, and FC OSD settings must all agree — this picker is a preview aid only.

## ArduCopter byte-identical
Presentation-only (preview canvas sizing + pointer-drag pixel→cell math), no runtime/param changes — same scope as the picker it replaces.

## Test plan
- [x] `npm run typecheck`
- [x] `npm run test` — 686 pass
- [x] `npm run test:unit --workspace @arduconfig/web` — 471 pass
- [x] `npx playwright test tests/e2e/views.spec.ts` — full suite, 148/148 pass (rewrote the layout-selector test for the new named options + default; updated two other OSD tests whose hardcoded row-count math assumed the old PAL default)