### PR TITLE
feat(rc-mixer): select an exact VTX power level per RCL row (level index)

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -4761,7 +4761,9 @@ export function App() {
   // otherwise the "Table not available" preview.
   const vtxTable = useVtxTable({
     runtime,
-    active: activeViewId === 'vtx',
+    // Also load on the RC Mixer view so a VTX_POWER term's level selector can
+    // list the real @VTX power levels by mW.
+    active: activeViewId === 'vtx' || activeViewId === 'rc-mixer',
     connected: snapshot.connection.kind === 'connected'
   })
   // NET_ENABLE is present on every networking-capable ArduPilot build (Ethernet
@@ -4913,6 +4915,18 @@ export function App() {
     () => deriveRcLogicChannelClaims(rcLogicVisibleAssignments),
     [rcLogicVisibleAssignments]
   )
+  // Non-zero @VTX power levels in table order — a VTX_POWER RCL term's level
+  // selector stores the 0-based index here into OPT bits 5-7. The firmware skips
+  // value=0 levels (get_power_mw_for_index), so we filter them out before indexing.
+  const rcMixerVtxPowerLevels = useMemo(() => {
+    const levels = vtxTable.table?.powerLevels
+    if (!levels) {
+      return undefined
+    }
+    return levels
+      .filter((level) => level.value !== 0)
+      .map((level, index) => ({ index, mw: level.value, label: level.label }))
+  }, [vtxTable.table])
   function handleRcLogicAddAssignment(channel: number): void {
     const drafts = rcLogicAddDrafts(rcLogicModel, channel)
     if (!drafts) {
@@ -7699,6 +7713,7 @@ export function App() {
         hiddenTermCount={rcLogicModel.hiddenTermCount}
         tableFull={rcLogicModel.freeTermIndex === null}
         externalClaimByChannel={externalChannelClaims}
+        vtxPowerLevels={rcMixerVtxPowerLevels}
       />
       ) : null}
 

--- a/apps/web/src/view-models/rc-logic.test.ts
+++ b/apps/web/src/view-models/rc-logic.test.ts
@@ -38,12 +38,15 @@ describe('readRcLogicModel', () => {
     expect(model.assignments[0]).toMatchObject({ id: 'rcl-2', inverted: true, functionId: 18 })
   })
 
-  it('reads the output position from OPT bits 4-5 (VTX power selector)', () => {
-    const pos = (opt: number) =>
-      readRcLogicModel(params({ RCL1_FUNC: 94, RCL1_OPT: opt, RCL1_SRC: 6 }), {}).assignments[0].outputPosition
-    expect(pos(0)).toBe('high') // neither bit
-    expect(pos(1 << 4)).toBe('middle') // bit 4
-    expect(pos(2 << 4)).toBe('low') // bit 5
+  it('reads level mode (OPT bit 4) + zero-based level index (bits 5-7) for VTX power', () => {
+    const read = (opt: number) => {
+      const a = readRcLogicModel(params({ RCL1_FUNC: 94, RCL1_OPT: opt, RCL1_SRC: 6 }), {}).assignments[0]
+      return { levelMode: a.levelMode, outputLevel: a.outputLevel }
+    }
+    expect(read(0)).toEqual({ levelMode: false, outputLevel: 0 }) // no level mode
+    expect(read(0x10)).toEqual({ levelMode: true, outputLevel: 0 }) // mode bit, index 0
+    expect(read(0x10 | (1 << 5))).toEqual({ levelMode: true, outputLevel: 1 })
+    expect(read(0x10 | (3 << 5))).toEqual({ levelMode: true, outputLevel: 3 })
   })
 
   it('keeps non-range terms (link/condition) out of the editor but counts them as used', () => {
@@ -86,41 +89,42 @@ describe('rcLogic draft mappers', () => {
     expect(Number(drafts.RCL1_OPT)).toBe(0b1100) // AND + negate
   })
 
-  it('folds the output position into OPT bits 4-5, preserving and clearing correctly', () => {
-    // Set LOW while negate (bit3) is already set — negate must survive.
-    expect(Number(rcLogicUpdateDrafts(params({ RCL1_OPT: 0b1000 }), {}, 1, { outputPosition: 'low' }).RCL1_OPT)).toBe(
-      0b1000 | (2 << 4)
-    )
-    // Clearing back to HIGH wipes bits 4-5 but keeps the AND bit.
+  it('folds level mode + index into OPT bit 4 and bits 5-7, preserving other bits', () => {
+    // Select level index 2 while negate (bit 3) is set — negate must survive.
     expect(
-      Number(rcLogicUpdateDrafts(params({ RCL1_OPT: (2 << 4) | 0b0100 }), {}, 1, { outputPosition: 'high' }).RCL1_OPT)
+      Number(rcLogicUpdateDrafts(params({ RCL1_OPT: 0b1000 }), {}, 1, { levelMode: true, outputLevel: 2 }).RCL1_OPT)
+    ).toBe(0b1000 | 0x10 | (2 << 5))
+    // Clearing level mode wipes bit 4 + bits 5-7 but keeps the AND bit.
+    expect(
+      Number(rcLogicUpdateDrafts(params({ RCL1_OPT: 0x10 | (2 << 5) | 0b0100 }), {}, 1, { levelMode: false }).RCL1_OPT)
     ).toBe(0b0100)
   })
 
-  it('folds inverted and output position together in a single OPT write', () => {
+  it('folds inverted and level selection together in a single OPT write', () => {
     const drafts = rcLogicUpdateDrafts(params({ RCL1_OPT: 0b0100 /* AND */ }), {}, 1, {
       inverted: true,
-      outputPosition: 'middle'
+      levelMode: true,
+      outputLevel: 1
     })
-    expect(Number(drafts.RCL1_OPT)).toBe(0b0100 | 0b1000 | (1 << 4)) // AND + negate + MIDDLE
+    expect(Number(drafts.RCL1_OPT)).toBe(0b0100 | 0b1000 | 0x10 | (1 << 5)) // AND + negate + level mode + idx 1
   })
 
-  it('clears the output position when the row switches to a non-multi-position function', () => {
-    // Row currently VTX Power (94) with LOW position + AND bit; switch to AUTO
-    // Mode (16, on/off) — bits 4-5 must clear so AUTO Mode doesn't inherit
+  it('clears the level field when the row switches to a non-level-select function', () => {
+    // Row currently VTX Power (94) with level index 2 + AND bit; switch to AUTO
+    // Mode (16, on/off) — the level field must clear so AUTO Mode doesn't inherit
     // selector mode, but the AND bit survives.
-    const drafts = rcLogicUpdateDrafts(params({ RCL1_FUNC: 94, RCL1_OPT: (2 << 4) | 0b0100 }), {}, 1, {
+    const drafts = rcLogicUpdateDrafts(params({ RCL1_FUNC: 94, RCL1_OPT: 0x10 | (2 << 5) | 0b0100 }), {}, 1, {
       functionId: 16
     })
     expect(drafts.RCL1_FUNC).toBe('16')
-    expect(Number(drafts.RCL1_OPT)).toBe(0b0100) // position wiped, AND kept
+    expect(Number(drafts.RCL1_OPT)).toBe(0b0100) // level field wiped, AND kept
   })
 
-  it('keeps the output position when switching between multi-position functions', () => {
+  it('keeps the level field when switching between level-select functions', () => {
     // Staying on VTX Power (94) — no OPT rewrite needed just from re-selecting it.
-    const drafts = rcLogicUpdateDrafts(params({ RCL1_FUNC: 94, RCL1_OPT: 2 << 4 }), {}, 1, { functionId: 94 })
+    const drafts = rcLogicUpdateDrafts(params({ RCL1_FUNC: 94, RCL1_OPT: 0x10 | (2 << 5) }), {}, 1, { functionId: 94 })
     expect(drafts.RCL1_FUNC).toBe('94')
-    expect(drafts.RCL1_OPT).toBeUndefined() // no position change → no redundant OPT draft
+    expect(drafts.RCL1_OPT).toBeUndefined() // no level change → no redundant OPT draft
   })
 
   it('remove clears the term drafts and disables a live term', () => {

--- a/apps/web/src/view-models/rc-logic.ts
+++ b/apps/web/src/view-models/rc-logic.ts
@@ -10,39 +10,46 @@
 import {
   RC_LOGIC_AUX_FUNCTION_OPTIONS,
   RC_LOGIC_NUM_TERMS,
+  RC_LOGIC_OPT_LEVEL_INDEX_MASK,
+  RC_LOGIC_OPT_LEVEL_INDEX_SHIFT,
+  RC_LOGIC_OPT_LEVEL_MODE_MASK,
   RC_LOGIC_OPT_NEGATE_BIT,
-  RC_LOGIC_OPT_OUTPOS_MASK,
-  RC_LOGIC_OPT_OUTPOS_SHIFT,
   RC_LOGIC_OPT_SOURCE_TYPE_MASK,
-  RcLogicOutputPosition,
   RcLogicSourceType,
-  isRcLogicMultiPositionFunction
+  isRcLogicLevelSelectFunction
 } from '@arduconfig/param-metadata'
 import type { ParameterState } from '@arduconfig/ardupilot-core'
 
 import type { ParameterDraftValues } from '../hooks/use-parameter-drafts'
-import { type RcMixerAssignment, type RcMixerFunctionDefinition, type RcMixerOutputPosition } from './rc-mixer'
+import { type RcMixerAssignment, type RcMixerFunctionDefinition } from './rc-mixer'
 
 const NEGATE_MASK = 1 << RC_LOGIC_OPT_NEGATE_BIT
-const OUTPOS_MASK_SHIFTED = RC_LOGIC_OPT_OUTPOS_MASK << RC_LOGIC_OPT_OUTPOS_SHIFT
+const LEVEL_INDEX_MASK_SHIFTED = RC_LOGIC_OPT_LEVEL_INDEX_MASK << RC_LOGIC_OPT_LEVEL_INDEX_SHIFT
+const LEVEL_FIELD_MASK = RC_LOGIC_OPT_LEVEL_MODE_MASK | LEVEL_INDEX_MASK_SHIFTED
 
-/** Decode OPT bits 4-5 into the view model's output position. */
-export function decodeOutputPosition(opt: number): RcMixerOutputPosition {
-  const value = (opt >> RC_LOGIC_OPT_OUTPOS_SHIFT) & RC_LOGIC_OPT_OUTPOS_MASK
-  if (value === RcLogicOutputPosition.Low) return 'low'
-  if (value === RcLogicOutputPosition.Middle) return 'middle'
-  return 'high'
+export interface RcLogicLevelSelection {
+  levelMode: boolean
+  /** Zero-based level index (0-7) from OPT bits 5-7. */
+  outputLevel: number
 }
 
-/** Fold an output position into OPT bits 4-5, preserving the other bits. */
-export function encodeOutputPosition(opt: number, position: RcMixerOutputPosition): number {
-  const value =
-    position === 'low'
-      ? RcLogicOutputPosition.Low
-      : position === 'middle'
-        ? RcLogicOutputPosition.Middle
-        : RcLogicOutputPosition.High
-  return (opt & ~OUTPOS_MASK_SHIFTED) | (value << RC_LOGIC_OPT_OUTPOS_SHIFT)
+/** Decode OPT bit 4 (level mode) + bits 5-7 (zero-based level index). */
+export function decodeLevel(opt: number): RcLogicLevelSelection {
+  return {
+    levelMode: (opt & RC_LOGIC_OPT_LEVEL_MODE_MASK) !== 0,
+    outputLevel: (opt >> RC_LOGIC_OPT_LEVEL_INDEX_SHIFT) & RC_LOGIC_OPT_LEVEL_INDEX_MASK
+  }
+}
+
+/** Fold level mode + a zero-based level index into OPT, preserving the other
+ *  bits. Clearing level mode wipes both the mode bit and the index. */
+export function encodeLevel(opt: number, levelMode: boolean, outputLevel: number): number {
+  const cleared = opt & ~LEVEL_FIELD_MASK
+  if (!levelMode) {
+    return cleared
+  }
+  const index = Math.max(0, Math.min(RC_LOGIC_OPT_LEVEL_INDEX_MASK, Math.round(outputLevel)))
+  return cleared | RC_LOGIC_OPT_LEVEL_MODE_MASK | (index << RC_LOGIC_OPT_LEVEL_INDEX_SHIFT)
 }
 const ADD_DEFAULT_LOW = 1700
 const ADD_DEFAULT_HIGH = 2100
@@ -128,6 +135,7 @@ export function readRcLogicModel(
       hiddenTermCount += 1
       continue
     }
+    const level = decodeLevel(opt)
     assignments.push({
       id: rcLogicAssignmentId(term),
       channel: effective(ids.src, 0),
@@ -135,7 +143,8 @@ export function readRcLogicModel(
       lowPwm: effective(ids.min, ADD_DEFAULT_LOW),
       highPwm: effective(ids.max, ADD_DEFAULT_HIGH),
       inverted: (opt & NEGATE_MASK) !== 0,
-      outputPosition: decodeOutputPosition(opt)
+      levelMode: level.levelMode,
+      outputLevel: level.outputLevel
     })
   }
 
@@ -186,22 +195,26 @@ export function rcLogicUpdateDrafts(
   if (patch.channel !== undefined) next[ids.src] = String(patch.channel)
   if (patch.lowPwm !== undefined) next[ids.min] = String(patch.lowPwm)
   if (patch.highPwm !== undefined) next[ids.max] = String(patch.highPwm)
-  // Negate (bit 3) and output position (bits 4-5) both live in OPT — fold every
-  // OPT-affecting change into one value read from the existing OPT so they don't
-  // clobber each other. Switching to a function with no multi-position output
-  // also clears the position bits, so a leftover LOW/MIDDLE doesn't strand the
-  // new function in selector mode.
-  const clearsPosition = patch.functionId !== undefined && !isRcLogicMultiPositionFunction(patch.functionId)
-  if (patch.inverted !== undefined || patch.outputPosition !== undefined || clearsPosition) {
+  // Negate (bit 3) and the level field (bit 4 mode + bits 5-7 index) all live in
+  // OPT — fold every OPT-affecting change into one value read from the existing
+  // OPT so they don't clobber each other. Switching to a function that has no
+  // multi-level output also clears the level field, so a leftover level doesn't
+  // strand the new function in selector mode.
+  const clearsLevel = patch.functionId !== undefined && !isRcLogicLevelSelectFunction(patch.functionId)
+  const levelTouched = patch.levelMode !== undefined || patch.outputLevel !== undefined
+  if (patch.inverted !== undefined || levelTouched || clearsLevel) {
     const current = effective(ids.opt, 0)
     let opt = current
     if (patch.inverted !== undefined) {
       opt = patch.inverted ? opt | NEGATE_MASK : opt & ~NEGATE_MASK
     }
-    if (patch.outputPosition !== undefined) {
-      opt = encodeOutputPosition(opt, patch.outputPosition)
-    } else if (clearsPosition) {
-      opt &= ~OUTPOS_MASK_SHIFTED
+    if (levelTouched) {
+      const existing = decodeLevel(current)
+      const levelMode = patch.levelMode ?? existing.levelMode
+      const outputLevel = patch.outputLevel ?? existing.outputLevel
+      opt = encodeLevel(opt, levelMode, outputLevel)
+    } else if (clearsLevel) {
+      opt = encodeLevel(opt, false, 0)
     }
     if (opt !== current) {
       next[ids.opt] = String(opt)

--- a/apps/web/src/view-models/rc-mixer.ts
+++ b/apps/web/src/view-models/rc-mixer.ts
@@ -62,15 +62,16 @@ export interface RcMixerAssignment {
   /** When true, the function is active when the channel is OUTSIDE the
    * [low, high] window. Mirrors BF's "inverted" semantics. */
   inverted: boolean
-  /** Output position emitted while this row is active (RCL OPT bits 4-5),
-   * for multi-position targets such as VTX power: 'high' (default) / 'middle'
-   * / 'low'. Multiple rows for the same function with different positions form
-   * a selector (lowest-numbered active row wins). Only meaningful on the
-   * firmware-backed RCL path; undefined on the preview scaffold. */
-  outputPosition?: RcMixerOutputPosition
+  /** RCL level mode (OPT bit 4): when true this row drives a multi-level target
+   * (e.g. VTX power) to a specific level instead of plain on/off, putting the
+   * function into selector mode. Only meaningful on the firmware-backed RCL
+   * path and only for level-select functions (VTX Power). */
+  levelMode?: boolean
+  /** Zero-based level index (OPT bits 5-7, 0-7) into the target's ACTIVE level
+   * list — for VTX power, the active @VTX power-level order. Meaningful only
+   * when `levelMode` is set. */
+  outputLevel?: number
 }
-
-export type RcMixerOutputPosition = 'high' | 'middle' | 'low'
 
 export interface RcMixerState {
   assignments: RcMixerAssignment[]

--- a/apps/web/src/views/RcMixer.tsx
+++ b/apps/web/src/views/RcMixer.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState, type PointerEvent as ReactPointerEvent } from 'react'
 
 import { Panel, StatusBadge, buttonStyle } from '@arduconfig/ui-kit'
-import { isRcLogicMultiPositionFunction } from '@arduconfig/param-metadata'
+import { isRcLogicLevelSelectFunction } from '@arduconfig/param-metadata'
 
 import {
   RC_MIXER_TRACK_MAX_PWM,
@@ -10,8 +10,7 @@ import {
   computeCursorPercent,
   type RcMixerAssignment,
   type RcMixerFunctionDefinition,
-  type RcMixerFunctionDefinitionLookup,
-  type RcMixerOutputPosition
+  type RcMixerFunctionDefinitionLookup
 } from '../view-models/rc-mixer'
 
 // Drag step (μs) — snap the range edges like Betaflight's 25 μs mode-range grid.
@@ -97,6 +96,10 @@ export interface RcMixerViewProps {
    *  aux functions) so the operator sees a channel is already in use before
    *  layering an RC Mixer term on it. Keyed by channel number. */
   externalClaimByChannel?: ReadonlyMap<number, readonly string[]>
+  /** Non-zero @VTX power levels in table order (0-based index = the value stored
+   *  in RCL OPT bits 5-7). Drives the VTX_POWER level selector; absent when no
+   *  VTX table is detected. */
+  vtxPowerLevels?: readonly { index: number; mw: number; label: string }[]
 }
 
 export function RcMixerView(props: RcMixerViewProps) {
@@ -114,7 +117,8 @@ export function RcMixerView(props: RcMixerViewProps) {
     onToggleEngine,
     hiddenTermCount,
     tableFull,
-    externalClaimByChannel
+    externalClaimByChannel,
+    vtxPowerLevels
   } = props
 
   // Drag-to-resize the PWM range bands (Betaflight-style). The band edges and the
@@ -453,21 +457,31 @@ export function RcMixerView(props: RcMixerViewProps) {
                               />
                               <span>Inverted</span>
                             </label>
-                            {firmwareSupported && isRcLogicMultiPositionFunction(assignment.functionId) ? (
+                            {firmwareSupported &&
+                            isRcLogicLevelSelectFunction(assignment.functionId) &&
+                            vtxPowerLevels &&
+                            vtxPowerLevels.length > 0 ? (
                               <label className="rc-mixer-assignment__position">
-                                <span>Output position</span>
+                                <span>VTX power</span>
                                 <select
-                                  value={assignment.outputPosition ?? 'high'}
-                                  onChange={(event) =>
-                                    onUpdateAssignment(assignment.id, {
-                                      outputPosition: event.target.value as RcMixerOutputPosition
-                                    })
-                                  }
-                                  data-testid={`rc-mixer-position-${assignment.id}`}
+                                  value={assignment.levelMode ? String(assignment.outputLevel ?? 0) : 'plain'}
+                                  onChange={(event) => {
+                                    const raw = event.target.value
+                                    onUpdateAssignment(
+                                      assignment.id,
+                                      raw === 'plain'
+                                        ? { levelMode: false }
+                                        : { levelMode: true, outputLevel: Number(raw) }
+                                    )
+                                  }}
+                                  data-testid={`rc-mixer-level-${assignment.id}`}
                                 >
-                                  <option value="high">High</option>
-                                  <option value="middle">Middle</option>
-                                  <option value="low">Low</option>
+                                  <option value="plain">Full power (on/off)</option>
+                                  {vtxPowerLevels.map((level) => (
+                                    <option key={level.index} value={String(level.index)}>
+                                      {level.mw} mW{level.label && level.label !== String(level.mw) ? ` (${level.label})` : ''}
+                                    </option>
+                                  ))}
                                 </select>
                               </label>
                             ) : null}

--- a/packages/param-metadata/src/shared-rc-logic.ts
+++ b/packages/param-metadata/src/shared-rc-logic.ts
@@ -19,17 +19,22 @@ export const RC_LOGIC_CATEGORY = 'rc-mixer'
 /** Table size — matches AP_RC_LOGIC_NUM_TERMS (default 12). */
 export const RC_LOGIC_NUM_TERMS = 12
 
-/** OPT bit layout (mirrors AP_RC_Logic.cpp @Bitmask). Source type is the 2-bit
- *  field in bits 0-1: 0=range, 1=link, 2=condition. */
+/** OPT bit layout (mirrors AP_RC_Logic_Term.cpp @Bitmask on sfd-rc-work,
+ *  commit bf9a7b7540). Source type is the 2-bit field in bits 0-1: 0=range,
+ *  1=link, 2=condition. */
 export const RC_LOGIC_OPT_SOURCE_TYPE_MASK = 0x3
 export const RC_LOGIC_OPT_COMBINE_AND_BIT = 2
 export const RC_LOGIC_OPT_NEGATE_BIT = 3
-/** Output position is the 2-bit field in bits 4-5: 0=HIGH (default), 1=MIDDLE,
- *  2=LOW. Any row with a non-HIGH position puts the whole function into
- *  "selector" mode (lowest-numbered active row drives its position) — this is
- *  how one RC channel drives a multi-position target such as VTX power. */
-export const RC_LOGIC_OPT_OUTPOS_SHIFT = 4
-export const RC_LOGIC_OPT_OUTPOS_MASK = 0x3
+/** Bit 4 (0x10) enables "level mode": an active row drives a multi-level target
+ *  (e.g. VTX power) to a specific level instead of plain on/off. Any level-mode
+ *  row puts the whole function into selector mode (lowest-numbered active row
+ *  wins). Bits 5-7 hold a ZERO-based level index (0-7). For VTX power the index
+ *  is the 0-based position in the ACTIVE @VTX power-level list; the firmware
+ *  emits it one-based to set_power_by_index (index i → the (i+1)-th active level). */
+export const RC_LOGIC_OPT_LEVEL_MODE_BIT = 4
+export const RC_LOGIC_OPT_LEVEL_MODE_MASK = 1 << RC_LOGIC_OPT_LEVEL_MODE_BIT
+export const RC_LOGIC_OPT_LEVEL_INDEX_SHIFT = 5
+export const RC_LOGIC_OPT_LEVEL_INDEX_MASK = 0x7
 
 export enum RcLogicSourceType {
   Range = 0,
@@ -37,27 +42,21 @@ export enum RcLogicSourceType {
   Condition = 2
 }
 
-export enum RcLogicOutputPosition {
-  High = 0,
-  Middle = 1,
-  Low = 2
-}
-
 /**
- * Aux functions whose target is a genuine multi-level/position output, so the
- * per-row output position (HIGH/MIDDLE/LOW, OPT bits 4-5) is meaningful. For a
- * plain on/off function the position is noise — HIGH is the only sensible value
- * — so the RC Mixer only offers the position selector for these. VTX Power is
- * the case this was built for: position → power level via AP_VideoTX::change_power.
- * Extend as the firmware gains other level-selectable aux targets.
+ * Aux functions whose target is a genuine multi-level output, so a row can
+ * select a specific level (OPT level mode + index) rather than plain on/off.
+ * For an on/off function the level is meaningless, so the RC Mixer only offers
+ * the level selector for these. VTX Power is the case this was built for (index
+ * → active power-table level via AP_VideoTX::set_power_by_index). Extend as the
+ * firmware gains other level-selectable aux targets.
  */
-export const RC_LOGIC_OUTPUT_POSITION_FUNCTIONS: ReadonlySet<number> = new Set<number>([
+export const RC_LOGIC_LEVEL_SELECT_FUNCTIONS: ReadonlySet<number> = new Set<number>([
   94 // VTX Power
 ])
 
-/** True when `functionId` interprets the RCL output position (see the set above). */
-export function isRcLogicMultiPositionFunction(functionId: number): boolean {
-  return RC_LOGIC_OUTPUT_POSITION_FUNCTIONS.has(functionId)
+/** True when `functionId` is a multi-level target that supports level selection. */
+export function isRcLogicLevelSelectFunction(functionId: number): boolean {
+  return RC_LOGIC_LEVEL_SELECT_FUNCTIONS.has(functionId)
 }
 
 /** Full ArduCopter AUX_FUNC value list (from RC_Channel.cpp RCn_OPTION @Values,
@@ -204,10 +203,10 @@ function termParameterDefinitions(n: number): Record<string, ParameterDefinition
       id: `${prefix}OPT`,
       label: `Term ${n} · options`,
       description:
-        'Packed term options: bits 0-1 source type (0 range, 1 link, 2 condition), bit 2 combine (0 OR / 1 AND), bit 3 negate, bits 4-5 output position (0 HIGH, 1 MIDDLE, 2 LOW) for a multi-position target such as VTX power — any non-HIGH row puts the function into selector mode.',
+        'Packed term options: bits 0-1 source type (0 range, 1 link, 2 condition), bit 2 combine (0 OR / 1 AND), bit 3 negate, bit 4 level mode, bits 5-7 zero-based level index (0-7) for a multi-level target such as VTX power — any level-mode row puts the function into selector mode (lowest active row wins).',
       category: RC_LOGIC_CATEGORY,
       minimum: 0,
-      maximum: 63,
+      maximum: 255,
       step: 1,
       bitmask: true,
       options: [
@@ -215,8 +214,10 @@ function termParameterDefinitions(n: number): Record<string, ParameterDefinition
         { value: 1, label: 'Source type bit 1' },
         { value: 2, label: 'Combine (AND)' },
         { value: 3, label: 'Negate' },
-        { value: 4, label: 'Output position bit 0' },
-        { value: 5, label: 'Output position bit 1' }
+        { value: 4, label: 'Level mode' },
+        { value: 5, label: 'Level index bit 0' },
+        { value: 6, label: 'Level index bit 1' },
+        { value: 7, label: 'Level index bit 2' }
       ]
     },
     [`${prefix}SRC`]: {

--- a/tests/e2e/rc-mixer.spec.ts
+++ b/tests/e2e/rc-mixer.spec.ts
@@ -59,22 +59,24 @@ test.describe('RC Mixer (AP_RC_Logic)', () => {
     await expect(page.getByTestId('rc-mixer-track-band-rcl-3')).toBeVisible()
 
     // Editing round-trips through the model (reads back the draft immediately).
-    await page.getByTestId('rc-mixer-function-rcl-3').selectOption('94') // VTX Power (multi-position)
+    await page.getByTestId('rc-mixer-function-rcl-3').selectOption('94') // VTX Power (level-select)
     await page.getByTestId('rc-mixer-low-rcl-3').fill('1800')
     await page.getByTestId('rc-mixer-high-rcl-3').fill('2000')
     await expect(page.getByTestId('rc-mixer-channel-8')).toContainText('VTX Power')
 
-    // The output-position selector only appears for a multi-position target like
-    // VTX Power, and round-trips through the draft model (this is how one channel
-    // drives multi-level VTX power in selector mode).
-    await expect(page.getByTestId('rc-mixer-position-rcl-3')).toHaveValue('high')
-    await page.getByTestId('rc-mixer-position-rcl-3').selectOption('low')
-    await expect(page.getByTestId('rc-mixer-position-rcl-3')).toHaveValue('low')
+    // VTX Power exposes a level selector listing the real @VTX power levels by mW
+    // (demo table 25/200/500/1W). Index i stores into OPT bits 5-7 — this is how a
+    // channel drives an exact VTX power level (selector mode). Defaults to plain.
+    const level = page.getByTestId('rc-mixer-level-rcl-3')
+    await expect(level).toHaveValue('plain', { timeout: 15000 })
+    await expect(level.locator('option')).toContainText(['Full power (on/off)', '25 mW', '200 mW', '500 mW', '800 mW (1W)'])
+    await level.selectOption('2') // 500 mW
+    await expect(level).toHaveValue('2')
 
-    // Switching to a plain on/off function hides the selector — position is noise
-    // there — and the row keeps working as an ordinary range term.
+    // Switching to a plain on/off function hides the level selector (VTX-only) and
+    // the row keeps working as an ordinary range term.
     await page.getByTestId('rc-mixer-function-rcl-3').selectOption('16') // AUTO Mode
-    await expect(page.getByTestId('rc-mixer-position-rcl-3')).toHaveCount(0)
+    await expect(page.getByTestId('rc-mixer-level-rcl-3')).toHaveCount(0)
     await expect(page.getByTestId('rc-mixer-channel-8')).toContainText('AUTO Mode')
 
     // Remove clears the term drafts -> row gone, channel 8 empty again (the
@@ -132,6 +134,6 @@ test.describe('RC Mixer (AP_RC_Logic)', () => {
     // RCL-gated chrome (external-claim badges, output-position selectors) stays
     // hidden in the preview scaffold — all of it is gated on RCL detection.
     await expect(page.locator('[data-testid^="rc-mixer-channel-claim-"]')).toHaveCount(0)
-    await expect(page.locator('[data-testid^="rc-mixer-position-"]')).toHaveCount(0)
+    await expect(page.locator('[data-testid^="rc-mixer-level-"]')).toHaveCount(0)
   })
 })


### PR DESCRIPTION
Mirrors the `sfd-rc-work` firmware redesign (`bf9a7b7540`/`ac1b6d9850`) that replaced the coarse Low/Mid/High output position with an exact level index, so one RC channel can reach **every** VTX power-table level, not just three.

## Firmware encoding (mirrored exactly)
`RCL<n>_OPT` bit 4 = level mode, bits 5–7 = **zero-based** level index (0–7). In level mode an active row drives a multi-level target (VTX power) to that specific level; the engine emits it one-based to `AP_VideoTX::set_power_by_index`, which walks the **non-zero** power levels — so index *i* selects the i-th supported level.

## Changes
- **param-metadata:** `RCL<n>_OPT` max 63→255, bit labels `4:Level mode / 5–7:Level index`; new level constants; the interim `RcLogicOutputPosition` + position set removed; `RC_LOGIC_LEVEL_SELECT_FUNCTIONS`/`isRcLogicLevelSelectFunction` (VTX Power).
- **RC Mixer:** `RcMixerAssignment` gains `levelMode` + `outputLevel` (0-based); `decodeLevel`/`encodeLevel` for OPT bit 4 + bits 5–7. The Low/Mid/High dropdown becomes a VTX-power selector listing the real `@VTX` levels by mW (non-zero, in table order → index), plus a "Full power (on/off)" plain option. Loads the `@VTX` table on the RC Mixer view too.
- Gated on **VTX-table + RCL detected + function == VTX Power**; switching a row off VTX Power clears the level field.

Only the current firmware encoding is supported (co-developed fork) — no migration from the interim position bits.

## ArduCopter byte-identical
RCL is fork-only, Expert+RCL-gated, VTX-table-gated for the level UI; presentational + draft-layer only.

## Validation ladder
Rung 1 web vitest (495) · Rung 3 full Playwright e2e (204; level dropdown lists demo `@VTX` levels by mW, index round-trips, hidden for non-VTX + preview scaffold).