### PR TITLE
fix(logs): live download progress bar + stop the mid-download freeze

### DIFF
--- a/apps/web/src/hooks/use-onboard-logs.ts
+++ b/apps/web/src/hooks/use-onboard-logs.ts
@@ -45,6 +45,8 @@ export interface OnboardLogsState {
   logNamesById: ReadonlyMap<number, string>
   activeDownloadId?: number
   activeDownloadPercent?: number
+  activeDownloadReceivedBytes?: number
+  activeDownloadTotalBytes?: number
 }
 
 export interface OnboardLogs extends OnboardLogsState {
@@ -114,12 +116,35 @@ export function useOnboardLogs(runtime: OnboardLogCapableRuntime | undefined): O
         return
       }
       const mavftpItem = mavftpItemsRef.current.get(id)
-      setState((prev) => ({ ...prev, activeDownloadId: id, activeDownloadPercent: 0 }))
+      setState((prev) => ({
+        ...prev,
+        activeDownloadId: id,
+        activeDownloadPercent: 0,
+        activeDownloadReceivedBytes: 0,
+        activeDownloadTotalBytes: log.sizeBytes || undefined
+      }))
+      // onProgress fires once per received burst packet — thousands of times for
+      // a large log. Committing state on every packet re-renders the whole app
+      // per packet and starves the paint loop, so the UI looks frozen and the
+      // percent never visibly moves. Coalesce to one update per whole-percent
+      // tick (≤101 renders total): smooth bar, no thrash.
+      let lastPercent = -1
       const onProgress = (progress: LogDownloadProgress) => {
         const percent =
           progress.totalBytes > 0 ? Math.round((progress.bytesReceived / progress.totalBytes) * 100) : 0
+        if (percent === lastPercent) {
+          return
+        }
+        lastPercent = percent
         setState((prev) =>
-          prev.activeDownloadId === id ? { ...prev, activeDownloadPercent: percent } : prev
+          prev.activeDownloadId === id
+            ? {
+                ...prev,
+                activeDownloadPercent: percent,
+                activeDownloadReceivedBytes: progress.bytesReceived,
+                activeDownloadTotalBytes: progress.totalBytes || prev.activeDownloadTotalBytes
+              }
+            : prev
         )
       }
       try {
@@ -141,7 +166,9 @@ export function useOnboardLogs(runtime: OnboardLogCapableRuntime | undefined): O
           status: 'ready',
           message: `Downloaded ${filename} (${bytes.length} bytes).`,
           activeDownloadId: undefined,
-          activeDownloadPercent: undefined
+          activeDownloadPercent: undefined,
+          activeDownloadReceivedBytes: undefined,
+          activeDownloadTotalBytes: undefined
         }))
       } catch (error) {
         setState((prev) => ({
@@ -149,7 +176,9 @@ export function useOnboardLogs(runtime: OnboardLogCapableRuntime | undefined): O
           status: 'error',
           message: error instanceof Error ? error.message : 'Onboard log download failed.',
           activeDownloadId: undefined,
-          activeDownloadPercent: undefined
+          activeDownloadPercent: undefined,
+          activeDownloadReceivedBytes: undefined,
+          activeDownloadTotalBytes: undefined
         }))
       }
     },

--- a/apps/web/src/sections/LogsSection.tsx
+++ b/apps/web/src/sections/LogsSection.tsx
@@ -138,6 +138,8 @@ export function LogsSection(props: LogsSectionProps) {
           })),
           activeDownloadId: onboardLogs.activeDownloadId,
           activeDownloadPercent: onboardLogs.activeDownloadPercent,
+          activeDownloadReceivedBytes: onboardLogs.activeDownloadReceivedBytes,
+          activeDownloadTotalBytes: onboardLogs.activeDownloadTotalBytes,
           onList: onboardLogs.list,
           onDownload: onboardLogs.download
         }}

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -12196,6 +12196,40 @@ details.metadata-settings-section:not([open]) > summary::after {
   border-bottom: none;
 }
 
+/* Download progress bar spans the full row width under the columns while a log
+   is streaming, so the operator sees continuous movement instead of a button
+   that looks frozen. */
+.logs-download-bar {
+  grid-column: 1 / -1;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-top: 2px;
+}
+
+.logs-download-bar__track {
+  flex: 1 1 auto;
+  height: 6px;
+  border-radius: 999px;
+  background: var(--surface-400, rgba(var(--edge-rgb), 0.12));
+  overflow: hidden;
+}
+
+.logs-download-bar__fill {
+  height: 100%;
+  border-radius: inherit;
+  background: var(--primary-500);
+  transition: width 0.15s linear;
+}
+
+.logs-download-bar__label {
+  flex: 0 0 auto;
+  font-family: var(--font-data);
+  font-size: 11px;
+  color: var(--text-muted);
+  font-variant-numeric: tabular-nums;
+}
+
 .modes-table__row--head {
   background: var(--bg-panel);
   font-family: var(--font-data);

--- a/apps/web/src/views/Logs.tsx
+++ b/apps/web/src/views/Logs.tsx
@@ -7,6 +7,12 @@ import {
   type ScopedFieldDraftMap
 } from './ScopedField'
 
+// Compact MB label for the download progress bar (one decimal, MiB base to
+// match the sizeLabel column). The unit suffix is rendered once by the caller.
+function formatMegabytes(bytes: number): string {
+  return (bytes / (1024 * 1024)).toFixed(1)
+}
+
 export interface LogsField {
   parameter: ParameterState
   liveValue: number | undefined
@@ -43,6 +49,8 @@ export interface OnboardLogsPanel {
   logs: readonly OnboardLogListItem[]
   activeDownloadId?: number
   activeDownloadPercent?: number
+  activeDownloadReceivedBytes?: number
+  activeDownloadTotalBytes?: number
   onList: () => void
   onDownload: (id: number) => void
 }
@@ -257,6 +265,7 @@ export function LogsView(props: LogsViewProps) {
                   <ul className="logs-onboard-list">
                     {onboardLogs.logs.map((log) => {
                       const downloading = onboardLogs.activeDownloadId === log.id
+                      const percent = onboardLogs.activeDownloadPercent ?? 0
                       return (
                         <li key={log.id} data-testid={`logs-onboard-row-${log.id}`}>
                           <span>{log.nameLabel ?? `Log ${log.id}`}</span>
@@ -269,10 +278,28 @@ export function LogsView(props: LogsViewProps) {
                             onClick={() => onboardLogs.onDownload(log.id)}
                             disabled={onboardLogs.activeDownloadId !== undefined}
                           >
-                            {downloading
-                              ? `Downloading ${onboardLogs.activeDownloadPercent ?? 0}%`
-                              : 'Download .bin'}
+                            {downloading ? `Downloading ${percent}%` : 'Download .bin'}
                           </button>
+                          {downloading ? (
+                            <div
+                              className="logs-download-bar"
+                              data-testid={`logs-onboard-progress-${log.id}`}
+                              role="progressbar"
+                              aria-valuemin={0}
+                              aria-valuemax={100}
+                              aria-valuenow={percent}
+                            >
+                              <div className="logs-download-bar__track">
+                                <div className="logs-download-bar__fill" style={{ width: `${percent}%` }} />
+                              </div>
+                              <span className="logs-download-bar__label">
+                                {percent}%
+                                {onboardLogs.activeDownloadTotalBytes
+                                  ? ` · ${formatMegabytes(onboardLogs.activeDownloadReceivedBytes ?? 0)} / ${formatMegabytes(onboardLogs.activeDownloadTotalBytes)} MB`
+                                  : ''}
+                              </span>
+                            </div>
+                          ) : null}
                         </li>
                       )
                     })}


### PR DESCRIPTION
Downloading an onboard log looked **frozen** — the only feedback was a "Downloading X%" button label, and the percent barely moved. Two problems, both fixed:

- **Freeze (root cause):** the burst/`LOG_DATA` `onProgress` callback fires **once per received packet** — thousands of times for a multi-MB log — and the hook committed React state on *every* one, re-rendering the whole app per packet and starving the paint loop. Now coalesced to **one state update per whole-percent tick** (≤101 total): smooth, no thrash.
- **Feedback:** a real full-width **progress bar** under the downloading row showing the percent and received/total MB, instead of only a button label.

Presentational + a hook-level render-coalesce — **ArduCopter byte-identical**.

**Validation:** the list/download round-trip stays out of the parallel e2e (documented MockTransport flakiness) — covered by the layered node tests. The onboard-logs wiring e2e + web vitest (511) are green, and the bar was verified live in demo mode.