### PR TITLE
fix: bug-hunt batch + RC Mixer write ordering & mode-channel

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -14,7 +14,6 @@ import {
   createRcRangeExerciseState,
   deriveCompassSetupAvailability,
   deriveEscSetupSummary,
-  buildParametersFromBackup,
   deriveAirframe,
   deriveModeExerciseAssignments,
   deriveModeAssignments,
@@ -134,7 +133,7 @@ import {
   formatCurrent,
   formatRemaining
 } from './device-display'
-import { buildRcChannelDisplays, derivePrimaryAndModeChannels } from './rc-channel-helpers'
+import { buildRcChannelDisplays, derivePrimaryStickChannels } from './rc-channel-helpers'
 import {
   connectButtonLabel,
   describeConnectFailure,
@@ -251,6 +250,7 @@ import { AP_PERIPH_PARAM_METADATA } from './view-models/ap-periph-param-metadata
 import { parseParamPck } from './view-models/param-pck'
 import { createMotorPreviewNodes } from './view-models/motor-preview'
 import { buildRecentNotices } from './view-models/recent-notices'
+import { orderDraftsByEnableGate } from './view-models/enable-gate-write-order'
 import { invertGuidedReorderMapping, pickedReorderPositions } from './view-models/motor-reorder-mapping'
 import { LiveGpsMapCard } from './live-gps-map'
 import { DisconnectedLanding } from './disconnected-landing'
@@ -799,6 +799,14 @@ export function App() {
   // motor-reorder workbench and a direction-test surface so the operator
   // never has to leave the popout to spin a motor or flip a reversal.
   const [motorDialogTab, setMotorDialogTab] = useState<'reorder' | 'direction'>('reorder')
+  // Guided motor-identify auto-spin: after the operator spins the FIRST motor,
+  // automatically spin each subsequent motor once the previous test window has
+  // fully closed, so they only ever click the position that moved. The wait is
+  // gated on the live motor-test status (not a fixed delay) — the old timed
+  // auto-advance fired while the FC was still armed from the prior test and got
+  // rejected with "the vehicle reports armed=true".
+  const [guidedReorderAutoSpin, setGuidedReorderAutoSpin] = useState(true)
+  const autoSpunGuidedReorderStepRef = useRef<number | null>(null)
   // Spin-error banner — when spinGuidedReorderStep or a manual dialog spin
   // fails (FC rejected DO_MOTOR_TEST, eligibility check failed, etc.) we
   // used to swallow the error; surface it inside the dialog so the
@@ -1717,28 +1725,6 @@ export function App() {
     invalidParameterGroups,
     rebootRequiredDrafts
   } = useParameterDraftDerivations({ snapshot, editedValues, enumOverrides: parameterEnumOverrides })
-  // Snapshot-vs-snapshot compare baseline (fleet management):
-  // - undefined / 'live' -> baseline is the live FC snapshot (the
-  //   default, existing "Restore Preview" behaviour)
-  // - a savedSnapshot.id -> baseline is THAT saved snapshot's
-  //   parameter values; the diff then reads "what changed from
-  //   snapshot A to snapshot B."
-  // This lets a fleet operator compare a pre-firmware-bump snapshot
-  // to a post-bump snapshot without their two intentional param
-  // changes being drowned in 100s of cross-version defaults.
-  const [snapshotCompareBaselineId, setSnapshotCompareBaselineId] = useState<string | undefined>(undefined)
-  // Live-FC param index, reused for both the live-baseline path (just
-  // pass snapshot.parameters straight through) AND the
-  // saved-snapshot-baseline path (used as the definition hydration
-  // source so diff rows still render with labels/units even when the
-  // baseline values come from a snapshot file).
-  const snapshotCompareBaselineParameters = useMemo(() => {
-    if (!snapshotCompareBaselineId) return snapshot.parameters
-    const baseline = savedSnapshots.find((entry) => entry.id === snapshotCompareBaselineId)
-    if (!baseline) return snapshot.parameters
-    const liveById = new Map(snapshot.parameters.map((parameter) => [parameter.id, parameter]))
-    return buildParametersFromBackup(baseline.backup, liveById)
-  }, [snapshotCompareBaselineId, savedSnapshots, snapshot.parameters])
   // Snapshot restore curation: off-by-default calibration exclusion (restoring
   // another unit's accel/gyro/compass calibration + AHRS trim onto different
   // hardware is wrong by default) plus a per-row Drop so the operator can
@@ -1759,7 +1745,12 @@ export function App() {
     selectedProfile: selectedSnapshot,
     restore: selectedSnapshotRestore
   } = useSelectedProfileDiff({
-    snapshotParameters: snapshotCompareBaselineParameters,
+    // Restore is ALWAYS computed against the live FC — never the compare
+    // baseline. The "Compare to baseline" picker is a display-only lens for
+    // seeing how two saved snapshots differ; wiring the restore write set to it
+    // caused a silent PARTIAL restore (params equal between the two snapshots
+    // but different on the live FC were skipped). The picker now only annotates.
+    snapshotParameters: snapshot.parameters,
     savedProfiles: savedSnapshots,
     selectedProfileId: selectedSnapshotId,
     resolveBackup: resolveSnapshotBackup,
@@ -1799,8 +1790,8 @@ export function App() {
     invalid: selectedSnapshotInvalidEntries,
     signature: selectedSnapshotDiffSignature
   } = useMemo(
-    () => selectEntityDiff(snapshotCompareBaselineParameters, filteredSnapshotRestoreDraftValues),
-    [snapshotCompareBaselineParameters, filteredSnapshotRestoreDraftValues]
+    () => selectEntityDiff(snapshot.parameters, filteredSnapshotRestoreDraftValues),
+    [snapshot.parameters, filteredSnapshotRestoreDraftValues]
   )
   const {
     handleCaptureLiveSnapshot,
@@ -2890,8 +2881,14 @@ export function App() {
     setScopedWriteProgress({ completed: 0, total: stagedDrafts.length, scopeLabel })
     try {
       const rebootRequiredCount = stagedDrafts.filter((entry) => entry.definition?.rebootRequired).length
+      // Write AP_PARAM_FLAG_ENABLE gates (e.g. RCL<n>_FUNC) before their
+      // dependent sub-params. setParameters is serial and confirms each readback
+      // before the next, so ordering the gate first means its term is live by
+      // the time MIN/MAX/OPT/SRC are written — otherwise those race a disabled,
+      // non-echoing sub-tree and each burns the full verify timeout.
+      const orderedDrafts = orderDraftsByEnableGate(stagedDrafts)
       const result = await runtime.setParameters(
-        stagedDrafts.map((entry) => ({
+        orderedDrafts.map((entry) => ({
           paramId: entry.id,
           paramValue: entry.nextValue as number
         })),
@@ -3876,6 +3873,50 @@ export function App() {
     spinGuidedReorderStep(guidedReorderStep)
   }
 
+  // Auto-spin the NEXT motor in the guided identify sequence. Only steps after
+  // the first fire automatically (the operator kicks the sequence off with an
+  // explicit Spin), and only once the previous motor test has left the
+  // requested/running window — i.e. the FC has stopped the last motor and will
+  // accept a fresh DO_MOTOR_TEST. Safety acknowledgements are re-checked here,
+  // so un-ticking props-off / area-clear mid-sequence pauses the auto-spin
+  // instead of spinning a motor unattended.
+  useEffect(() => {
+    if (!guidedReorderActive) {
+      autoSpunGuidedReorderStepRef.current = null
+      return
+    }
+    if (!guidedReorderAutoSpin || !guidedReorderAwaitingSpin || guidedReorderStep === 0) {
+      return
+    }
+    if (autoSpunGuidedReorderStepRef.current === guidedReorderStep) {
+      return // already auto-spun this step — never double-fire (StrictMode / async)
+    }
+    const motorTestStatus = snapshot.motorTest.status
+    if (motorTestStatus === 'requested' || motorTestStatus === 'running') {
+      return // previous motor still spinning — wait for its window to close
+    }
+    if (busyAction !== undefined) {
+      return
+    }
+    if (!propsRemovedAcknowledged || !testAreaAcknowledged) {
+      return // safety gate — hold auto-spin until re-acknowledged
+    }
+    autoSpunGuidedReorderStepRef.current = guidedReorderStep
+    spinGuidedReorderStep(guidedReorderStep)
+    // spinGuidedReorderStep is a stable component-scope function; the primitive
+    // deps below fully determine when an auto-spin should fire.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [
+    guidedReorderActive,
+    guidedReorderAutoSpin,
+    guidedReorderAwaitingSpin,
+    guidedReorderStep,
+    snapshot.motorTest.status,
+    busyAction,
+    propsRemovedAcknowledged,
+    testAreaAcknowledged
+  ])
+
   function handleStartGuidedReorder(): void {
     if (effectiveMotorOutputs.length === 0) {
       return
@@ -4836,7 +4877,7 @@ export function App() {
     () => buildRcMixerFunctionLookup(rcLogicFunctionCatalogMemo),
     [rcLogicFunctionCatalogMemo]
   )
-  const rcLogicExcludedChannels = useMemo(() => derivePrimaryAndModeChannels(snapshot), [snapshot])
+  const rcLogicExcludedChannels = useMemo(() => derivePrimaryStickChannels(snapshot), [snapshot])
   // Remove on an ALREADY-APPLIED term only STAGES a FUNC=0 draft (same
   // stage-then-apply model every other RC Mixer edit uses) — readRcLogicModel
   // still reports the term as "touched" while that draft is pending, so the
@@ -5031,6 +5072,7 @@ export function App() {
         guidedReorderStep={guidedReorderStep}
         guidedReorderMapping={guidedReorderMapping}
         guidedReorderAwaitingSpin={guidedReorderAwaitingSpin}
+        guidedReorderAutoSpin={guidedReorderAutoSpin}
         guidedReorderCompleted={guidedReorderCompleted}
         onClose={handleCloseMotorReorderDialog}
         onTabChange={setMotorDialogTab}
@@ -5042,6 +5084,7 @@ export function App() {
         onStartGuidedReorder={handleStartGuidedReorder}
         onCancelGuidedReorder={handleCancelGuidedReorder}
         onSpinGuidedReorderCurrent={handleSpinGuidedReorderCurrent}
+        onToggleGuidedReorderAutoSpin={setGuidedReorderAutoSpin}
         onPickGuidedReorderPosition={handlePickGuidedReorderPosition}
         onStageReorderDrafts={handleStageMotorReorderDrafts}
         onSpinSingleMotor={handleDialogSpinSingleMotor}
@@ -7397,8 +7440,6 @@ export function App() {
             handleToggleSelectedProvisioningProfileProtection,
             handleToggleSelectedSnapshotProtection
           }}
-          snapshotCompareBaselineId={snapshotCompareBaselineId}
-          onSnapshotCompareBaselineIdChange={setSnapshotCompareBaselineId}
         />
       ) : null}
 

--- a/apps/web/src/hooks/use-rc-mixer.ts
+++ b/apps/web/src/hooks/use-rc-mixer.ts
@@ -7,7 +7,7 @@ import { useCallback, useMemo, useState } from 'react'
 
 import type { ConfiguratorSnapshot } from '@arduconfig/ardupilot-core'
 
-import { derivePrimaryAndModeChannels } from '../rc-channel-helpers'
+import { derivePrimaryStickChannels } from '../rc-channel-helpers'
 import {
   buildRcMixerFunctionLookup,
   createAssignment,
@@ -33,7 +33,7 @@ export function useRcMixer(snapshot: ConfiguratorSnapshot) {
     () => buildRcMixerFunctionLookup(rcMixerFunctionCatalog),
     [rcMixerFunctionCatalog]
   )
-  const excludedChannels = useMemo(() => derivePrimaryAndModeChannels(snapshot), [snapshot])
+  const excludedChannels = useMemo(() => derivePrimaryStickChannels(snapshot), [snapshot])
   const rcMixerChannels = useMemo(
     () => groupAssignmentsByChannel(rcMixerState.assignments, 16, excludedChannels),
     [rcMixerState.assignments, excludedChannels]

--- a/apps/web/src/rc-channel-helpers.ts
+++ b/apps/web/src/rc-channel-helpers.ts
@@ -69,19 +69,18 @@ export function getModeChannelNumber(snapshot: ConfiguratorSnapshot): number | u
 }
 
 /**
- * Channels reserved for the primary stick axes (RCMAP_ROLL/PITCH/THROTTLE/YAW)
- * and the flight-mode switch. ArduPilot's RCn_OPTION / AP_RC_Logic AUX
- * functions are never assigned to these in practice, so views that edit AUX
- * functions only (e.g. the RC Mixer tab) exclude them rather than listing all
- * 16 channels.
+ * Channels reserved for the primary stick axes (RCMAP_ROLL/PITCH/THROTTLE/YAW).
+ * These are continuous control inputs, not switch channels, so views that edit
+ * AUX functions only (e.g. the RC Mixer tab) exclude them rather than listing
+ * all 16 channels.
+ *
+ * The flight-mode channel is deliberately NOT excluded: ArduPilot RC Logic lets
+ * you layer a range function on the mode channel (activate a function only in a
+ * given mode-switch PWM window), so hiding it wrongly reads as "the mixer can't
+ * see my channel." It shows as a normal aux row.
  */
-export function derivePrimaryAndModeChannels(snapshot: ConfiguratorSnapshot): Set<number> {
-  const channels = new Set<number>(buildRcmapRoleByChannel(snapshot).keys())
-  const modeChannel = getModeChannelNumber(snapshot)
-  if (modeChannel !== undefined) {
-    channels.add(modeChannel)
-  }
-  return channels
+export function derivePrimaryStickChannels(snapshot: ConfiguratorSnapshot): Set<number> {
+  return new Set<number>(buildRcmapRoleByChannel(snapshot).keys())
 }
 
 export function buildRcChannelDisplays(snapshot: ConfiguratorSnapshot, visibleCount = 8): RcChannelDisplay[] {

--- a/apps/web/src/sections/CalibrationSection.tsx
+++ b/apps/web/src/sections/CalibrationSection.tsx
@@ -289,12 +289,19 @@ export function CalibrationSection(props: CalibrationSectionProps): ReactElement
                 const currentOffset = readParameterValue(snapshot, 'BATT_AMP_OFFSET')
                 const currentPerVolt = readParameterValue(snapshot, 'BATT_AMP_PERVLT')
                 const monitorMode = readRoundedParameter(snapshot, 'BATT_MONITOR')
-                // Only show the current cal card when the FC's monitor mode
-                // actually reads current (analog voltage+current = 4, plus
-                // a handful of CAN/SMBUS variants that also expose current).
-                // BATT_MONITOR=3 (voltage only) or 0 (off) → no current path
-                // to calibrate, hide the card.
-                const monitorReadsCurrent = monitorMode !== undefined && [4, 5, 7, 8, 9, 10, 12, 13, 14, 16].includes(monitorMode)
+                // This card calibrates the ANALOG current sensor via
+                // BATT_AMP_OFFSET/BATT_AMP_PERVLT, so it only applies to monitor
+                // types whose driver actually reads current through that path —
+                // the AP_BattMonitor_Analog family: 4 (Analog Voltage+Current),
+                // 25 (Synthetic Current + Analog Voltage, a subclass of Analog),
+                // 28 (AD7091R5 ADC), and 31 (Analog Current Only). Verified
+                // against the AP_BattMonitor driver factory in ~/ardupilot.
+                // Smart/CAN/SMBus/ESC monitors (7/8/9/13/14/16/…) report already-
+                // calibrated current over their own bus and ignore these params,
+                // so the card is hidden for them; voltage-only (3) and disabled
+                // (0) have no current path at all.
+                const monitorUsesAnalogCurrentCal =
+                  monitorMode !== undefined && [4, 25, 28, 31].includes(monitorMode)
                 const connected = snapshot.connection.kind === 'connected'
                 const blockedReason = !connected
                   ? 'Connect to a vehicle first.'
@@ -302,10 +309,10 @@ export function CalibrationSection(props: CalibrationSectionProps): ReactElement
                     ? 'Finish parameter sync and disarm before applying.'
                     : monitorMode === undefined
                       ? 'BATT_MONITOR not retrieved yet.'
-                      : !monitorReadsCurrent
-                        ? `BATT_MONITOR=${monitorMode} doesn't read current — switch the monitor mode in Power first.`
+                      : !monitorUsesAnalogCurrentCal
+                        ? `BATT_MONITOR=${monitorMode} has no analog current sensor to calibrate — set it up in Power first.`
                         : undefined
-                if (!monitorReadsCurrent && monitorMode !== undefined) {
+                if (!monitorUsesAnalogCurrentCal && monitorMode !== undefined) {
                   // Hide entirely on monitor modes that don't expose current
                   // (voltage-only setups AND BATT_MONITOR=0 / disabled) —
                   // keeps the cal stack tidy on FCs without a current sensor.

--- a/apps/web/src/sections/MotorReorderDialog.tsx
+++ b/apps/web/src/sections/MotorReorderDialog.tsx
@@ -44,9 +44,13 @@ export interface MotorReorderDialogProps {
   guidedReorderActive: boolean
   guidedReorderStep: number
   guidedReorderMapping: Record<string, number>
-  /** Operator-paced identify: true while waiting for the explicit Spin
-   *  click (no auto-spin — it raced the FC's previous test window). */
+  /** True while waiting for a motor to spin. The first motor waits for an
+   *  explicit Spin click; when auto-spin is on, later motors spin themselves
+   *  once the previous test window closes (gated on the live motor-test
+   *  status so it can't race the FC's still-armed test). */
   guidedReorderAwaitingSpin: boolean
+  /** When true, each motor after the first spins automatically on advance. */
+  guidedReorderAutoSpin: boolean
   /** True once an identify sequence finished this dialog session. Gates
    *  the Stage button's primary emphasis and the no-changes note. */
   guidedReorderCompleted: boolean
@@ -59,6 +63,7 @@ export interface MotorReorderDialogProps {
   onStartGuidedReorder: () => void
   onCancelGuidedReorder: () => void
   onSpinGuidedReorderCurrent: () => void
+  onToggleGuidedReorderAutoSpin: (next: boolean) => void
   onPickGuidedReorderPosition: (motorNumber: number) => void
   onStageReorderDrafts: () => void
   onSpinSingleMotor: (channelNumber: number) => void
@@ -102,6 +107,7 @@ export function MotorReorderDialog({
   guidedReorderStep,
   guidedReorderMapping,
   guidedReorderAwaitingSpin,
+  guidedReorderAutoSpin,
   guidedReorderCompleted,
   onClose,
   onTabChange,
@@ -111,6 +117,7 @@ export function MotorReorderDialog({
   onStartGuidedReorder,
   onCancelGuidedReorder,
   onSpinGuidedReorderCurrent,
+  onToggleGuidedReorderAutoSpin,
   onPickGuidedReorderPosition,
   onStageReorderDrafts,
   onSpinSingleMotor,
@@ -299,12 +306,16 @@ export function MotorReorderDialog({
                     {guidedReorderAwaitingSpin ? (
                       <>
                         <strong>OUT{effectiveMotorOutputs[guidedReorderStep]?.channelNumber ?? '?'}</strong>
-                        {' '}({guidedReorderStep + 1} / {effectiveMotorOutputs.length}) — click Spin when ready.
+                        {' '}({guidedReorderStep + 1} / {effectiveMotorOutputs.length}) —{' '}
+                        {guidedReorderAutoSpin && guidedReorderStep > 0
+                          ? 'auto-spinning as soon as the previous motor stops (or Spin now).'
+                          : 'click Spin when ready.'}
                       </>
                     ) : (
                       <>
                         <strong>OUT{effectiveMotorOutputs[guidedReorderStep]?.channelNumber ?? '?'} spun</strong>
-                        {' '}({guidedReorderStep + 1} / {effectiveMotorOutputs.length}). Click the position that moved, or Spin again.
+                        {' '}({guidedReorderStep + 1} / {effectiveMotorOutputs.length}). Click the position that moved
+                        {guidedReorderAutoSpin ? ' — the next motor then spins automatically.' : ', or Spin again.'}
                       </>
                     )}
                   </p>
@@ -316,7 +327,13 @@ export function MotorReorderDialog({
                       disabled={busyAction !== undefined || motorTestBusy}
                       data-testid="motor-reorder-guided-spin"
                     >
-                      {motorTestBusy ? 'Spinning…' : guidedReorderAwaitingSpin ? 'Spin' : 'Spin again'}
+                      {motorTestBusy
+                        ? 'Spinning…'
+                        : guidedReorderAwaitingSpin
+                          ? guidedReorderAutoSpin && guidedReorderStep > 0
+                            ? 'Spin now'
+                            : 'Spin'
+                          : 'Spin again'}
                     </button>
                     <button
                       type="button"
@@ -327,6 +344,14 @@ export function MotorReorderDialog({
                       Cancel identify
                     </button>
                   </div>
+                  <label className="motor-reorder-autospin" data-testid="motor-reorder-guided-autospin">
+                    <input
+                      type="checkbox"
+                      checked={guidedReorderAutoSpin}
+                      onChange={(event) => onToggleGuidedReorderAutoSpin(event.target.checked)}
+                    />
+                    <span>Auto-spin each motor after the first (uncheck to spin every motor by hand)</span>
+                  </label>
                 </div>
               ) : (
                 <div className="switch-exercise-controls" style={{ marginBottom: 10 }}>

--- a/apps/web/src/sections/SnapshotsSection.tsx
+++ b/apps/web/src/sections/SnapshotsSection.tsx
@@ -143,13 +143,6 @@ export interface SnapshotsSectionProps {
   refs: SnapshotsSectionRefs
   derived: SnapshotsSectionDerived
   handlers: SnapshotsSectionHandlers
-  // Snapshot-vs-snapshot compare picker. undefined / 'live' means
-  // baseline is the live FC snapshot (the default "Restore Preview"
-  // behaviour); a savedSnapshot.id swaps the baseline to that saved
-  // snapshot's parameter values. Owned by App.tsx so the derived
-  // diff above is consistent with the picker's value.
-  snapshotCompareBaselineId: string | undefined
-  onSnapshotCompareBaselineIdChange: (next: string | undefined) => void
 }
 
 export function SnapshotsSection(props: SnapshotsSectionProps): ReactElement {
@@ -170,9 +163,7 @@ export function SnapshotsSection(props: SnapshotsSectionProps): ReactElement {
     safetyAcks,
     refs,
     derived,
-    handlers,
-    snapshotCompareBaselineId,
-    onSnapshotCompareBaselineIdChange
+    handlers
   } = props
 
   const {
@@ -730,50 +721,12 @@ export function SnapshotsSection(props: SnapshotsSectionProps): ReactElement {
 
                 <div className="snapshots-detail-section-heading">
                   <div>
-                    <h4>{snapshotCompareBaselineId ? 'Changed between snapshots' : 'Restore preview — changed parameters'}</h4>
+                    <h4>Restore preview — changed parameters</h4>
                   </div>
                   <span className="snapshots-counter-chip">
-                    {selectedSnapshotChangedEntries.length}
-                    {snapshotCompareBaselineId ? ' diff' : ' writes'}
+                    {selectedSnapshotChangedEntries.length} writes
                   </span>
                 </div>
-
-                {/* Compare baseline picker. Default is the live FC; the
-                    operator can swap to any OTHER saved snapshot to get
-                    a snapshot-vs-snapshot diff. Hidden when only the
-                    selected snapshot exists (no other baseline to pick). */}
-                {savedSnapshots.length > 1 ? (
-                  <div className="snapshots-compare-picker" data-testid="snapshot-compare-picker">
-                    <label>
-                      <span>Compare to baseline:</span>
-                      <select
-                        data-testid="snapshot-compare-baseline-select"
-                        value={snapshotCompareBaselineId ?? '__live__'}
-                        onChange={(event) => {
-                          const next = event.target.value
-                          onSnapshotCompareBaselineIdChange(next === '__live__' ? undefined : next)
-                        }}
-                      >
-                        <option value="__live__">Live flight controller (default)</option>
-                        {savedSnapshots
-                          .filter((entry) => entry.id !== selectedSnapshot.id)
-                          .map((entry) => (
-                            <option key={entry.id} value={entry.id}>
-                              {entry.label}
-                              {entry.backup.hardware?.uid && isMeaningfulHardwareUid(entry.backup.hardware.uid)
-                                ? `  ·  UID ${formatHardwareUidShort(entry.backup.hardware.uid)}`
-                                : ''}
-                            </option>
-                          ))}
-                      </select>
-                    </label>
-                    {snapshotCompareBaselineId ? (
-                      <small className="snapshots-compare-picker__note">
-                        Diff is &ldquo;baseline snapshot value &rarr; selected snapshot value.&rdquo; Restore writes the SELECTED snapshot to the live FC regardless of this baseline.
-                      </small>
-                    ) : null}
-                  </div>
-                ) : null}
 
                 {snapshotRestoreDroppedParamIds.size > 0 ? (
                   <div className="snapshot-restore-dropped-note" data-testid="snapshot-restore-dropped-note">

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -8716,6 +8716,19 @@ details.metadata-settings-section:not([open]) > summary::after {
   color: var(--text-muted);
 }
 
+.motor-reorder-autospin {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-top: 8px;
+  font-size: 12px;
+  color: var(--text-muted);
+  cursor: pointer;
+}
+.motor-reorder-autospin input {
+  cursor: pointer;
+}
+
 .motor-reorder-table {
   display: grid;
   gap: 1px;

--- a/apps/web/src/view-models/arm-switch.ts
+++ b/apps/web/src/view-models/arm-switch.ts
@@ -16,10 +16,10 @@ export const ARM_SWITCH_OPTION_VALUE = 153
 /** RCn_OPTION value for Arm/Disarm bundled with AirMode-on-arm. */
 export const ARM_SWITCH_AIRMODE_OPTION_VALUE = 154
 
-// RCn_OPTION only makes sense on AUX channels — the primary stick axes and
-// the mode-switch channel are excluded elsewhere in the app (see
-// derivePrimaryAndModeChannels) and by convention start no earlier than
-// channel 5. Internal to this module (never referenced externally).
+// RCn_OPTION only makes sense on AUX channels — the primary stick axes are
+// excluded elsewhere in the app (see derivePrimaryStickChannels) and AUX
+// options by convention start no earlier than channel 5. Internal to this
+// module (never referenced externally).
 const ARM_SWITCH_MIN_CHANNEL = 5
 const ARM_SWITCH_MAX_CHANNEL = 16
 

--- a/apps/web/src/view-models/enable-gate-write-order.test.ts
+++ b/apps/web/src/view-models/enable-gate-write-order.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from 'vitest'
+
+import type { ParameterDraftEntry } from '@arduconfig/ardupilot-core'
+
+import { orderDraftsByEnableGate } from './enable-gate-write-order'
+
+// Minimal draft factory — only id + definition.enableGate matter to the sort.
+function draft(id: string, enableGate = false): ParameterDraftEntry {
+  return {
+    id,
+    status: 'staged',
+    nextValue: 1,
+    definition: enableGate ? { id, label: id, description: '', category: 'radio', enableGate: true } : undefined
+  } as ParameterDraftEntry
+}
+
+const ids = (list: ParameterDraftEntry[]) => list.map((entry) => entry.id)
+
+describe('orderDraftsByEnableGate', () => {
+  it('leaves a batch with no enable-gate params untouched', () => {
+    const input = [draft('ATC_RAT_RLL_P'), draft('ATC_RAT_RLL_I'), draft('INS_GYRO_FILTER')]
+    expect(ids(orderDraftsByEnableGate(input))).toEqual(['ATC_RAT_RLL_P', 'ATC_RAT_RLL_I', 'INS_GYRO_FILTER'])
+  })
+
+  it('moves the RCL term FUNC gate ahead of its MIN/MAX/OPT/SRC dependents', () => {
+    // The RC Mixer stages sub-params before FUNC — exactly the ordering that
+    // times out because the term is still disabled when MIN/MAX are written.
+    const input = [
+      draft('RCL3_MIN'),
+      draft('RCL3_MAX'),
+      draft('RCL3_SRC'),
+      draft('RCL3_FUNC', true),
+      draft('RCL3_OPT')
+    ]
+    expect(ids(orderDraftsByEnableGate(input))).toEqual([
+      'RCL3_FUNC',
+      'RCL3_MIN',
+      'RCL3_MAX',
+      'RCL3_SRC',
+      'RCL3_OPT'
+    ])
+  })
+
+  it('keeps each gate ahead of its own dependents across two terms', () => {
+    const input = [
+      draft('RCL3_MIN'),
+      draft('RCL4_MAX'),
+      draft('RCL3_FUNC', true),
+      draft('RCL4_FUNC', true),
+      draft('RCL3_MAX'),
+      draft('RCL4_MIN')
+    ]
+    const out = ids(orderDraftsByEnableGate(input))
+    expect(out.indexOf('RCL3_FUNC')).toBeLessThan(out.indexOf('RCL3_MIN'))
+    expect(out.indexOf('RCL3_FUNC')).toBeLessThan(out.indexOf('RCL3_MAX'))
+    expect(out.indexOf('RCL4_FUNC')).toBeLessThan(out.indexOf('RCL4_MIN'))
+    expect(out.indexOf('RCL4_FUNC')).toBeLessThan(out.indexOf('RCL4_MAX'))
+  })
+
+  it('does not confuse RCL1 with RCL10 (exact prefix, not substring)', () => {
+    const input = [draft('RCL10_MIN'), draft('RCL1_FUNC', true), draft('RCL1_MAX')]
+    const out = ids(orderDraftsByEnableGate(input))
+    // RCL10_MIN is NOT a dependent of RCL1_FUNC, so it keeps its leading spot.
+    expect(out).toEqual(['RCL10_MIN', 'RCL1_FUNC', 'RCL1_MAX'])
+  })
+
+  it('leaves a dependent alone when its gate is not part of this batch', () => {
+    // FUNC already enabled on the FC (not staged) — MIN/MAX echo fine, no reorder.
+    const input = [draft('RCL2_MIN'), draft('RCL2_MAX')]
+    expect(ids(orderDraftsByEnableGate(input))).toEqual(['RCL2_MIN', 'RCL2_MAX'])
+  })
+
+  it('preserves the relative order of unrelated params outside the gate group', () => {
+    const input = [
+      draft('SERVO1_FUNCTION'),
+      draft('RCL3_MIN'),
+      draft('SERVO2_FUNCTION'),
+      draft('RCL3_FUNC', true)
+    ]
+    const out = ids(orderDraftsByEnableGate(input))
+    // Unrelated servo params stay in order; the gate precedes its dependent.
+    expect(out.indexOf('SERVO1_FUNCTION')).toBeLessThan(out.indexOf('SERVO2_FUNCTION'))
+    expect(out.indexOf('RCL3_FUNC')).toBeLessThan(out.indexOf('RCL3_MIN'))
+  })
+})

--- a/apps/web/src/view-models/enable-gate-write-order.ts
+++ b/apps/web/src/view-models/enable-gate-write-order.ts
@@ -1,0 +1,59 @@
+import type { ParameterDraftEntry } from '@arduconfig/ardupilot-core'
+
+/**
+ * Reorder a batch of parameter-write drafts so any enable-gate parameter (one
+ * whose definition sets `enableGate`, e.g. RCL3_FUNC) is written before the
+ * dependent siblings sharing its `<GROUP>_` prefix (RCL3_MIN/MAX/OPT/SRC).
+ *
+ * ArduPilot hides an enable-gated sub-tree until the gate is set, and does not
+ * reliably echo a PARAM_SET to a hidden sub-param. Because `runtime.setParameters`
+ * writes serially and confirms each write's readback before the next, ordering
+ * the gate first means the term is live (gate confirmed) by the time its
+ * dependents are written — so they echo immediately instead of racing a
+ * disabled term and timing out on verification.
+ *
+ * The reorder is minimal: each gate group clusters at the gate's position with
+ * the gate first; params outside any present gate group keep their original
+ * relative order. A gate whose group has no dependents in the batch, or a
+ * dependent whose gate is NOT in the batch (already enabled on the FC), is left
+ * where it is.
+ */
+export function orderDraftsByEnableGate(
+  drafts: readonly ParameterDraftEntry[]
+): ParameterDraftEntry[] {
+  const groupPrefixOf = (id: string): string | undefined => {
+    const underscore = id.lastIndexOf('_')
+    return underscore > 0 ? id.slice(0, underscore + 1) : undefined
+  }
+
+  // Prefix -> index of the enable-gate param actually present in this batch.
+  const gateIndexByPrefix = new Map<string, number>()
+  drafts.forEach((draft, index) => {
+    if (draft.definition?.enableGate) {
+      const prefix = groupPrefixOf(draft.id)
+      if (prefix !== undefined) {
+        gateIndexByPrefix.set(prefix, index)
+      }
+    }
+  })
+  if (gateIndexByPrefix.size === 0) {
+    return [...drafts]
+  }
+
+  const keyed = drafts.map((draft, index) => {
+    if (draft.definition?.enableGate) {
+      return { draft, sortPos: index, rank: 0, index }
+    }
+    const prefix = groupPrefixOf(draft.id)
+    const gateIndex = prefix !== undefined ? gateIndexByPrefix.get(prefix) : undefined
+    if (gateIndex !== undefined) {
+      // Dependent of a gate present in this batch — cluster it right after its
+      // gate (sortPos = gate index, rank 1 so the gate at rank 0 comes first).
+      return { draft, sortPos: gateIndex, rank: 1, index }
+    }
+    return { draft, sortPos: index, rank: 0, index }
+  })
+
+  keyed.sort((a, b) => a.sortPos - b.sortPos || a.rank - b.rank || a.index - b.index)
+  return keyed.map((entry) => entry.draft)
+}

--- a/apps/web/src/view-models/rc-mixer.test.ts
+++ b/apps/web/src/view-models/rc-mixer.test.ts
@@ -54,15 +54,23 @@ describe('groupAssignmentsByChannel', () => {
     expect(groups.find((group) => group.channel === 1)?.assignments).toEqual([])
   })
 
-  it('ignores assignments outside the 1..maxChannel window', () => {
-    const groups = groupAssignmentsByChannel([assign(9)], 4)
-    expect(groups).toHaveLength(4)
-    expect(groups.every((group) => group.assignments.length === 0)).toBe(true)
+  it('surfaces an assignment above the 1..maxChannel window so a firmware term stays manageable', () => {
+    const nine = assign(9)
+    const groups = groupAssignmentsByChannel([nine], 4)
+    expect(groups.map((group) => group.channel)).toEqual([1, 2, 3, 4, 9])
+    expect(groups.find((group) => group.channel === 9)?.assignments).toEqual([nine])
   })
 
-  it('omits excluded channels (e.g. the primary stick axes) from the rows entirely', () => {
-    const groups = groupAssignmentsByChannel([assign(2)], 6, new Set([1, 2, 3, 4]))
-    expect(groups.map((group) => group.channel)).toEqual([5, 6])
+  it('omits EMPTY excluded channels but keeps an excluded channel that carries a live term', () => {
+    // Nothing assigned on the excluded stick axes → they stay hidden.
+    const empty = groupAssignmentsByChannel([], 6, new Set([1, 2, 3, 4]))
+    expect(empty.map((group) => group.channel)).toEqual([5, 6])
+    // A firmware-set RCL term whose SRC points at excluded channel 2 must still
+    // appear (on its own row) so it can be seen and removed.
+    const two = assign(2)
+    const withTerm = groupAssignmentsByChannel([two], 6, new Set([1, 2, 3, 4]))
+    expect(withTerm.map((group) => group.channel)).toEqual([2, 5, 6])
+    expect(withTerm.find((group) => group.channel === 2)?.assignments).toEqual([two])
   })
 })
 

--- a/apps/web/src/view-models/rc-mixer.ts
+++ b/apps/web/src/view-models/rc-mixer.ts
@@ -129,12 +129,17 @@ export function buildRcMixerFunctionLookup(
 }
 
 /**
- * Group assignments by channel for the channel-row layout. Channels with no
- * assignments are still surfaced so the UI can show "+ Add" affordances on
- * every channel in the 1..maxChannel range — except those in `excludeChannels`
- * (the primary stick axes and the flight-mode switch), which never get an AUX
- * function assigned in practice and would otherwise clutter the mixer with
- * rows nobody uses.
+ * Group assignments by channel for the channel-row layout. Empty channels in
+ * the 1..maxChannel range are surfaced so the UI can show "+ Add" affordances —
+ * except those in `excludeChannels` (the primary stick axes), which are
+ * continuous control inputs, not switch channels, and would otherwise clutter
+ * the mixer with rows nobody uses.
+ *
+ * An assignment that actually EXISTS on an excluded or out-of-window channel is
+ * still surfaced on its own row, however: a firmware-set RCL term can point its
+ * `RCLn_SRC` at an RCMAP/flight-mode channel (or a channel above maxChannel),
+ * and silently dropping it would leave the term invisible and impossible to
+ * remove from the mixer. We only suppress empty excluded rows, never live ones.
  */
 export function groupAssignmentsByChannel(
   assignments: readonly RcMixerAssignment[],
@@ -149,10 +154,14 @@ export function groupAssignmentsByChannel(
     byChannel.set(channel, [])
   }
   for (const assignment of assignments) {
-    const bucket = byChannel.get(assignment.channel)
-    if (bucket) {
-      bucket.push(assignment)
+    let bucket = byChannel.get(assignment.channel)
+    if (!bucket) {
+      // Excluded or out-of-window channel that nonetheless carries a live term —
+      // surface it so it stays visible and removable rather than dropped.
+      bucket = []
+      byChannel.set(assignment.channel, bucket)
     }
+    bucket.push(assignment)
   }
   return Array.from(byChannel.entries())
     .sort(([left], [right]) => left - right)

--- a/apps/web/src/views/Osd.tsx
+++ b/apps/web/src/views/Osd.tsx
@@ -694,7 +694,11 @@ export function OsdView(props: OsdViewProps) {
                                         max={layout.columns - 1}
                                         value={clampCellToLayout(placed.column, layout.columns - 1)}
                                         onChange={(event) =>
-                                          onElementMove?.(row.elementId, clampCellToLayout(Number(event.target.value), layout.columns - 1), clampCellToLayout(placed.row, layout.rows - 1))
+                                          // Commit the untouched Y axis at its real stored value, not the
+                                          // grid-clamped display value — otherwise editing X silently truncates
+                                          // an element positioned outside the previewed grid (e.g. an HD-placed
+                                          // element viewed under analog NTSC). Only the edited axis is clamped.
+                                          onElementMove?.(row.elementId, clampCellToLayout(Number(event.target.value), layout.columns - 1), placed.row)
                                         }
                                       />
                                     </label>
@@ -706,7 +710,8 @@ export function OsdView(props: OsdViewProps) {
                                         max={layout.rows - 1}
                                         value={clampCellToLayout(placed.row, layout.rows - 1)}
                                         onChange={(event) =>
-                                          onElementMove?.(row.elementId, clampCellToLayout(placed.column, layout.columns - 1), clampCellToLayout(Number(event.target.value), layout.rows - 1))
+                                          // Untouched X axis keeps its real stored value; only the edited Y axis is clamped.
+                                          onElementMove?.(row.elementId, placed.column, clampCellToLayout(Number(event.target.value), layout.rows - 1))
                                         }
                                       />
                                     </label>

--- a/apps/web/src/views/ScopedField.tsx
+++ b/apps/web/src/views/ScopedField.tsx
@@ -138,11 +138,16 @@ export function ScopedSelectField(props: ScopedSelectFieldProps) {
   const status = statusModifier(draftStatusById, parameter.id)
   const currentValue = editedValues[parameter.id] ?? String(liveValue ?? '')
   const matchesKnownOption = options.some((option) => String(option.value) === currentValue)
-  // Sticky "I picked Custom…" flag — without it, typing e.g. "6" (a real
+  // Sticky "I'm in Custom… mode" flag — without it, typing e.g. "6" (a real
   // FLTMODE value) into the number input would make matchesKnownOption true
   // again and the custom input would vanish out from under the operator's
-  // cursor mid-edit.
-  const [customModeForced, setCustomModeForced] = useState(false)
+  // cursor mid-edit. Latch it on first render when the field AUTO-enters custom
+  // mode because the live value is already unlisted (e.g. a scripting-defined
+  // FLTMODEn=29): otherwise that path — not just the dropdown-initiated one —
+  // hits the same mid-edit collapse the flag exists to prevent.
+  const [customModeForced, setCustomModeForced] = useState(
+    () => allowCustomValue && currentValue !== '' && !matchesKnownOption
+  )
   const showCustomInput = allowCustomValue && (customModeForced || (currentValue !== '' && !matchesKnownOption))
 
   if (allowCustomValue) {

--- a/packages/param-metadata/src/arducopter-4.7-overrides.ts
+++ b/packages/param-metadata/src/arducopter-4.7-overrides.ts
@@ -1,6 +1,7 @@
 import type { ParameterDefinition, ParameterValueOption } from './types.js'
 import {
   ARDUCOPTER_BATTERY_FAILSAFE_ACTION_LABELS,
+  ARDUCOPTER_BATTERY_MONITOR_LABELS,
   ARDUCOPTER_FS_GCS_LABELS,
   ARDUCOPTER_MOT_PWM_TYPE_LABELS,
   ARDUCOPTER_RSSI_TYPE_LABELS,
@@ -59,6 +60,15 @@ const BATTERY_FAILSAFE_ACTION_LABELS_4_7: Record<number, string> = {
   6: FAILSAFE_6_LABEL_4_7
 }
 
+// BATT_MONITOR gains 30:INA3221, 31:Analog Current Only, 32:TIBQ76952 after 4.6.
+// Source: libraries/AP_BattMonitor/AP_BattMonitor_Params.cpp @Values.
+const BATTERY_MONITOR_LABELS_4_7: Record<number, string> = {
+  ...ARDUCOPTER_BATTERY_MONITOR_LABELS,
+  30: 'INA3221',
+  31: 'Analog Current Only',
+  32: 'TIBQ76952-I2C'
+}
+
 /**
  * ArduCopter parameter metadata that changed in the 4.7 release line, keyed by
  * parameter id. Each value is a partial patch (options / range / description)
@@ -81,5 +91,6 @@ export const ARDUCOPTER_4_7_PARAMETER_OVERRIDES: Record<string, Partial<Paramete
   FS_THR_ENABLE: { options: enumOptions(THROTTLE_FAILSAFE_LABELS_4_7) },
   FS_GCS_ENABLE: { options: enumOptions(FS_GCS_LABELS_4_7) },
   BATT_FS_LOW_ACT: { options: enumOptions(BATTERY_FAILSAFE_ACTION_LABELS_4_7) },
-  BATT_FS_CRT_ACT: { options: enumOptions(BATTERY_FAILSAFE_ACTION_LABELS_4_7) }
+  BATT_FS_CRT_ACT: { options: enumOptions(BATTERY_FAILSAFE_ACTION_LABELS_4_7) },
+  BATT_MONITOR: { maximum: 32, options: enumOptions(BATTERY_MONITOR_LABELS_4_7) }
 }

--- a/packages/param-metadata/src/arducopter-enums.ts
+++ b/packages/param-metadata/src/arducopter-enums.ts
@@ -100,15 +100,15 @@ export const ARDUCOPTER_BATTERY_MONITOR_LABELS: Record<number, string> = {
   22: 'LTC2946',
   23: 'Torqeedo',
   24: 'Fuel Level Analog',
-  // 25..32 added through 4.7 — keep in sync with AP_BattMonitor Type enum.
+  // 25..29 already exist in 4.6 (verified against Copter-4.6.0
+  // AP_BattMonitor_Params.cpp @Values). Values 30..32 (INA3221 / Analog Current
+  // Only / TIBQ76952) landed after 4.6 and live in the 4.7 override
+  // (arducopter-4.7-overrides.ts) so the 4.6 catalog stays byte-identical.
   25: 'Synthetic Current + Analog Voltage',
   26: 'INA239 SPI',
   27: 'EFI',
   28: 'AD7091R5',
-  29: 'Scripting',
-  30: 'INA3221',
-  31: 'Analog Current Only',
-  32: 'TIBQ76952-I2C'
+  29: 'Scripting'
 }
 
 export const ARDUCOPTER_BATTERY_VOLTAGE_SOURCE_LABELS: Record<number, string> = {
@@ -301,6 +301,39 @@ export const ARDUCOPTER_GPS_TYPE_LABELS: Record<number, string> = {
   24: 'Unicore NMEA',
   25: 'Unicore Moving Baseline NMEA',
   26: 'SBF DualAntenna'
+}
+
+// Bit indices for the legacy GPS_GNSS_MODE / GPS_GNSS_MODE2 bitmask (which GNSS
+// constellations the receiver should track). Renamed GPS1_GNSS_MODE /
+// GPS2_GNSS_MODE in 4.6+; the bit layout is unchanged across versions.
+// Source: libraries/AP_GPS/AP_GPS.cpp @Bitmask (verified against the local fork).
+export const ARDUCOPTER_GPS_GNSS_MODE_BIT_LABELS: Record<number, string> = {
+  0: 'GPS',
+  1: 'SBAS',
+  2: 'Galileo',
+  3: 'BeiDou',
+  4: 'IMES',
+  5: 'QZSS',
+  6: 'GLONASS'
+}
+
+// Legacy CAM_TRIGG_TYPE value map. This is the pre-4.2 camera-shutter enum, which
+// is DIFFERENT from the modern CAM1_TYPE enum (0:None,1:Servo,2:Relay,…). The 4.5
+// AP_Camera::convert_params() shows the legacy semantics: 0=Servo, and 1/2/3 map
+// to Relay/GoPro/Mount (cam1_type = cam_trigg_type + 1). Do not substitute the
+// CAM1_TYPE labels here — a legacy FC reporting CAM_TRIGG_TYPE uses these values.
+export const ARDUCOPTER_CAM_TRIGG_TYPE_LABELS: Record<number, string> = {
+  0: 'Servo',
+  1: 'Relay',
+  2: 'GoPro (Solo Gimbal)',
+  3: 'Mount'
+}
+
+// CAM_AUTO_ONLY: whether distance-based triggering is limited to AUTO mode.
+// Source: libraries/AP_Camera/AP_Camera.cpp @Values 0:Always,1:Only when in AUTO.
+export const ARDUCOPTER_CAM_AUTO_ONLY_LABELS: Record<number, string> = {
+  0: 'Always',
+  1: 'Only in AUTO mode'
 }
 
 export const ARDUCOPTER_GPS_AUTO_CONFIG_LABELS: Record<number, string> = {

--- a/packages/param-metadata/src/arducopter.ts
+++ b/packages/param-metadata/src/arducopter.ts
@@ -10,6 +10,8 @@ import {
   ARDUCOPTER_BATTERY_FAILSAFE_ACTION_LABELS,
   ARDUCOPTER_BATTERY_MONITOR_LABELS,
   ARDUCOPTER_BATTERY_VOLTAGE_SOURCE_LABELS,
+  ARDUCOPTER_CAM_AUTO_ONLY_LABELS,
+  ARDUCOPTER_CAM_TRIGG_TYPE_LABELS,
   ARDUCOPTER_FLTMODE_CHANNEL_LABELS,
   ARDUCOPTER_FLIGHT_MODE_LABELS,
   ARDUCOPTER_FRAME_CLASS_LABELS,
@@ -17,6 +19,7 @@ import {
   ARDUCOPTER_FS_EKF_ACTION_LABELS,
   ARDUCOPTER_FS_GCS_LABELS,
   ARDUCOPTER_GPS_AUTO_CONFIG_LABELS,
+  ARDUCOPTER_GPS_GNSS_MODE_BIT_LABELS,
   ARDUCOPTER_GPS_AUTO_SWITCH_LABELS,
   ARDUCOPTER_GPS_PRIMARY_LABELS,
   ARDUCOPTER_GPS_RATE_MS_LABELS,
@@ -103,6 +106,11 @@ const gpsSwitchingNotes = [
 const gpsRateNotes = [
   'Higher GPS update rates can help responsiveness but also increase bus load and CPU work on some targets.',
   'Only raise the GPS rate if the attached module and link can sustain it cleanly.'
+]
+
+const gnssModeNotes = [
+  'GPS is required for a fix — leave it checked whenever you enable any constellation.',
+  'Selecting more constellations than the receiver can track concurrently can reduce update rate; leave the mask at 0 to keep the module at its own default unless you have a reason to restrict it.'
 ]
 
 const vtxEnableNotes = [
@@ -1361,6 +1369,49 @@ export const arducopterMetadata: FirmwareMetadataBundle = {
       notes: gpsRateNotes,
       options: enumOptions(ARDUCOPTER_GPS_RATE_MS_LABELS)
     },
+    GPS_GNSS_MODE: {
+      id: 'GPS_GNSS_MODE',
+      label: 'Primary GNSS Systems',
+      description: 'Which GNSS constellations the primary GPS should track. Leave all unchecked (0) to keep the receiver at its own configured default.',
+      category: 'peripherals',
+      minimum: 0,
+      maximum: 127,
+      bitmask: true,
+      rebootRequired: true,
+      notes: gnssModeNotes,
+      options: enumOptions(ARDUCOPTER_GPS_GNSS_MODE_BIT_LABELS)
+    },
+    GPS_GNSS_MODE2: {
+      id: 'GPS_GNSS_MODE2',
+      label: 'Secondary GNSS Systems',
+      description: 'Which GNSS constellations the secondary GPS should track. Leave all unchecked (0) to keep the receiver at its own configured default.',
+      category: 'peripherals',
+      minimum: 0,
+      maximum: 127,
+      bitmask: true,
+      rebootRequired: true,
+      notes: gnssModeNotes,
+      options: enumOptions(ARDUCOPTER_GPS_GNSS_MODE_BIT_LABELS)
+    },
+    CAM_TRIGG_TYPE: {
+      id: 'CAM_TRIGG_TYPE',
+      label: 'Camera Trigger Type',
+      description: 'How the camera shutter is triggered. Legacy camera parameter (renamed CAM1_TYPE on 4.2+); values differ from the modern camera-type enum.',
+      category: 'peripherals',
+      minimum: 0,
+      maximum: 3,
+      rebootRequired: true,
+      options: enumOptions(ARDUCOPTER_CAM_TRIGG_TYPE_LABELS)
+    },
+    CAM_AUTO_ONLY: {
+      id: 'CAM_AUTO_ONLY',
+      label: 'Distance Trigger in AUTO Only',
+      description: 'When enabled, distance-based camera triggering only runs in AUTO mode.',
+      category: 'peripherals',
+      minimum: 0,
+      maximum: 1,
+      options: enumOptions(ARDUCOPTER_CAM_AUTO_ONLY_LABELS)
+    },
     // New 4.5+ per-instance GPS params. The legacy GPS_TYPE / GPS_TYPE2 /
     // GPS_RATE_MS resolutions are still curated above and stay readable via
     // the runtime's bidirectional alias shim (see runtime.ts). These entries
@@ -1567,7 +1618,8 @@ export const arducopterMetadata: FirmwareMetadataBundle = {
       description: 'Battery sensing source configuration.',
       category: 'power',
       minimum: 0,
-      maximum: 24,
+      // 4.6 supports monitor types 0..29; the 4.7 override bumps this to 32.
+      maximum: 29,
       rebootRequired: true,
       notes: batteryMonitorNotes,
       options: enumOptions(ARDUCOPTER_BATTERY_MONITOR_LABELS)

--- a/packages/param-metadata/src/arduplane.ts
+++ b/packages/param-metadata/src/arduplane.ts
@@ -3481,7 +3481,8 @@ export const arduplaneMetadata: FirmwareMetadataBundle = {
       description: 'Battery sensing source configuration.',
       category: 'power',
       minimum: 0,
-      maximum: 24,
+      // Shares the ArduPilot AP_BattMonitor type enum; 4.6 supports 0..29.
+      maximum: 29,
       rebootRequired: true,
       notes: batteryMonitorNotes,
       options: enumOptions(ARDUCOPTER_BATTERY_MONITOR_LABELS)

--- a/packages/param-metadata/src/shared-rc-logic.ts
+++ b/packages/param-metadata/src/shared-rc-logic.ts
@@ -165,6 +165,10 @@ function termParameterDefinitions(n: number): Record<string, ParameterDefinition
       description:
         'Auxiliary function this table row activates (0 disables the row). Same value list as an RC channel option (RCn_OPTION).',
       category: RC_LOGIC_CATEGORY,
+      // AP_PARAM_FLAG_ENABLE: FUNC gates the RCL<n>_* sub-tree. The batch writer
+      // sets it (and confirms its readback) before the term's MIN/MAX/OPT/SRC so
+      // those writes don't race a still-disabled, non-echoing sub-param.
+      enableGate: true,
       options: RC_LOGIC_AUX_FUNCTION_OPTIONS as ParameterValueOption[]
     },
     [`${prefix}OPT`]: {

--- a/packages/param-metadata/src/types.ts
+++ b/packages/param-metadata/src/types.ts
@@ -121,6 +121,16 @@ export interface ParameterDefinition {
    * RNGFND1_TYPE = Analog. Value is rounded before comparison.
    */
   visibleWhen?: { paramId: string; in: number[] }
+  /**
+   * Marks this parameter as the AP_PARAM_FLAG_ENABLE gate for its group — the
+   * sibling params sharing its `<GROUP>_` prefix (e.g. RCL3_FUNC gates
+   * RCL3_MIN/MAX/OPT/SRC). ArduPilot hides an enable-gated sub-tree until the
+   * gate is set, and does not reliably echo a PARAM_SET to a hidden sub-param.
+   * The batch writer therefore writes the gate FIRST and waits for its readback
+   * (so the sub-tree is live) before writing the dependents — otherwise the
+   * dependent writes race the still-disabled term and time out on verification.
+   */
+  enableGate?: boolean
 }
 
 export interface PresetGroupDefinition {

--- a/tests/e2e/app.spec.ts
+++ b/tests/e2e/app.spec.ts
@@ -342,22 +342,25 @@ test.describe('browser configurator regression flows', () => {
     await expect(startButton).toBeEnabled()
     await startButton.click()
 
-    // Banner replaces the start button while identify is in progress.
-    // Operator-paced (field feedback): nothing spins until the explicit
-    // Spin click, and the next motor never auto-spins after a pick.
+    // Banner replaces the start button while identify is in progress. The
+    // FIRST motor always waits for an explicit Spin click.
     const banner = page.getByTestId('motor-reorder-guided-banner')
     await expect(banner).toBeVisible()
     await expect(banner).toContainText('1 / 4')
     await expect(banner).toContainText('click Spin when ready')
 
+    // Auto-spin is on by default — it spins every motor after the first.
+    await expect(page.getByTestId('motor-reorder-guided-autospin').locator('input')).toBeChecked()
+
     await page.getByTestId('motor-reorder-guided-spin').click()
     await expect(banner).toContainText(/OUT\d+ spun/, { timeout: COMMAND_ACK_TIMEOUT })
 
-    // Picking a position advances to the next output — back into the
-    // "click Spin when ready" state rather than auto-spinning.
+    // Picking a position advances to the next output and — with auto-spin on —
+    // spins it automatically once the previous motor's test window closes, so
+    // the operator never has to click Spin again.
     await page.getByTestId('motor-reorder-pick-1').click()
     await expect(banner).toContainText('2 / 4')
-    await expect(banner).toContainText('click Spin when ready')
+    await expect(banner).toContainText(/OUT\d+ spun/, { timeout: COMMAND_ACK_TIMEOUT })
 
     // Cancel cleanly even if mid-sequence.
     const cancel = page.getByTestId('motor-reorder-guided-cancel')

--- a/tests/e2e/rc-mixer.spec.ts
+++ b/tests/e2e/rc-mixer.spec.ts
@@ -51,10 +51,9 @@ test.describe('RC Mixer (AP_RC_Logic)', () => {
     // otherwise the free-slot allocation races an empty model.
     await expect(page.getByTestId('rc-mixer-track-band-rcl-2')).toBeVisible()
 
-    // Add a term on channel 8 -> allocates the first free slot (term 3) and the
-    // pending row appears, driven entirely by the staged RCL3_* drafts. (Ch8,
-    // not ch7: the demo's FLTMODE_CH=7 makes channel 7 the mode-switch channel,
-    // which the RC Mixer now excludes as a non-AUX-candidate.)
+    // Add a term on channel 8 (an empty aux channel) -> allocates the first free
+    // slot (term 3) and the pending row appears, driven entirely by the staged
+    // RCL3_* drafts.
     await page.getByTestId('rc-mixer-add-channel-8').click()
     await expect(page.getByTestId('rc-mixer-assignment-rcl-3')).toBeVisible()
     await expect(page.getByTestId('rc-mixer-track-band-rcl-3')).toBeVisible()

--- a/tests/e2e/views.spec.ts
+++ b/tests/e2e/views.spec.ts
@@ -1533,24 +1533,26 @@ test.describe('Config view', () => {
 })
 
 test.describe('RC Mixer view', () => {
-  test('shows only AUX channels, not the primary stick axes or the mode switch', async ({ page }) => {
+  test('hides the primary stick axes but shows AUX channels including the mode switch', async ({ page }) => {
     // Demo Copter: RCMAP_ROLL/PITCH/THROTTLE/YAW = 1/2/3/4, FLTMODE_CH = 7,
     // RCL_ENABLE = 1 with real range terms on ch5 (ArmDisarm) and ch6 (LAND).
-    // Channels 1-4 and 7 are stick axes / the mode switch, never AUX
-    // candidates in practice — the mixer should skip them entirely rather
-    // than listing all 16 channels.
+    // Only channels 1-4 (the continuous stick axes) are skipped. The flight-mode
+    // channel (7) IS shown — ArduPilot RC Logic can layer a range function on
+    // the mode channel, so hiding it wrongly reads as "the mixer lost my channel."
     await page.goto('/')
     await page.getByTestId('transport-mode-select').selectOption('demo')
     await page.getByTestId('connect-button').click()
     await page.getByTestId('product-mode-expert').check()
     await page.getByTestId('view-button-rc-mixer').click()
 
-    for (const channel of [1, 2, 3, 4, 7]) {
+    for (const channel of [1, 2, 3, 4]) {
       await expect(page.getByTestId(`rc-mixer-channel-${channel}`)).toHaveCount(0)
     }
-    // AUX channels remain, including the ones with real assigned functions.
+    // AUX channels remain, including the ones with real assigned functions and
+    // the flight-mode channel (7), which now appears as a normal aux row.
     await expect(page.getByTestId('rc-mixer-channel-5')).toBeVisible()
     await expect(page.getByTestId('rc-mixer-channel-6')).toBeVisible()
+    await expect(page.getByTestId('rc-mixer-channel-7')).toBeVisible()
     await expect(page.getByTestId('rc-mixer-channel-8')).toBeVisible()
   })
 


### PR DESCRIPTION
Bug-hunt batch (manual sweep + parallel deep-review agents) plus two RC Mixer improvements found during live H743 testing.

## Fixes
- **OSD** align X/Y no longer corrupts the untouched axis for elements outside the previewed grid.
- **Snapshots** "Apply Restore" always diffs/writes the selected snapshot vs the **live FC** (was silently partial when a compare-baseline was picked); removed the broken compare-baseline picker.
- **Power** `BATT_MONITOR` max corrected to the real 4.6 range (0–29, was 24); 30/31/32 moved to the 4.7 override. Battery current-cal card now shows for exactly the analog-current monitor types (4/25/28/31, source-verified) and hides for smart/CAN monitors.
- **Config** curated metadata added so `CAM_TRIGG_TYPE` (legacy enum, distinct from `CAM1_TYPE`), `GPS_GNSS_MODE`/`_MODE2` (GNSS bitmask), `CAM_AUTO_ONLY` render as proper editors.
- **FLTMODE** custom-value editor no longer collapses mid-edit for an already-unlisted live value.
- **RC Mixer** a firmware-set RCL term on an excluded channel is now surfaced (viewable/removable) instead of dropped.

## Features / behavior
- **Motors** guided reorder auto-spins each motor after the first, once the previous test window closes (gated on live motor-test status so it can't race the FC's armed test); opt-out toggle.
- **RC Mixer** enable-gated sub-params write correctly — `RCL<n>_FUNC` (AP_PARAM_FLAG_ENABLE) is ordered ahead of its `MIN/MAX/OPT/SRC` dependents, so they echo immediately instead of each burning the 15s verify timeout on a hidden sub-tree.
- **RC Mixer** the flight-mode channel is shown (only the RCMAP stick axes are hidden) — ArduPilot RC Logic can layer a range function on the mode channel.

## ArduCopter byte-identical
Runtime/transport/write paths unchanged. UI + curated-metadata only, including deliberate scoped Copter metadata corrections (BATT_MONITOR 4.6 range; CAM/GPS enum coverage). Enable-gate ordering only reorders batches containing an enable-gate param (currently just `RCL<n>_FUNC`).

## Validation ladder
Rung 1 (mock/node 702) · web vitest 483 (incl. new `enable-gate-write-order` + `rc-mixer` tests) · Rung 3 full Playwright e2e (203 passed, 6 visual skipped). RC Mixer write-ordering root-caused against the `sfd-rc-work` firmware; hardware re-verification of the RCL write path pending.