### PR TITLE
feat(rc): cross-subsystem channel-conflict awareness (RC Mixer ↔ arm/mode/receiver)

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -250,6 +250,7 @@ import { AP_PERIPH_PARAM_METADATA } from './view-models/ap-periph-param-metadata
 import { parseParamPck } from './view-models/param-pck'
 import { createMotorPreviewNodes } from './view-models/motor-preview'
 import { buildRecentNotices } from './view-models/recent-notices'
+import { deriveExternalChannelClaims, deriveRcLogicChannelClaims } from './view-models/channel-usage'
 import { orderDraftsByEnableGate } from './view-models/enable-gate-write-order'
 import { invertGuidedReorderMapping, pickedReorderPositions } from './view-models/motor-reorder-mapping'
 import { LiveGpsMapCard } from './live-gps-map'
@@ -4903,6 +4904,15 @@ export function App() {
     () => groupAssignmentsByChannel(rcLogicVisibleAssignments, 16, rcLogicExcludedChannels),
     [rcLogicVisibleAssignments, rcLogicExcludedChannels]
   )
+  // Cross-subsystem channel awareness (both directions):
+  //  - external claims (flight-mode switch / RCn_OPTION aux funcs) badged in the
+  //    RC Mixer so a channel already in use is visible before layering a term.
+  //  - RCL-term claims surfaced back in the Receiver / Modes / arm-switch views.
+  const externalChannelClaims = useMemo(() => deriveExternalChannelClaims(snapshot), [snapshot])
+  const rcLogicChannelClaims = useMemo(
+    () => deriveRcLogicChannelClaims(rcLogicVisibleAssignments),
+    [rcLogicVisibleAssignments]
+  )
   function handleRcLogicAddAssignment(channel: number): void {
     const drafts = rcLogicAddDrafts(rcLogicModel, channel)
     if (!drafts) {
@@ -7082,7 +7092,8 @@ export function App() {
             receiverAdvancedInvalidCount,
             receiverHasPendingReview,
             armSwitchAvailable,
-            armSwitchAssignment
+            armSwitchAssignment,
+            rcLogicChannelClaims
           }}
           handlers={{
             handleStartRcMappingExercise,
@@ -7113,6 +7124,7 @@ export function App() {
         <ModesView
           modeChannelLabel={configuredModeChannel !== undefined ? `CH${configuredModeChannel}` : 'Not configured'}
           modeChannelParamName={snapshot.vehicle?.vehicle === 'ArduRover' ? 'MODE_CH' : 'FLTMODE_CH'}
+          modeChannelRcLogicClaim={configuredModeChannel !== undefined ? rcLogicChannelClaims.get(configuredModeChannel) : undefined}
           joystickModeNote={
             snapshot.vehicle?.vehicle === 'ArduSub'
               ? 'ArduSub selects modes via joystick button assignments (BTNn_FUNCTION), not an RC mode-switch channel — configure them in the Parameters view.'
@@ -7686,6 +7698,7 @@ export function App() {
         onToggleEngine={handleRcLogicToggleEngine}
         hiddenTermCount={rcLogicModel.hiddenTermCount}
         tableFull={rcLogicModel.freeTermIndex === null}
+        externalClaimByChannel={externalChannelClaims}
       />
       ) : null}
 

--- a/apps/web/src/sections/ReceiverSection.tsx
+++ b/apps/web/src/sections/ReceiverSection.tsx
@@ -84,6 +84,10 @@ export interface ReceiverSectionDerived {
    *  RCn_OPTION at all, so the Arm switch card has something to bind to. */
   armSwitchAvailable: boolean
   armSwitchAssignment: ArmSwitchAssignment
+  /** RC Mixer (AP_RC_Logic) function labels per channel, so aux-channel cards
+   *  and the arm-switch card can warn that a channel already carries an RCL
+   *  term (the reverse of the RC Mixer's own "also used by" badge). */
+  rcLogicChannelClaims?: ReadonlyMap<number, readonly string[]>
 }
 
 export interface ReceiverSectionHandlers {
@@ -262,7 +266,8 @@ export function ReceiverSection(props: ReceiverSectionProps): ReactElement {
     receiverAdvancedInvalidCount,
     receiverHasPendingReview,
     armSwitchAvailable,
-    armSwitchAssignment
+    armSwitchAssignment,
+    rcLogicChannelClaims
   } = derived
 
   const {
@@ -356,6 +361,16 @@ export function ReceiverSection(props: ReceiverSectionProps): ReactElement {
                     testId="receiver-channel-bars"
                   />
 
+                  {rcLogicChannelClaims && rcLogicChannelClaims.size > 0 ? (
+                    <p className="receiver-rcl-summary" data-testid="receiver-rcl-summary">
+                      ⚠ RC Mixer terms also drive:{' '}
+                      {[...rcLogicChannelClaims.entries()]
+                        .sort(([left], [right]) => left - right)
+                        .map(([channel, labels]) => `CH${channel} (${labels.join(', ')})`)
+                        .join(', ')}
+                      . These channels carry both their normal input and an RC Mixer function.
+                    </p>
+                  ) : null}
 
                   <div className="receiver-channel-disclosure">
                     <div>
@@ -919,6 +934,15 @@ export function ReceiverSection(props: ReceiverSectionProps): ReactElement {
                                 : 'not assigned'}
                             </StatusBadge>
                           </div>
+
+                          {armSwitchAssignment.channel !== undefined &&
+                          rcLogicChannelClaims?.get(armSwitchAssignment.channel)?.length ? (
+                            <p className="switch-exercise-warning" data-testid="receiver-arm-switch-rcl-conflict">
+                              ⚠ CH{armSwitchAssignment.channel} also drives an RC Mixer function
+                              ({rcLogicChannelClaims.get(armSwitchAssignment.channel)!.join(', ')}) — the arm switch
+                              and the RC Mixer term both act on this channel.
+                            </p>
+                          ) : null}
 
                           <label className="receiver-arm-switch__field">
                             <span>Channel</span>

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -6813,6 +6813,15 @@ textarea:focus {
   align-items: center;
 }
 
+.receiver-rcl-summary,
+.modes-mode-channel__rcl-claim {
+  display: block;
+  margin-top: 4px;
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--warning, #b8860b);
+}
+
 .rc-channel-card__header span,
 .rc-channel-card__footer span {
   color: var(--text-muted);
@@ -8085,6 +8094,11 @@ details.metadata-settings-section:not([open]) > summary::after {
   display: block;
   color: var(--text-muted);
   font-size: 10px;
+}
+
+.rc-mixer-channel__external-claim {
+  color: var(--warning, #b8860b);
+  font-weight: 600;
 }
 
 .rc-mixer-channel__header-right {

--- a/apps/web/src/view-models/channel-usage.test.ts
+++ b/apps/web/src/view-models/channel-usage.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'vitest'
+
+import type { ConfiguratorSnapshot } from '@arduconfig/ardupilot-core'
+
+import type { RcMixerAssignment } from './rc-mixer'
+import { auxFunctionLabel, deriveExternalChannelClaims, deriveRcLogicChannelClaims } from './channel-usage'
+
+function snapshot(values: Record<string, number>): ConfiguratorSnapshot {
+  return {
+    parameters: Object.entries(values).map(([id, value]) => ({ id, value }))
+  } as unknown as ConfiguratorSnapshot
+}
+
+function assignment(channel: number, functionId: number): RcMixerAssignment {
+  return { id: `rcl-${channel}`, channel, functionId, lowPwm: 1700, highPwm: 2100, inverted: false }
+}
+
+describe('deriveExternalChannelClaims', () => {
+  it('flags the flight-mode channel', () => {
+    const claims = deriveExternalChannelClaims(snapshot({ FLTMODE_CH: 7 }))
+    expect(claims.get(7)).toEqual(['Flight mode switch'])
+  })
+
+  it('labels an RCn_OPTION aux function by name (arm, VTX power)', () => {
+    const claims = deriveExternalChannelClaims(snapshot({ RC6_OPTION: 153, RC8_OPTION: 94 }))
+    expect(claims.get(6)).toEqual(['ArmDisarm (4.2 and higher)'])
+    expect(claims.get(8)).toEqual(['VTX Power'])
+  })
+
+  it('combines both claims when a channel is the mode switch AND has an option', () => {
+    const claims = deriveExternalChannelClaims(snapshot({ FLTMODE_CH: 5, RC5_OPTION: 153 }))
+    expect(claims.get(5)).toEqual(['Flight mode switch', 'ArmDisarm (4.2 and higher)'])
+  })
+
+  it('ignores channels with no claim (RCn_OPTION = 0 or absent)', () => {
+    const claims = deriveExternalChannelClaims(snapshot({ RC9_OPTION: 0 }))
+    expect(claims.has(9)).toBe(false)
+  })
+})
+
+describe('deriveRcLogicChannelClaims', () => {
+  it('lists the RCL function(s) each channel drives, skipping pending (FUNC=0) rows', () => {
+    const claims = deriveRcLogicChannelClaims([assignment(6, 153), assignment(8, 94), assignment(10, 0)])
+    expect(claims.get(6)).toEqual(['ArmDisarm (4.2 and higher)'])
+    expect(claims.get(8)).toEqual(['VTX Power'])
+    expect(claims.has(10)).toBe(false)
+  })
+
+  it('de-dupes repeated function labels on one channel', () => {
+    const claims = deriveRcLogicChannelClaims([assignment(7, 94), assignment(7, 94)])
+    expect(claims.get(7)).toEqual(['VTX Power'])
+  })
+})
+
+describe('auxFunctionLabel', () => {
+  it('resolves known values and falls back for unknown ones', () => {
+    expect(auxFunctionLabel(153)).toBe('ArmDisarm (4.2 and higher)')
+    expect(auxFunctionLabel(99999)).toBe('Option 99999')
+  })
+})

--- a/apps/web/src/view-models/channel-usage.ts
+++ b/apps/web/src/view-models/channel-usage.ts
@@ -1,0 +1,82 @@
+// Cross-subsystem channel usage — so the RC Mixer can warn that a channel is
+// already claimed by arm / flight-mode / another RCn_OPTION aux function, and
+// (the reverse) so the Receiver / Modes / arm-switch surfaces can warn that a
+// channel already carries an RC Mixer (AP_RC_Logic) term. Keeps the user from
+// unknowingly layering two mechanisms on one channel.
+
+import { RC_LOGIC_AUX_FUNCTION_OPTIONS } from '@arduconfig/param-metadata'
+import type { ConfiguratorSnapshot } from '@arduconfig/ardupilot-core'
+
+import { getModeChannelNumber } from '../rc-channel-helpers'
+import { readRoundedParameter } from '../selectors/parameter-read'
+import type { RcMixerAssignment } from './rc-mixer'
+
+const AUX_LABEL_BY_VALUE = new Map<number, string>(
+  RC_LOGIC_AUX_FUNCTION_OPTIONS.map((option) => [option.value, option.label])
+)
+
+/** Human label for an RCn_OPTION / RCL FUNC aux-function value. */
+export function auxFunctionLabel(value: number): string {
+  return AUX_LABEL_BY_VALUE.get(value) ?? `Option ${value}`
+}
+
+/**
+ * Non-RCL claims on each channel: the flight-mode switch (FLTMODE_CH / MODE_CH)
+ * and any standard RCn_OPTION aux function. Keyed by channel number; the value
+ * is the list of claim labels (usually one, occasionally both). RCL terms are
+ * intentionally excluded — they are the RC Mixer's own rows, not an "external"
+ * claim. Consumed by the RC Mixer to badge each channel.
+ */
+export function deriveExternalChannelClaims(snapshot: ConfiguratorSnapshot): Map<number, string[]> {
+  const claims = new Map<number, string[]>()
+  const add = (channel: number, label: string): void => {
+    const existing = claims.get(channel)
+    if (existing) {
+      existing.push(label)
+    } else {
+      claims.set(channel, [label])
+    }
+  }
+
+  const modeChannel = getModeChannelNumber(snapshot)
+  if (modeChannel !== undefined) {
+    add(modeChannel, 'Flight mode switch')
+  }
+
+  for (let channel = 1; channel <= 16; channel += 1) {
+    const option = readRoundedParameter(snapshot, `RC${channel}_OPTION`)
+    if (option !== undefined && option !== 0) {
+      add(channel, auxFunctionLabel(option))
+    }
+  }
+
+  return claims
+}
+
+/**
+ * RC Mixer (RCL) function labels per channel — the reverse direction. Keyed by
+ * channel; the value is the list of RCL function labels the channel drives.
+ * Consumed by the Receiver / Modes / arm-switch surfaces to warn that a channel
+ * already carries an RC Mixer term. A row with FUNC = 0 (pending, no function
+ * picked yet) is skipped — it is not yet an active claim.
+ */
+export function deriveRcLogicChannelClaims(
+  assignments: readonly RcMixerAssignment[]
+): Map<number, string[]> {
+  const claims = new Map<number, string[]>()
+  for (const assignment of assignments) {
+    if (assignment.functionId === 0) {
+      continue
+    }
+    const label = auxFunctionLabel(assignment.functionId)
+    const existing = claims.get(assignment.channel)
+    if (existing) {
+      if (!existing.includes(label)) {
+        existing.push(label)
+      }
+    } else {
+      claims.set(assignment.channel, [label])
+    }
+  }
+  return claims
+}

--- a/apps/web/src/views/Modes.tsx
+++ b/apps/web/src/views/Modes.tsx
@@ -20,6 +20,9 @@ export interface ModesViewSlot {
 export interface ModesViewProps {
   modeChannelLabel: string
   modeChannelParamName: string
+  /** RC Mixer (AP_RC_Logic) function labels layered on the mode channel, if any,
+   *  so the operator sees the mode switch shares its channel with an RCL term. */
+  modeChannelRcLogicClaim?: readonly string[]
   currentSlotLabel: string
   currentSlotSubtext: string
   activeModeLabel: string
@@ -46,6 +49,7 @@ export function ModesView(props: ModesViewProps) {
   const {
     modeChannelLabel,
     modeChannelParamName,
+    modeChannelRcLogicClaim,
     currentSlotLabel,
     currentSlotSubtext,
     activeModeLabel,
@@ -101,6 +105,11 @@ export function ModesView(props: ModesViewProps) {
               <span>Mode channel</span>
               <strong>{modeChannelLabel}</strong>
               <small>{modeChannelParamName} selects which RC channel switches the flight mode.</small>
+              {modeChannelRcLogicClaim?.length ? (
+                <small className="modes-mode-channel__rcl-claim" data-testid="modes-mode-channel-rcl-claim">
+                  ⚠ This channel also drives an RC Mixer function: {modeChannelRcLogicClaim.join(', ')}
+                </small>
+              ) : null}
             </article>
             <article className="modes-status__card">
               <span>Current slot</span>

--- a/apps/web/src/views/RcMixer.tsx
+++ b/apps/web/src/views/RcMixer.tsx
@@ -92,6 +92,10 @@ export interface RcMixerViewProps {
   hiddenTermCount?: number
   /** True when every RCL term slot is in use — the "Add function" buttons stop. */
   tableFull?: boolean
+  /** Per-channel claims from OTHER subsystems (flight-mode switch, RCn_OPTION
+   *  aux functions) so the operator sees a channel is already in use before
+   *  layering an RC Mixer term on it. Keyed by channel number. */
+  externalClaimByChannel?: ReadonlyMap<number, readonly string[]>
 }
 
 export function RcMixerView(props: RcMixerViewProps) {
@@ -108,7 +112,8 @@ export function RcMixerView(props: RcMixerViewProps) {
     engineEnabled,
     onToggleEngine,
     hiddenTermCount,
-    tableFull
+    tableFull,
+    externalClaimByChannel
   } = props
 
   // Drag-to-resize the PWM range bands (Betaflight-style). The band edges and the
@@ -244,6 +249,15 @@ export function RcMixerView(props: RcMixerViewProps) {
                   <div>
                     <strong>Channel {channel}</strong>
                     <small>{assignments.length === 0 ? 'No assignments' : `${assignments.length} assigned`}</small>
+                    {firmwareSupported && externalClaimByChannel?.get(channel)?.length ? (
+                      <small
+                        className="rc-mixer-channel__external-claim"
+                        data-testid={`rc-mixer-channel-claim-${channel}`}
+                        title="This channel is already used by another subsystem. Layering an RC Mixer term here stacks on top of it."
+                      >
+                        ⚠ Also used by: {externalClaimByChannel.get(channel)!.join(', ')}
+                      </small>
+                    ) : null}
                   </div>
                   <div className="rc-mixer-channel__header-right">
                     {typeof livePwm === 'number' ? (

--- a/tests/e2e/rc-mixer.spec.ts
+++ b/tests/e2e/rc-mixer.spec.ts
@@ -123,5 +123,9 @@ test.describe('RC Mixer (AP_RC_Logic)', () => {
     await expect(callout).toContainText('Not available in ArduPilot')
     // No real engine controls without RCL_*.
     await expect(page.getByTestId('rc-mixer-engine-controls')).toHaveCount(0)
+    // RCL-gated chrome (external-claim badges, output-position selectors) stays
+    // hidden in the preview scaffold — all of it is gated on RCL detection.
+    await expect(page.locator('[data-testid^="rc-mixer-channel-claim-"]')).toHaveCount(0)
+    await expect(page.locator('[data-testid^="rc-mixer-position-"]')).toHaveCount(0)
   })
 })

--- a/tests/e2e/views.spec.ts
+++ b/tests/e2e/views.spec.ts
@@ -1554,6 +1554,22 @@ test.describe('RC Mixer view', () => {
     await expect(page.getByTestId('rc-mixer-channel-6')).toBeVisible()
     await expect(page.getByTestId('rc-mixer-channel-7')).toBeVisible()
     await expect(page.getByTestId('rc-mixer-channel-8')).toBeVisible()
+
+    // Cross-subsystem awareness: ch7 is the flight-mode switch, so the mixer
+    // badges it as already claimed even though it has no RCL term of its own.
+    await expect(page.getByTestId('rc-mixer-channel-claim-7')).toContainText('Flight mode switch')
+  })
+
+  test('surfaces RC Mixer term usage back in the Receiver view (reverse awareness)', async ({ page }) => {
+    // Demo Copter has RCL terms on ch5 (ArmDisarm) and ch6; the Receiver view
+    // summarises that those channels also carry an RC Mixer function.
+    await page.goto('/')
+    await page.getByTestId('transport-mode-select').selectOption('demo')
+    await page.getByTestId('connect-button').click()
+    await page.getByTestId('view-button-receiver').click()
+    const summary = page.getByTestId('receiver-rcl-summary')
+    await expect(summary).toContainText('CH5')
+    await expect(summary).toContainText('RC Mixer')
   })
 
   test('function picker only offers functions the connected vehicle firmware actually supports', async ({ page }) => {


### PR DESCRIPTION
Surfaces when one RC channel is claimed by more than one mechanism, in both directions, so the operator doesn't unknowingly layer an RC Mixer (AP_RC_Logic) term on a channel already used for arming, flight-mode switching, or another `RCn_OPTION` aux function.

## Changes
- New pure helper `channel-usage.ts` (+ tests): `deriveExternalChannelClaims` (flight-mode switch + `RCn_OPTION` aux funcs per channel, labelled via the aux function catalog) and `deriveRcLogicChannelClaims` (RCL function labels per channel); `auxFunctionLabel` resolves a value to its name.
- **RC Mixer:** each channel row badges "⚠ Also used by: …" when claimed by the mode switch or an `RCn_OPTION` function (its own RCL rows are excluded — shown as the rows themselves).
- **Reverse:** the Receiver view summarises which channels also carry an RCL term; the Modes view flags the mode channel when it does; the arm-switch card warns when the arm channel also drives an RCL function. (Receiver uses a single summary line rather than per-card notes because a streaming channel is classed "primary" and rendered outside the aux-card grid.)

## Gating (RCL detection)
The RC Mixer badge only renders on the firmware-backed RCL path (`firmwareSupported`); the reverse notes derive from the RCL model, so with no RCL params the claim map is empty and none of them render. The preview scaffold shows none of this chrome — asserted by a regression test (claim badges + position selectors have count 0 without RCL).

## ArduCopter byte-identical
Presentational only — reads existing params (`FLTMODE_CH`/`MODE_CH`, `RCn_OPTION`) and the RCL model to render advisory badges; no runtime, transport, or write-path change.

## Validation ladder
Rung 1 web vitest (493, incl. new `channel-usage` tests) · Rung 3 full Playwright e2e (204 passed, 6 visual skipped; RC Mixer badge + Receiver reverse-summary + preview-gating asserted).