### PR TITLE
feat(rc-mixer): surface common functions first in the function dropdown

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -373,6 +373,7 @@ import {
 } from './view-models/peripherals'
 import {
   buildRcMixerFunctionLookup,
+  orderRcMixerFunctionCatalog,
   groupAssignmentsByChannel,
   type RcMixerAssignment
 } from './view-models/rc-mixer'
@@ -4875,7 +4876,7 @@ export function App() {
     () => readRcLogicModel(snapshot.parameters, editedValues),
     [snapshot.parameters, editedValues]
   )
-  const rcLogicFunctionCatalogMemo = useMemo(() => rcLogicFunctionCatalog(), [])
+  const rcLogicFunctionCatalogMemo = useMemo(() => orderRcMixerFunctionCatalog(rcLogicFunctionCatalog()), [])
   const rcLogicFunctionLookup = useMemo(
     () => buildRcMixerFunctionLookup(rcLogicFunctionCatalogMemo),
     [rcLogicFunctionCatalogMemo]

--- a/apps/web/src/hooks/use-rc-mixer.ts
+++ b/apps/web/src/hooks/use-rc-mixer.ts
@@ -14,6 +14,7 @@ import {
   createIdleRcMixerState,
   filterRcMixerFunctionCatalogForVehicle,
   groupAssignmentsByChannel,
+  orderRcMixerFunctionCatalog,
   RC_MIXER_FUNCTION_CATALOG,
   type RcMixerAssignment,
   type RcMixerState
@@ -26,7 +27,10 @@ export function useRcMixer(snapshot: ConfiguratorSnapshot) {
   // parachutes/Precision Loiter/airmode aren't universal) rather than
   // showing Rover a "Precision Loiter" entry it can never use.
   const rcMixerFunctionCatalog = useMemo(
-    () => filterRcMixerFunctionCatalogForVehicle(RC_MIXER_FUNCTION_CATALOG, snapshot.vehicle?.vehicle),
+    () =>
+      orderRcMixerFunctionCatalog(
+        filterRcMixerFunctionCatalogForVehicle(RC_MIXER_FUNCTION_CATALOG, snapshot.vehicle?.vehicle)
+      ),
     [snapshot.vehicle?.vehicle]
   )
   const rcMixerFunctionLookup = useMemo(

--- a/apps/web/src/view-models/rc-mixer.test.ts
+++ b/apps/web/src/view-models/rc-mixer.test.ts
@@ -1,14 +1,51 @@
 import { describe, expect, it } from 'vitest'
 
+import { RC_LOGIC_AUX_FUNCTION_OPTIONS } from '@arduconfig/param-metadata'
+
 import {
   buildRcMixerFunctionLookup,
   createAssignment,
   filterRcMixerFunctionCatalogForVehicle,
   groupAssignmentsByChannel,
+  orderRcMixerFunctionCatalog,
   RC_MIXER_FUNCTION_CATALOG,
+  RC_MIXER_PRIORITY_FUNCTIONS,
   type RcMixerAssignment,
   type RcMixerFunctionDefinition
 } from './rc-mixer'
+
+describe('orderRcMixerFunctionCatalog', () => {
+  const catalog: RcMixerFunctionDefinition[] = [
+    { id: 20, label: 'Zebra', description: '' },
+    { id: 4, label: 'RTL', description: '' },
+    { id: 21, label: 'Apple', description: '' },
+    { id: 94, label: 'VTX Power', description: '' },
+    { id: 22, label: 'Mango', description: '' },
+    { id: 0, label: 'Do Nothing', description: '' }
+  ]
+
+  it('puts priority functions first (in priority order), then the rest alphabetically', () => {
+    const ordered = orderRcMixerFunctionCatalog(catalog).map((entry) => entry.label)
+    // Priority ids present here: 0, 94, 4 → in RC_MIXER_PRIORITY_FUNCTIONS order (0, then 4, then 94).
+    expect(ordered.slice(0, 3)).toEqual(['Do Nothing', 'RTL', 'VTX Power'])
+    // Remainder alphabetical by label.
+    expect(ordered.slice(3)).toEqual(['Apple', 'Mango', 'Zebra'])
+  })
+
+  it('does not mutate the input and keeps every entry', () => {
+    const input = [...catalog]
+    const ordered = orderRcMixerFunctionCatalog(catalog)
+    expect(catalog).toEqual(input)
+    expect(ordered).toHaveLength(catalog.length)
+  })
+
+  it('every priority id references a real RCL aux function (guards against typos)', () => {
+    const ids = new Set(RC_LOGIC_AUX_FUNCTION_OPTIONS.map((option) => option.value))
+    for (const id of RC_MIXER_PRIORITY_FUNCTIONS) {
+      expect(ids.has(id)).toBe(true)
+    }
+  })
+})
 
 describe('createAssignment', () => {
   it('seeds the documented PWM defaults and a unique id per call', () => {

--- a/apps/web/src/view-models/rc-mixer.ts
+++ b/apps/web/src/view-models/rc-mixer.ts
@@ -47,6 +47,48 @@ export function filterRcMixerFunctionCatalogForVehicle(
   return catalog.filter((definition) => !definition.vehicles || (definition.vehicles as readonly string[]).includes(vehicleKind))
 }
 
+/** Curated "surface these first" order for the RC Mixer function dropdown — the
+ *  aux functions most commonly assigned to a switch, in a sensible priority.
+ *  Everything not listed here follows, sorted alphabetically by label. Ids are
+ *  from RC_LOGIC_AUX_FUNCTION_OPTIONS (RCn_OPTION values). */
+export const RC_MIXER_PRIORITY_FUNCTIONS: readonly number[] = [
+  0, // Do Nothing (clears the row)
+  153, // ArmDisarm (4.2 and higher)
+  154, // ArmDisarm with AirMode
+  4, // RTL
+  18, // LAND Mode
+  16, // AUTO Mode
+  94, // VTX Power
+  11, // Fence Enable
+  9, // Camera Trigger
+  31, // Motor Emergency Stop
+  7, // Save WP
+  46 // RC Override Enable
+]
+
+/** Order a function catalog for the dropdown: the common/priority functions
+ *  first (in RC_MIXER_PRIORITY_FUNCTIONS order), then everything else
+ *  alphabetically by label. Pure; does not mutate the input. */
+export function orderRcMixerFunctionCatalog(
+  catalog: readonly RcMixerFunctionDefinition[]
+): RcMixerFunctionDefinition[] {
+  const priorityRank = new Map(RC_MIXER_PRIORITY_FUNCTIONS.map((id, index) => [id, index]))
+  return [...catalog].sort((left, right) => {
+    const rankLeft = priorityRank.get(left.id)
+    const rankRight = priorityRank.get(right.id)
+    if (rankLeft !== undefined && rankRight !== undefined) {
+      return rankLeft - rankRight
+    }
+    if (rankLeft !== undefined) {
+      return -1
+    }
+    if (rankRight !== undefined) {
+      return 1
+    }
+    return left.label.localeCompare(right.label)
+  })
+}
+
 export interface RcMixerAssignment {
   /** Stable, sortable id within a session. Generated on row creation. */
   id: string

--- a/tests/e2e/rc-mixer.spec.ts
+++ b/tests/e2e/rc-mixer.spec.ts
@@ -58,6 +58,12 @@ test.describe('RC Mixer (AP_RC_Logic)', () => {
     await expect(page.getByTestId('rc-mixer-assignment-rcl-3')).toBeVisible()
     await expect(page.getByTestId('rc-mixer-track-band-rcl-3')).toBeVisible()
 
+    // The function dropdown surfaces common functions first (Do Nothing, then
+    // arm/RTL/…/VTX Power), with the long tail alphabetical after.
+    const funcOptions = await page.getByTestId('rc-mixer-function-rcl-3').locator('option').allTextContents()
+    expect(funcOptions[0]).toBe('Do Nothing (0)')
+    expect(funcOptions.slice(0, 8)).toContain('VTX Power (94)')
+
     // Editing round-trips through the model (reads back the draft immediately).
     await page.getByTestId('rc-mixer-function-rcl-3').selectOption('94') // VTX Power (level-select)
     await page.getByTestId('rc-mixer-low-rcl-3').fill('1800')


### PR DESCRIPTION
The function picker listed 129 aux functions in raw value order, so common picks (arm, RTL, VTX power…) were buried. Now the dropdown puts a curated set of common functions first, then everything else alphabetically by label.

## Changes
- New `RC_MIXER_PRIORITY_FUNCTIONS` (Do Nothing, ArmDisarm, RTL, LAND, AUTO, VTX Power, Fence, Camera Trigger, Motor E-Stop, Save WP, RC Override) + pure `orderRcMixerFunctionCatalog`: priority ids in list order, then the tail sorted by label.
- Applied to both the firmware-backed RCL catalog and the preview scaffold catalog. Order-only; the id→label lookup is unchanged.

## ArduCopter byte-identical
Presentational (dropdown ordering) only.

## Validation ladder
Rung 1 web vitest (498, incl. ordering tests + a guard that every priority id is a real aux function) · Rung 3 full Playwright e2e (204; dropdown leads with Do Nothing, common functions in the top block).