### PR TITLE
feat(pwa): restore the "new version ready — Refresh" prompt without a service worker

### DIFF
--- a/apps/web/src/sw-update.test.ts
+++ b/apps/web/src/sw-update.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest'
+
+import { extractAppBundlePath } from './sw-update'
+
+describe('extractAppBundlePath', () => {
+  it('extracts the hashed entry bundle from a served index.html', () => {
+    const html = `<!doctype html><html><head>
+      <link rel="modulepreload" href="/assets/react-vendor-C3vNzB_l.js">
+      <script type="module" crossorigin src="/assets/index-DZkYp__6.js"></script>
+      <link rel="stylesheet" href="/assets/index-DV3veTCI.css">
+      </head><body></body></html>`
+    expect(extractAppBundlePath(html)).toBe('assets/index-DZkYp__6.js')
+  })
+
+  it('extracts from a script src URL (the loaded-tab baseline)', () => {
+    expect(extractAppBundlePath('http://127.0.0.1:4173/assets/index-ABC123xy.js')).toBe('assets/index-ABC123xy.js')
+  })
+
+  it('matches under a non-root deploy base', () => {
+    const html = `<script type="module" src="/ArduConfigurator/assets/index-9zXq-1Ab.js"></script>`
+    expect(extractAppBundlePath(html)).toBe('assets/index-9zXq-1Ab.js')
+  })
+
+  it('returns null when there is no hashed entry (e.g. vite dev serving /src/main.tsx)', () => {
+    expect(extractAppBundlePath('<script type="module" src="/src/main.tsx"></script>')).toBeNull()
+  })
+
+  it('does not match the entry stylesheet (.css), only the .js bundle', () => {
+    expect(extractAppBundlePath('<link href="/assets/index-DV3veTCI.css">')).toBeNull()
+  })
+
+  it('picks the entry index-*.js, not a same-name-prefixed vendor chunk', () => {
+    // Only `index-<hash>.js` should match; react-vendor / param-metadata chunks
+    // start with a different name and must not be picked up.
+    const html = `<link rel="modulepreload" href="/assets/param-metadata-S83YFtaK.js">
+      <script type="module" src="/assets/index-DZkYp__6.js"></script>`
+    expect(extractAppBundlePath(html)).toBe('assets/index-DZkYp__6.js')
+  })
+})

--- a/apps/web/src/sw-update.ts
+++ b/apps/web/src/sw-update.ts
@@ -1,26 +1,33 @@
 // The offline-shell service worker was RETIRED — it stranded users on a stale
 // app shell across deploys (white screen until a hard refresh). apps/web/public/
-// sw.js is now a self-destructing SW; this module just makes the running app
-// unregister any lingering SW and clear its caches, and registers nothing new.
-// The app loads fresh from the network on every visit.
+// sw.js is now a self-destructing SW; registerServiceWorker() makes the running
+// app unregister any lingering SW and clear its caches, and registers nothing.
+//
+// But retiring the SW also removed the "new version is ready — Refresh" prompt:
+// a tab left open across a deploy keeps running the old bundle with no signal.
+// useServiceWorkerUpdate() brings that prompt back WITHOUT a service worker, by
+// polling the deployed index.html and comparing its hashed entry-bundle name to
+// the one THIS tab loaded. No SW = no stale-shell risk; the check is pure
+// network polling. Refresh does a plain location.reload() to pick up the new
+// bundle.
 
-import { useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 
-// Kept as a union (not just 'idle') so consumers that switch on 'available'
-// still type-check; the hook now only ever returns 'idle', so no update banner
-// is shown.
+// Kept as a union so App.tsx's banner can switch on 'available'.
 export type SwUpdateState = { kind: 'idle' } | { kind: 'available'; apply: () => void }
+
+// How often to re-check for a new deploy while the tab stays open. Also checked
+// on tab refocus (visibilitychange) so an app left open overnight notices a
+// deploy promptly on the next glance, without hammering the server in between.
+const UPDATE_POLL_INTERVAL_MS = 5 * 60 * 1000
+// Debounce refocus checks so rapid tab switching doesn't fire a burst of fetches.
+const REFOCUS_DEBOUNCE_MS = 30 * 1000
 
 let cleanupStarted = false
 
 /**
  * Unregister any previously-installed service worker and clear its caches;
  * register nothing. Idempotent, safe to call once on app boot.
- *
- * The load-bearing recovery for an already-white-screened tab is the
- * self-destructing sw.js itself (driven by the browser's own SW update check,
- * independent of the page JS). This is the belt-and-suspenders cleanup for tabs
- * whose JS did run.
  */
 export function registerServiceWorker(): void {
   if (cleanupStarted) return
@@ -44,10 +51,103 @@ export function registerServiceWorker(): void {
   })
 }
 
-/** The SW update prompt is retired — always idle (no banner renders). */
+/**
+ * Extract the hashed entry-bundle path (`assets/index-<hash>.js`) from a string —
+ * either the served index.html or a script `src`. Vite emits the app entry as a
+ * single `assets/index-<hash>.js` whose hash changes on every build, so this is
+ * a stable per-deploy fingerprint. Returns null when no hashed entry is present
+ * (e.g. `vite dev`, where the entry is an un-hashed `/src/main.tsx`), which
+ * disables the check rather than false-prompting. Pure — unit-tested.
+ */
+export function extractAppBundlePath(text: string): string | null {
+  const match = text.match(/assets\/index-[A-Za-z0-9_-]+\.js/)
+  return match ? match[0] : null
+}
+
+/** The entry bundle THIS tab actually loaded, read from the live document's
+ *  module script tag. This is the baseline the poll compares against — using
+ *  the running tab's bundle (not a first-fetch of index.html) means a deploy
+ *  that lands between page-load and the first poll is still detected. */
+function readLoadedAppBundlePath(): string | null {
+  if (typeof document === 'undefined') return null
+  const scripts = Array.from(document.querySelectorAll<HTMLScriptElement>('script[type="module"][src]'))
+  for (const script of scripts) {
+    const path = extractAppBundlePath(script.src)
+    if (path) return path
+  }
+  return null
+}
+
+/** Fetch the deployed index.html (bypassing the browser cache) and return its
+ *  current entry-bundle path, or null on any failure (offline, blip) so the
+ *  caller simply retries next interval. */
+async function fetchDeployedAppBundlePath(): Promise<string | null> {
+  try {
+    const url = `${import.meta.env.BASE_URL}index.html`
+    const response = await fetch(url, { cache: 'no-store' })
+    if (!response.ok) return null
+    return extractAppBundlePath(await response.text())
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Returns `{ kind: 'available', apply }` once a newer deployment is detected
+ * (the deployed index.html points at a different entry bundle than this tab
+ * loaded); `{ kind: 'idle' }` otherwise. `apply` reloads the page.
+ *
+ * e2e seam: `?appUpdate=available` forces the available state immediately
+ * (mirrors the app's other URL-param test seams), so the banner can be
+ * exercised without an actual redeploy.
+ */
 export function useServiceWorkerUpdate(): SwUpdateState {
-  const [state] = useState<SwUpdateState>({ kind: 'idle' })
-  return state
+  const [available, setAvailable] = useState(false)
+  const loadedBundleRef = useRef<string | null>(null)
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return
+
+    if (new URLSearchParams(window.location.search).get('appUpdate') === 'available') {
+      setAvailable(true)
+      return
+    }
+
+    // Baseline: the bundle this tab is running. If it can't be determined
+    // (dev server, no hashed entry), skip the check entirely — never prompt.
+    loadedBundleRef.current = readLoadedAppBundlePath()
+    if (!loadedBundleRef.current) return
+
+    let cancelled = false
+    let lastRefocusCheck = 0
+
+    const check = async (): Promise<void> => {
+      const deployed = await fetchDeployedAppBundlePath()
+      if (cancelled || deployed === null) return
+      if (deployed !== loadedBundleRef.current) {
+        setAvailable(true)
+      }
+    }
+
+    const interval = window.setInterval(() => void check(), UPDATE_POLL_INTERVAL_MS)
+    const onVisibility = (): void => {
+      if (document.visibilityState !== 'visible') return
+      const now = Date.now()
+      if (now - lastRefocusCheck < REFOCUS_DEBOUNCE_MS) return
+      lastRefocusCheck = now
+      void check()
+    }
+    document.addEventListener('visibilitychange', onVisibility)
+
+    return () => {
+      cancelled = true
+      window.clearInterval(interval)
+      document.removeEventListener('visibilitychange', onVisibility)
+    }
+  }, [])
+
+  if (!available) return { kind: 'idle' }
+  return { kind: 'available', apply: () => window.location.reload() }
 }
 
 export function __resetForTests(): void {

--- a/tests/e2e/views.spec.ts
+++ b/tests/e2e/views.spec.ts
@@ -3616,3 +3616,23 @@ test.describe('Snapshot restore', () => {
     await expect(page.getByTestId('snapshot-diff-drop-BATT_LOW_VOLT')).toHaveCount(0)
   })
 })
+
+test.describe('App update banner', () => {
+  test('shows a "new version ready" banner with a Refresh action when an update is detected', async ({ page }) => {
+    // The offline-shell SW was retired, but the "new version ready — Refresh"
+    // prompt is back as a service-worker-free version poll (compares the
+    // deployed index.html entry-bundle hash to the one this tab loaded). The
+    // ?appUpdate=available seam forces the detected state so the banner can be
+    // exercised without an actual redeploy.
+    await page.goto('/?appUpdate=available')
+    const banner = page.getByTestId('sw-update-banner')
+    await expect(banner).toBeVisible()
+    await expect(banner).toContainText('A new version of ArduConfigurator is ready.')
+    await expect(page.getByTestId('sw-update-refresh')).toBeVisible()
+  })
+
+  test('does not show the update banner on a normal load', async ({ page }) => {
+    await page.goto('/')
+    await expect(page.getByTestId('sw-update-banner')).toHaveCount(0)
+  })
+})


### PR DESCRIPTION
## Summary
Retiring the offline-shell service worker (it stranded users on a stale white-screen shell) also silently removed the update prompt — `useServiceWorkerUpdate()` was hard-wired to always return `idle`, so the `sw-update-banner` (still fully wired in `App.tsx`) never showed. A tab left open across a deploy kept running the old bundle with no signal.

This brings the banner back as a **service-worker-free version poll**:
- Baseline = the hashed entry bundle *this* tab loaded (from the live document's `<script type=module src>`), so a deploy landing between page-load and first poll is still caught.
- Every 5 min **and** on tab refocus (`visibilitychange`, 30s-debounced), fetch the deployed `index.html` (`cache: 'no-store'`) and compare its `assets/index-<hash>.js` to the baseline. Mismatch → banner flips to available; Refresh does `location.reload()`.
- No SW → no stale-shell risk. Dev / un-hashed entry → never prompts. Fetch failures → silently retry. `registerServiceWorker()`'s SW-cleanup is unchanged.
- e2e seam `?appUpdate=available` (mirrors `?aiProvider=mock`).

## ArduCopter byte-identical
Web app-shell only — no runtime/transport/protocol changes.

## Test plan
- [x] `npm run typecheck`
- [x] `npm run test` — 686 pass
- [x] `npm run test:unit --workspace @arduconfig/web` — 477 pass (6 new `extractAppBundlePath` unit tests)
- [x] Full e2e suite (all 7 specs): `npx playwright test` → **200 passed / 6 skipped** (2 new banner tests)