### PR TITLE
feat(rc-mixer): per-row output position for RCL selector mode (multi-level VTX power)

### DIFF
--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -8169,6 +8169,17 @@ details.metadata-settings-section:not([open]) > summary::after {
   font-size: 10px;
 }
 
+.rc-mixer-assignment__position {
+  grid-column: 1 / span 2;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 10px;
+}
+.rc-mixer-assignment__position select {
+  font-size: 11px;
+}
+
 .rc-mixer-assignment__status {
   align-items: end;
   justify-items: end;

--- a/apps/web/src/view-models/rc-logic.test.ts
+++ b/apps/web/src/view-models/rc-logic.test.ts
@@ -38,6 +38,14 @@ describe('readRcLogicModel', () => {
     expect(model.assignments[0]).toMatchObject({ id: 'rcl-2', inverted: true, functionId: 18 })
   })
 
+  it('reads the output position from OPT bits 4-5 (VTX power selector)', () => {
+    const pos = (opt: number) =>
+      readRcLogicModel(params({ RCL1_FUNC: 94, RCL1_OPT: opt, RCL1_SRC: 6 }), {}).assignments[0].outputPosition
+    expect(pos(0)).toBe('high') // neither bit
+    expect(pos(1 << 4)).toBe('middle') // bit 4
+    expect(pos(2 << 4)).toBe('low') // bit 5
+  })
+
   it('keeps non-range terms (link/condition) out of the editor but counts them as used', () => {
     const model = readRcLogicModel(params({ RCL3_FUNC: 16, RCL3_OPT: 1 /* link */ }), {})
     expect(model.assignments).toHaveLength(0)
@@ -76,6 +84,25 @@ describe('rcLogic draft mappers', () => {
     const drafts = rcLogicUpdateDrafts(params({ RCL1_OPT: 0b0100 }), {}, 1, { functionId: 22, inverted: true })
     expect(drafts.RCL1_FUNC).toBe('22')
     expect(Number(drafts.RCL1_OPT)).toBe(0b1100) // AND + negate
+  })
+
+  it('folds the output position into OPT bits 4-5, preserving and clearing correctly', () => {
+    // Set LOW while negate (bit3) is already set — negate must survive.
+    expect(Number(rcLogicUpdateDrafts(params({ RCL1_OPT: 0b1000 }), {}, 1, { outputPosition: 'low' }).RCL1_OPT)).toBe(
+      0b1000 | (2 << 4)
+    )
+    // Clearing back to HIGH wipes bits 4-5 but keeps the AND bit.
+    expect(
+      Number(rcLogicUpdateDrafts(params({ RCL1_OPT: (2 << 4) | 0b0100 }), {}, 1, { outputPosition: 'high' }).RCL1_OPT)
+    ).toBe(0b0100)
+  })
+
+  it('folds inverted and output position together in a single OPT write', () => {
+    const drafts = rcLogicUpdateDrafts(params({ RCL1_OPT: 0b0100 /* AND */ }), {}, 1, {
+      inverted: true,
+      outputPosition: 'middle'
+    })
+    expect(Number(drafts.RCL1_OPT)).toBe(0b0100 | 0b1000 | (1 << 4)) // AND + negate + MIDDLE
   })
 
   it('remove clears the term drafts and disables a live term', () => {

--- a/apps/web/src/view-models/rc-logic.ts
+++ b/apps/web/src/view-models/rc-logic.ts
@@ -11,15 +11,38 @@ import {
   RC_LOGIC_AUX_FUNCTION_OPTIONS,
   RC_LOGIC_NUM_TERMS,
   RC_LOGIC_OPT_NEGATE_BIT,
+  RC_LOGIC_OPT_OUTPOS_MASK,
+  RC_LOGIC_OPT_OUTPOS_SHIFT,
   RC_LOGIC_OPT_SOURCE_TYPE_MASK,
+  RcLogicOutputPosition,
   RcLogicSourceType
 } from '@arduconfig/param-metadata'
 import type { ParameterState } from '@arduconfig/ardupilot-core'
 
 import type { ParameterDraftValues } from '../hooks/use-parameter-drafts'
-import { type RcMixerAssignment, type RcMixerFunctionDefinition } from './rc-mixer'
+import { type RcMixerAssignment, type RcMixerFunctionDefinition, type RcMixerOutputPosition } from './rc-mixer'
 
 const NEGATE_MASK = 1 << RC_LOGIC_OPT_NEGATE_BIT
+const OUTPOS_MASK_SHIFTED = RC_LOGIC_OPT_OUTPOS_MASK << RC_LOGIC_OPT_OUTPOS_SHIFT
+
+/** Decode OPT bits 4-5 into the view model's output position. */
+export function decodeOutputPosition(opt: number): RcMixerOutputPosition {
+  const value = (opt >> RC_LOGIC_OPT_OUTPOS_SHIFT) & RC_LOGIC_OPT_OUTPOS_MASK
+  if (value === RcLogicOutputPosition.Low) return 'low'
+  if (value === RcLogicOutputPosition.Middle) return 'middle'
+  return 'high'
+}
+
+/** Fold an output position into OPT bits 4-5, preserving the other bits. */
+export function encodeOutputPosition(opt: number, position: RcMixerOutputPosition): number {
+  const value =
+    position === 'low'
+      ? RcLogicOutputPosition.Low
+      : position === 'middle'
+        ? RcLogicOutputPosition.Middle
+        : RcLogicOutputPosition.High
+  return (opt & ~OUTPOS_MASK_SHIFTED) | (value << RC_LOGIC_OPT_OUTPOS_SHIFT)
+}
 const ADD_DEFAULT_LOW = 1700
 const ADD_DEFAULT_HIGH = 2100
 
@@ -110,7 +133,8 @@ export function readRcLogicModel(
       functionId: func,
       lowPwm: effective(ids.min, ADD_DEFAULT_LOW),
       highPwm: effective(ids.max, ADD_DEFAULT_HIGH),
-      inverted: (opt & NEGATE_MASK) !== 0
+      inverted: (opt & NEGATE_MASK) !== 0,
+      outputPosition: decodeOutputPosition(opt)
     })
   }
 
@@ -161,9 +185,18 @@ export function rcLogicUpdateDrafts(
   if (patch.channel !== undefined) next[ids.src] = String(patch.channel)
   if (patch.lowPwm !== undefined) next[ids.min] = String(patch.lowPwm)
   if (patch.highPwm !== undefined) next[ids.max] = String(patch.highPwm)
-  if (patch.inverted !== undefined) {
-    const opt = effective(ids.opt, 0)
-    next[ids.opt] = String(patch.inverted ? opt | NEGATE_MASK : opt & ~NEGATE_MASK)
+  // Negate (bit 3) and output position (bits 4-5) both live in OPT — fold both
+  // into a single value read from the existing OPT so one doesn't clobber the
+  // other when they're patched together.
+  if (patch.inverted !== undefined || patch.outputPosition !== undefined) {
+    let opt = effective(ids.opt, 0)
+    if (patch.inverted !== undefined) {
+      opt = patch.inverted ? opt | NEGATE_MASK : opt & ~NEGATE_MASK
+    }
+    if (patch.outputPosition !== undefined) {
+      opt = encodeOutputPosition(opt, patch.outputPosition)
+    }
+    next[ids.opt] = String(opt)
   }
   return next
 }

--- a/apps/web/src/view-models/rc-mixer.ts
+++ b/apps/web/src/view-models/rc-mixer.ts
@@ -62,7 +62,15 @@ export interface RcMixerAssignment {
   /** When true, the function is active when the channel is OUTSIDE the
    * [low, high] window. Mirrors BF's "inverted" semantics. */
   inverted: boolean
+  /** Output position emitted while this row is active (RCL OPT bits 4-5),
+   * for multi-position targets such as VTX power: 'high' (default) / 'middle'
+   * / 'low'. Multiple rows for the same function with different positions form
+   * a selector (lowest-numbered active row wins). Only meaningful on the
+   * firmware-backed RCL path; undefined on the preview scaffold. */
+  outputPosition?: RcMixerOutputPosition
 }
+
+export type RcMixerOutputPosition = 'high' | 'middle' | 'low'
 
 export interface RcMixerState {
   assignments: RcMixerAssignment[]

--- a/apps/web/src/views/RcMixer.tsx
+++ b/apps/web/src/views/RcMixer.tsx
@@ -9,7 +9,8 @@ import {
   computeCursorPercent,
   type RcMixerAssignment,
   type RcMixerFunctionDefinition,
-  type RcMixerFunctionDefinitionLookup
+  type RcMixerFunctionDefinitionLookup,
+  type RcMixerOutputPosition
 } from '../view-models/rc-mixer'
 
 // Drag step (μs) — snap the range edges like Betaflight's 25 μs mode-range grid.
@@ -437,6 +438,24 @@ export function RcMixerView(props: RcMixerViewProps) {
                               />
                               <span>Inverted</span>
                             </label>
+                            {firmwareSupported ? (
+                              <label className="rc-mixer-assignment__position">
+                                <span>Output position</span>
+                                <select
+                                  value={assignment.outputPosition ?? 'high'}
+                                  onChange={(event) =>
+                                    onUpdateAssignment(assignment.id, {
+                                      outputPosition: event.target.value as RcMixerOutputPosition
+                                    })
+                                  }
+                                  data-testid={`rc-mixer-position-${assignment.id}`}
+                                >
+                                  <option value="high">High</option>
+                                  <option value="middle">Middle</option>
+                                  <option value="low">Low</option>
+                                </select>
+                              </label>
+                            ) : null}
                           </div>
 
                           <div className="rc-mixer-assignment__status">

--- a/packages/param-metadata/src/shared-rc-logic.ts
+++ b/packages/param-metadata/src/shared-rc-logic.ts
@@ -24,11 +24,23 @@ export const RC_LOGIC_NUM_TERMS = 12
 export const RC_LOGIC_OPT_SOURCE_TYPE_MASK = 0x3
 export const RC_LOGIC_OPT_COMBINE_AND_BIT = 2
 export const RC_LOGIC_OPT_NEGATE_BIT = 3
+/** Output position is the 2-bit field in bits 4-5: 0=HIGH (default), 1=MIDDLE,
+ *  2=LOW. Any row with a non-HIGH position puts the whole function into
+ *  "selector" mode (lowest-numbered active row drives its position) — this is
+ *  how one RC channel drives a multi-position target such as VTX power. */
+export const RC_LOGIC_OPT_OUTPOS_SHIFT = 4
+export const RC_LOGIC_OPT_OUTPOS_MASK = 0x3
 
 export enum RcLogicSourceType {
   Range = 0,
   Link = 1,
   Condition = 2
+}
+
+export enum RcLogicOutputPosition {
+  High = 0,
+  Middle = 1,
+  Low = 2
 }
 
 /** Full ArduCopter AUX_FUNC value list (from RC_Channel.cpp RCn_OPTION @Values,
@@ -175,17 +187,19 @@ function termParameterDefinitions(n: number): Record<string, ParameterDefinition
       id: `${prefix}OPT`,
       label: `Term ${n} · options`,
       description:
-        'Packed term options: bits 0-1 source type (0 range, 1 link, 2 condition), bit 2 combine (0 OR / 1 AND), bit 3 negate.',
+        'Packed term options: bits 0-1 source type (0 range, 1 link, 2 condition), bit 2 combine (0 OR / 1 AND), bit 3 negate, bits 4-5 output position (0 HIGH, 1 MIDDLE, 2 LOW) for a multi-position target such as VTX power — any non-HIGH row puts the function into selector mode.',
       category: RC_LOGIC_CATEGORY,
       minimum: 0,
-      maximum: 15,
+      maximum: 63,
       step: 1,
       bitmask: true,
       options: [
         { value: 0, label: 'Source type bit 0' },
         { value: 1, label: 'Source type bit 1' },
         { value: 2, label: 'Combine (AND)' },
-        { value: 3, label: 'Negate' }
+        { value: 3, label: 'Negate' },
+        { value: 4, label: 'Output position bit 0' },
+        { value: 5, label: 'Output position bit 1' }
       ]
     },
     [`${prefix}SRC`]: {

--- a/tests/e2e/rc-mixer.spec.ts
+++ b/tests/e2e/rc-mixer.spec.ts
@@ -64,6 +64,13 @@ test.describe('RC Mixer (AP_RC_Logic)', () => {
     await page.getByTestId('rc-mixer-high-rcl-3').fill('2000')
     await expect(page.getByTestId('rc-mixer-channel-8')).toContainText('AUTO Mode')
 
+    // The output-position selector (RCL OPT bits 4-5) round-trips through the
+    // draft model too — this is how one channel drives multi-level VTX power
+    // in selector mode.
+    await expect(page.getByTestId('rc-mixer-position-rcl-3')).toHaveValue('high')
+    await page.getByTestId('rc-mixer-position-rcl-3').selectOption('low')
+    await expect(page.getByTestId('rc-mixer-position-rcl-3')).toHaveValue('low')
+
     // Remove clears the term drafts -> row gone, channel 8 empty again (the
     // channel header reflects "No assignments" now that the redundant
     // per-channel empty paragraph was dropped in the vertical-condense pass).


### PR DESCRIPTION
Mirrors the `sfd-rc-work` firmware change adding an output position to each RC Logic row (`RCL<n>_OPT` bits 4–5: `0 HIGH` / `1 MIDDLE` / `2 LOW`). When any row for a function uses a non-HIGH position the function runs in **selector mode** (lowest-numbered active row wins), so one RC channel can drive low/mid/high VTX power. No new params — packed into the existing `RCL<n>_OPT`.

## Changes
- **param-metadata:** `RCL<n>_OPT` `maximum` 15 → 63, bit 4/5 labels + updated description; new `RC_LOGIC_OPT_OUTPOS_SHIFT/MASK` + `RcLogicOutputPosition` enum.
- **RC Mixer:** `RcMixerAssignment` gains `outputPosition` (`high`/`middle`/`low`); `readRcLogicModel` decodes OPT bits 4–5, `rcLogicUpdateDrafts` folds it back in alongside the negate bit in a single OPT write. Per-row High/Middle/Low selector on the firmware-backed RCL path (hidden on the preview scaffold).
- Existing `VTX_POWER` aux function (id 94) is already in the RCL function list — nothing else needed to target VTX power.

## ArduCopter byte-identical
RCL is fork-only and Expert+RCL-gated; the OPT metadata change touches only RCL params (absent on stock builds), and HIGH (default) emits no new bits — on-wire output unchanged for anyone not using selector mode.

## Validation ladder
Rung 1 web vitest (486, incl. new `rc-logic` output-position round-trip tests) · Rung 3 full Playwright e2e (203 passed, 6 visual skipped; RC Mixer spec asserts the position selector round-trips). Hardware verification of the selector write path on the `sfd-rc-work` build pending.