### PR TITLE
fix(rc-mixer): align the Inverted/Negate checkboxes with their labels

### DIFF
--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -8253,6 +8253,20 @@ details.metadata-settings-section:not([open]) > summary::after {
   font-size: 10px;
 }
 
+/* Reset the padding/border/full-width sizing the global `input` rule
+   (styles.css ~389) inherits onto these checkboxes — without it the native
+   box is padded and pushed away from its "Inverted"/"Negate" label. Mirrors
+   the `.scoped-checkbox-option input` reset used by the bitmask grids. */
+.rc-mixer-assignment__inverted input[type='checkbox'],
+.rc-mixer-logic-term__negate input[type='checkbox'] {
+  width: auto;
+  min-height: 0;
+  padding: 0;
+  margin: 0;
+  border: none;
+  flex: none;
+}
+
 .rc-mixer-assignment__position {
   grid-column: 1 / span 2;
   display: flex;


### PR DESCRIPTION
## What

In the RC Mixer, the `Inverted` (range term) and `Negate` (logic term) checkboxes rendered with a large gap between the box and their label text. The global `input, select, textarea` reset (`styles.css` ~389) applies `padding: 5px 8px` + a border to **every** input — including these bare checkboxes — so the native box was padded and pushed away from the word.

## Fix

Add the same reset the bitmask grids already use (`.scoped-checkbox-option input`) to `.rc-mixer-assignment__inverted input` and `.rc-mixer-logic-term__negate input`: neutralize the inherited padding/border/width so the checkbox sits at native size next to its label.

CSS-only. Web build passes.

## ArduCopter byte-identical

RC Mixer is Expert + RCL-gated; CSS only.