### PR TITLE
feat(vtx): render the @VTX table read-only for a digital/MSP VTX (learned)

### DIFF
--- a/apps/web/src/hooks/use-vtx-table.ts
+++ b/apps/web/src/hooks/use-vtx-table.ts
@@ -3,9 +3,11 @@
 // firmware exposes it the VTX view shows a real editable band/frequency grid,
 // otherwise it keeps the "Table not available" preview.
 //
-// Slice 1 scope: band FREQUENCIES are editable + savable (the hardware-validated
-// half of the firmware feature); power levels are surfaced read-only because the
-// Tramp/SmartAudio drivers don't consume the table's power values yet.
+// Bands/frequencies and power levels are both editable + savable for an analog
+// VTX — the firmware now resolves the selectable power set from this table (its
+// non-zero entries, in order), so the values are authoritative. For a digital
+// video system the table is instead learned from the goggles over MSP and the
+// VTX view renders it read-only (see VtxSection's tableLearned).
 
 import { useCallback, useEffect, useState } from 'react'
 

--- a/apps/web/src/sections/VtxSection.tsx
+++ b/apps/web/src/sections/VtxSection.tsx
@@ -13,7 +13,12 @@ import { isVtxReviewParamId } from '../param-review'
 import { readRoundedParameter } from '../selectors/parameter-read'
 import { selectViewCatalog } from '../selectors/view-catalog'
 import { selectViewDrafts } from '../selectors/view-drafts'
-import { isVtxControlSerialProtocol, type SerialPortViewModel } from '../serial-port-helpers'
+import {
+  isAnalogVtxControlSerialProtocol,
+  isDigitalVtxSerialProtocol,
+  isVtxControlSerialProtocol,
+  type SerialPortViewModel
+} from '../serial-port-helpers'
 import type { UseVtxTableResult } from '../hooks/use-vtx-table'
 import { VtxView } from '../views/Vtx'
 
@@ -73,6 +78,20 @@ export function VtxSection(props: VtxSectionProps) {
     [serialPortViewModels]
   )
 
+  // For a digital/MSP video system (DJI/HDZero/Walksnail over MSP DisplayPort)
+  // the @VTX table is LEARNED — the goggles push their bands/power into the FC
+  // over MSP_SET_VTXTABLE_*. We must not author/upload it, so the table renders
+  // read-only. An analog VTX-control link (SmartAudio/Tramp/Crossfire) means the
+  // operator authors the table, so it wins even alongside an MSP DisplayPort OSD
+  // (a common analog-VTX + digital-goggles combo): learned only when a digital
+  // VTX link exists AND no analog control link does.
+  const vtxTableLearned = useMemo(() => {
+    const ports = serialPortViewModels
+    const hasDigitalVtx = ports.some((port) => isDigitalVtxSerialProtocol(port.protocolValue))
+    const hasAnalogControl = ports.some((port) => isAnalogVtxControlSerialProtocol(port.protocolValue))
+    return hasDigitalVtx && !hasAnalogControl
+  }, [serialPortViewModels])
+
   const { entries: vtxDraftEntries, staged: vtxStagedDrafts, invalid: vtxInvalidDrafts } = useMemo(
     () => selectViewDrafts(parameterDraftEntries, isVtxReviewParamId),
     [parameterDraftEntries]
@@ -100,6 +119,7 @@ export function VtxSection(props: VtxSectionProps) {
       onApply={() => void onApplyScopedDrafts(vtxDraftEntries, 'vtx:apply', 'VTX')}
       onRevert={() => onDiscardScopedDrafts(vtxDraftEntries.map((entry) => entry.id), 'VTX')}
       vtxTable={vtxTable}
+      tableLearned={vtxTableLearned}
     />
   )
 }

--- a/apps/web/src/serial-port-helpers.test.ts
+++ b/apps/web/src/serial-port-helpers.test.ts
@@ -2,6 +2,8 @@ import { describe, expect, it } from 'vitest'
 
 import {
   describeSerialPortUsage,
+  isAnalogVtxControlSerialProtocol,
+  isDigitalVtxSerialProtocol,
   isNotificationLedServoFunction,
   isOsdSerialProtocol,
   isReceiverSerialProtocol,
@@ -43,6 +45,34 @@ describe('protocol classifiers', () => {
     expect(isOsdSerialProtocol(42)).toBe(true)
     expect(isOsdSerialProtocol(32)).toBe(true)
     expect(isOsdSerialProtocol(29)).toBe(false)
+  })
+
+  it('splits analog VTX-control links from digital (table-learning) video links', () => {
+    // Analog control = the operator authors the @VTX table.
+    expect(isAnalogVtxControlSerialProtocol(37)).toBe(true) // SmartAudio
+    expect(isAnalogVtxControlSerialProtocol(44)).toBe(true) // IRC Tramp
+    expect(isAnalogVtxControlSerialProtocol(29)).toBe(true) // Crossfire VTX
+    expect(isAnalogVtxControlSerialProtocol(33)).toBe(false) // DJI is digital
+    expect(isAnalogVtxControlSerialProtocol(42)).toBe(false) // DisplayPort is digital
+
+    // Digital = the goggles push (learn) the table over MSP.
+    expect(isDigitalVtxSerialProtocol(42)).toBe(true) // MSP DisplayPort
+    expect(isDigitalVtxSerialProtocol(33)).toBe(true) // DJI FPV
+    expect(isDigitalVtxSerialProtocol(32)).toBe(false) // plain MSP telemetry is not a VTX
+    expect(isDigitalVtxSerialProtocol(37)).toBe(false) // SmartAudio is analog
+
+    // The demo's SmartAudio (37) + DisplayPort (42) combo: analog control is
+    // present, so the table stays operator-authored (editable), not learned.
+    const demo = [37, 42]
+    const learned =
+      demo.some((p) => isDigitalVtxSerialProtocol(p)) && !demo.some((p) => isAnalogVtxControlSerialProtocol(p))
+    expect(learned).toBe(false)
+    // A pure digital rig (DisplayPort only) learns the table.
+    const digitalOnly = [42]
+    expect(
+      digitalOnly.some((p) => isDigitalVtxSerialProtocol(p)) &&
+        !digitalOnly.some((p) => isAnalogVtxControlSerialProtocol(p))
+    ).toBe(true)
   })
 
   it('flags only the NeoPixel/notification LED servo-function band (120..123)', () => {

--- a/apps/web/src/serial-port-helpers.ts
+++ b/apps/web/src/serial-port-helpers.ts
@@ -102,6 +102,19 @@ export function isVtxControlSerialProtocol(protocolValue: number | undefined): b
   return protocolValue === 29 || protocolValue === 33 || protocolValue === 37 || protocolValue === 44
 }
 
+/** Analog VTX control links — the operator authors the @VTX table for these.
+ *  29 Crossfire VTX, 37 SmartAudio, 44 IRC Tramp. */
+export function isAnalogVtxControlSerialProtocol(protocolValue: number | undefined): boolean {
+  return protocolValue === 29 || protocolValue === 37 || protocolValue === 44
+}
+
+/** Digital VTX video systems that LEARN the @VTX table (goggles push it over
+ *  MSP): 33 DJI FPV, 42 MSP DisplayPort. Generic MSP (32) is excluded — a plain
+ *  MSP telemetry link is not necessarily a video system. */
+export function isDigitalVtxSerialProtocol(protocolValue: number | undefined): boolean {
+  return protocolValue === 33 || protocolValue === 42
+}
+
 /** 32 MSP, 33 DJI FPV, 42 DisplayPort — the OSD-bearing links. */
 export function isOsdSerialProtocol(protocolValue: number | undefined): boolean {
   return protocolValue === 32 || protocolValue === 33 || protocolValue === 42

--- a/apps/web/src/views/Vtx.tsx
+++ b/apps/web/src/views/Vtx.tsx
@@ -39,6 +39,9 @@ export interface VtxViewProps {
   onRevert: () => void
   /** MAVFTP-backed VTX band/frequency table (detection + edit state). */
   vtxTable: UseVtxTableResult
+  /** True when a digital/MSP video system owns the @VTX table (learned from the
+   *  goggles over MSP). The table then renders read-only — no edit/upload. */
+  tableLearned: boolean
 }
 
 export function VtxView(props: VtxViewProps) {
@@ -62,7 +65,8 @@ export function VtxView(props: VtxViewProps) {
     isApplying,
     isBusy,
     onApply,
-    onRevert
+    onRevert,
+    tableLearned
   } = props
 
   const frequency = frequencyField?.liveValue
@@ -231,7 +235,7 @@ export function VtxView(props: VtxViewProps) {
                   ) : null}
 
                   {vtxTable.status === 'available' && vtxTable.table ? (
-                    <VtxTableEditor vtxTable={vtxTable} />
+                    <VtxTableEditor vtxTable={vtxTable} learned={tableLearned} />
                   ) : vtxTable.status === 'unavailable' ? (
                     <div className="bf-vtx-callout" data-testid="vtx-table-unavailable">
                       <StatusBadge tone="warning">Table not available</StatusBadge>
@@ -281,11 +285,13 @@ export function VtxView(props: VtxViewProps) {
 }
 
 /**
- * Editable band/frequency grid + editable power levels, shown when the firmware
- * exposes a VTX table over MAVFTP. Both halves edit the in-RAM draft and Save
- * uploads the whole table (@VTX/vtxtable.dat).
+ * Band/frequency grid + power levels, shown when the firmware exposes a VTX
+ * table over MAVFTP. For an analog VTX the operator authors it: both halves edit
+ * the in-RAM draft and Save uploads the whole table (@VTX/vtxtable.dat). For a
+ * digital/MSP video system (`learned`) the goggles own the table (pushed over
+ * MSP), so it renders read-only — no upload, import/export, or field editing.
  */
-function VtxTableEditor({ vtxTable }: { vtxTable: UseVtxTableResult }) {
+function VtxTableEditor({ vtxTable, learned }: { vtxTable: UseVtxTableResult; learned: boolean }) {
   const [importOpen, setImportOpen] = useState(false)
   const [importText, setImportText] = useState('')
   const [importError, setImportError] = useState<string | undefined>(undefined)
@@ -314,12 +320,21 @@ function VtxTableEditor({ vtxTable }: { vtxTable: UseVtxTableResult }) {
 
   return (
     <div className="bf-vtx-table" data-testid="vtx-table-editor">
-      <p className="setup-gui-box__note">
-        VTX band/frequency + power table from the flight controller (<code>@VTX/vtxtable.dat</code>). Edit any frequency
-        cell (MHz, 0 = channel disabled) or power level, then Save to upload the whole table. Factory bands use the
-        VTX&apos;s own frequency map.
-      </p>
+      {learned ? (
+        <p className="setup-gui-box__note" data-testid="vtx-table-learned-note">
+          This band/frequency + power table (<code>@VTX/vtxtable.dat</code>) is provided by your digital VTX and learned
+          over MSP, so it is read-only here. Analog VTXs (SmartAudio/Tramp) let you author and upload the table.
+        </p>
+      ) : (
+        <p className="setup-gui-box__note">
+          VTX band/frequency + power table from the flight controller (<code>@VTX/vtxtable.dat</code>). Edit any frequency
+          cell (MHz, 0 = channel disabled) or power level, then Save to upload the whole table. Factory bands use the
+          VTX&apos;s own frequency map.
+        </p>
+      )}
 
+      {learned ? null : (
+      <>
       <div className="bf-vtx-table__io" data-testid="vtx-table-io">
         <button
           type="button"
@@ -393,6 +408,8 @@ function VtxTableEditor({ vtxTable }: { vtxTable: UseVtxTableResult }) {
           ) : null}
         </div>
       ) : null}
+      </>
+      )}
       <div className="bf-vtx-table__scroll">
         <table className="bf-vtx-table__grid">
           <thead>
@@ -423,6 +440,7 @@ function VtxTableEditor({ vtxTable }: { vtxTable: UseVtxTableResult }) {
                       step={1}
                       data-testid={`vtx-table-freq-${bandIndex}-${channel}`}
                       value={band.frequencies[channel] ?? 0}
+                      disabled={learned}
                       onChange={(event) =>
                         vtxTable.setFrequency(bandIndex, channel, Number(event.target.value))
                       }
@@ -458,6 +476,7 @@ function VtxTableEditor({ vtxTable }: { vtxTable: UseVtxTableResult }) {
                     step={1}
                     data-testid={`vtx-table-power-value-${index}`}
                     value={level.value}
+                    disabled={learned}
                     onChange={(event) => vtxTable.setPowerValue(index, Number(event.target.value))}
                   />
                 </td>
@@ -467,6 +486,7 @@ function VtxTableEditor({ vtxTable }: { vtxTable: UseVtxTableResult }) {
                     maxLength={3}
                     data-testid={`vtx-table-power-label-${index}`}
                     value={level.label}
+                    disabled={learned}
                     onChange={(event) => vtxTable.setPowerLabel(index, event.target.value)}
                   />
                 </td>
@@ -475,8 +495,8 @@ function VtxTableEditor({ vtxTable }: { vtxTable: UseVtxTableResult }) {
           </tbody>
         </table>
         <small>
-          Protocol value sent to the VTX (mW for Tramp; index/dBm for SmartAudio) plus a short display label. Saved as
-          part of the table upload.
+          Protocol value sent to the VTX (mW for Tramp; index/dBm for SmartAudio; dBm for MSP digital) plus a short
+          display label. The firmware resolves an exact power level by its position in this table.
         </small>
       </div>
 
@@ -487,26 +507,28 @@ function VtxTableEditor({ vtxTable }: { vtxTable: UseVtxTableResult }) {
         </div>
       ) : null}
 
-      <div className="bf-vtx-table__actions">
-        <button
-          type="button"
-          style={buttonStyle('primary')}
-          data-testid="vtx-table-save"
-          onClick={vtxTable.save}
-          disabled={!vtxTable.dirty || vtxTable.saving}
-        >
-          {vtxTable.saving ? 'Uploading…' : vtxTable.dirty ? 'Save VTX Table' : 'Saved'}
-        </button>
-        <button
-          type="button"
-          style={buttonStyle()}
-          data-testid="vtx-table-reset"
-          onClick={vtxTable.reset}
-          disabled={!vtxTable.dirty || vtxTable.saving}
-        >
-          Reset
-        </button>
-      </div>
+      {learned ? null : (
+        <div className="bf-vtx-table__actions">
+          <button
+            type="button"
+            style={buttonStyle('primary')}
+            data-testid="vtx-table-save"
+            onClick={vtxTable.save}
+            disabled={!vtxTable.dirty || vtxTable.saving}
+          >
+            {vtxTable.saving ? 'Uploading…' : vtxTable.dirty ? 'Save VTX Table' : 'Saved'}
+          </button>
+          <button
+            type="button"
+            style={buttonStyle()}
+            data-testid="vtx-table-reset"
+            onClick={vtxTable.reset}
+            disabled={!vtxTable.dirty || vtxTable.saving}
+          >
+            Reset
+          </button>
+        </div>
+      )}
     </div>
   )
 }

--- a/packages/ardupilot-core/src/vtx-table.ts
+++ b/packages/ardupilot-core/src/vtx-table.ts
@@ -11,10 +11,11 @@
 //   per power (numPowerLevels ×):  value[u16]  label[3]
 //   [tail] crc[u32]  = crc_crc32(0, buf, len-4)  over everything before it
 //
-// The band/frequency half is hardware-validated and stable; power-level
-// semantics (how `value` is consumed by the Tramp/SmartAudio drivers) are
-// still evolving on the firmware side, so consumers should treat power as
-// read-only for now.
+// `value` is the verbatim protocol value the VTX expects — mW for Tramp,
+// index/dBm for SmartAudio, dBm for MSP digital — and `label` is the authored
+// display string. The firmware resolves an exact power level by the position of
+// a non-zero entry in this table (index i = the i-th non-zero level, matching
+// the RC Mixer's level selector), so power is authoritative, not read-only.
 
 /** MAVLink-FTP path the firmware exposes the table blob at. */
 export const VTX_TABLE_FTP_PATH = '@VTX/vtxtable.dat'


### PR DESCRIPTION
## What

The `sfd-vtx-tables` firmware makes the `@VTX` table authoritative for power selection and lets **MSP digital video systems** (DJI/HDZero/Walksnail) push their bands/power into the FC over `MSP_SET_VTXTABLE_*`. For a digital VTX the table is **learned from the goggles**, not authored by us — so the configurator must not offer edit/upload.

## Change

- **Read-only table for a learned (digital) VTX**: disabled frequency/power fields, no Save / Betaflight import / export, and a *'provided by your digital VTX (learned over MSP)'* note. Analog VTXs keep the full editable/uploadable table.
- **Detection** (serial-port protocol): a digital VTX link (DJI `33` / MSP DisplayPort `42`) with **no** analog VTX-control link (SmartAudio `37` / Tramp `44` / Crossfire `29`) ⇒ learned/read-only. Analog control **wins** even alongside an MSP DisplayPort OSD — the common analog-VTX + digital-goggles combo (which the demo uses), so authoring stays editable there.
- **Stale comments refreshed**: the firmware now consumes the table's power values authoritatively (`value` = verbatim protocol value — mW for Tramp, dBm for SmartAudio/MSP; index i = the i-th non-zero level).

Matches the firmware exactly (`AP_VideoTX_Table`, `table_power_slot`, MSP ingest path).

## Validation

- Typecheck clean; web build OK.
- New unit tests for `isAnalogVtxControlSerialProtocol` / `isDigitalVtxSerialProtocol` + the learned-derivation combo.
- **Full Playwright suite: 205 passed** (analog VTX table edit/import/export path unchanged).
- Beacon grep-guard clean.

## Note

The digital read-only path is covered by unit tests; there's no digital-only demo scenario to exercise it end-to-end (the demo is the analog+OSD combo). A demo VTX scenario variant would be a separate follow-up.

## ArduCopter byte-identical

VTX view is Expert-gated; presentational + a serial-protocol-derived read-only flag.