### PR TITLE
feat(ui): global write-progress bar for scoped parameter applies

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -691,6 +691,14 @@ export function App() {
   // shows "Writing… (N/M)" instead of a frozen "Writing…" while a large
   // show-all → write-all batch grinds through one verified write at a time.
   const [applyAllProgress, setApplyAllProgress] = useState<{ completed: number; total: number }>()
+  // Live write-progress for the SCOPED apply path (snapshot restore, receiver,
+  // config, power, servo mapping, …). The Parameters "Apply All" button shows
+  // its own inline "(N/M)" label; the scoped applies had no progress signal at
+  // all — just a frozen "Applying…" — so this drives a global progress bar for
+  // them (most visible on a many-parameter snapshot restore).
+  const [scopedWriteProgress, setScopedWriteProgress] = useState<
+    { completed: number; total: number; scopeLabel: string } | undefined
+  >(undefined)
   // Setup-tab guided exercises that aren't RC-side and aren't motor-side
   // (orientation 6-pose, mode-switch activity observer, mode-switch
   // exercise) live in their own hook — see use-setup-exercises.ts.
@@ -2878,6 +2886,7 @@ export function App() {
 
     const appliedParamIds: string[] = []
     setBusyAction(busyKey)
+    setScopedWriteProgress({ completed: 0, total: stagedDrafts.length, scopeLabel })
     try {
       const rebootRequiredCount = stagedDrafts.filter((entry) => entry.definition?.rebootRequired).length
       const result = await runtime.setParameters(
@@ -2885,7 +2894,8 @@ export function App() {
           paramId: entry.id,
           paramValue: entry.nextValue as number
         })),
-        UI_PARAMETER_WRITE_OPTIONS
+        UI_PARAMETER_WRITE_OPTIONS,
+        (progress) => setScopedWriteProgress({ completed: progress.completed, total: progress.total, scopeLabel })
       )
       appliedParamIds.push(...result.applied.map((entry) => entry.paramId))
       setParameterNotice({
@@ -2931,6 +2941,7 @@ export function App() {
         clearDrafts(appliedParamIds)
       }
 
+      setScopedWriteProgress(undefined)
       setBusyAction(undefined)
     }
   }
@@ -5881,6 +5892,19 @@ export function App() {
           >
             Refresh
           </button>
+        </div>
+      ) : null}
+      {scopedWriteProgress ? (
+        <div className="write-progress-banner" role="status" aria-live="polite" data-testid="write-progress-banner">
+          <span className="write-progress-banner__label">
+            Writing {scopedWriteProgress.scopeLabel.toLowerCase()} — {scopedWriteProgress.completed} / {scopedWriteProgress.total} parameters
+          </span>
+          <progress
+            className="write-progress-banner__bar"
+            data-testid="write-progress-bar"
+            value={scopedWriteProgress.completed}
+            max={scopedWriteProgress.total}
+          />
         </div>
       ) : null}
 	    <main className="app-shell">

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -479,6 +479,50 @@ textarea:focus {
   outline-offset: 2px;
 }
 
+/* Global write-progress bar for scoped param applies (snapshot restore et al).
+ * Bottom-left so it doesn't collide with the bottom-right update banner. */
+.write-progress-banner {
+  position: fixed;
+  left: 16px;
+  bottom: calc(var(--statusbar-height, 32px) + 16px);
+  z-index: 200;
+  display: grid;
+  gap: 6px;
+  padding: 10px 14px;
+  min-width: 260px;
+  max-width: 360px;
+  background: var(--surface-300);
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  box-shadow: 0 12px 32px rgba(0, 0, 0, 0.45);
+  color: var(--surface-950);
+  font-size: 13px;
+}
+.write-progress-banner__label {
+  font-variant-numeric: tabular-nums;
+}
+.write-progress-banner__bar {
+  appearance: none;
+  width: 100%;
+  height: 6px;
+  border: none;
+  border-radius: 3px;
+  overflow: hidden;
+  background: var(--surface-500);
+}
+.write-progress-banner__bar::-webkit-progress-bar {
+  background: var(--surface-500);
+  border-radius: 3px;
+}
+.write-progress-banner__bar::-webkit-progress-value {
+  background: var(--accent, #ffbb00);
+  border-radius: 3px;
+}
+.write-progress-banner__bar::-moz-progress-bar {
+  background: var(--accent, #ffbb00);
+  border-radius: 3px;
+}
+
 .app-shell {
   display: grid;
   grid-template-rows: auto 1fr var(--statusbar-height);

--- a/tests/e2e/views.spec.ts
+++ b/tests/e2e/views.spec.ts
@@ -3636,3 +3636,30 @@ test.describe('App update banner', () => {
     await expect(page.getByTestId('sw-update-banner')).toHaveCount(0)
   })
 })
+
+test.describe('Scoped write-progress bar', () => {
+  test('a scoped parameter apply shows a global write-progress bar', async ({ page }) => {
+    // The scoped apply path (snapshot restore, receiver, config, power, …) used
+    // to show only a frozen "Applying…" — no progress. It now drives a global
+    // write-progress bar. setScopedWriteProgress is set synchronously at the
+    // start of the apply handler (before the awaited batch write) and cleared
+    // in finally, so the bar is deterministically visible for the whole write.
+    await page.goto('/')
+    await connectViaHeader(page)
+    await expectParameterSyncComplete(page)
+
+    await page.getByTestId('view-button-config').click()
+    const rates = page.getByTestId('config-section-system-rates')
+    await rates.scrollIntoViewIfNeeded()
+    // Stage a config edit (INS_FAST_SAMPLE) so config:apply has something to write.
+    await rates.locator('.scoped-editor-field', { hasText: 'Fast sampling' }).locator('input[type=number]').fill('3')
+
+    await page.getByTestId('config-apply').click()
+    const banner = page.getByTestId('write-progress-banner')
+    await expect(banner).toBeVisible()
+    await expect(page.getByTestId('write-progress-bar')).toBeVisible()
+    await expect(banner).toContainText('parameters')
+    // It clears once the write completes.
+    await expect(banner).toHaveCount(0)
+  })
+})


### PR DESCRIPTION
## Summary
The scoped apply path (snapshot restore, receiver, config, power, servo mapping) showed only a frozen "Applying…" — a many-parameter snapshot restore looked hung. `runtime.setParameters` already supports an `onProgress` callback (used by the AI-assistant apply); this wires it into `handleApplyScopedParameterDrafts` to drive a global bottom-left progress bar ("Writing <scope> — N / M parameters" + a `<progress>`). Set synchronously at the handler start and cleared in `finally`, so it's deterministically visible for the whole write. (Parameters "Apply All" keeps its own inline "(N/M)" label.)

## ArduCopter byte-identical
Web UI only — reuses the existing verified batch-write path + its progress callback.

## Test plan
- [x] `npm run typecheck` · `npm run test` (686) · `npm run test:unit` (477)
- [x] Full e2e suite (all 7 specs): **201 passed / 6 skipped**, incl. a new scoped-apply progress test