### PR TITLE
fix(setup): correct the Outputs guided-step hint to the current review-only gate

### DIFF
--- a/apps/web/src/view-models/guided-setup-overview.test.ts
+++ b/apps/web/src/view-models/guided-setup-overview.test.ts
@@ -206,7 +206,8 @@ describe('buildGuidedSetupOverview', () => {
     const outputs = buildGuidedSetupOverview(
       baseInputs({ setupFlowSections: [section({ id: 'outputs', sequenceState: 'current' })], selectedSetupSectionId: 'outputs' })
     )
-    expect(outputs.guidedSetupContextHint).toContain('motor-verification bench')
+    expect(outputs.guidedSetupContextHint).toContain('Motors bench')
+    expect(outputs.guidedSetupContextHint).toContain('reviewed and confirmed here')
 
     const other = buildGuidedSetupOverview(
       baseInputs({ setupFlowSections: [section({ id: 'battery', sequenceState: 'current' })], selectedSetupSectionId: 'battery' })

--- a/apps/web/src/view-models/guided-setup-overview.ts
+++ b/apps/web/src/view-models/guided-setup-overview.ts
@@ -177,7 +177,7 @@ export function buildGuidedSetupOverview(inputs: GuidedSetupOverviewInputs): Gui
     selectedSetupSection?.id === 'airframe'
       ? 'Opening the board-orientation page does not complete this step. The orientation check must pass and the airframe review must still be confirmed here.'
       : selectedSetupSection?.id === 'outputs'
-        ? 'Opening the motor-verification bench does not complete this step. Motor order verification plus the output and ESC reviews still need to be completed.'
+        ? 'Opening the Motors bench does not complete this step. The output map still needs to be reviewed and confirmed here — motor order and direction are checked manually in Motors → Test / Motor Setup.'
         : undefined
 
   return {


### PR DESCRIPTION
## What

The guided Setup **Outputs** step's context hint still described sub-gates that were retired in the Motors-tab redesign — *"Motor order verification plus the output and ESC reviews still need to be completed."* The actual completion gate is now only the operator's **output-map review confirmation** (`setup-flow-sections.ts:307-310`); motor order/direction is checked manually in Motors → Test / Motor Setup, not gated. Surfaced by the guided-setup audit — the gate itself was already correct, only the hint over-described.

## Change

Reword the hint + update its co-located test assertion. Presentational only.

## Validation

- `npm run typecheck` clean.
- `guided-setup-overview.test.ts` — 9 pass (assertion updated to the new wording).
- No other code/e2e referenced the old string.

## ArduCopter byte-identical

Presentational string only.