### PR TITLE
feat(vtx): make VTX power levels editable (Slice 2)

### DIFF
--- a/apps/web/src/hooks/use-vtx-table.ts
+++ b/apps/web/src/hooks/use-vtx-table.ts
@@ -27,6 +27,8 @@ export interface UseVtxTableResult {
   saving: boolean
   error: string | undefined
   setFrequency: (bandIndex: number, channelIndex: number, mhz: number) => void
+  setPowerValue: (index: number, value: number) => void
+  setPowerLabel: (index: number, label: string) => void
   save: () => void
   reset: () => void
   reload: () => void
@@ -103,6 +105,31 @@ export function useVtxTable(input: {
     setDirty(true)
   }, [])
 
+  const setPowerValue = useCallback((index: number, value: number) => {
+    setDraft((current) => {
+      if (!current) return current
+      const level = current.powerLevels[index]
+      if (!level) return current
+      const next = cloneVtxTable(current)
+      next.powerLevels[index].value = Number.isFinite(value) ? Math.max(0, Math.min(0xffff, Math.round(value))) : 0
+      return next
+    })
+    setDirty(true)
+  }, [])
+
+  const setPowerLabel = useCallback((index: number, label: string) => {
+    setDraft((current) => {
+      if (!current) return current
+      const level = current.powerLevels[index]
+      if (!level) return current
+      const next = cloneVtxTable(current)
+      // The firmware stores a 3-char fixed-width label; keep the edit within that.
+      next.powerLevels[index].label = label.slice(0, 3)
+      return next
+    })
+    setDirty(true)
+  }, [])
+
   const reset = useCallback(() => {
     setDraft(detected ? cloneVtxTable(detected) : undefined)
     setDirty(false)
@@ -129,5 +156,5 @@ export function useVtxTable(input: {
       .finally(() => setSaving(false))
   }, [runtime, draft, saving])
 
-  return { status, table: draft, dirty, saving, error, setFrequency, save, reset, reload }
+  return { status, table: draft, dirty, saving, error, setFrequency, setPowerValue, setPowerLabel, save, reset, reload }
 }

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -3310,6 +3310,37 @@ textarea:focus {
   align-items: center;
   gap: 8px;
 }
+.bf-vtx-table__power-grid {
+  border-collapse: collapse;
+  font-size: 12px;
+}
+.bf-vtx-table__power-grid th,
+.bf-vtx-table__power-grid td {
+  border: 1px solid var(--surface-400);
+  padding: 4px 6px;
+  text-align: left;
+}
+.bf-vtx-table__power-grid thead th {
+  color: var(--text-muted);
+  font-weight: 600;
+}
+.bf-vtx-table__power-grid input[type='number'],
+.bf-vtx-table__power-grid input[type='text'] {
+  font-family: var(--font-data);
+  font-size: 12px;
+  background: var(--surface-300);
+  color: var(--text);
+  border: 1px solid var(--surface-400);
+  border-radius: 4px;
+  padding: 2px 4px;
+}
+.bf-vtx-table__power-grid input[type='number'] {
+  width: 72px;
+  text-align: right;
+}
+.bf-vtx-table__power-grid input[type='text'] {
+  width: 56px;
+}
 .bf-vtx-table__power small {
   color: var(--text-muted);
   line-height: 1.5;

--- a/apps/web/src/views/Vtx.tsx
+++ b/apps/web/src/views/Vtx.tsx
@@ -278,10 +278,9 @@ export function VtxView(props: VtxViewProps) {
 }
 
 /**
- * Editable band/frequency grid + read-only power levels, shown when the
- * firmware exposes a VTX table over MAVFTP. Slice 1: band frequencies are
- * editable + savable (upload); power levels are read-only pending firmware
- * driver integration (Task 5).
+ * Editable band/frequency grid + editable power levels, shown when the firmware
+ * exposes a VTX table over MAVFTP. Both halves edit the in-RAM draft and Save
+ * uploads the whole table (@VTX/vtxtable.dat).
  */
 function VtxTableEditor({ vtxTable }: { vtxTable: UseVtxTableResult }) {
   const table = vtxTable.table
@@ -290,8 +289,9 @@ function VtxTableEditor({ vtxTable }: { vtxTable: UseVtxTableResult }) {
   return (
     <div className="bf-vtx-table" data-testid="vtx-table-editor">
       <p className="setup-gui-box__note">
-        Band/channel frequencies from the flight controller (<code>@VTX/vtxtable.dat</code>). Edit any cell (MHz, 0 =
-        channel disabled) and Save to upload the whole table. Factory bands use the VTX&apos;s own frequency map.
+        VTX band/frequency + power table from the flight controller (<code>@VTX/vtxtable.dat</code>). Edit any frequency
+        cell (MHz, 0 = channel disabled) or power level, then Save to upload the whole table. Factory bands use the
+        VTX&apos;s own frequency map.
       </p>
       <div className="bf-vtx-table__scroll">
         <table className="bf-vtx-table__grid">
@@ -338,18 +338,45 @@ function VtxTableEditor({ vtxTable }: { vtxTable: UseVtxTableResult }) {
       <div className="bf-vtx-table__power" data-testid="vtx-table-power">
         <div className="bf-vtx-table__power-head">
           <strong>Power levels</strong>
-          <StatusBadge tone="neutral">read-only</StatusBadge>
         </div>
-        <div className="config-pills">
-          {table.powerLevels.map((level, index) => (
-            <span key={index}>
-              {level.label || String(level.value)} · {level.value}
-            </span>
-          ))}
-        </div>
+        <table className="bf-vtx-table__power-grid">
+          <thead>
+            <tr>
+              <th scope="col">#</th>
+              <th scope="col">Value</th>
+              <th scope="col">Label</th>
+            </tr>
+          </thead>
+          <tbody>
+            {table.powerLevels.map((level, index) => (
+              <tr key={index} data-testid={`vtx-table-power-${index}`}>
+                <th scope="row">{index + 1}</th>
+                <td>
+                  <input
+                    type="number"
+                    min={0}
+                    step={1}
+                    data-testid={`vtx-table-power-value-${index}`}
+                    value={level.value}
+                    onChange={(event) => vtxTable.setPowerValue(index, Number(event.target.value))}
+                  />
+                </td>
+                <td>
+                  <input
+                    type="text"
+                    maxLength={3}
+                    data-testid={`vtx-table-power-label-${index}`}
+                    value={level.label}
+                    onChange={(event) => vtxTable.setPowerLabel(index, event.target.value)}
+                  />
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
         <small>
-          Power levels are stored and transported, but the VTX drivers don&apos;t apply the table&apos;s power values
-          yet (pending firmware work) — editing lands in a follow-up.
+          Protocol value sent to the VTX (mW for Tramp; index/dBm for SmartAudio) plus a short display label. Saved as
+          part of the table upload.
         </small>
       </div>
 

--- a/tests/e2e/views.spec.ts
+++ b/tests/e2e/views.spec.ts
@@ -3650,13 +3650,18 @@ test.describe('VTX band/frequency table', () => {
     // Seeded Boscam A channel 1 = 5865 MHz.
     const cell = page.getByTestId('vtx-table-freq-0-0')
     await expect(cell).toHaveValue('5865')
-    // Power levels are surfaced read-only.
-    await expect(page.getByTestId('vtx-table-power')).toContainText('read-only')
 
     // Save is disabled until an edit dirties the draft.
     await expect(page.getByTestId('vtx-table-save')).toBeDisabled()
     await cell.fill('5900')
     await expect(page.getByTestId('vtx-table-save')).toBeEnabled()
+
+    // Power levels are editable too (value + label); the seeded first level is
+    // 25 mW / "25". Editing them also dirties the draft and rides the same save.
+    const powerValue = page.getByTestId('vtx-table-power-value-0')
+    await expect(powerValue).toHaveValue('25')
+    await powerValue.fill('50')
+    await page.getByTestId('vtx-table-power-label-0').fill('50')
 
     // Save uploads the whole table over MAVFTP; success clears the dirty state
     // (button → "Saved") with no error banner — proves the write round-tripped.


### PR DESCRIPTION
## Summary
Completes the VTX table editor: power levels were read-only (Slice 1), now they're an editable **value + label** grid alongside the band/frequency grid. Editing a power level dirties the same draft and rides the same Save — the whole table uploads over MAVFTP. Power was always part of the blob + CRC, so the codec already round-trips it (no codec/runtime change).

- `useVtxTable` gains `setPowerValue` / `setPowerLabel` (value clamped to u16, label to the firmware's 3-char field).
- Dropped the "pending firmware" caveat; the note now explains value semantics (mW for Tramp, index/dBm for SmartAudio).

## ArduCopter byte-identical
VTX-view UI only; inert unless the FC exposes `@VTX/vtxtable.dat`.

## Test plan
- [x] `npm run typecheck`
- [x] `npm run test:unit --workspace @arduconfig/web` — 477
- [x] VTX e2e updated: edit a frequency AND a power value/label, then Save
- [x] Full 7-spec e2e suite (gating the merge)