### PR TITLE
feat(rc-mixer): edit condition & link RCL terms (Logic section)

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -378,13 +378,16 @@ import {
   type RcMixerAssignment
 } from './view-models/rc-mixer'
 import {
+  type RcLogicLogicTerm,
   readRcLogicModel,
   rcLogicAddDrafts,
+  rcLogicAddLogicTermDrafts,
   rcLogicFunctionCatalog,
   rcLogicRemovePlan,
   rcLogicTermFromAssignmentId,
   rcLogicTermParamIds,
-  rcLogicUpdateDrafts
+  rcLogicUpdateDrafts,
+  rcLogicUpdateLogicTermDrafts
 } from './view-models/rc-logic'
 import { armSwitchAssignmentDrafts, deriveArmSwitchAssignment } from './view-models/arm-switch'
 import { type StatusTone } from './status-tone'
@@ -4966,6 +4969,37 @@ export function App() {
       })
     }
   }
+  // Condition/link terms for the Logic section, with the same removed-term
+  // self-heal the channel assignments use.
+  const rcLogicVisibleLogicTerms = useMemo(
+    () =>
+      rcLogicModel.logicTerms.filter((logicTerm) => {
+        const term = rcLogicTermFromAssignmentId(logicTerm.id)
+        if (term === null || !rcLogicRemovedTerms.has(term)) {
+          return true
+        }
+        return editedValues[rcLogicTermParamIds(term).func] !== '0'
+      }),
+    [rcLogicModel.logicTerms, rcLogicRemovedTerms, editedValues]
+  )
+  function handleRcLogicAddLogicTerm(): void {
+    const drafts = rcLogicAddLogicTermDrafts(rcLogicModel)
+    if (!drafts) {
+      setParameterNotice({
+        tone: 'warning',
+        text: 'All 12 RC logic terms are in use — remove one before adding another.'
+      })
+      return
+    }
+    mergeDrafts(drafts)
+  }
+  function handleRcLogicUpdateLogicTerm(id: string, patch: Partial<RcLogicLogicTerm>): void {
+    const term = rcLogicTermFromAssignmentId(id)
+    if (term === null) {
+      return
+    }
+    mergeDrafts(rcLogicUpdateLogicTermDrafts(snapshot.parameters, editedValues, term, patch))
+  }
   function handleRcLogicToggleEngine(enabled: boolean): void {
     setDraft('RCL_ENABLE', enabled ? '1' : '0')
   }
@@ -7711,7 +7745,10 @@ export function App() {
         firmwareSupported={hasRcLogicParams}
         engineEnabled={rcLogicModel.enabled}
         onToggleEngine={handleRcLogicToggleEngine}
-        hiddenTermCount={rcLogicModel.hiddenTermCount}
+        logicTerms={hasRcLogicParams ? rcLogicVisibleLogicTerms : undefined}
+        onAddLogicTerm={handleRcLogicAddLogicTerm}
+        onUpdateLogicTerm={handleRcLogicUpdateLogicTerm}
+        onRemoveLogicTerm={handleRcLogicRemoveAssignment}
         tableFull={rcLogicModel.freeTermIndex === null}
         externalClaimByChannel={externalChannelClaims}
         vtxPowerLevels={rcMixerVtxPowerLevels}

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -7918,6 +7918,68 @@ details.metadata-settings-section:not([open]) > summary::after {
   gap: 6px;
 }
 
+/* Logic conditions & links section (condition/link RCL terms). */
+.rc-mixer-logic {
+  margin-top: 14px;
+  padding-top: 12px;
+  border-top: 1px solid var(--border, #2a2f37);
+  display: grid;
+  gap: 8px;
+}
+.rc-mixer-logic__header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+}
+.rc-mixer-logic__header small {
+  display: block;
+  color: var(--text-muted);
+  font-size: 11px;
+}
+.rc-mixer-logic__list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 6px;
+}
+.rc-mixer-logic__empty {
+  color: var(--text-muted);
+  font-size: 12px;
+}
+.rc-mixer-logic-term {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: end;
+  gap: 8px;
+  padding: 8px;
+  border: 1px solid var(--border, #2a2f37);
+  border-radius: 8px;
+}
+.rc-mixer-logic-term label {
+  display: grid;
+  gap: 2px;
+  font-size: 11px;
+  color: var(--text-muted);
+}
+.rc-mixer-logic-term__negate {
+  flex-direction: row;
+  align-items: center;
+  gap: 6px;
+}
+.rc-mixer-logic-term__meta {
+  margin-left: auto;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+.rc-mixer-logic-term__meta small {
+  color: var(--text-muted);
+  font-size: 11px;
+  max-width: 220px;
+}
+
 /* AP_RC_Logic engine controls (shown when the firmware supports RCL_*). */
 .rc-mixer-engine {
   display: grid;

--- a/apps/web/src/view-models/rc-logic.test.ts
+++ b/apps/web/src/view-models/rc-logic.test.ts
@@ -4,8 +4,10 @@ import type { ParameterState } from '@arduconfig/ardupilot-core'
 
 import {
   rcLogicAddDrafts,
+  rcLogicAddLogicTermDrafts,
   rcLogicRemovePlan,
   rcLogicUpdateDrafts,
+  rcLogicUpdateLogicTermDrafts,
   readRcLogicModel
 } from './rc-logic'
 
@@ -30,7 +32,7 @@ describe('readRcLogicModel', () => {
       inverted: false
     })
     expect(model.freeTermIndex).toBe(2)
-    expect(model.hiddenTermCount).toBe(0)
+    expect(model.logicTerms).toHaveLength(0)
   })
 
   it('reads the negate bit as inverted', () => {
@@ -49,11 +51,17 @@ describe('readRcLogicModel', () => {
     expect(read(0x10 | (3 << 5))).toEqual({ levelMode: true, outputLevel: 3 })
   })
 
-  it('keeps non-range terms (link/condition) out of the editor but counts them as used', () => {
-    const model = readRcLogicModel(params({ RCL3_FUNC: 16, RCL3_OPT: 1 /* link */ }), {})
+  it('surfaces a link term in logicTerms (not the channel assignments)', () => {
+    const model = readRcLogicModel(params({ RCL3_FUNC: 16, RCL3_OPT: 1 /* link */, RCL3_SRC: 11 }), {})
     expect(model.assignments).toHaveLength(0)
-    expect(model.hiddenTermCount).toBe(1)
+    expect(model.logicTerms).toHaveLength(1)
+    expect(model.logicTerms[0]).toMatchObject({ id: 'rcl-3', sourceType: 'link', functionId: 16, sourceValue: 11 })
     expect(model.freeTermIndex).toBe(1) // term 3 used, 1/2 still free
+  })
+
+  it('surfaces a condition term with its condition id', () => {
+    const model = readRcLogicModel(params({ RCL2_FUNC: 94, RCL2_OPT: 2 /* condition */, RCL2_SRC: 0 /* RC failsafe */ }), {})
+    expect(model.logicTerms[0]).toMatchObject({ id: 'rcl-2', sourceType: 'condition', functionId: 94, sourceValue: 0 })
   })
 
   it('surfaces a pending (draft-only) row even before a function is picked', () => {
@@ -125,6 +133,36 @@ describe('rcLogic draft mappers', () => {
     const drafts = rcLogicUpdateDrafts(params({ RCL1_FUNC: 94, RCL1_OPT: 0x10 | (2 << 5) }), {}, 1, { functionId: 94 })
     expect(drafts.RCL1_FUNC).toBe('94')
     expect(drafts.RCL1_OPT).toBeUndefined() // no level change → no redundant OPT draft
+  })
+
+  it('adds a condition logic term on the free slot (RC failsafe, no function)', () => {
+    const model = readRcLogicModel(params({ RCL1_FUNC: 153 }), {})
+    expect(rcLogicAddLogicTermDrafts(model)).toEqual({
+      RCL2_FUNC: '0',
+      RCL2_OPT: '2', // condition source type
+      RCL2_SRC: '0' // condition 0 = RC failsafe
+    })
+    const full = readRcLogicModel(
+      params(Object.fromEntries(Array.from({ length: 12 }, (_, i) => [`RCL${i + 1}_FUNC`, 153]))),
+      {}
+    )
+    expect(rcLogicAddLogicTermDrafts(full)).toBeNull()
+  })
+
+  it('logic-term update writes source type / value / function and folds OPT', () => {
+    // Condition term; set the target function to VTX Power and pick a condition.
+    const drafts = rcLogicUpdateLogicTermDrafts(params({ RCL1_OPT: 2 /* condition */ }), {}, 1, {
+      functionId: 94,
+      sourceValue: 1 // battery failsafe
+    })
+    expect(drafts.RCL1_FUNC).toBe('94')
+    expect(drafts.RCL1_SRC).toBe('1')
+
+    // Flip condition -> link: OPT source-type bits change AND SRC resets (the
+    // value spaces differ — condition id vs watched function).
+    const flipped = rcLogicUpdateLogicTermDrafts(params({ RCL1_OPT: 2, RCL1_SRC: 3 }), {}, 1, { sourceType: 'link' })
+    expect(Number(flipped.RCL1_OPT) & 0x3).toBe(1) // link
+    expect(flipped.RCL1_SRC).toBe('0')
   })
 
   it('remove clears the term drafts and disables a live term', () => {

--- a/apps/web/src/view-models/rc-logic.ts
+++ b/apps/web/src/view-models/rc-logic.ts
@@ -82,15 +82,32 @@ export function rcLogicTermFromAssignmentId(id: string): number | null {
   return match ? Number(match[1]) : null
 }
 
+/** A non-range RCL term (condition or link) shown in the Logic section rather
+ *  than the channel grid — it has no channel/PWM window, just a source value. */
+export interface RcLogicLogicTerm {
+  /** rcl-<term> — same id scheme as range assignments. */
+  id: string
+  /** 'condition' → SRC is a condition id (0-4); 'link' → SRC is the watched AUX_FUNC. */
+  sourceType: 'condition' | 'link'
+  /** Target AUX_FUNC this term drives. */
+  functionId: number
+  /** Condition id (condition) or watched AUX_FUNC (link) — the RCL SRC value. */
+  sourceValue: number
+  /** Negate (OPT bit 3). */
+  inverted: boolean
+  /** VTX level selection (OPT bit 4 + bits 5-7), same encoding as range terms. */
+  levelMode?: boolean
+  outputLevel?: number
+}
+
 export interface RcLogicModel {
   enabled: boolean
-  /** Range-term assignments, one per visible term (Phase 1). */
+  /** Range-term assignments (the channel grid). */
   assignments: RcMixerAssignment[]
+  /** Condition/link terms (the Logic conditions & links section). */
+  logicTerms: RcLogicLogicTerm[]
   /** First unused term slot (1-based), or null when the table is full. */
   freeTermIndex: number | null
-  /** Configured terms that aren't editable range terms (link/condition) — kept
-   *  intact but not shown in the channel editor. */
-  hiddenTermCount: number
 }
 
 function makeReaders(parameters: readonly ParameterState[], drafts: ParameterDraftValues) {
@@ -114,8 +131,8 @@ export function readRcLogicModel(
   const { hasDraft, effective } = makeReaders(parameters, drafts)
 
   const assignments: RcMixerAssignment[] = []
+  const logicTerms: RcLogicLogicTerm[] = []
   let freeTermIndex: number | null = null
-  let hiddenTermCount = 0
 
   for (let term = 1; term <= RC_LOGIC_NUM_TERMS; term += 1) {
     const ids = rcLogicTermParamIds(term)
@@ -131,28 +148,36 @@ export function readRcLogicModel(
       continue
     }
     const sourceType = opt & RC_LOGIC_OPT_SOURCE_TYPE_MASK
-    if (sourceType !== RcLogicSourceType.Range) {
-      hiddenTermCount += 1
-      continue
-    }
     const level = decodeLevel(opt)
-    assignments.push({
-      id: rcLogicAssignmentId(term),
-      channel: effective(ids.src, 0),
-      functionId: func,
-      lowPwm: effective(ids.min, ADD_DEFAULT_LOW),
-      highPwm: effective(ids.max, ADD_DEFAULT_HIGH),
-      inverted: (opt & NEGATE_MASK) !== 0,
-      levelMode: level.levelMode,
-      outputLevel: level.outputLevel
-    })
+    if (sourceType === RcLogicSourceType.Range) {
+      assignments.push({
+        id: rcLogicAssignmentId(term),
+        channel: effective(ids.src, 0),
+        functionId: func,
+        lowPwm: effective(ids.min, ADD_DEFAULT_LOW),
+        highPwm: effective(ids.max, ADD_DEFAULT_HIGH),
+        inverted: (opt & NEGATE_MASK) !== 0,
+        levelMode: level.levelMode,
+        outputLevel: level.outputLevel
+      })
+    } else {
+      logicTerms.push({
+        id: rcLogicAssignmentId(term),
+        sourceType: sourceType === RcLogicSourceType.Link ? 'link' : 'condition',
+        functionId: func,
+        sourceValue: effective(ids.src, 0),
+        inverted: (opt & NEGATE_MASK) !== 0,
+        levelMode: level.levelMode,
+        outputLevel: level.outputLevel
+      })
+    }
   }
 
   return {
     enabled: effective('RCL_ENABLE', 0) === 1,
     assignments,
-    freeTermIndex,
-    hiddenTermCount
+    logicTerms,
+    freeTermIndex
   }
 }
 
@@ -239,4 +264,69 @@ export function rcLogicRemovePlan(parameters: readonly ParameterState[], term: n
     clear: [ids.func, ids.opt, ids.src, ids.min, ids.max],
     disable: liveFunc !== 0 ? { [ids.func]: '0' } : {}
   }
+}
+
+/** Drafts that allocate a new CONDITION logic term on the first free slot. It
+ *  starts on condition 0 (RC failsafe) with no function; the operator picks the
+ *  target function and can flip it to a link term. Null when the table is full. */
+export function rcLogicAddLogicTermDrafts(model: RcLogicModel): ParameterDraftValues | null {
+  if (model.freeTermIndex === null) {
+    return null
+  }
+  const ids = rcLogicTermParamIds(model.freeTermIndex)
+  return {
+    [ids.func]: '0', // operator picks the target function
+    [ids.opt]: String(RcLogicSourceType.Condition), // condition source, OR, not negated, no level
+    [ids.src]: '0' // condition 0 = RC failsafe
+  }
+}
+
+/** Drafts for editing one field of a logic (condition/link) term. Source type
+ *  (OPT bits 0-1), negate (bit 3), and level (bit 4 + 5-7) all fold into OPT;
+ *  the source value (condition id or watched AUX_FUNC) is SRC. Switching the
+ *  source type resets SRC, since a condition id and a watched function are
+ *  different value spaces. */
+export function rcLogicUpdateLogicTermDrafts(
+  parameters: readonly ParameterState[],
+  drafts: ParameterDraftValues,
+  term: number,
+  patch: Partial<RcLogicLogicTerm>
+): ParameterDraftValues {
+  const ids = rcLogicTermParamIds(term)
+  const { effective } = makeReaders(parameters, drafts)
+  const next: ParameterDraftValues = {}
+  if (patch.functionId !== undefined) next[ids.func] = String(patch.functionId)
+  if (patch.sourceValue !== undefined) {
+    next[ids.src] = String(patch.sourceValue)
+  } else if (patch.sourceType !== undefined) {
+    next[ids.src] = '0' // type changed without a new value → reset the source
+  }
+  const clearsLevel = patch.functionId !== undefined && !isRcLogicLevelSelectFunction(patch.functionId)
+  const optTouched =
+    patch.sourceType !== undefined ||
+    patch.inverted !== undefined ||
+    patch.levelMode !== undefined ||
+    patch.outputLevel !== undefined ||
+    clearsLevel
+  if (optTouched) {
+    const current = effective(ids.opt, RcLogicSourceType.Condition)
+    let opt = current
+    if (patch.sourceType !== undefined) {
+      const sourceType = patch.sourceType === 'link' ? RcLogicSourceType.Link : RcLogicSourceType.Condition
+      opt = (opt & ~RC_LOGIC_OPT_SOURCE_TYPE_MASK) | sourceType
+    }
+    if (patch.inverted !== undefined) {
+      opt = patch.inverted ? opt | NEGATE_MASK : opt & ~NEGATE_MASK
+    }
+    if (patch.levelMode !== undefined || patch.outputLevel !== undefined) {
+      const existing = decodeLevel(current)
+      opt = encodeLevel(opt, patch.levelMode ?? existing.levelMode, patch.outputLevel ?? existing.outputLevel)
+    } else if (clearsLevel) {
+      opt = encodeLevel(opt, false, 0)
+    }
+    if (opt !== current) {
+      next[ids.opt] = String(opt)
+    }
+  }
+  return next
 }

--- a/apps/web/src/views/RcMixer.tsx
+++ b/apps/web/src/views/RcMixer.tsx
@@ -1,7 +1,19 @@
 import { useEffect, useState, type PointerEvent as ReactPointerEvent } from 'react'
 
 import { Panel, StatusBadge, buttonStyle } from '@arduconfig/ui-kit'
-import { isRcLogicLevelSelectFunction } from '@arduconfig/param-metadata'
+import { RC_LOGIC_CONDITION_LABELS, isRcLogicLevelSelectFunction } from '@arduconfig/param-metadata'
+
+/** A condition/link term shown in the Logic section (no channel/PWM). */
+export interface RcMixerLogicTerm {
+  id: string
+  sourceType: 'condition' | 'link'
+  /** Condition id (condition) or watched AUX_FUNC (link). */
+  sourceValue: number
+  functionId: number
+  inverted: boolean
+  levelMode?: boolean
+  outputLevel?: number
+}
 
 import {
   RC_MIXER_TRACK_MAX_PWM,
@@ -88,8 +100,14 @@ export interface RcMixerViewProps {
   /** RCL_ENABLE state (only meaningful when firmwareSupported). */
   engineEnabled?: boolean
   onToggleEngine?: (enabled: boolean) => void
-  /** Configured non-range terms (link/condition) preserved but not shown here. */
-  hiddenTermCount?: number
+  /** Condition/link terms — shown in the Logic section below the channels. */
+  logicTerms?: readonly RcMixerLogicTerm[]
+  /** Add a new (condition) logic term. */
+  onAddLogicTerm?: () => void
+  /** Remove a logic term by id. */
+  onRemoveLogicTerm?: (id: string) => void
+  /** Mutate any field on a logic term. */
+  onUpdateLogicTerm?: (id: string, patch: Partial<RcMixerLogicTerm>) => void
   /** True when every RCL term slot is in use — the "Add function" buttons stop. */
   tableFull?: boolean
   /** Per-channel claims from OTHER subsystems (flight-mode switch, RCn_OPTION
@@ -115,7 +133,10 @@ export function RcMixerView(props: RcMixerViewProps) {
     firmwareSupported,
     engineEnabled,
     onToggleEngine,
-    hiddenTermCount,
+    logicTerms,
+    onAddLogicTerm,
+    onRemoveLogicTerm,
+    onUpdateLogicTerm,
     tableFull,
     externalClaimByChannel,
     vtxPowerLevels
@@ -213,15 +234,9 @@ export function RcMixerView(props: RcMixerViewProps) {
               </span>
             </label>
             <p className="bf-note">
-              This firmware reports the AP_RC_Logic engine. Each row below is a real range term; changes are staged as{' '}
-              <code>RCL_*</code> parameter drafts and written through the normal verified write path.
-              {hiddenTermCount ? (
-                <>
-                  {' '}
-                  <strong>{hiddenTermCount}</strong> configured link/condition term
-                  {hiddenTermCount === 1 ? ' is' : 's are'} preserved but not shown here (range terms only for now).
-                </>
-              ) : null}
+              This firmware reports the AP_RC_Logic engine. Each channel row is a real range term; changes are staged as{' '}
+              <code>RCL_*</code> parameter drafts and written through the normal verified write path. Condition and link
+              terms live in the Logic section below.
             </p>
           </div>
         ) : (
@@ -513,6 +528,141 @@ export function RcMixerView(props: RcMixerViewProps) {
             )
           })}
         </div>
+
+        {firmwareSupported ? (
+          <section className="rc-mixer-logic" data-testid="rc-mixer-logic-section">
+            <header className="rc-mixer-logic__header">
+              <div>
+                <strong>Logic conditions &amp; links</strong>
+                <small>Drive a function from a vehicle condition (failsafe, armed) or another function&apos;s state — no channel needed.</small>
+              </div>
+              <button
+                type="button"
+                style={buttonStyle()}
+                onClick={() => onAddLogicTerm?.()}
+                disabled={tableFull}
+                title={tableFull ? 'All 12 RC logic terms are in use.' : undefined}
+                data-testid="rc-mixer-add-logic-term"
+              >
+                + Add logic term
+              </button>
+            </header>
+            {logicTerms && logicTerms.length > 0 ? (
+              <ul className="rc-mixer-logic__list">
+                {logicTerms.map((term) => {
+                  const definition = functionLookup.byId.get(term.functionId)
+                  return (
+                    <li key={term.id} className="rc-mixer-logic-term" data-testid={`rc-mixer-logic-term-${term.id}`}>
+                      <label>
+                        <span>Source</span>
+                        <select
+                          value={term.sourceType}
+                          onChange={(event) => onUpdateLogicTerm?.(term.id, { sourceType: event.target.value as 'condition' | 'link' })}
+                          data-testid={`rc-mixer-logic-source-${term.id}`}
+                        >
+                          <option value="condition">Condition</option>
+                          <option value="link">Link</option>
+                        </select>
+                      </label>
+                      {term.sourceType === 'condition' ? (
+                        <label>
+                          <span>When</span>
+                          <select
+                            value={String(term.sourceValue)}
+                            onChange={(event) => onUpdateLogicTerm?.(term.id, { sourceValue: Number(event.target.value) })}
+                            data-testid={`rc-mixer-logic-condition-${term.id}`}
+                          >
+                            {Object.entries(RC_LOGIC_CONDITION_LABELS).map(([value, label]) => (
+                              <option key={value} value={value}>
+                                {label}
+                              </option>
+                            ))}
+                          </select>
+                        </label>
+                      ) : (
+                        <label>
+                          <span>Watching</span>
+                          <select
+                            value={String(term.sourceValue)}
+                            onChange={(event) => onUpdateLogicTerm?.(term.id, { sourceValue: Number(event.target.value) })}
+                            data-testid={`rc-mixer-logic-watch-${term.id}`}
+                          >
+                            {functionCatalog.map((entry) => (
+                              <option key={entry.id} value={entry.id}>
+                                {entry.label} ({entry.id})
+                              </option>
+                            ))}
+                          </select>
+                        </label>
+                      )}
+                      <label>
+                        <span>Drives</span>
+                        <select
+                          value={String(term.functionId)}
+                          onChange={(event) => onUpdateLogicTerm?.(term.id, { functionId: Number(event.target.value) })}
+                          data-testid={`rc-mixer-logic-function-${term.id}`}
+                        >
+                          {functionCatalog.map((entry) => (
+                            <option key={entry.id} value={entry.id}>
+                              {entry.label} ({entry.id})
+                            </option>
+                          ))}
+                        </select>
+                      </label>
+                      {isRcLogicLevelSelectFunction(term.functionId) && vtxPowerLevels && vtxPowerLevels.length > 0 ? (
+                        <label>
+                          <span>VTX power</span>
+                          <select
+                            value={term.levelMode ? String(term.outputLevel ?? 0) : 'plain'}
+                            onChange={(event) => {
+                              const raw = event.target.value
+                              onUpdateLogicTerm?.(
+                                term.id,
+                                raw === 'plain' ? { levelMode: false } : { levelMode: true, outputLevel: Number(raw) }
+                              )
+                            }}
+                            data-testid={`rc-mixer-logic-level-${term.id}`}
+                          >
+                            <option value="plain">Full power (on/off)</option>
+                            {vtxPowerLevels.map((level) => (
+                              <option key={level.index} value={String(level.index)}>
+                                {level.mw} mW{level.label && level.label !== String(level.mw) ? ` (${level.label})` : ''}
+                              </option>
+                            ))}
+                          </select>
+                        </label>
+                      ) : null}
+                      <label className="rc-mixer-logic-term__negate">
+                        <input
+                          type="checkbox"
+                          checked={term.inverted}
+                          onChange={(event) => onUpdateLogicTerm?.(term.id, { inverted: event.target.checked })}
+                          data-testid={`rc-mixer-logic-negate-${term.id}`}
+                        />
+                        <span>Negate</span>
+                      </label>
+                      <div className="rc-mixer-logic-term__meta">
+                        <small>{definition?.description ?? 'Unknown function.'}</small>
+                        <button
+                          type="button"
+                          style={buttonStyle()}
+                          onClick={() => onRemoveLogicTerm?.(term.id)}
+                          data-testid={`rc-mixer-logic-remove-${term.id}`}
+                        >
+                          Remove
+                        </button>
+                      </div>
+                    </li>
+                  )
+                })}
+              </ul>
+            ) : (
+              <p className="rc-mixer-logic__empty" data-testid="rc-mixer-logic-empty">
+                No condition or link terms yet. Add one to drive a function from failsafe, arming, or another function&apos;s state.
+              </p>
+            )}
+          </section>
+        ) : null}
       </Panel>
     </div>
   )

--- a/packages/param-metadata/src/shared-rc-logic.ts
+++ b/packages/param-metadata/src/shared-rc-logic.ts
@@ -42,6 +42,17 @@ export enum RcLogicSourceType {
   Condition = 2
 }
 
+/** Condition source ids used in RCL<n>_SRC when the source type is Condition.
+ *  Mirrors the AP_RC_Logic README condition table — all map onto existing
+ *  ArduPilot vehicle state. */
+export const RC_LOGIC_CONDITION_LABELS: Record<number, string> = {
+  0: 'RC failsafe',
+  1: 'Battery failsafe',
+  2: 'GCS failsafe',
+  3: 'EKF failsafe',
+  4: 'Armed'
+}
+
 /**
  * Aux functions whose target is a genuine multi-level output, so a row can
  * select a specific level (OPT level mode + index) rather than plain on/off.

--- a/tests/e2e/rc-mixer.spec.ts
+++ b/tests/e2e/rc-mixer.spec.ts
@@ -93,6 +93,41 @@ test.describe('RC Mixer (AP_RC_Logic)', () => {
     await expect(page.getByTestId('rc-mixer-channel-8')).toContainText('No assignments')
   })
 
+  test('Logic section adds a condition/link term and drives a function (VTX power on failsafe)', async ({ page }) => {
+    await page.goto('/')
+    await connectCopterDemo(page)
+    await page.getByTestId('view-button-rc-mixer').click()
+    // Wait for the seeded range terms to sync so the free slot is term 3.
+    await expect(page.getByTestId('rc-mixer-track-band-rcl-2')).toBeVisible()
+
+    const section = page.getByTestId('rc-mixer-logic-section')
+    await expect(section).toBeVisible()
+    await expect(page.getByTestId('rc-mixer-logic-empty')).toBeVisible()
+
+    await page.getByTestId('rc-mixer-add-logic-term').click()
+    const term = 'rcl-3'
+    await expect(page.getByTestId(`rc-mixer-logic-term-${term}`)).toBeVisible()
+    // Defaults to a condition term.
+    await expect(page.getByTestId(`rc-mixer-logic-source-${term}`)).toHaveValue('condition')
+
+    // Condition → RC failsafe, driving VTX Power at a specific level (the level
+    // selector reads the demo @VTX table).
+    await page.getByTestId(`rc-mixer-logic-condition-${term}`).selectOption('0') // RC failsafe
+    await page.getByTestId(`rc-mixer-logic-function-${term}`).selectOption('94') // VTX Power
+    const level = page.getByTestId(`rc-mixer-logic-level-${term}`)
+    await expect(level).toBeVisible({ timeout: 15000 })
+    await level.selectOption('0') // 25 mW
+
+    // Flip to a link term — the condition dropdown is replaced by a watched-function picker.
+    await page.getByTestId(`rc-mixer-logic-source-${term}`).selectOption('link')
+    await expect(page.getByTestId(`rc-mixer-logic-watch-${term}`)).toBeVisible()
+    await expect(page.getByTestId(`rc-mixer-logic-condition-${term}`)).toHaveCount(0)
+
+    // Remove clears the term.
+    await page.getByTestId(`rc-mixer-logic-remove-${term}`).click()
+    await expect(page.getByTestId(`rc-mixer-logic-term-${term}`)).toHaveCount(0)
+  })
+
   test('range edges adjust via the drag handle (keyboard + pointer)', async ({ page }) => {
     await page.goto('/')
     await connectCopterDemo(page)


### PR DESCRIPTION
Phase 2 of the RC Mixer: **condition** and **link** terms — previously read but "preserved but not shown" — are now editable in a new "Logic conditions & links" section below the channel grid. This makes the firmware's condition→function examples expressible end-to-end (e.g. **RC failsafe → VTX Power at level 0**).

## Changes
- **Model:** `readRcLogicModel` surfaces non-range terms as `logicTerms` (sourceType condition/link, `sourceValue` = condition id or watched `AUX_FUNC`, function, negate, VTX level) instead of just counting them. New mappers `rcLogicAddLogicTermDrafts` / `rcLogicUpdateLogicTermDrafts` (source type → OPT bits 0-1, negate → bit 3, level → bit 4 + 5-7, source value → SRC; switching source type resets SRC since condition ids and watched functions are different value spaces). Remove reuses `rcLogicRemovePlan`.
- **param-metadata:** `RC_LOGIC_CONDITION_LABELS` (RC/battery/GCS/EKF failsafe, armed).
- **RC Mixer view:** per-term source-type picker (Condition/Link) that swaps the source input (condition-id vs watched-function dropdown), target function picker, VTX level selector (VTX Power only), negate, remove; plus "+ Add logic term". Channel-grouped range view unchanged.

Layout: kept the channel grid for range terms and added the Logic section for condition/link terms (the "keep channels + Logic section" option).

## ArduCopter byte-identical
RCL is fork-only, Expert+RCL-gated; presentational + draft-layer only, written through the normal verified write path.

## Validation ladder
Rung 1 web vitest (501, new `logicTerms` read + add/update mapper tests) · Rung 3 full Playwright e2e (205; add a condition term → VTX Power at a level, flip to link, remove).