### PR TITLE
feat(receiver): name the claiming section in "also used by" + drop redundant Flight Mode Switch card

### DIFF
--- a/apps/web/src/sections/ReceiverSection.tsx
+++ b/apps/web/src/sections/ReceiverSection.tsx
@@ -42,7 +42,7 @@ import type { useSetupExercises } from '../hooks/use-setup-exercises'
 import { formatParameterValue } from '../parameter-format'
 import { formatModeAssignment, modeSlotParamId } from '../modes-failsafe-helpers'
 import { RcChannelBars } from '../rc-channel-bars'
-import { readRoundedParameter, selectParameterById } from '../selectors/parameter-read'
+import { selectParameterById } from '../selectors/parameter-read'
 import { RC_DIRECTION_PROMPTS, type RcDirectionResult } from '../view-models/receiver-direction-check'
 import { RC_CALIBRATION_AXIS_ORDER, RC_CALIBRATION_SWITCH_CHANNELS, rcCalibrationCaptureComplete } from '../setup-exercise-helpers'
 import { StickCraftPreview } from '../preview-components'
@@ -246,7 +246,6 @@ export function ReceiverSection(props: ReceiverSectionProps): ReactElement {
     modeSwitchEstimate,
     modeExerciseAssignments,
     modeAssignments,
-    modeSwitchActivity,
     recentModeSwitchChange,
     configuredModeChannel,
     rssiType,
@@ -860,37 +859,6 @@ export function ReceiverSection(props: ReceiverSectionProps): ReactElement {
                 {activeReceiverTaskId === 'flight-modes' ? (
                   <div className="receiver-task-panel receiver-task-panel--stack">
                     <div className="receiver-task-two-up">
-                      <div className="mode-estimate-card">
-                        <div className="mode-estimate-card__header">
-                          <strong>Flight mode switch</strong>
-                          <StatusBadge tone={recentModeSwitchChange ? 'warning' : modeSwitchEstimate.estimatedSlot !== undefined ? 'success' : 'neutral'}>
-                            {recentModeSwitchChange ? 'Switch moved' : modeSwitchEstimate.estimatedSlot !== undefined ? 'Stable' : 'Waiting'}
-                          </StatusBadge>
-                        </div>
-                        <p>
-                          {modeSwitchEstimate.channelNumber === undefined
-                            ? 'Mode channel is not configured yet.'
-                            : modeSwitchEstimate.pwm === undefined
-                              ? `Configured for CH${modeSwitchEstimate.channelNumber}, waiting for that channel to stream.`
-                              : `Estimated slot ${modeSwitchEstimate.estimatedSlot} on CH${modeSwitchEstimate.channelNumber} at ${modeSwitchEstimate.pwm} µs.`}
-                        </p>
-                        <small>
-                          {modeSwitchEstimate.configuredParamId && modeSwitchEstimate.configuredValue !== undefined
-                            ? `${modeSwitchEstimate.configuredParamId} = ${formatModeAssignment(modeSwitchEstimate.configuredValue, snapshot.vehicle?.vehicle)}`
-                            : `Heartbeat mode: ${snapshot.vehicle?.flightMode ?? 'Unknown'}`}
-                        </small>
-                        {modeSwitchActivity ? (
-                          <small>
-                            {modeSwitchActivity.previousSlot !== undefined && modeSwitchActivity.previousSlot !== modeSwitchActivity.currentSlot
-                              ? `Last slot change: ${formatModeAssignment(readRoundedParameter(snapshot, modeSlotParamId(snapshot.vehicle?.vehicle, modeSwitchActivity.previousSlot)), snapshot.vehicle?.vehicle)} -> ${formatModeAssignment(
-                                  readRoundedParameter(snapshot, modeSlotParamId(snapshot.vehicle?.vehicle, modeSwitchActivity.currentSlot)),
-                                  snapshot.vehicle?.vehicle
-                                )}`
-                              : `Last switch movement: ${modeSwitchActivity.previousPwm ?? modeSwitchActivity.currentPwm} µs -> ${modeSwitchActivity.currentPwm} µs`}
-                          </small>
-                        ) : null}
-                      </div>
-
                       {modeChannelParameter ? (
                         <div className="scoped-review-card scoped-review-card--compact">
                           <div className="switch-exercise-card__header">

--- a/apps/web/src/view-models/channel-usage.test.ts
+++ b/apps/web/src/view-models/channel-usage.test.ts
@@ -16,20 +16,20 @@ function assignment(channel: number, functionId: number): RcMixerAssignment {
 }
 
 describe('deriveExternalChannelClaims', () => {
-  it('flags the flight-mode channel', () => {
+  it('names the owning section for the flight-mode channel', () => {
     const claims = deriveExternalChannelClaims(snapshot({ FLTMODE_CH: 7 }))
-    expect(claims.get(7)).toEqual(['Flight mode switch'])
+    expect(claims.get(7)).toEqual(['Flight modes'])
   })
 
-  it('labels an RCn_OPTION aux function by name (arm, VTX power)', () => {
+  it('names the arm-switch section for an arm RCn_OPTION and the function for others', () => {
     const claims = deriveExternalChannelClaims(snapshot({ RC6_OPTION: 153, RC8_OPTION: 94 }))
-    expect(claims.get(6)).toEqual(['ArmDisarm (4.2 and higher)'])
-    expect(claims.get(8)).toEqual(['VTX Power'])
+    expect(claims.get(6)).toEqual(['Arm switch'])
+    expect(claims.get(8)).toEqual(['RC option — VTX Power'])
   })
 
-  it('combines both claims when a channel is the mode switch AND has an option', () => {
+  it('combines both claims when a channel is the mode channel AND has an option', () => {
     const claims = deriveExternalChannelClaims(snapshot({ FLTMODE_CH: 5, RC5_OPTION: 153 }))
-    expect(claims.get(5)).toEqual(['Flight mode switch', 'ArmDisarm (4.2 and higher)'])
+    expect(claims.get(5)).toEqual(['Flight modes', 'Arm switch'])
   })
 
   it('ignores channels with no claim (RCn_OPTION = 0 or absent)', () => {

--- a/apps/web/src/view-models/channel-usage.ts
+++ b/apps/web/src/view-models/channel-usage.ts
@@ -38,15 +38,19 @@ export function deriveExternalChannelClaims(snapshot: ConfiguratorSnapshot): Map
     }
   }
 
+  // Labels name the SECTION that owns the channel so the operator knows where to
+  // look: the flight-mode channel → "Flight modes", an arm RCn_OPTION → "Arm
+  // switch", any other RCn_OPTION → "RC option — <function>".
   const modeChannel = getModeChannelNumber(snapshot)
   if (modeChannel !== undefined) {
-    add(modeChannel, 'Flight mode switch')
+    add(modeChannel, 'Flight modes')
   }
 
   for (let channel = 1; channel <= 16; channel += 1) {
     const option = readRoundedParameter(snapshot, `RC${channel}_OPTION`)
     if (option !== undefined && option !== 0) {
-      add(channel, auxFunctionLabel(option))
+      const isArm = option === 41 || option === 153 || option === 154
+      add(channel, isArm ? 'Arm switch' : `RC option — ${auxFunctionLabel(option)}`)
     }
   }
 

--- a/tests/e2e/views.spec.ts
+++ b/tests/e2e/views.spec.ts
@@ -1557,7 +1557,7 @@ test.describe('RC Mixer view', () => {
 
     // Cross-subsystem awareness: ch7 is the flight-mode switch, so the mixer
     // badges it as already claimed even though it has no RCL term of its own.
-    await expect(page.getByTestId('rc-mixer-channel-claim-7')).toContainText('Flight mode switch')
+    await expect(page.getByTestId('rc-mixer-channel-claim-7')).toContainText('Flight modes')
   })
 
   test('surfaces RC Mixer term usage back in the Receiver view (reverse awareness)', async ({ page }) => {


### PR DESCRIPTION
Two small Receiver/RC-Mixer UX tweaks.

- **RC Mixer "⚠ Also used by" badges name the owning section** so it's clear where the channel is configured: flight-mode channel → "Flight modes", arm `RCn_OPTION` (41/153/154) → "Arm switch", any other `RCn_OPTION` → "RC option — <function>" (was the raw function label / "Flight mode switch").
- **Removed the redundant "Flight Mode Switch" card** from the Receiver flight-modes task — it duplicated the Mode Channel card (which owns `FLTMODE_CH`) and the live mode-switch card already in the channel strip. The task now shows Mode Channel + Arm Switch (+ RC Options).

## ArduCopter byte-identical
Presentational only (label wording + removing a duplicate read-only card).

## Validation ladder
Rung 1 web vitest (498, updated claim labels) · Rung 3 full Playwright e2e (204; RC Mixer claim reads "Flight modes", receiver flight-modes tests unaffected).