### PR TITLE
test(e2e): fix app.spec tuning flows for the collapsed Pilot sections (#42 follow-up)

### DIFF
--- a/tests/e2e/app.spec.ts
+++ b/tests/e2e/app.spec.ts
@@ -86,6 +86,9 @@ async function applySingleTuningChange(page: Page, value: string): Promise<void>
   // explicitly: a prior apply leaves the Tuning task on Review (the active task
   // is now operator-driven and sticky, never auto-switched).
   await page.getByTestId('tuning-tab-rates').click()
+  // The Pilot mode sections are collapsible and default collapsed — expand
+  // Angle to reach its ATC_INPUT_TC control.
+  await page.locator('details.bf-gui-box > summary').filter({ hasText: 'Angle' }).click()
   await page.getByTestId('tuning-input-ATC_INPUT_TC').fill(value)
   await page.getByTestId('tuning-input-ATC_INPUT_TC').blur()
   // Editing stages in place and no longer auto-redirects to Review, so the
@@ -469,7 +472,9 @@ test.describe('browser configurator regression flows', () => {
     await connectToVehicle(page, 'demo')
     await openView(page, 'tuning')
 
-    // Default landing task is rates, so the flight-feel input is visible.
+    // Default landing task is rates (Pilot); its mode sections are collapsible
+    // and default collapsed — expand Angle to reach the flight-feel input.
+    await page.locator('details.bf-gui-box > summary').filter({ hasText: 'Angle' }).click()
     const input = page.getByTestId('tuning-input-ATC_INPUT_TC')
     await expect(input).toBeVisible()
 
@@ -888,6 +893,8 @@ test.describe('browser configurator regression flows', () => {
     await expect(page.getByText(/Saved snapshot "Provisioning baseline" with \d+ parameters\./)).toBeVisible()
 
     await openView(page, 'tuning')
+    // Pilot mode sections default collapsed — expand Angle to reach ATC_INPUT_TC.
+    await page.locator('details.bf-gui-box > summary').filter({ hasText: 'Angle' }).click()
     await page.getByTestId('tuning-input-ATC_INPUT_TC').fill('0.2')
 
     await openView(page, 'snapshots')


### PR DESCRIPTION
#42 made the Pilot mode sections collapsible + default collapsed and updated `views.spec.ts`, but missed the `app.spec.ts` regression flows that fill `ATC_INPUT_TC` (the shared `applySingleTuningChange` helper + two direct fills). Those `locator.fill` calls timed out on the now-hidden input — 5 failing tests a full-suite run surfaced:

- staging a tuning change stays in place
- snapshots and presets stay consistent through a tuning-write round-trip
- the post-write refresh follow-up does not block additional preset writes
- destructive acknowledgments reset when preset and snapshot diffs change
- snapshots can build a provisioning profile with batch metadata and a staged overlay

Fix: expand the Angle section before filling, mirroring the `views.spec` fix. **Test-only — no product change.** All 5 green locally.