### PR TITLE
feat(tuning): make the Pilot tab's mode sections collapsible (default collapsed)

### DIFF
--- a/apps/web/src/sections/TuningCopterSection.tsx
+++ b/apps/web/src/sections/TuningCopterSection.tsx
@@ -215,10 +215,10 @@ export function TuningCopterSection(props: TuningCopterSectionProps): ReactEleme
           <>
                 {activeTuningTaskId === 'rates' ? (
                   <div className="tuning-task-panel tuning-task-panel--stack">
-                    <section className="bf-gui-box">
-                      <div className="bf-gui-box__titlebar">
+                    <details className="bf-gui-box">
+                      <summary className="bf-gui-box__titlebar">
                         <strong>Angle</strong>
-                      </div>
+                      </summary>
                       <div className="bf-gui-box__body">
                         <div className="switch-exercise-card__header">
                           <div>
@@ -241,12 +241,12 @@ export function TuningCopterSection(props: TuningCopterSectionProps): ReactEleme
                           {flightFeelParameters.map((parameter) => renderTuningControl(parameter))}
                         </div>
                       </div>
-                    </section>
+                    </details>
 
-                    <section className="bf-gui-box">
-                      <div className="bf-gui-box__titlebar">
+                    <details className="bf-gui-box">
+                      <summary className="bf-gui-box__titlebar">
                         <strong>Attitude (Acro)</strong>
-                      </div>
+                      </summary>
                       <div className="bf-gui-box__body">
                         <div className="switch-exercise-card__header">
                           <div>
@@ -268,12 +268,12 @@ export function TuningCopterSection(props: TuningCopterSectionProps): ReactEleme
                           {tuningAccelerationParameters.map((parameter) => renderTuningControl(parameter))}
                         </div>
                       </div>
-                    </section>
+                    </details>
 
-                    <section className="bf-gui-box">
-                      <div className="bf-gui-box__titlebar">
+                    <details className="bf-gui-box">
+                      <summary className="bf-gui-box__titlebar">
                         <strong>Alt Hold</strong>
-                      </div>
+                      </summary>
                       <div className="bf-gui-box__body">
                         <div className="switch-exercise-card__header">
                           <div>
@@ -290,12 +290,12 @@ export function TuningCopterSection(props: TuningCopterSectionProps): ReactEleme
                           <p className="bf-note">No altitude-hold pilot parameters reported by this firmware.</p>
                         )}
                       </div>
-                    </section>
+                    </details>
 
-                    <section className="bf-gui-box">
-                      <div className="bf-gui-box__titlebar">
+                    <details className="bf-gui-box">
+                      <summary className="bf-gui-box__titlebar">
                         <strong>Loiter</strong>
-                      </div>
+                      </summary>
                       <div className="bf-gui-box__body">
                         <div className="switch-exercise-card__header">
                           <div>
@@ -312,7 +312,7 @@ export function TuningCopterSection(props: TuningCopterSectionProps): ReactEleme
                           <p className="bf-note">No loiter pilot parameters reported by this firmware.</p>
                         )}
                       </div>
-                    </section>
+                    </details>
                   </div>
                 ) : null}
 

--- a/tests/e2e/views.spec.ts
+++ b/tests/e2e/views.spec.ts
@@ -839,9 +839,11 @@ test.describe('Tuning tab', () => {
     await connectViaHeader(page)
     await openView(page, 'tuning')
 
-    // The "rates" task renders the Flight Feel controls. The demo seeds
-    // ATC_INPUT_TC as the float32-widened 0.15000000596046448 (what a real FC
-    // reports); the number field must show it rounded, not all the digits.
+    // The "rates" (Pilot) task renders the Flight Feel controls under the
+    // collapsible Angle section (default collapsed) — expand it first. The demo
+    // seeds ATC_INPUT_TC as the float32-widened 0.15000000596046448 (what a real
+    // FC reports); the number field must show it rounded, not all the digits.
+    await page.locator('details.bf-gui-box > summary').filter({ hasText: 'Angle' }).click()
     const input = page.getByTestId('tuning-input-ATC_INPUT_TC')
     await expect(input).toBeVisible({ timeout: 10000 })
     await expect(input).toHaveValue('0.15')
@@ -852,6 +854,8 @@ test.describe('Tuning tab', () => {
     await connectViaHeader(page)
     await openView(page, 'tuning')
 
+    // Pilot modes are collapsible and default collapsed — expand Angle first.
+    await page.locator('details.bf-gui-box > summary').filter({ hasText: 'Angle' }).click()
     const input = page.getByTestId('tuning-input-ATC_INPUT_TC')
     await expect(input).toBeVisible({ timeout: 10000 })
     // The first tuning slider is the first Flight Feel control (ATC_INPUT_TC).
@@ -863,6 +867,21 @@ test.describe('Tuning tab', () => {
     await expect(input).toHaveValue('0.3')
     // Mid-drag (before release) nothing is staged.
     await expect(page.locator('.tuning-control--staged')).toHaveCount(0)
+  })
+
+  test('Pilot mode sections are collapsible and default collapsed', async ({ page }) => {
+    await page.goto('/')
+    await connectViaHeader(page)
+    await openView(page, 'tuning')
+
+    // The Pilot tab opens as a compact list of collapsible mode pills; their
+    // controls stay hidden until the operator expands a mode.
+    const angleSummary = page.locator('details.bf-gui-box > summary').filter({ hasText: 'Angle' })
+    await expect(angleSummary).toBeVisible()
+    await expect(page.getByTestId('tuning-input-ATC_INPUT_TC')).toBeHidden()
+
+    await angleSummary.click()
+    await expect(page.getByTestId('tuning-input-ATC_INPUT_TC')).toBeVisible()
   })
 })
 
@@ -2609,9 +2628,10 @@ test.describe('ArduPlane demo', () => {
 
     await openView(page, 'tuning')
 
-    // The large Copter tuning workbench is the default ('rates') tab — its
+    // The large Copter tuning workbench is the default ('rates'/Pilot) tab — its
     // ATC_INPUT_TC control is a signature workbench field and must still be
-    // present and untouched.
+    // present. It lives under the collapsible Angle section (default collapsed).
+    await page.locator('details.bf-gui-box > summary').filter({ hasText: 'Angle' }).click()
     await expect(page.getByTestId('tuning-input-ATC_INPUT_TC')).toBeVisible({ timeout: 10000 })
 
     // AutoTune now lives in its own task tab; open it to reveal the surface.


### PR DESCRIPTION
The **Pilot** (`rates`) tab stacked four always-expanded mode sections — **Angle, Attitude (Acro), Alt Hold, Loiter** — making it long and scroll-heavy.

Each is now a collapsible `<details>`, reusing the existing `details.bf-gui-box` disclosure pattern already used on the OSD tab (chevron + hidden native marker — **no new CSS**). They **default collapsed**, so the tab opens as a compact list of four mode pills you expand on demand.

**Before:** four full mode sections stacked, lots of scrolling. **After:** four collapsible pills; expand only what you're tuning.

- Copter-only surface (`TuningCopterSection`); Plane/Rover/Sub tuning untouched. Presentational — **ArduCopter byte-identical**.
- **e2e:** updated the three Copter tuning tests that read a Pilot-tab control (`ATC_INPUT_TC` lives under Angle) to expand the section first, and added a test asserting the sections default collapsed and expand on click. Tuning tab (3) + AutoTune + profile round-trip green.