### PR TITLE
fix(rc-mixer): audit follow-ups — VTX level index correctness + RCL_ENABLE ordering + edge cases

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -252,6 +252,7 @@ import { createMotorPreviewNodes } from './view-models/motor-preview'
 import { buildRecentNotices } from './view-models/recent-notices'
 import { deriveExternalChannelClaims, deriveRcLogicChannelClaims } from './view-models/channel-usage'
 import { orderDraftsByEnableGate } from './view-models/enable-gate-write-order'
+import { deriveVtxPowerLevels } from './view-models/vtx-power-levels'
 import { invertGuidedReorderMapping, pickedReorderPositions } from './view-models/motor-reorder-mapping'
 import { LiveGpsMapCard } from './live-gps-map'
 import { DisconnectedLanding } from './disconnected-landing'
@@ -4920,17 +4921,30 @@ export function App() {
     [rcLogicVisibleAssignments]
   )
   // Non-zero @VTX power levels in table order — a VTX_POWER RCL term's level
-  // selector stores the 0-based index here into OPT bits 5-7. The firmware skips
-  // value=0 levels (get_power_mw_for_index), so we filter them out before indexing.
-  const rcMixerVtxPowerLevels = useMemo(() => {
-    const levels = vtxTable.table?.powerLevels
-    if (!levels) {
-      return undefined
+  // selector stores the 0-based index here into OPT bits 5-7. Use the DETECTED
+  // (saved) table, not the editable draft: the RCL index resolves against what
+  // the FC actually has, so unsaved VTX-table edits must not shift it.
+  const rcMixerVtxPowerLevels = useMemo(
+    () => deriveVtxPowerLevels(vtxTable.detected?.powerLevels),
+    [vtxTable.detected]
+  )
+  // A slot freed by a prior remove stays in rcLogicRemovedTerms even after the
+  // disable is applied (the Set is never pruned). Reusing that slot for a new
+  // term would leave the new (FUNC=0) row hidden by the removed-term filter, so
+  // clear the slot from the set when it's re-allocated.
+  function unmarkRcLogicRemovedTerm(term: number | null): void {
+    if (term === null) {
+      return
     }
-    return levels
-      .filter((level) => level.value !== 0)
-      .map((level, index) => ({ index, mw: level.value, label: level.label }))
-  }, [vtxTable.table])
+    setRcLogicRemovedTerms((current) => {
+      if (!current.has(term)) {
+        return current
+      }
+      const next = new Set(current)
+      next.delete(term)
+      return next
+    })
+  }
   function handleRcLogicAddAssignment(channel: number): void {
     const drafts = rcLogicAddDrafts(rcLogicModel, channel)
     if (!drafts) {
@@ -4940,6 +4954,7 @@ export function App() {
       })
       return
     }
+    unmarkRcLogicRemovedTerm(rcLogicModel.freeTermIndex)
     mergeDrafts(drafts)
   }
   function handleRcLogicUpdateAssignment(assignmentId: string, patch: Partial<RcMixerAssignment>): void {
@@ -4991,6 +5006,7 @@ export function App() {
       })
       return
     }
+    unmarkRcLogicRemovedTerm(rcLogicModel.freeTermIndex)
     mergeDrafts(drafts)
   }
   function handleRcLogicUpdateLogicTerm(id: string, patch: Partial<RcLogicLogicTerm>): void {
@@ -7119,7 +7135,6 @@ export function App() {
             modeExerciseAssignments,
             modeAssignments,
             modeSwitchExercise,
-            modeSwitchActivity,
             recentModeSwitchChange,
             configuredModeChannel,
             rssiType,

--- a/apps/web/src/hooks/use-vtx-table.ts
+++ b/apps/web/src/hooks/use-vtx-table.ts
@@ -23,6 +23,10 @@ export interface UseVtxTableResult {
   status: VtxTableStatus
   /** Editable working copy of the table (undefined until available). */
   table: VtxTable | undefined
+  /** The last table READ FROM the FC (undefined until available). Unlike
+   *  `table` this does not reflect unsaved edits — consumers that must match
+   *  what the FC actually has (e.g. the RC Mixer's RCL level index) use this. */
+  detected: VtxTable | undefined
   dirty: boolean
   saving: boolean
   error: string | undefined
@@ -168,6 +172,7 @@ export function useVtxTable(input: {
   return {
     status,
     table: draft,
+    detected,
     dirty,
     saving,
     error,

--- a/apps/web/src/sections/ReceiverSection.tsx
+++ b/apps/web/src/sections/ReceiverSection.tsx
@@ -59,7 +59,6 @@ export interface ReceiverSectionDerived {
   modeExerciseAssignments: ReturnType<typeof deriveModeExerciseAssignments>
   modeAssignments: ReturnType<typeof deriveModeAssignments>
   modeSwitchExercise: ReturnType<typeof useSetupExercises>['modeSwitchExercise']
-  modeSwitchActivity: ReturnType<typeof useSetupExercises>['modeSwitchActivity']
   recentModeSwitchChange: boolean | undefined
   configuredModeChannel: number | undefined
   rssiType: number | undefined

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -7980,6 +7980,14 @@ details.metadata-settings-section:not([open]) > summary::after {
   max-width: 220px;
 }
 
+.rc-mixer-vtx-level-note {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 11px;
+  color: var(--warning, #b8860b);
+}
+
 /* AP_RC_Logic engine controls (shown when the firmware supports RCL_*). */
 .rc-mixer-engine {
   display: grid;

--- a/apps/web/src/view-models/enable-gate-write-order.test.ts
+++ b/apps/web/src/view-models/enable-gate-write-order.test.ts
@@ -82,4 +82,21 @@ describe('orderDraftsByEnableGate', () => {
     expect(out.indexOf('SERVO1_FUNCTION')).toBeLessThan(out.indexOf('SERVO2_FUNCTION'))
     expect(out.indexOf('RCL3_FUNC')).toBeLessThan(out.indexOf('RCL3_MIN'))
   })
+
+  it('orders a "_ENABLE" feature master-enable ahead of the whole feature, above per-term gates', () => {
+    // Enabling the RCL engine + adding a term in one batch: RCL_ENABLE (an
+    // AP_PARAM_FLAG_ENABLE gate over the whole RCLn_* subtree) must go first,
+    // then the per-term FUNC gate, then its sub-params.
+    const input = [
+      draft('RCL3_MIN'),
+      draft('RCL3_FUNC', true),
+      draft('RCL_ENABLE', true), // marked enableGate; id ends in _ENABLE
+      draft('RCL3_MAX')
+    ]
+    const out = ids(orderDraftsByEnableGate(input))
+    expect(out[0]).toBe('RCL_ENABLE')
+    expect(out.indexOf('RCL_ENABLE')).toBeLessThan(out.indexOf('RCL3_FUNC'))
+    expect(out.indexOf('RCL3_FUNC')).toBeLessThan(out.indexOf('RCL3_MIN'))
+    expect(out.indexOf('RCL3_FUNC')).toBeLessThan(out.indexOf('RCL3_MAX'))
+  })
 })

--- a/apps/web/src/view-models/enable-gate-write-order.ts
+++ b/apps/web/src/view-models/enable-gate-write-order.ts
@@ -42,7 +42,12 @@ export function orderDraftsByEnableGate(
 
   const keyed = drafts.map((draft, index) => {
     if (draft.definition?.enableGate) {
-      return { draft, sortPos: index, rank: 0, index }
+      // A "_ENABLE" master feature-enable (e.g. RCL_ENABLE) gates the WHOLE
+      // feature sub-tree, not just its exact-prefix siblings, so pin it to the
+      // front of the batch. Per-group gates (e.g. RCL3_FUNC) keep their position
+      // and cluster their own dependents after them.
+      const sortPos = draft.id.endsWith('_ENABLE') ? -1 : index
+      return { draft, sortPos, rank: 0, index }
     }
     const prefix = groupPrefixOf(draft.id)
     const gateIndex = prefix !== undefined ? gateIndexByPrefix.get(prefix) : undefined

--- a/apps/web/src/view-models/vtx-power-levels.test.ts
+++ b/apps/web/src/view-models/vtx-power-levels.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest'
+
+import { deriveVtxPowerLevels } from './vtx-power-levels'
+
+describe('deriveVtxPowerLevels', () => {
+  it('returns undefined for an absent table', () => {
+    expect(deriveVtxPowerLevels(undefined)).toBeUndefined()
+  })
+
+  it('indexes the non-zero levels 0-based in table order', () => {
+    expect(
+      deriveVtxPowerLevels([
+        { value: 25, label: '25' },
+        { value: 400, label: '400' },
+        { value: 800, label: '800' },
+        { value: 1600, label: '1W6' }
+      ])
+    ).toEqual([
+      { index: 0, mw: 25, label: '25' },
+      { index: 1, mw: 400, label: '400' },
+      { index: 2, mw: 800, label: '800' },
+      { index: 3, mw: 1600, label: '1W6' }
+    ])
+  })
+
+  it('drops a 0-value (disabled/pit) level and RE-INDEXES the survivors', () => {
+    // Matches the firmware: get_power_mw_for_index counts only active (non-zero)
+    // levels, so a middle zero must shift the indices of everything after it.
+    const out = deriveVtxPowerLevels([
+      { value: 25, label: '25' },
+      { value: 0, label: 'pit' },
+      { value: 800, label: '800' }
+    ])
+    expect(out).toEqual([
+      { index: 0, mw: 25, label: '25' },
+      { index: 1, mw: 800, label: '800' } // NOT index 2 — the zero row is skipped
+    ])
+  })
+
+  it('returns an empty list for an all-zero table', () => {
+    expect(deriveVtxPowerLevels([{ value: 0, label: '-' }])).toEqual([])
+  })
+})

--- a/apps/web/src/view-models/vtx-power-levels.ts
+++ b/apps/web/src/view-models/vtx-power-levels.ts
@@ -1,0 +1,24 @@
+// The RC Mixer's VTX_POWER level selector stores a 0-based index into the
+// vehicle's ACTIVE (non-zero) @VTX power levels — the firmware's
+// set_power_by_index / get_power_mw_for_index walk exactly the non-zero
+// entries, so a value=0 (disabled/pit) row is dropped and the index runs over
+// the surviving list, in table order.
+
+export interface VtxPowerLevelOption {
+  /** 0-based index over the non-zero levels = the value stored in OPT bits 5-7. */
+  index: number
+  /** Protocol value (mW for Tramp/MSP, dBm/index for SmartAudio). */
+  mw: number
+  label: string
+}
+
+export function deriveVtxPowerLevels(
+  powerLevels: readonly { value: number; label: string }[] | undefined
+): VtxPowerLevelOption[] | undefined {
+  if (!powerLevels) {
+    return undefined
+  }
+  return powerLevels
+    .filter((level) => level.value !== 0)
+    .map((level, index) => ({ index, mw: level.value, label: level.label }))
+}

--- a/apps/web/src/views/RcMixer.tsx
+++ b/apps/web/src/views/RcMixer.tsx
@@ -76,6 +76,75 @@ const TRACK_TICKS = [
 // channel are visually distinct without needing a per-function colour map.
 const BAND_HUES = [210, 285, 30, 150, 0, 60] as const
 
+/** Human display for a @VTX power level. `value` is the protocol value — mW for
+ *  Tramp/MSP but dBm/index for SmartAudio — so prefer the author-set label and
+ *  append "mW" only when the label is a bare number (a real milliwatt figure). */
+function powerLevelDisplay(level: { mw: number; label: string }): string {
+  const label = level.label?.trim()
+  if (label) {
+    return /^\d+$/.test(label) ? `${label} mW` : label
+  }
+  return `${level.mw} mW`
+}
+
+/** The VTX-power level selector shared by range rows and logic terms. Only shown
+ *  for a VTX-power target on the firmware-backed path. Handles three edge cases
+ *  the audit flagged: an out-of-range stored index (adds a synthetic option so
+ *  the row doesn't silently read "Full power"), and a stored level with NO
+ *  detected table (surfaces it with a reset instead of leaving it invisible). */
+function VtxLevelSelector(props: {
+  functionId: number
+  levelMode: boolean | undefined
+  outputLevel: number | undefined
+  vtxPowerLevels: readonly { index: number; mw: number; label: string }[] | undefined
+  firmwareSupported: boolean
+  testId: string
+  onChange: (patch: { levelMode: boolean; outputLevel?: number }) => void
+}) {
+  const { functionId, levelMode, outputLevel, vtxPowerLevels, firmwareSupported, testId, onChange } = props
+  if (!firmwareSupported || !isRcLogicLevelSelectFunction(functionId)) {
+    return null
+  }
+  const level = outputLevel ?? 0
+  if (!vtxPowerLevels || vtxPowerLevels.length === 0) {
+    // No VTX table detected. Don't offer a picker with no options — but if a
+    // level is already stored, surface it (else it's invisible + uneditable).
+    if (!levelMode) {
+      return null
+    }
+    return (
+      <div className="rc-mixer-vtx-level-note" data-testid={`${testId}-notable`}>
+        <small>⚠ Level {level} set — no VTX table detected.</small>
+        <button type="button" style={buttonStyle()} onClick={() => onChange({ levelMode: false })}>
+          Reset to full power
+        </button>
+      </div>
+    )
+  }
+  const outOfRange = levelMode === true && !vtxPowerLevels.some((entry) => entry.index === level)
+  return (
+    <label className="rc-mixer-assignment__position">
+      <span>VTX power</span>
+      <select
+        value={levelMode ? String(level) : 'plain'}
+        onChange={(event) => {
+          const raw = event.target.value
+          onChange(raw === 'plain' ? { levelMode: false } : { levelMode: true, outputLevel: Number(raw) })
+        }}
+        data-testid={testId}
+      >
+        <option value="plain">Full power (on/off) — max</option>
+        {vtxPowerLevels.map((entry) => (
+          <option key={entry.index} value={String(entry.index)}>
+            {powerLevelDisplay(entry)}
+          </option>
+        ))}
+        {outOfRange ? <option value={String(level)}>level {level} (not in current table)</option> : null}
+      </select>
+    </label>
+  )
+}
+
 export interface RcMixerViewProps {
   /** RC channels 1..maxChannel, each with zero or more assignments. */
   channels: readonly { channel: number; assignments: readonly RcMixerAssignment[] }[]
@@ -157,7 +226,7 @@ export function RcMixerView(props: RcMixerViewProps) {
       return 'max'
     }
     const level = vtxPowerLevels.find((entry) => entry.index === (outputLevel ?? 0))
-    return level ? `${level.mw} mW` : `level ${outputLevel ?? 0}`
+    return level ? powerLevelDisplay(level) : `level ${outputLevel ?? 0}`
   }
 
   // Drag-to-resize the PWM range bands (Betaflight-style). The band edges and the
@@ -496,34 +565,15 @@ export function RcMixerView(props: RcMixerViewProps) {
                               />
                               <span>Inverted</span>
                             </label>
-                            {firmwareSupported &&
-                            isRcLogicLevelSelectFunction(assignment.functionId) &&
-                            vtxPowerLevels &&
-                            vtxPowerLevels.length > 0 ? (
-                              <label className="rc-mixer-assignment__position">
-                                <span>VTX power</span>
-                                <select
-                                  value={assignment.levelMode ? String(assignment.outputLevel ?? 0) : 'plain'}
-                                  onChange={(event) => {
-                                    const raw = event.target.value
-                                    onUpdateAssignment(
-                                      assignment.id,
-                                      raw === 'plain'
-                                        ? { levelMode: false }
-                                        : { levelMode: true, outputLevel: Number(raw) }
-                                    )
-                                  }}
-                                  data-testid={`rc-mixer-level-${assignment.id}`}
-                                >
-                                  <option value="plain">Full power (on/off) — max</option>
-                                  {vtxPowerLevels.map((level) => (
-                                    <option key={level.index} value={String(level.index)}>
-                                      {level.mw} mW{level.label && level.label !== String(level.mw) ? ` (${level.label})` : ''}
-                                    </option>
-                                  ))}
-                                </select>
-                              </label>
-                            ) : null}
+                            <VtxLevelSelector
+                              functionId={assignment.functionId}
+                              levelMode={assignment.levelMode}
+                              outputLevel={assignment.outputLevel}
+                              vtxPowerLevels={vtxPowerLevels}
+                              firmwareSupported={firmwareSupported}
+                              testId={`rc-mixer-level-${assignment.id}`}
+                              onChange={(patch) => onUpdateAssignment(assignment.id, patch)}
+                            />
                           </div>
 
                           <div className="rc-mixer-assignment__status">
@@ -633,29 +683,15 @@ export function RcMixerView(props: RcMixerViewProps) {
                           ))}
                         </select>
                       </label>
-                      {isRcLogicLevelSelectFunction(term.functionId) && vtxPowerLevels && vtxPowerLevels.length > 0 ? (
-                        <label>
-                          <span>VTX power</span>
-                          <select
-                            value={term.levelMode ? String(term.outputLevel ?? 0) : 'plain'}
-                            onChange={(event) => {
-                              const raw = event.target.value
-                              onUpdateLogicTerm?.(
-                                term.id,
-                                raw === 'plain' ? { levelMode: false } : { levelMode: true, outputLevel: Number(raw) }
-                              )
-                            }}
-                            data-testid={`rc-mixer-logic-level-${term.id}`}
-                          >
-                            <option value="plain">Full power (on/off) — max</option>
-                            {vtxPowerLevels.map((level) => (
-                              <option key={level.index} value={String(level.index)}>
-                                {level.mw} mW{level.label && level.label !== String(level.mw) ? ` (${level.label})` : ''}
-                              </option>
-                            ))}
-                          </select>
-                        </label>
-                      ) : null}
+                      <VtxLevelSelector
+                        functionId={term.functionId}
+                        levelMode={term.levelMode}
+                        outputLevel={term.outputLevel}
+                        vtxPowerLevels={vtxPowerLevels}
+                        firmwareSupported={firmwareSupported}
+                        testId={`rc-mixer-logic-level-${term.id}`}
+                        onChange={(patch) => onUpdateLogicTerm?.(term.id, patch)}
+                      />
                       <label className="rc-mixer-logic-term__negate">
                         <input
                           type="checkbox"

--- a/packages/param-metadata/src/shared-rc-logic.ts
+++ b/packages/param-metadata/src/shared-rc-logic.ts
@@ -273,6 +273,11 @@ export function buildRcLogicParameterDefinitions(): FirmwareMetadataBundle['para
       description:
         'Enable the RC logic / range-function engine — activates ArduPilot AUX functions from RC channel PWM ranges (Betaflight-style Modes/Adjustments).',
       category: RC_LOGIC_CATEGORY,
+      // AP_PARAM_FLAG_ENABLE on the whole RCL subgroup — enabling it + writing
+      // terms in one batch must send RCL_ENABLE first (the RCL<n>_* sub-tree is
+      // hidden/non-echoing while disabled). The batch writer treats a "_ENABLE"
+      // enableGate as a feature master-enable, ordering it ahead of everything.
+      enableGate: true,
       options: [
         { value: 0, label: 'Disabled' },
         { value: 1, label: 'Enabled' }

--- a/tests/e2e/rc-mixer.spec.ts
+++ b/tests/e2e/rc-mixer.spec.ts
@@ -75,7 +75,7 @@ test.describe('RC Mixer (AP_RC_Logic)', () => {
     // channel drives an exact VTX power level (selector mode). Defaults to plain.
     const level = page.getByTestId('rc-mixer-level-rcl-3')
     await expect(level).toHaveValue('plain', { timeout: 15000 })
-    await expect(level.locator('option')).toContainText(['Full power (on/off) — max', '25 mW', '200 mW', '500 mW', '800 mW (1W)'])
+    await expect(level.locator('option')).toContainText(['Full power (on/off) — max', '25 mW', '200 mW', '500 mW', '1W'])
     await level.selectOption('2') // 500 mW
     await expect(level).toHaveValue('2')
     // The row band shows the resolved power at a glance, not just in the dropdown.


### PR DESCRIPTION
A parallel adversarial audit of this session's RC Mixer work confirmed the firmware encoding is an **exact mirror** and the bug-hunt batch is correct; these are the confirmed follow-ups it surfaced.

## Fixes
- **[HIGH] VTX level index → detected table.** The level index now resolves against the DETECTED (saved) `@VTX` table, not the editable draft, so unsaved VTX-table edits can't shift the RCL index / mW label. `useVtxTable` exposes `detected`; level list derived by the new tested `deriveVtxPowerLevels` (non-zero filter + 0-based re-index — mirrors the firmware active-level walk, incl. a mid-zero level shifting survivors).
- **[HIGH] Freed-slot re-add no longer hidden.** Re-allocated RCL slots are unmarked from the removed-terms set, so re-adding into a reused slot doesn't leave the new (FUNC=0) row hidden.
- **[MED] RCL_ENABLE ordered first.** `RCL_ENABLE` (confirmed `AP_PARAM_FLAG_ENABLE` over the `RCLn_*` subtree) is now an `enableGate`, and `orderDraftsByEnableGate` orders a `_ENABLE` feature master-enable ahead of the whole feature — enabling the engine + writing terms in one apply sends `RCL_ENABLE` first.
- **[MED] Level-selector edge cases** (extracted to a shared `VtxLevelSelector`): out-of-range stored index shows "level N (not in current table)" instead of silently "Full power"; a stored level with no detected table is surfaced with "Reset to full power" instead of invisible.
- **[LOW] SmartAudio label** — uses the table's author-set label (append "mW" only for a bare number), so a dBm value isn't mislabeled "mW".
- Hygiene: dropped the dead `modeSwitchActivity` prop hop.

## ArduCopter byte-identical
RCL is fork-only, Expert+RCL-gated; presentational + draft-layer + write-ordering only. `RCL_ENABLE`-first ordering only reorders batches containing an `enableGate` param.

## Validation ladder
Rung 1 web vitest (506, new `vtx-power-levels` + `RCL_ENABLE`-ordering tests) · Rung 3 full Playwright e2e (205 passed).