### PR TITLE
fix(metadata): correct three safety-label / metadata-honesty defects (audit)

### DIFF
--- a/apps/web/src/modes-failsafe-helpers.ts
+++ b/apps/web/src/modes-failsafe-helpers.ts
@@ -79,27 +79,31 @@ export function genericFailsafeRow(
 }
 
 // Vehicle-correct enum label for a failsafe-action summary value.
-// ArduCopter (and pre-connect / Unknown) returns the exact ARDUCOPTER_*
-// formatter output — byte-identical. A connected non-Copter resolves the
-// label from the param's bound catalog definition (metadataByVehicle
-// gives the right per-vehicle options): Plane/Rover/Sub battery & RC
-// failsafe action enums differ from Copter's, so the Copter map would
-// otherwise show a wrong action to the operator (safety-relevant).
+//
+// Resolve from the param's bound catalog definition first so the summary card
+// matches the editor dropdown that renders the same param — including the
+// version-gated 4.7 ArduCopter label overrides. The hard-coded copterFormat is
+// 4.6-only, so on a detected 4.7 build it made the summary describe a failsafe
+// action differently from the editor a few pixels below it (safety-relevant
+// honesty bug). On 4.6 / pre-connect / Unknown the bound options ARE the
+// ARDUCOPTER_* maps, so the label is unchanged; a value with no matching option
+// (or an unsynced param) falls back to copterFormat exactly as before. A
+// connected non-Copter resolves its own per-vehicle failsafe action enum via
+// metadataByVehicle — unchanged from before.
 export function failsafeActionLabel(
   snapshot: ConfiguratorSnapshot,
   paramId: string,
   value: number | undefined,
   copterFormat: (value: number | undefined) => string
 ): string {
-  if ((snapshot.vehicle?.vehicle ?? 'ArduCopter') === 'ArduCopter') {
-    return copterFormat(value)
+  if (value !== undefined) {
+    const definition = selectParameterById(snapshot, paramId)?.definition
+    const option = definition?.options?.find((entry) => entry.value === Math.round(value))
+    if (option) {
+      return option.label
+    }
   }
-  if (value === undefined) {
-    return copterFormat(undefined)
-  }
-  const definition = selectParameterById(snapshot, paramId)?.definition
-  const option = definition?.options?.find((entry) => entry.value === Math.round(value))
-  return option ? option.label : copterFormat(value)
+  return copterFormat(value)
 }
 
 export function buildSharedBatteryFailsafeRows(snapshot: ConfiguratorSnapshot): FailsafeViewRow[] {

--- a/apps/web/src/views/Vtx.tsx
+++ b/apps/web/src/views/Vtx.tsx
@@ -517,8 +517,9 @@ function VtxTableEditor({ vtxTable, learned }: { vtxTable: UseVtxTableResult; le
           </tbody>
         </table>
         <small>
-          Protocol value sent to the VTX (mW for Tramp; index/dBm for SmartAudio; dBm for MSP digital) plus a short
-          display label. The firmware resolves an exact power level by its position in this table.
+          Power in <strong>milliwatts (mW)</strong> plus a short display label. The firmware stores the table value as mW
+          for every protocol and derives the SmartAudio dBm / dac step from it, so enter mW here (e.g. 400, not 26 dBm).
+          The exact level is resolved by its position in this table.
         </small>
       </div>
 

--- a/packages/ardupilot-core/src/vtx-table.ts
+++ b/packages/ardupilot-core/src/vtx-table.ts
@@ -11,11 +11,12 @@
 //   per power (numPowerLevels ×):  value[u16]  label[3]
 //   [tail] crc[u32]  = crc_crc32(0, buf, len-4)  over everything before it
 //
-// `value` is the verbatim protocol value the VTX expects — mW for Tramp,
-// index/dBm for SmartAudio, dBm for MSP digital — and `label` is the authored
-// display string. The firmware resolves an exact power level by the position of
-// a non-zero entry in this table (index i = the i-th non-zero level, matching
-// the RC Mixer's level selector), so power is authoritative, not read-only.
+// `value` is power in mW for every protocol — the firmware stores it as mW and
+// derives the SmartAudio dBm/dac step from it (AP_VideoTX::load_power_levels_from_table),
+// so it is NOT a raw dBm/index even for SmartAudio/MSP — and `label` is the
+// authored display string. The firmware resolves an exact power level by the
+// position of a non-zero entry in this table (index i = the i-th non-zero level,
+// matching the RC Mixer's level selector), so power is authoritative, not read-only.
 
 /** MAVLink-FTP path the firmware exposes the table blob at. */
 export const VTX_TABLE_FTP_PATH = '@VTX/vtxtable.dat'
@@ -40,7 +41,9 @@ export interface VtxTableBand {
 }
 
 export interface VtxTablePowerLevel {
-  /** Protocol value sent to the VTX (mW for Tramp, index/dBm for SmartAudio). */
+  /** Power in mW. The firmware stores this as mW for every protocol and derives
+   *  the SmartAudio dBm/dac step from it (AP_VideoTX::load_power_levels_from_table),
+   *  so it is NOT a raw dBm/index value even for SmartAudio. */
   value: number
   /** Short display label ("25", "200", "1W"); trimmed of storage padding. */
   label: string

--- a/packages/param-metadata/src/arducopter.ts
+++ b/packages/param-metadata/src/arducopter.ts
@@ -2348,7 +2348,11 @@ export const arducopterMetadata: FirmwareMetadataBundle = {
       label: 'EKF Failsafe Action',
       description: 'Action taken when the EKF flags position or velocity variance over the threshold.',
       category: 'failsafe',
-      minimum: 1,
+      // ArduPilot FS_EKF_ACTION is 0..3 (0:Report only, 1:Land, 2:AltHold,
+      // 3:Land even in Stabilize — Parameters.h enum FS_EKF_Action). The lower
+      // bound was 1, which rejected the valid "Report Only" (0) option the
+      // enum itself offers — staging it failed validation with no clear reason.
+      minimum: 0,
       maximum: 3,
       notes: advancedFailsafeNotes,
       options: enumOptions(ARDUCOPTER_FS_EKF_ACTION_LABELS)


### PR DESCRIPTION
Three audit findings, all metadata/label honesty — **no write-behaviour change**:

1. **`FS_EKF_ACTION` rejected a valid value.** Its allowed minimum was `1`, but ArduPilot's enum is `0..3` with `0:Report only` a real value (`Parameters.h FS_EKF_Action::REPORT_ONLY=0`). The dropdown offered "Report Only" while the param rejected it as below-minimum. Lowered to `0`. *(Verified against ArduPilot source — the auditor had the direction backwards; the label was right, the bound was wrong.)*
2. **Failsafe summary showed stale 4.6 labels on 4.7.** `failsafeActionLabel` short-circuited ArduCopter to the hard-coded 4.6 `copterFormat`, bypassing the version-gated metadata the editor uses — so a 4.7 build described the same action two ways on one screen. Now reads the param's bound (version-gated) definition first, falling back to `copterFormat` — provably identical on 4.6/pre-connect/Unknown, non-Copter path unchanged.
3. **VTX power-unit hint was wrong.** Claimed "dBm for SmartAudio/MSP"; the fork firmware (`AP_VideoTX::load_power_levels_from_table`) stores the value as **mW** for every protocol and derives dBm/dac from it. Corrected the hint + two code comments (entering dBm would set a wrong, regulatory-relevant power).

**ArduCopter byte-identical:** 4.6/pre-connect labels unchanged; only a detected 4.7 build sees corrected summary labels; `FS_EKF_ACTION` only widens a validation bound to match ArduPilot.

Gates: typecheck · metadata node test (66) · web vitest (511) · Failsafe + VTX e2e (8) — all green.