### PR TITLE
fix(rc-mixer): show RCL output-position selector only for multi-position targets

### DIFF
--- a/apps/web/src/view-models/rc-logic.test.ts
+++ b/apps/web/src/view-models/rc-logic.test.ts
@@ -105,6 +105,24 @@ describe('rcLogic draft mappers', () => {
     expect(Number(drafts.RCL1_OPT)).toBe(0b0100 | 0b1000 | (1 << 4)) // AND + negate + MIDDLE
   })
 
+  it('clears the output position when the row switches to a non-multi-position function', () => {
+    // Row currently VTX Power (94) with LOW position + AND bit; switch to AUTO
+    // Mode (16, on/off) — bits 4-5 must clear so AUTO Mode doesn't inherit
+    // selector mode, but the AND bit survives.
+    const drafts = rcLogicUpdateDrafts(params({ RCL1_FUNC: 94, RCL1_OPT: (2 << 4) | 0b0100 }), {}, 1, {
+      functionId: 16
+    })
+    expect(drafts.RCL1_FUNC).toBe('16')
+    expect(Number(drafts.RCL1_OPT)).toBe(0b0100) // position wiped, AND kept
+  })
+
+  it('keeps the output position when switching between multi-position functions', () => {
+    // Staying on VTX Power (94) — no OPT rewrite needed just from re-selecting it.
+    const drafts = rcLogicUpdateDrafts(params({ RCL1_FUNC: 94, RCL1_OPT: 2 << 4 }), {}, 1, { functionId: 94 })
+    expect(drafts.RCL1_FUNC).toBe('94')
+    expect(drafts.RCL1_OPT).toBeUndefined() // no position change → no redundant OPT draft
+  })
+
   it('remove clears the term drafts and disables a live term', () => {
     const live = rcLogicRemovePlan(params({ RCL1_FUNC: 153 }), 1)
     expect(live.clear).toContain('RCL1_FUNC')

--- a/apps/web/src/view-models/rc-logic.ts
+++ b/apps/web/src/view-models/rc-logic.ts
@@ -15,7 +15,8 @@ import {
   RC_LOGIC_OPT_OUTPOS_SHIFT,
   RC_LOGIC_OPT_SOURCE_TYPE_MASK,
   RcLogicOutputPosition,
-  RcLogicSourceType
+  RcLogicSourceType,
+  isRcLogicMultiPositionFunction
 } from '@arduconfig/param-metadata'
 import type { ParameterState } from '@arduconfig/ardupilot-core'
 
@@ -185,18 +186,26 @@ export function rcLogicUpdateDrafts(
   if (patch.channel !== undefined) next[ids.src] = String(patch.channel)
   if (patch.lowPwm !== undefined) next[ids.min] = String(patch.lowPwm)
   if (patch.highPwm !== undefined) next[ids.max] = String(patch.highPwm)
-  // Negate (bit 3) and output position (bits 4-5) both live in OPT — fold both
-  // into a single value read from the existing OPT so one doesn't clobber the
-  // other when they're patched together.
-  if (patch.inverted !== undefined || patch.outputPosition !== undefined) {
-    let opt = effective(ids.opt, 0)
+  // Negate (bit 3) and output position (bits 4-5) both live in OPT — fold every
+  // OPT-affecting change into one value read from the existing OPT so they don't
+  // clobber each other. Switching to a function with no multi-position output
+  // also clears the position bits, so a leftover LOW/MIDDLE doesn't strand the
+  // new function in selector mode.
+  const clearsPosition = patch.functionId !== undefined && !isRcLogicMultiPositionFunction(patch.functionId)
+  if (patch.inverted !== undefined || patch.outputPosition !== undefined || clearsPosition) {
+    const current = effective(ids.opt, 0)
+    let opt = current
     if (patch.inverted !== undefined) {
       opt = patch.inverted ? opt | NEGATE_MASK : opt & ~NEGATE_MASK
     }
     if (patch.outputPosition !== undefined) {
       opt = encodeOutputPosition(opt, patch.outputPosition)
+    } else if (clearsPosition) {
+      opt &= ~OUTPOS_MASK_SHIFTED
     }
-    next[ids.opt] = String(opt)
+    if (opt !== current) {
+      next[ids.opt] = String(opt)
+    }
   }
   return next
 }

--- a/apps/web/src/views/RcMixer.tsx
+++ b/apps/web/src/views/RcMixer.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState, type PointerEvent as ReactPointerEvent } from 'react'
 
 import { Panel, StatusBadge, buttonStyle } from '@arduconfig/ui-kit'
+import { isRcLogicMultiPositionFunction } from '@arduconfig/param-metadata'
 
 import {
   RC_MIXER_TRACK_MAX_PWM,
@@ -452,7 +453,7 @@ export function RcMixerView(props: RcMixerViewProps) {
                               />
                               <span>Inverted</span>
                             </label>
-                            {firmwareSupported ? (
+                            {firmwareSupported && isRcLogicMultiPositionFunction(assignment.functionId) ? (
                               <label className="rc-mixer-assignment__position">
                                 <span>Output position</span>
                                 <select

--- a/packages/param-metadata/src/shared-rc-logic.ts
+++ b/packages/param-metadata/src/shared-rc-logic.ts
@@ -43,6 +43,23 @@ export enum RcLogicOutputPosition {
   Low = 2
 }
 
+/**
+ * Aux functions whose target is a genuine multi-level/position output, so the
+ * per-row output position (HIGH/MIDDLE/LOW, OPT bits 4-5) is meaningful. For a
+ * plain on/off function the position is noise — HIGH is the only sensible value
+ * — so the RC Mixer only offers the position selector for these. VTX Power is
+ * the case this was built for: position → power level via AP_VideoTX::change_power.
+ * Extend as the firmware gains other level-selectable aux targets.
+ */
+export const RC_LOGIC_OUTPUT_POSITION_FUNCTIONS: ReadonlySet<number> = new Set<number>([
+  94 // VTX Power
+])
+
+/** True when `functionId` interprets the RCL output position (see the set above). */
+export function isRcLogicMultiPositionFunction(functionId: number): boolean {
+  return RC_LOGIC_OUTPUT_POSITION_FUNCTIONS.has(functionId)
+}
+
 /** Full ArduCopter AUX_FUNC value list (from RC_Channel.cpp RCn_OPTION @Values,
  *  Copter-applicable). RCL<n>_FUNC reuses this exact list (@CopyFieldsFrom
  *  RC1_OPTION in the firmware). */

--- a/tests/e2e/rc-mixer.spec.ts
+++ b/tests/e2e/rc-mixer.spec.ts
@@ -59,17 +59,23 @@ test.describe('RC Mixer (AP_RC_Logic)', () => {
     await expect(page.getByTestId('rc-mixer-track-band-rcl-3')).toBeVisible()
 
     // Editing round-trips through the model (reads back the draft immediately).
-    await page.getByTestId('rc-mixer-function-rcl-3').selectOption('16') // AUTO Mode
+    await page.getByTestId('rc-mixer-function-rcl-3').selectOption('94') // VTX Power (multi-position)
     await page.getByTestId('rc-mixer-low-rcl-3').fill('1800')
     await page.getByTestId('rc-mixer-high-rcl-3').fill('2000')
-    await expect(page.getByTestId('rc-mixer-channel-8')).toContainText('AUTO Mode')
+    await expect(page.getByTestId('rc-mixer-channel-8')).toContainText('VTX Power')
 
-    // The output-position selector (RCL OPT bits 4-5) round-trips through the
-    // draft model too — this is how one channel drives multi-level VTX power
-    // in selector mode.
+    // The output-position selector only appears for a multi-position target like
+    // VTX Power, and round-trips through the draft model (this is how one channel
+    // drives multi-level VTX power in selector mode).
     await expect(page.getByTestId('rc-mixer-position-rcl-3')).toHaveValue('high')
     await page.getByTestId('rc-mixer-position-rcl-3').selectOption('low')
     await expect(page.getByTestId('rc-mixer-position-rcl-3')).toHaveValue('low')
+
+    // Switching to a plain on/off function hides the selector — position is noise
+    // there — and the row keeps working as an ordinary range term.
+    await page.getByTestId('rc-mixer-function-rcl-3').selectOption('16') // AUTO Mode
+    await expect(page.getByTestId('rc-mixer-position-rcl-3')).toHaveCount(0)
+    await expect(page.getByTestId('rc-mixer-channel-8')).toContainText('AUTO Mode')
 
     // Remove clears the term drafts -> row gone, channel 8 empty again (the
     // channel header reflects "No assignments" now that the redundant


### PR DESCRIPTION
The per-row output position (HIGH/MIDDLE/LOW) was showing on every RCL row, but it only produces distinct behaviour for a multi-**level** target — VTX Power (position → power level via `AP_VideoTX::change_power`). For a plain on/off function the position is noise (HIGH is the only sensible value).

## Changes
- New `RC_LOGIC_OUTPUT_POSITION_FUNCTIONS` set + `isRcLogicMultiPositionFunction` in param-metadata (currently `{ 94: VTX Power }`; extend as the firmware gains other level-selectable aux targets).
- RC Mixer renders the output-position dropdown only when the row's function is in that set (still only on the firmware-backed RCL path).
- Switching a row **off** a multi-position function clears `OPT` bits 4–5, so a leftover LOW/MIDDLE can't strand the new function in selector mode (firmware treats any non-HIGH row for a function as selector mode).

## ArduCopter byte-identical
RCL is fork-only and Expert+RCL-gated; presentational gating plus a draft-layer OPT cleanup — no runtime/transport/write-path change, and HIGH (default) still emits no position bits.

## Validation ladder
Rung 1 web vitest (495, incl. new clear-on-function-change tests) · Rung 3 full Playwright e2e (204 passed; dropdown shows for VTX Power, hides for AUTO Mode).