### PR TITLE
fix(rc-mixer): stage RCL MIN/MAX as integers so writes confirm on the first apply

### DIFF
--- a/apps/web/src/view-models/rc-logic.test.ts
+++ b/apps/web/src/view-models/rc-logic.test.ts
@@ -90,6 +90,17 @@ describe('rcLogic draft mappers', () => {
     expect(rcLogicAddDrafts(full, 8)).toBeNull()
   })
 
+  it('rounds fractional MIN/MAX to integers (Int16 params must match the FC readback)', () => {
+    // A band drag can produce a fractional PWM; staging it verbatim would never
+    // confirm against the Int16 the FC stores, timing out the verified write.
+    const drafts = rcLogicUpdateDrafts(params({}), {}, 1, {
+      lowPwm: 1289.9074734910278,
+      highPwm: 1689.9074734910278
+    })
+    expect(drafts.RCL1_MIN).toBe('1290')
+    expect(drafts.RCL1_MAX).toBe('1690')
+  })
+
   it('folds inverted into OPT bit 3 while preserving other option bits', () => {
     // OPT already has combine=AND (bit2); toggling inverted must keep it.
     const drafts = rcLogicUpdateDrafts(params({ RCL1_OPT: 0b0100 }), {}, 1, { functionId: 22, inverted: true })

--- a/apps/web/src/view-models/rc-logic.ts
+++ b/apps/web/src/view-models/rc-logic.ts
@@ -218,8 +218,11 @@ export function rcLogicUpdateDrafts(
   const next: ParameterDraftValues = {}
   if (patch.functionId !== undefined) next[ids.func] = String(patch.functionId)
   if (patch.channel !== undefined) next[ids.src] = String(patch.channel)
-  if (patch.lowPwm !== undefined) next[ids.min] = String(patch.lowPwm)
-  if (patch.highPwm !== undefined) next[ids.max] = String(patch.highPwm)
+  // RCL<n>_MIN/MAX are Int16 PWM — always stage an integer. A fractional value
+  // (e.g. from a band drag) can never equal the Int16 the FC stores, so the
+  // verified write would never confirm and would burn the full readback timeout.
+  if (patch.lowPwm !== undefined) next[ids.min] = String(Math.round(patch.lowPwm))
+  if (patch.highPwm !== undefined) next[ids.max] = String(Math.round(patch.highPwm))
   // Negate (bit 3) and the level field (bit 4 mode + bits 5-7 index) all live in
   // OPT — fold every OPT-affecting change into one value read from the existing
   // OPT so they don't clobber each other. Switching to a function that has no

--- a/apps/web/src/views/RcMixer.tsx
+++ b/apps/web/src/views/RcMixer.tsx
@@ -279,7 +279,10 @@ export function RcMixerView(props: RcMixerViewProps) {
       rail,
       low: assignment.lowPwm,
       high: assignment.highPwm,
-      grabPwm: pwmFromClientX(event.clientX, rail)
+      // Snap the grab point too, so a "move" drag's delta (pwm - grabPwm) is a
+      // clean multiple of the grid step rather than a fractional value that
+      // would drift MIN/MAX off an integer.
+      grabPwm: snapPwm(pwmFromClientX(event.clientX, rail))
     })
   }
 


### PR DESCRIPTION
## What

RC Mixer band edits to `RCL<n>_MIN/MAX` took two applies to "take" and burned a 15s timeout on the first. Root cause: the move-drag captured its grab point *unsnapped* but compared it to a snapped pwm, so the move delta was fractional (e.g. `+0.907`). Both edges drifted off an integer and were staged verbatim.

`RCL<n>_MIN/MAX` are **Int16** PWM params, so the FC truncates to `1690` and stores it — the value reached the FC and persisted across reboot the whole time. But the verified write waits for a `PARAM_VALUE` echo equal to `1689.907`, which the Int16 echo can never match → first apply reports "unconfirmed" and times out → second apply re-diffs against the now-integer FC value and confirms instantly.

## Fix

- **`rc-logic.ts`** — round MIN/MAX to integers when staging. Robust: every edit source (drag, number input) flows through `rcLogicUpdateDrafts`.
- **`RcMixer.tsx`** — snap the drag grab point so the move delta is a clean grid step, not a fractional drift.

## Validation (ladder)

1. Mock runtime — `npm run test` / web vitest: **507 pass** (new rounding test in `rc-logic.test.ts`).
2. Playwright e2e — **full suite 205 pass**, 6 visual skipped (RC Mixer drag + round-trip specs included).

Beacon grep-guard clean.

## ArduCopter byte-identical

RC Mixer is Expert + RCL-gated; not on the ArduCopter path.