### PR TITLE
chore(receiver): drop superfluous export on internal arm-switch channel bounds

### DIFF
--- a/apps/web/src/view-models/arm-switch.ts
+++ b/apps/web/src/view-models/arm-switch.ts
@@ -19,9 +19,9 @@ export const ARM_SWITCH_AIRMODE_OPTION_VALUE = 154
 // RCn_OPTION only makes sense on AUX channels — the primary stick axes and
 // the mode-switch channel are excluded elsewhere in the app (see
 // derivePrimaryAndModeChannels) and by convention start no earlier than
-// channel 5.
-export const ARM_SWITCH_MIN_CHANNEL = 5
-export const ARM_SWITCH_MAX_CHANNEL = 16
+// channel 5. Internal to this module (never referenced externally).
+const ARM_SWITCH_MIN_CHANNEL = 5
+const ARM_SWITCH_MAX_CHANNEL = 16
 
 export interface ArmSwitchAssignment {
   /** The channel currently carrying an Arm/Disarm RCn_OPTION value, or


### PR DESCRIPTION
## Summary
`ARM_SWITCH_MIN_CHANNEL` / `ARM_SWITCH_MAX_CHANNEL` in `arm-switch.ts` were exported but only referenced inside their own module (loop bounds). Demoted to plain module-level `const`. Surfaced by a `ts-prune` dead-export audit.

## ArduCopter byte-identical
No behavior change — export-surface tightening only.

## Test plan
- [x] `npm run typecheck --workspace @arduconfig/web` (green)