### PR TITLE
fix(receiver,rc-mixer): correct inverted pitch direction check, RC Mixer remove button, add Scripting 3/4

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -380,6 +380,7 @@ import {
   rcLogicFunctionCatalog,
   rcLogicRemovePlan,
   rcLogicTermFromAssignmentId,
+  rcLogicTermParamIds,
   rcLogicUpdateDrafts
 } from './view-models/rc-logic'
 import { armSwitchAssignmentDrafts, deriveArmSwitchAssignment } from './view-models/arm-switch'
@@ -4816,9 +4817,30 @@ export function App() {
     [rcLogicFunctionCatalogMemo]
   )
   const rcLogicExcludedChannels = useMemo(() => derivePrimaryAndModeChannels(snapshot), [snapshot])
+  // Remove on an ALREADY-APPLIED term only STAGES a FUNC=0 draft (same
+  // stage-then-apply model every other RC Mixer edit uses) — readRcLogicModel
+  // still reports the term as "touched" while that draft is pending, so the
+  // row stayed visible after clicking Remove and looked like the button did
+  // nothing. Hide it locally the instant Remove is clicked; the check
+  // against editedValues (not just membership) means a term falls back out
+  // of this set on its own once the draft is applied (cleared) or discarded
+  // (reverted to a nonzero live func, at which point it belongs back on
+  // screen) — no separate reset path needed.
+  const [rcLogicRemovedTerms, setRcLogicRemovedTerms] = useState<ReadonlySet<number>>(() => new Set())
+  const rcLogicVisibleAssignments = useMemo(
+    () =>
+      rcLogicModel.assignments.filter((assignment) => {
+        const term = rcLogicTermFromAssignmentId(assignment.id)
+        if (term === null || !rcLogicRemovedTerms.has(term)) {
+          return true
+        }
+        return editedValues[rcLogicTermParamIds(term).func] !== '0'
+      }),
+    [rcLogicModel.assignments, rcLogicRemovedTerms, editedValues]
+  )
   const rcLogicChannels = useMemo(
-    () => groupAssignmentsByChannel(rcLogicModel.assignments, 16, rcLogicExcludedChannels),
-    [rcLogicModel.assignments, rcLogicExcludedChannels]
+    () => groupAssignmentsByChannel(rcLogicVisibleAssignments, 16, rcLogicExcludedChannels),
+    [rcLogicVisibleAssignments, rcLogicExcludedChannels]
   )
   function handleRcLogicAddAssignment(channel: number): void {
     const drafts = rcLogicAddDrafts(rcLogicModel, channel)
@@ -4847,6 +4869,15 @@ export function App() {
     clearDrafts(plan.clear)
     if (Object.keys(plan.disable).length > 0) {
       mergeDrafts(plan.disable)
+      // Disabling an already-applied term only stages a draft (same
+      // stage-then-apply model as every other RC Mixer edit) — hide the row
+      // immediately instead of leaving it visible until the operator applies
+      // the global staged changes.
+      setRcLogicRemovedTerms((current) => {
+        const next = new Set(current)
+        next.add(term)
+        return next
+      })
     }
   }
   function handleRcLogicToggleEngine(enabled: boolean): void {

--- a/apps/web/src/preview-components.tsx
+++ b/apps/web/src/preview-components.tsx
@@ -114,7 +114,12 @@ export function StickCraftPreview({
       value = (pwm - 1500) / 500
     }
     const reversed = readRoundedParameter(snapshot, `RC${obs.channelNumber}_REVERSED`) === 1
-    return Math.max(-1, Math.min(1, reversed ? -value : value))
+    const oriented = reversed ? -value : value
+    // Pitch is inverted relative to roll/yaw here — matches the same
+    // hardware-verified correction in receiver-direction-check.ts's
+    // evaluateRcDirection (see its comment for the full trace).
+    const axisOriented = axisId === 'pitch' ? -oriented : oriented
+    return Math.max(-1, Math.min(1, axisOriented))
   }
   const rollNorm = axisNorm('roll')
   const pitchNorm = axisNorm('pitch')
@@ -159,12 +164,12 @@ export function StickCraftPreview({
     // display:contents wrapper exposes the live attitude for tests without
     // affecting layout (e.g. asserting a centred yaw holds heading).
     //
-    // rollNorm/pitchNorm are ArduPilot's own norm_input() convention (verified
-    // against rc_input_to_roll_pitch_rad + its unit test in AP_Math): positive
-    // norm_input -> positive target angle -> roll-right / pitch-up. FlightDeckPreview's
-    // rollDeg/pitchDeg use that same positive-is-up/right convention directly
-    // (confirmed by the other FlightDeckPreview call site, which feeds real
-    // ATTITUDE.pitch/roll unmodified) — neither axis needs a sign flip here.
+    // rollNorm/pitchNorm follow ArduPilot's norm_input() convention for roll
+    // (verified against rc_input_to_roll_pitch_rad + its unit test in
+    // AP_Math). Pitch is inverted inside axisNorm() — hands-on hardware
+    // testing showed this preview and the Endpoints verdict both read
+    // pitch backwards despite the source-level convention checking out end
+    // to end, so the empirical result wins (see axisNorm's comment).
     <div
       style={{ display: 'contents' }}
       data-testid="receiver-stick-attitude"

--- a/apps/web/src/view-models/rc-mixer.ts
+++ b/apps/web/src/view-models/rc-mixer.ts
@@ -92,7 +92,9 @@ export const RC_MIXER_FUNCTION_CATALOG: readonly RcMixerFunctionDefinition[] = [
   { id: 83, label: 'Disable airmode', description: 'Forces airmode off while held; vehicle-dependent.', vehicles: ['ArduCopter'] },
   { id: 153, label: 'Arm without safety', description: 'Arms even with safety switch active. Off-flight bench use only.' },
   { id: 300, label: 'Scripting 1', description: 'Triggers Lua script flag 1 (vehicle must run a script that reads it).' },
-  { id: 301, label: 'Scripting 2', description: 'Triggers Lua script flag 2.' }
+  { id: 301, label: 'Scripting 2', description: 'Triggers Lua script flag 2.' },
+  { id: 302, label: 'Scripting 3', description: 'Triggers Lua script flag 3.' },
+  { id: 303, label: 'Scripting 4', description: 'Triggers Lua script flag 4.' }
 ]
 
 export function createIdleRcMixerState(): RcMixerState {

--- a/apps/web/src/view-models/receiver-direction-check.test.ts
+++ b/apps/web/src/view-models/receiver-direction-check.test.ts
@@ -33,10 +33,13 @@ describe('evaluateRcDirection (centred axes)', () => {
     expect(evaluateRcDirection({ axisId: 'roll', pwm: 1100, ...CENTERED, reversed: true })).toBe('correct')
   })
 
-  it('pitch-up is the classic Mode-2 case: stick-back reads low, so reversed=1 is correct', () => {
-    // Mode-2 TX: pulling back (pitch up) drives the wire LOW.
-    expect(evaluateRcDirection({ axisId: 'pitch', pwm: 1100, ...CENTERED, reversed: true })).toBe('correct')
-    expect(evaluateRcDirection({ axisId: 'pitch', pwm: 1100, ...CENTERED, reversed: false })).toBe('reversed')
+  it('pitch is inverted relative to roll/yaw (hardware-verified correction)', () => {
+    // Mode-2 TX: pulling back (pitch up) drives the wire LOW. Unlike
+    // roll/yaw, hands-on hardware testing confirmed pitch reads correctly
+    // UNREVERSED here — see evaluateRcDirection's comment for the full trace
+    // and why the source-level derivation didn't predict this.
+    expect(evaluateRcDirection({ axisId: 'pitch', pwm: 1100, ...CENTERED, reversed: false })).toBe('correct')
+    expect(evaluateRcDirection({ axisId: 'pitch', pwm: 1100, ...CENTERED, reversed: true })).toBe('reversed')
   })
 
   it('yaw-right matches the roll sign convention', () => {

--- a/apps/web/src/view-models/receiver-direction-check.ts
+++ b/apps/web/src/view-models/receiver-direction-check.ts
@@ -85,7 +85,17 @@ export function evaluateRcDirection(input: RcDirectionAxisInput): RcDirectionRes
   }
   const rawSign = delta > 0 ? 1 : -1
   const normSign = input.reversed ? -rawSign : rawSign
-  return normSign > 0 ? 'correct' : 'reversed'
+  // Pitch is inverted relative to roll/yaw here: hands-on hardware
+  // verification (toggling RCn_REVERSED on a real FC) confirmed the verdict
+  // was backwards for pitch specifically — flips to the wrong label when
+  // reversed is toggled, on both this verdict and the reactive stick-craft
+  // preview, which share this sign convention. Source-level tracing of
+  // RC_Channel::norm_input -> rc_input_to_roll_pitch_rad -> the attitude
+  // controller found no flip anywhere in that chain, so whatever the
+  // discrepancy is, it isn't in that path; empirical hardware behavior
+  // wins over the derivation here.
+  const orientedSign = input.axisId === 'pitch' ? -normSign : normSign
+  return orientedSign > 0 ? 'correct' : 'reversed'
 }
 
 /**

--- a/tests/e2e/views.spec.ts
+++ b/tests/e2e/views.spec.ts
@@ -1576,6 +1576,34 @@ test.describe('RC Mixer view', () => {
     expect(optionLabels.some((label) => label.startsWith('Land'))).toBe(true)
     expect(optionLabels.some((label) => label.startsWith('Do nothing'))).toBe(true)
   })
+
+  test('Remove on an already-applied assignment hides it immediately, and discarding the pending change restores it', async ({ page }) => {
+    // Regression: Remove on a real (already-written) RCL term only staged a
+    // FUNC=0 draft — readRcLogicModel still reported the term as "touched"
+    // while that draft was pending, so the row stayed on screen and looked
+    // like the button did nothing.
+    await page.goto('/')
+    await page.getByTestId('transport-mode-select').selectOption('demo')
+    await page.getByTestId('connect-button').click()
+    await page.getByTestId('product-mode-expert').check()
+    await page.getByTestId('view-button-rc-mixer').click()
+
+    // Demo seeds a real, already-applied ArmDisarm assignment on channel 5.
+    const channel5 = page.getByTestId('rc-mixer-channel-5')
+    await channel5.scrollIntoViewIfNeeded()
+    await expect(channel5.locator('[data-testid^="rc-mixer-remove-"]')).toBeVisible()
+
+    await channel5.locator('[data-testid^="rc-mixer-remove-"]').first().click()
+    await expect(channel5.locator('[data-testid^="rc-mixer-remove-"]')).toHaveCount(0)
+    await expect(channel5).toContainText('No assignments')
+    // The removal is staged (not yet written) — the global bar reflects it.
+    await expect(page.getByTestId('global-draft-bar')).toBeVisible()
+
+    // Discarding the pending change reverts FUNC back to its live (nonzero)
+    // value — the row must reappear rather than staying hidden forever.
+    await page.getByTestId('global-draft-discard').click()
+    await expect(channel5.locator('[data-testid^="rc-mixer-remove-"]')).toBeVisible()
+  })
 })
 
 // The receiver Bind (ELRS/CRSF) button is currently hidden in the UI


### PR DESCRIPTION
## Summary
- **Receiver Endpoints pitch direction**: hands-on hardware testing confirmed the pitch direction-check verdict and the reactive stick-craft preview were both backwards (toggling RCn_REVERSED flipped to the wrong label). Traced the full chain (`RC_Channel::norm_input` → `rc_input_to_roll_pitch_rad` → the attitude controller) against real ArduPilot source — every link matched what this app already computed, confirmed via two independent source facts. No flip found in that derivation, so empirical hardware behavior wins: pitch is now inverted relative to roll/yaw in both the verdict and the visual craft, consistently.
- **RC Mixer Remove button**: Remove on an already-applied AP_RC_Logic term only staged a `FUNC=0` draft — the row stayed visible until the operator noticed and applied the global staged-changes bar, looking like the button did nothing. Now hides the row immediately; falls back out of the hidden set on its own if the removal is later discarded (reverted to its live value).
- **RC Mixer**: added Scripting 3/4 (`RCn_OPTION` 302/303, confirmed against `RC_Channel.h`'s `SCRIPTING_3`/`SCRIPTING_4`) alongside the existing Scripting 1/2.

## ArduCopter byte-identical
Presentation/verdict logic only for the pitch and RC Mixer remove fixes; the Scripting addition is a static catalog entry.

## Test plan
- [x] `npm run typecheck`
- [x] `npm run test` — 686 pass
- [x] `npm run test:unit --workspace @arduconfig/web` — 471 pass (updated the pitch-convention test to the corrected expectation)
- [x] `npx playwright test tests/e2e/views.spec.ts` — full suite, 149/149 pass (new RC Mixer remove-button regression test, incl. discard-restores-row path)