### PR TITLE
feat(vtx): Betaflight vtxtable import/export (download & upload community tables)

### DIFF
--- a/apps/web/src/hooks/use-vtx-table.ts
+++ b/apps/web/src/hooks/use-vtx-table.ts
@@ -29,6 +29,9 @@ export interface UseVtxTableResult {
   setFrequency: (bandIndex: number, channelIndex: number, mhz: number) => void
   setPowerValue: (index: number, value: number) => void
   setPowerLabel: (index: number, label: string) => void
+  /** Replace the working draft wholesale (e.g. from a Betaflight import).
+   *  Marks dirty; Save then uploads it. */
+  loadTable: (table: VtxTable) => void
   save: () => void
   reset: () => void
   reload: () => void
@@ -130,6 +133,12 @@ export function useVtxTable(input: {
     setDirty(true)
   }, [])
 
+  const loadTable = useCallback((table: VtxTable) => {
+    setDraft(cloneVtxTable(table))
+    setDirty(true)
+    setError(undefined)
+  }, [])
+
   const reset = useCallback(() => {
     setDraft(detected ? cloneVtxTable(detected) : undefined)
     setDirty(false)
@@ -156,5 +165,18 @@ export function useVtxTable(input: {
       .finally(() => setSaving(false))
   }, [runtime, draft, saving])
 
-  return { status, table: draft, dirty, saving, error, setFrequency, setPowerValue, setPowerLabel, save, reset, reload }
+  return {
+    status,
+    table: draft,
+    dirty,
+    saving,
+    error,
+    setFrequency,
+    setPowerValue,
+    setPowerLabel,
+    loadTable,
+    save,
+    reset,
+    reload
+  }
 }

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -3349,6 +3349,34 @@ textarea:focus {
   display: flex;
   gap: 8px;
 }
+.bf-vtx-table__io {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+.bf-vtx-table__import {
+  display: grid;
+  gap: 8px;
+  padding: 10px;
+  border: 1px solid var(--surface-400);
+  border-radius: 8px;
+  background: var(--surface-200);
+}
+.bf-vtx-table__import textarea {
+  width: 100%;
+  font-family: var(--font-data);
+  font-size: 12px;
+  background: var(--surface-300);
+  color: var(--text);
+  border: 1px solid var(--surface-400);
+  border-radius: 6px;
+  padding: 6px 8px;
+  resize: vertical;
+}
+.bf-vtx-table__import-actions {
+  display: flex;
+  gap: 8px;
+}
 
 .osd-grid {
   display: grid;

--- a/apps/web/src/views/Vtx.tsx
+++ b/apps/web/src/views/Vtx.tsx
@@ -1,7 +1,10 @@
+import { useRef, useState } from 'react'
 import { Panel, StatusBadge, buttonStyle } from '@arduconfig/ui-kit'
 import type { ParameterState } from '@arduconfig/ardupilot-core'
+import { parseBetaflightVtxTable, serializeBetaflightVtxTable } from '@arduconfig/ardupilot-core'
 
 import type { UseVtxTableResult } from '../hooks/use-vtx-table'
+import { downloadTextFile } from '../download-file'
 import { ScopedField, ScopedSelectField, type ScopedFieldDraftMap } from './ScopedField'
 
 export interface VtxLinkPort {
@@ -283,9 +286,32 @@ export function VtxView(props: VtxViewProps) {
  * uploads the whole table (@VTX/vtxtable.dat).
  */
 function VtxTableEditor({ vtxTable }: { vtxTable: UseVtxTableResult }) {
+  const [importOpen, setImportOpen] = useState(false)
+  const [importText, setImportText] = useState('')
+  const [importError, setImportError] = useState<string | undefined>(undefined)
+  const fileInputRef = useRef<HTMLInputElement>(null)
   const table = vtxTable.table
   if (!table) return null
   const channels = Array.from({ length: table.numChannels }, (_, index) => index)
+
+  const handleExport = (): void => {
+    downloadTextFile('vtxtable.txt', serializeBetaflightVtxTable(table), 'text/plain')
+  }
+  const applyImport = (text: string): void => {
+    try {
+      vtxTable.loadTable(parseBetaflightVtxTable(text))
+      setImportError(undefined)
+      setImportOpen(false)
+      setImportText('')
+    } catch (caught) {
+      setImportError(caught instanceof Error ? caught.message : 'Could not parse that Betaflight table.')
+    }
+  }
+  const handleFile = (file: File | undefined): void => {
+    if (!file) return
+    void file.text().then(applyImport).catch(() => setImportError('Could not read that file.'))
+  }
+
   return (
     <div className="bf-vtx-table" data-testid="vtx-table-editor">
       <p className="setup-gui-box__note">
@@ -293,6 +319,80 @@ function VtxTableEditor({ vtxTable }: { vtxTable: UseVtxTableResult }) {
         cell (MHz, 0 = channel disabled) or power level, then Save to upload the whole table. Factory bands use the
         VTX&apos;s own frequency map.
       </p>
+
+      <div className="bf-vtx-table__io" data-testid="vtx-table-io">
+        <button
+          type="button"
+          style={buttonStyle()}
+          data-testid="vtx-table-export-bf"
+          onClick={handleExport}
+        >
+          Export Betaflight table
+        </button>
+        <button
+          type="button"
+          style={buttonStyle()}
+          data-testid="vtx-table-import-toggle"
+          onClick={() => {
+            setImportOpen((open) => !open)
+            setImportError(undefined)
+          }}
+        >
+          {importOpen ? 'Cancel import' : 'Import Betaflight table'}
+        </button>
+        <input
+          ref={fileInputRef}
+          type="file"
+          accept=".txt,.config,text/plain"
+          style={{ display: 'none' }}
+          data-testid="vtx-table-import-file"
+          onChange={(event) => {
+            handleFile(event.target.files?.[0])
+            event.target.value = ''
+          }}
+        />
+      </div>
+
+      {importOpen ? (
+        <div className="bf-vtx-table__import" data-testid="vtx-table-import-panel">
+          <p className="setup-gui-box__note">
+            Paste a Betaflight <code>vtxtable</code> snippet (or a full CLI dump), or load a <code>.txt</code> file. It
+            loads into the editor below — review it, then Save to upload.
+          </p>
+          <textarea
+            data-testid="vtx-table-import-text"
+            value={importText}
+            onChange={(event) => setImportText(event.target.value)}
+            placeholder={'vtxtable bands 5\nvtxtable channels 8\nvtxtable band 1 BOSCAM_A A FACTORY 5865 …'}
+            rows={5}
+          />
+          <div className="bf-vtx-table__import-actions">
+            <button
+              type="button"
+              style={buttonStyle('primary')}
+              data-testid="vtx-table-import-load"
+              onClick={() => applyImport(importText)}
+              disabled={importText.trim().length === 0}
+            >
+              Load pasted table
+            </button>
+            <button
+              type="button"
+              style={buttonStyle()}
+              data-testid="vtx-table-import-file-button"
+              onClick={() => fileInputRef.current?.click()}
+            >
+              Load .txt file…
+            </button>
+          </div>
+          {importError ? (
+            <div className="parameter-follow-up parameter-follow-up--warning" data-testid="vtx-table-import-error">
+              <StatusBadge tone="danger">import failed</StatusBadge>
+              <p>{importError}</p>
+            </div>
+          ) : null}
+        </div>
+      ) : null}
       <div className="bf-vtx-table__scroll">
         <table className="bf-vtx-table__grid">
           <thead>

--- a/packages/ardupilot-core/src/vtx-table.ts
+++ b/packages/ardupilot-core/src/vtx-table.ts
@@ -218,3 +218,143 @@ export function serializeVtxTable(table: VtxTable): Uint8Array {
   buf[o++] = (crc >> 24) & 0xff
   return buf
 }
+
+// ---------------------------------------------------------------------------
+// Betaflight `vtxtable` CLI interchange — lets users import a table shared as
+// a Betaflight CLI snippet (or full dump) and export the current table in the
+// same format. Betaflight's vtxtable model maps 1:1 onto AP_VideoTX_Table with
+// identical field limits (name ≤8, letter 1, label ≤3, freq 0 = disabled,
+// FACTORY/CUSTOM), so the conversion is lossless. Reference:
+// https://github.com/betaflight/betaflight/wiki/VTX-CLI-Settings
+//
+//   vtxtable bands <n>
+//   vtxtable channels <n>
+//   vtxtable band <1-based> <name(≤8, quote if spaces)> <letter> <FACTORY|CUSTOM> <freq…>
+//   vtxtable powerlevels <n>
+//   vtxtable powervalues <v…>
+//   vtxtable powerlabels <l…>
+
+/** Split a CLI line into tokens, honoring double-quoted band names. */
+function tokenizeCliLine(line: string): string[] {
+  const tokens: string[] = []
+  const re = /"([^"]*)"|(\S+)/g
+  let match: RegExpExecArray | null
+  while ((match = re.exec(line)) !== null) {
+    tokens.push(match[1] !== undefined ? match[1] : match[2])
+  }
+  return tokens
+}
+
+/**
+ * Parse a Betaflight `vtxtable` table from CLI text (a bare snippet or a full
+ * `diff`/`dump` — non-vtxtable lines are ignored). Throws
+ * {@link VtxTableParseError} on a table that's missing required rows, is
+ * internally inconsistent, or exceeds the firmware's limits (so the user gets
+ * a clear reason rather than a silently-truncated table the FC can't hold).
+ */
+export function parseBetaflightVtxTable(text: string): VtxTable {
+  let numChannels: number | undefined
+  const bandByIndex = new Map<number, VtxTableBand>()
+  let powerValues: number[] | undefined
+  let powerLabels: string[] | undefined
+
+  for (const rawLine of text.split(/\r?\n/)) {
+    const line = rawLine.replace(/#.*$/, '').trim() // strip trailing comments
+    if (line.length === 0) continue
+    const tokens = tokenizeCliLine(line)
+    if (tokens[0]?.toLowerCase() !== 'vtxtable' || tokens.length < 2) continue
+    const kind = tokens[1].toLowerCase()
+    if (kind === 'channels') {
+      numChannels = Number(tokens[2])
+    } else if (kind === 'band') {
+      const index = Number(tokens[2])
+      if (!Number.isInteger(index) || index < 1) {
+        throw new VtxTableParseError(`Invalid vtxtable band index "${tokens[2]}".`)
+      }
+      const name = tokens[3] ?? ''
+      const letter = tokens[4] ?? ''
+      const factoryToken = (tokens[5] ?? '').toUpperCase()
+      if (factoryToken !== 'FACTORY' && factoryToken !== 'CUSTOM') {
+        throw new VtxTableParseError(`vtxtable band ${index} missing FACTORY/CUSTOM flag.`)
+      }
+      const frequencies = tokens.slice(6).map((token) => {
+        const value = Number(token)
+        return Number.isFinite(value) ? Math.max(0, Math.round(value)) : 0
+      })
+      bandByIndex.set(index, { name, letter: letter.slice(0, 1), isFactory: factoryToken === 'FACTORY', frequencies })
+    } else if (kind === 'powervalues') {
+      powerValues = tokens.slice(2).map((token) => Math.max(0, Math.round(Number(token) || 0)))
+    } else if (kind === 'powerlabels') {
+      powerLabels = tokens.slice(2).map((token) => token)
+    }
+    // `bands`/`powerlevels` counts are advisory — derived from the actual rows.
+  }
+
+  if (bandByIndex.size === 0) {
+    throw new VtxTableParseError('No vtxtable band rows found in the imported text.')
+  }
+  // Assemble bands in index order, requiring a contiguous 1..N.
+  const maxIndex = Math.max(...bandByIndex.keys())
+  const bands: VtxTableBand[] = []
+  for (let index = 1; index <= maxIndex; index += 1) {
+    const band = bandByIndex.get(index)
+    if (!band) {
+      throw new VtxTableParseError(`vtxtable is missing band ${index} (bands must be a contiguous 1..N).`)
+    }
+    bands.push(band)
+  }
+  // Channel count: explicit `channels` row, else the widest band.
+  const resolvedChannels = numChannels ?? Math.max(...bands.map((band) => band.frequencies.length))
+  // Normalize every band to exactly `resolvedChannels` frequencies (pad 0 / trim).
+  for (const band of bands) {
+    if (band.frequencies.length < resolvedChannels) {
+      band.frequencies = [...band.frequencies, ...new Array(resolvedChannels - band.frequencies.length).fill(0)]
+    } else if (band.frequencies.length > resolvedChannels) {
+      band.frequencies = band.frequencies.slice(0, resolvedChannels)
+    }
+  }
+  const values = powerValues ?? []
+  const labels = powerLabels ?? []
+  const powerCount = Math.max(values.length, labels.length)
+  const powerLevels: VtxTablePowerLevel[] = []
+  for (let i = 0; i < powerCount; i += 1) {
+    powerLevels.push({ value: values[i] ?? 0, label: (labels[i] ?? String(values[i] ?? 0)).slice(0, VTX_TABLE_POWER_LABEL_LEN) })
+  }
+
+  // Enforce the firmware's storage limits — a table that can't fit is an error,
+  // not a silent truncation.
+  if (bands.length > VTX_TABLE_MAX_BANDS) {
+    throw new VtxTableParseError(`Too many bands (${bands.length}); the flight controller supports at most ${VTX_TABLE_MAX_BANDS}.`)
+  }
+  if (resolvedChannels > VTX_TABLE_MAX_CHANNELS) {
+    throw new VtxTableParseError(`Too many channels (${resolvedChannels}); the maximum is ${VTX_TABLE_MAX_CHANNELS}.`)
+  }
+  if (powerLevels.length > VTX_TABLE_MAX_POWER_LEVELS) {
+    throw new VtxTableParseError(`Too many power levels (${powerLevels.length}); the maximum is ${VTX_TABLE_MAX_POWER_LEVELS}.`)
+  }
+  const longName = bands.find((band) => band.name.length > VTX_TABLE_BAND_NAME_LEN)
+  if (longName) {
+    throw new VtxTableParseError(`Band name "${longName.name}" exceeds ${VTX_TABLE_BAND_NAME_LEN} characters.`)
+  }
+
+  return { version: VTX_TABLE_VERSION, numChannels: resolvedChannels, bands, powerLevels }
+}
+
+/** Render a VtxTable as a Betaflight `vtxtable` CLI snippet (the shareable
+ *  format users paste into a configurator or save to a file). */
+export function serializeBetaflightVtxTable(table: VtxTable): string {
+  const quote = (name: string): string => (/\s/.test(name) ? `"${name}"` : name)
+  const lines: string[] = []
+  lines.push(`vtxtable bands ${table.bands.length}`)
+  lines.push(`vtxtable channels ${table.numChannels}`)
+  table.bands.forEach((band, index) => {
+    const freqs = Array.from({ length: table.numChannels }, (_, c) => band.frequencies[c] ?? 0).join(' ')
+    lines.push(
+      `vtxtable band ${index + 1} ${quote(band.name)} ${band.letter || '?'} ${band.isFactory ? 'FACTORY' : 'CUSTOM'} ${freqs}`
+    )
+  })
+  lines.push(`vtxtable powerlevels ${table.powerLevels.length}`)
+  lines.push(`vtxtable powervalues ${table.powerLevels.map((level) => level.value).join(' ')}`)
+  lines.push(`vtxtable powerlabels ${table.powerLevels.map((level) => level.label || String(level.value)).join(' ')}`)
+  return lines.join('\n') + '\n'
+}

--- a/tests/e2e/views.spec.ts
+++ b/tests/e2e/views.spec.ts
@@ -3669,6 +3669,44 @@ test.describe('VTX band/frequency table', () => {
     await expect(page.getByTestId('vtx-table-save')).toHaveText('Saved', { timeout: 10000 })
     await expect(page.getByTestId('vtx-table-error')).toHaveCount(0)
   })
+
+  test('imports a Betaflight vtxtable snippet into the editor and exports the table', async ({ page }) => {
+    await page.goto('/')
+    await connectViaHeader(page)
+    await page.getByTestId('view-button-vtx').click()
+    await expect(page.getByTestId('vtx-table-editor')).toBeVisible({ timeout: 15000 })
+
+    // Import a Betaflight snippet with a distinctive band-1 channel-1 frequency.
+    await page.getByTestId('vtx-table-import-toggle').click()
+    await page.getByTestId('vtx-table-import-text').fill(
+      [
+        'vtxtable bands 1',
+        'vtxtable channels 2',
+        'vtxtable band 1 CUSTOM_A A CUSTOM 5111 5222',
+        'vtxtable powerlevels 2',
+        'vtxtable powervalues 25 200',
+        'vtxtable powerlabels 25 200'
+      ].join('\n')
+    )
+    await page.getByTestId('vtx-table-import-load').click()
+    // The imported table replaces the editor draft: band-1 ch-1 = 5111.
+    await expect(page.getByTestId('vtx-table-freq-0-0')).toHaveValue('5111')
+    await expect(page.getByTestId('vtx-table-power-value-0')).toHaveValue('25')
+    // Loading an import dirties the draft (Save enabled).
+    await expect(page.getByTestId('vtx-table-save')).toBeEnabled()
+
+    // A malformed snippet surfaces an inline error, not a crash.
+    await page.getByTestId('vtx-table-import-toggle').click()
+    await page.getByTestId('vtx-table-import-text').fill('vtxtable band 1 X X 5800')
+    await page.getByTestId('vtx-table-import-load').click()
+    await expect(page.getByTestId('vtx-table-import-error')).toBeVisible()
+
+    // Export downloads a vtxtable.txt file.
+    await page.getByTestId('vtx-table-import-toggle').click() // close the import panel
+    const download = page.waitForEvent('download')
+    await page.getByTestId('vtx-table-export-bf').click()
+    expect((await download).suggestedFilename()).toBe('vtxtable.txt')
+  })
 })
 
 test.describe('Scoped write-progress bar', () => {

--- a/tests/vtx-table.test.mjs
+++ b/tests/vtx-table.test.mjs
@@ -96,3 +96,80 @@ test('names/labels are trimmed of the fixed-width storage padding', () => {
 test('exposes the MAVLink-FTP path', () => {
   assert.equal(VTX_TABLE_FTP_PATH, '@VTX/vtxtable.dat')
 })
+
+// --- Betaflight vtxtable CLI interchange ---
+
+import { parseBetaflightVtxTable, serializeBetaflightVtxTable } from '../packages/ardupilot-core/dist/index.js'
+
+const BF_SAMPLE = `# a shared Betaflight snippet
+vtxtable bands 2
+vtxtable channels 8
+vtxtable band 1 BOSCAM_A A FACTORY 5865 5845 5825 5805 5785 5765 5745 5725
+vtxtable band 2 "RACE B" R CUSTOM 5658 5695 5732 5769 5806 5843 5880 5917
+vtxtable powerlevels 3
+vtxtable powervalues 0 1 2
+vtxtable powerlabels 25 200 1W
+`
+
+test('parseBetaflightVtxTable maps a BF CLI snippet 1:1', () => {
+  const table = parseBetaflightVtxTable(BF_SAMPLE)
+  assert.equal(table.numChannels, 8)
+  assert.equal(table.bands.length, 2)
+  assert.deepEqual(table.bands[0], {
+    name: 'BOSCAM_A', letter: 'A', isFactory: true,
+    frequencies: [5865, 5845, 5825, 5805, 5785, 5765, 5745, 5725]
+  })
+  // Quoted name with a space, CUSTOM flag.
+  assert.equal(table.bands[1].name, 'RACE B')
+  assert.equal(table.bands[1].isFactory, false)
+  assert.deepEqual(table.powerLevels, [
+    { value: 0, label: '25' }, { value: 1, label: '200' }, { value: 2, label: '1W' }
+  ])
+})
+
+test('parse ignores non-vtxtable lines (works on a full dump)', () => {
+  const dump = `# diff\nset foo = 1\nvtxtable bands 1\nvtxtable channels 2\nvtxtable band 1 X X CUSTOM 5800 5900\nvtxtable powervalues 25\nvtxtable powerlabels 25\nsave`
+  const table = parseBetaflightVtxTable(dump)
+  assert.equal(table.bands.length, 1)
+  assert.equal(table.numChannels, 2)
+  assert.deepEqual(table.bands[0].frequencies, [5800, 5900])
+})
+
+test('BF serialize → parse round-trips', () => {
+  const table = parseBetaflightVtxTable(BF_SAMPLE)
+  const roundTripped = parseBetaflightVtxTable(serializeBetaflightVtxTable(table))
+  assert.deepEqual(roundTripped, table)
+})
+
+test('BF serialize quotes names with spaces and emits FACTORY/CUSTOM', () => {
+  const text = serializeBetaflightVtxTable(parseBetaflightVtxTable(BF_SAMPLE))
+  assert.match(text, /vtxtable band 1 BOSCAM_A A FACTORY 5865/)
+  assert.match(text, /vtxtable band 2 "RACE B" R CUSTOM 5658/)
+  assert.match(text, /vtxtable powerlabels 25 200 1W/)
+})
+
+test('BF import round-trips through the BINARY blob codec too (same model)', () => {
+  const table = parseBetaflightVtxTable(BF_SAMPLE)
+  assert.deepEqual(parseVtxTable(serializeVtxTable(table)), table)
+})
+
+test('parse rejects tables that exceed the firmware limits', () => {
+  const tooManyBands = ['vtxtable channels 1']
+  for (let i = 1; i <= 13; i += 1) tooManyBands.push(`vtxtable band ${i} B${i} ${i} CUSTOM 5800`)
+  assert.throws(() => parseBetaflightVtxTable(tooManyBands.join('\n')), /Too many bands/)
+})
+
+test('parse rejects a non-contiguous band set and a missing FACTORY/CUSTOM flag', () => {
+  assert.throws(
+    () => parseBetaflightVtxTable('vtxtable channels 1\nvtxtable band 2 X X CUSTOM 5800'),
+    /missing band 1/
+  )
+  assert.throws(
+    () => parseBetaflightVtxTable('vtxtable channels 1\nvtxtable band 1 X X 5800'),
+    /FACTORY\/CUSTOM/
+  )
+})
+
+test('parse throws when there are no vtxtable band rows', () => {
+  assert.throws(() => parseBetaflightVtxTable('set foo = 1\nsave'), VtxTableParseError)
+})


### PR DESCRIPTION
## Summary
Completes the Betaflight-style VTX-table workflow: users can share tables in Betaflight's exact `vtxtable` CLI format — grab a community table and push it to ArduPilot, or export the FC's table to share.

- **Codec** (`vtx-table.ts`): `parseBetaflightVtxTable` / `serializeBetaflightVtxTable`. The BF `vtxtable` model maps 1:1 onto `AP_VideoTX_Table` (name ≤8, letter 1, label ≤3, freq 0 = disabled, FACTORY/CUSTOM) — lossless. Parser ignores non-vtxtable lines (works on a bare snippet **or** a full CLI diff/dump), honors quoted band names, and rejects over-limit/malformed tables with a clear reason instead of silently truncating.
- **UI**: the VTX editor gains an Import/Export toolbar. Export downloads `vtxtable.txt`; Import accepts a pasted snippet or a `.txt`/`.config` file → loads into the editor for review → existing Save uploads over MAVFTP.

## ArduCopter byte-identical
Additive VTX-view UI + a pure codec; no existing path changed. Inert unless the FC exposes `@VTX/vtxtable.dat`.

## Test plan
- [x] `npm run typecheck`
- [x] `npm run test` — 696 (8 new BF codec tests incl. a cross-check that a BF import round-trips through the binary `@VTX` blob codec)
- [x] `npm run test:unit --workspace @arduconfig/web` — 477
- [x] VTX e2e: import (paste → grid updates; malformed → inline error) + export (downloads `vtxtable.txt`)
- [x] Full 7-spec e2e suite (gating the merge)