### PR TITLE
feat(setup): fix guided Radio navigation, flag step completion, condense long steps

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1568,6 +1568,24 @@ export function App() {
     setShowReceiverMappingDiagnostics(false)
   }, [activeViewId])
 
+  // When a guided RC exercise finishes on the Receiver view, return to the Setup
+  // wizard so the step's completion cue + Continue are visible — otherwise the
+  // operator is stranded on Receiver with no next step. Only fires on the
+  // edge into a passing state (ref starts true so a restored/already-passed
+  // exercise on load doesn't yank the view).
+  const returnedFromExerciseRef = useRef(true)
+  useEffect(() => {
+    const exercisePassed =
+      rcRangeExercise.status === 'passed' ||
+      modeSwitchExercise.status === 'passed' ||
+      rcMappingSession.status === 'ready'
+    if (exercisePassed && !returnedFromExerciseRef.current && activeViewId === 'receiver') {
+      setActiveViewId('setup')
+      setSetupMode('wizard')
+    }
+    returnedFromExerciseRef.current = exercisePassed
+  }, [rcRangeExercise.status, modeSwitchExercise.status, rcMappingSession.status, activeViewId])
+
   useEffect(() => {
     if (outputMapping.motorOutputs.length === 0) {
       setMotorTestOutput(undefined)
@@ -2654,9 +2672,14 @@ export function App() {
         setOutputTaskOverride(outputTaskId)
       }
     }
-    const performScroll = () => {
+    const performScroll = (attemptsLeft = 8) => {
       const target = document.getElementById(scrollTargetId)
       if (!target) {
+        // The target view may still be painting (the Receiver/Motors views are
+        // heavy). Retry across a few frames instead of silently no-op'ing.
+        if (attemptsLeft > 0) {
+          requestAnimationFrame(() => performScroll(attemptsLeft - 1))
+        }
         return
       }
 
@@ -5727,32 +5750,25 @@ export function App() {
       case 'motor-verification-reset':
         handleResetMotorVerification()
         return
+      // The RC exercises live in specific Receiver tabs. Pin the matching tab
+      // (the override survives the view switch — the clear effect early-returns
+      // once activeViewId is 'receiver') and route via scrollToPanel so the
+      // header offset and the paint-aware retry are consistent with every other
+      // guided nav, instead of a bare scrollIntoView that races the heavy view.
       case 'mode-switch-exercise':
         handleStartModeSwitchExercise()
-        setActiveViewId('receiver')
-        requestAnimationFrame(() => {
-          requestAnimationFrame(() => {
-            document.getElementById('setup-panel-rc')?.scrollIntoView({ behavior: 'smooth', block: 'start' })
-          })
-        })
+        setReceiverTaskOverride('flight-modes')
+        scrollToPanel('setup-panel-rc')
         return
       case 'rc-range-exercise':
         handleStartRcRangeExercise()
-        setActiveViewId('receiver')
-        requestAnimationFrame(() => {
-          requestAnimationFrame(() => {
-            document.getElementById('setup-panel-rc')?.scrollIntoView({ behavior: 'smooth', block: 'start' })
-          })
-        })
+        setReceiverTaskOverride('endpoints')
+        scrollToPanel('setup-panel-rc')
         return
       case 'rc-mapping-exercise':
         handleStartRcMappingExercise()
-        setActiveViewId('receiver')
-        requestAnimationFrame(() => {
-          requestAnimationFrame(() => {
-            document.getElementById('setup-panel-rc')?.scrollIntoView({ behavior: 'smooth', block: 'start' })
-          })
-        })
+        setReceiverTaskOverride('mapping')
+        scrollToPanel('setup-panel-rc')
         return
       case 'confirm-step':
         if (action.sectionId) {
@@ -6971,8 +6987,13 @@ export function App() {
 
                       <SetupWizardDetail selectedSetupSection={selectedSetupSection} snapshot={snapshot} />
 
-                      {['airframe', 'accelerometer', 'compass'].includes(selectedSetupSection.id)
-                        ? renderAdditionalSettingsCard(
+                      {['airframe', 'accelerometer', 'compass'].includes(selectedSetupSection.id) ? (
+                        <details className="setup-wizard__advanced-disclosure" data-testid="setup-wizard-advanced">
+                          <summary>
+                            <strong>Advanced settings</strong>
+                            <span>board orientation, sensors &amp; related parameters</span>
+                          </summary>
+                          {renderAdditionalSettingsCard(
                             'Advanced setup settings',
                             'Board orientation, sensor, and related setup parameters stay attached to the guided flow when this step needs them.',
                             setupAdditionalGroups,
@@ -6982,8 +7003,9 @@ export function App() {
                             'setup:additional',
                             'Apply Setup Changes',
                             'advanced setup settings'
-                          )
-                        : null}
+                          )}
+                        </details>
+                      ) : null}
                     </div>
 
                     <SetupWizardAside

--- a/apps/web/src/sections/SetupWizardAside.tsx
+++ b/apps/web/src/sections/SetupWizardAside.tsx
@@ -112,7 +112,7 @@ export function SetupWizardAside({
           ) : null}
           <button
             id={SETUP_WIZARD_NEXT_STEP_ID}
-            className={`setup-wizard__continue-button${continueButtonTargeted ? ' setup-wizard__continue-button--target' : ''}`}
+            className={`setup-wizard__continue-button${continueButtonTargeted ? ' setup-wizard__continue-button--target guided-action-pulse' : ''}`}
             data-testid="setup-wizard-next-step"
             style={{
               ...buttonStyle(nextSetupSection && selectedSetupSection.status === 'complete' ? 'hero' : 'secondary'),

--- a/apps/web/src/sections/SetupWizardDetail.tsx
+++ b/apps/web/src/sections/SetupWizardDetail.tsx
@@ -36,8 +36,13 @@ export function SetupWizardDetail({ selectedSetupSection, snapshot }: SetupWizar
         />
       ) : null}
 
-      <div className="setup-flow__criteria">
-        <strong>Completion Criteria</strong>
+      <details className="setup-flow__criteria" data-testid="setup-wizard-criteria">
+        <summary>
+          <strong>Completion Criteria</strong>
+          <span className="setup-flow__criteria-count">
+            {selectedSetupSection.criteriaMetCount}/{selectedSetupSection.criteria.length} done
+          </span>
+        </summary>
         <ul>
           {selectedSetupSection.criteria.map((criterion) => (
             <li key={criterion.label} className={criterion.met ? 'is-met' : undefined}>
@@ -46,7 +51,7 @@ export function SetupWizardDetail({ selectedSetupSection, snapshot }: SetupWizar
             </li>
           ))}
         </ul>
-      </div>
+      </details>
 
       {selectedSetupSection.evidence.length > 0 ? (
         <div className="setup-wizard__evidence">

--- a/apps/web/src/sections/SetupWizardHeader.tsx
+++ b/apps/web/src/sections/SetupWizardHeader.tsx
@@ -55,6 +55,16 @@ export function SetupWizardHeader({
         </div>
       </div>
 
+      {selectedSetupSection.status === 'complete' ? (
+        <div className="setup-wizard__complete-banner" data-testid="setup-wizard-complete-banner" role="status">
+          <span className="setup-wizard__complete-check" aria-hidden="true">✓</span>
+          <strong>{selectedSetupSection.title} complete</strong>
+          <span className="setup-wizard__complete-count">
+            {selectedSetupSection.criteriaMetCount}/{selectedSetupSection.criteria.length} checks
+          </span>
+        </div>
+      ) : null}
+
       <div className="switch-exercise-progress" aria-hidden="true">
         <div className="switch-exercise-progress__fill" style={{ width: `${setupFlowProgress}%` }} />
       </div>

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -2200,6 +2200,56 @@ textarea:focus {
   gap: 10px;
 }
 
+/* The criteria checklist and the advanced-settings card are collapsible
+   disclosures so a guided step stays short — the summary carries an at-a-glance
+   progress count and the detail expands on demand. */
+.setup-flow__criteria > summary,
+.setup-wizard__advanced-disclosure > summary {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  cursor: pointer;
+  list-style: none;
+  padding: 6px 0;
+}
+.setup-flow__criteria > summary::-webkit-details-marker,
+.setup-wizard__advanced-disclosure > summary::-webkit-details-marker {
+  display: none;
+}
+.setup-flow__criteria > summary::before,
+.setup-wizard__advanced-disclosure > summary::before {
+  content: '▸';
+  color: var(--text-muted);
+  font-size: 11px;
+  transition: transform 0.15s ease;
+}
+.setup-flow__criteria[open] > summary::before,
+.setup-wizard__advanced-disclosure[open] > summary::before {
+  transform: rotate(90deg);
+}
+.setup-flow__criteria[open] > ul {
+  margin-top: 10px;
+}
+.setup-flow__criteria-count {
+  margin-left: auto;
+  color: var(--text-muted);
+  font-size: 12px;
+  text-transform: none;
+  letter-spacing: 0;
+}
+.setup-wizard__advanced-disclosure {
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  padding: 2px 12px;
+}
+.setup-wizard__advanced-disclosure > summary strong {
+  font-size: 13px;
+}
+.setup-wizard__advanced-disclosure > summary span {
+  color: var(--text-muted);
+  font-size: 12px;
+}
+
 .setup-flow__criteria strong {
   font-size: 13px;
   letter-spacing: 0.08em;
@@ -4048,6 +4098,40 @@ textarea:focus {
   border-radius: var(--radius-xl);
   border: 1px solid var(--border);
   background: linear-gradient(180deg, rgba(var(--fill-rgb), 0.98), rgba(var(--fill-rgb), 1));
+}
+
+.setup-wizard__complete-banner {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin: 12px 0 0;
+  padding: 9px 14px;
+  border-radius: var(--radius-lg);
+  border: 1px solid var(--good, #3fbf6a);
+  background: color-mix(in srgb, var(--good, #3fbf6a) 14%, transparent);
+  color: var(--text);
+  font-size: 13px;
+}
+.setup-wizard__complete-banner strong {
+  letter-spacing: -0.01em;
+}
+.setup-wizard__complete-count {
+  margin-left: auto;
+  color: var(--text-muted);
+  font-size: 12px;
+}
+.setup-wizard__complete-check {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 20px;
+  height: 20px;
+  border-radius: 999px;
+  background: var(--good, #3fbf6a);
+  color: #04140a;
+  font-size: 13px;
+  font-weight: 700;
+  flex: none;
 }
 
 .setup-wizard__header h3 {

--- a/tests/e2e/views.spec.ts
+++ b/tests/e2e/views.spec.ts
@@ -2431,6 +2431,34 @@ test.describe('ArduPlane demo', () => {
     await expect(page.getByRole('button', { name: 'Confirm Output Review' })).toBeEnabled()
   })
 
+  test('guided setup condenses long steps into disclosures and flags completion', async ({ page }) => {
+    await page.goto('/?guidedSetupStep=airframe')
+    await page.getByTestId('transport-mode-select').selectOption('demo')
+    await page.getByTestId('connect-button').click()
+    await expect(page.getByTestId('session-vehicle-name')).toHaveText('ArduCopter', { timeout: VEHICLE_CONNECT_TIMEOUT })
+    await expect(page.getByTestId('setup-wizard')).toBeVisible()
+
+    // The completion-criteria checklist is collapsed into a disclosure with an
+    // at-a-glance "N/N done" summary, so the checklist items are hidden until
+    // expanded — this is the anti-scrolling condense pass.
+    const criteria = page.getByTestId('setup-wizard-criteria')
+    await expect(criteria).toContainText('done')
+    const firstCriterion = criteria.locator('li').first()
+    await expect(firstCriterion).toBeHidden()
+    await criteria.locator('summary').click()
+    await expect(firstCriterion).toBeVisible()
+
+    // The advanced-settings parameter editor is behind its own disclosure on the
+    // airframe step instead of always stacked open below the checklist.
+    await expect(page.getByTestId('setup-wizard-advanced')).toBeVisible()
+
+    // A completed step surfaces an explicit completion banner (Vehicle Link is
+    // complete once connected + params synced), navigated via the step rail so
+    // the live session is preserved.
+    await page.getByRole('button', { name: /Vehicle Link/ }).click()
+    await expect(page.getByTestId('setup-wizard-complete-banner')).toContainText('complete')
+  })
+
   test('Plane Outputs Direction & Test shows an honest note, not the quad motor bench', async ({ page }) => {
     await page.goto('/')
     await page.getByTestId('transport-mode-select').selectOption('demo-plane')


### PR DESCRIPTION
Three UX fixes to the guided Setup flow, from field feedback (Radio mis-navigates, completion isn't obvious, pages are too long). All UI/navigation-layer only.

## 1. Radio navigation
- **Lands on the right Receiver tab.** The RC exercises (stick/mapping/mode-switch) dropped you at the *top* of the Receiver view on an arbitrary tab (the start-handlers never pinned a tab). Each now sets `receiverTaskOverride` to the matching tab (`endpoints`/`mapping`/`flight-modes`) — the override survives the view switch (the clear-effect early-returns once the view is `receiver`).
- **One scroll mechanism.** Replaced the three hardcoded `scrollIntoView({block:'start'})` calls (no header offset, raced the heavy view) with `scrollToPanel`, so header offset + paint-aware retry match every other guided nav.
- **No more silent no-scroll.** `scrollToPanel` now retries across frames instead of no-op'ing when the target hasn't painted.
- **No more being stranded.** Finishing an RC exercise returns to the Setup wizard so the next step/Continue is visible.

## 2. Completion is explicit
- A **"✓ <Step> complete — N/N checks" banner** in the wizard header, and the **Continue button pulses** when the step is done. Previously completion was only a subtle badge/word flip.

## 3. Long steps condense
- The **completion-criteria checklist** and the **advanced-settings parameter editor** collapse into `<details>` disclosures (summary carries the "N/N done" progress), instead of stacking task card + full checklist + advanced editor all expanded.

## Validation
- Typecheck + web build clean.
- **Full Playwright suite: 205 passed.**
- New e2e: `guided setup condenses long steps into disclosures and flags completion` (collapse → expand, advanced disclosure, Vehicle-Link completion banner).
- Beacon grep-guard clean.

## ArduCopter byte-identical
UI/navigation layer only (`apps/web` views/sections/handlers/CSS). No runtime, param writes, or criteria-`met` logic touched; the wizard↔UI coupling (exercise state + `receiverTaskOverride` release on mapping complete) is preserved.