### PR TITLE
fix(ux): six functional / UX audit findings

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -391,7 +391,7 @@ import {
   rcLogicUpdateLogicTermDrafts
 } from './view-models/rc-logic'
 import { armSwitchAssignmentDrafts, deriveArmSwitchAssignment } from './view-models/arm-switch'
-import { type StatusTone } from './status-tone'
+import { statusToneLabel, type StatusTone } from './status-tone'
 import {
   createSavedSnapshot,
   type SavedParameterSnapshot,
@@ -1074,7 +1074,22 @@ export function App() {
       })),
     [rcAxisObservations, snapshot]
   )
-  const { results: rcDirectionResults, activeAxis: rcDirectionActiveAxis } = useLatchedRcDirections(rcDirectionInputs)
+  const { results: rcDirectionResults, activeAxis: rcDirectionActiveAxis, reset: resetRcDirections } =
+    useLatchedRcDirections(rcDirectionInputs)
+  // Re-running the guided stick-range exercise starts a fresh direction check,
+  // so clear the latched verdicts AND the captured throttle rest-baseline. The
+  // baseline is grabbed from the first throttle sample and held for the whole
+  // session; without this, a first sample taken with throttle not at rest (e.g.
+  // raised at connect) permanently poisons the throttle correct/reversed verdict
+  // with no in-app way to clear it. Fires only on the idle/passed/failed→running
+  // transition (a deliberate re-check), never mid-run.
+  const previousRcRangeStatusRef = useRef(rcRangeExercise.status)
+  useEffect(() => {
+    if (rcRangeExercise.status === 'running' && previousRcRangeStatusRef.current !== 'running') {
+      resetRcDirections()
+    }
+    previousRcRangeStatusRef.current = rcRangeExercise.status
+  }, [rcRangeExercise.status, resetRcDirections])
   const receiverChannelDisplays = useReceiverChannelDisplays({
     snapshot,
     rcChannelDisplays,
@@ -7247,7 +7262,7 @@ export function App() {
           isBatteryVerified={snapshot.liveVerification.batteryTelemetry.verified}
           batteryHealthLabel={batteryHealthLabel(snapshot)}
           batteryHealthTone={batteryHealthTone(snapshot)}
-          parameterNotice={parameterNotice ? { tone: parameterNotice.tone, toneLabel: parameterNotice.tone, text: parameterNotice.text } : null}
+          parameterNotice={parameterNotice ? { tone: parameterNotice.tone, toneLabel: statusToneLabel(parameterNotice.tone), text: parameterNotice.text } : null}
           liveMetrics={{
             voltageText: formatVoltage(snapshot.liveVerification.batteryTelemetry.voltageV),
             currentText: formatCurrent(snapshot.liveVerification.batteryTelemetry.currentA),

--- a/apps/web/src/hooks/use-mavftp-browser.ts
+++ b/apps/web/src/hooks/use-mavftp-browser.ts
@@ -8,6 +8,10 @@ import { downloadBinaryFile } from '../download-file'
 export interface MavftpCapableRuntime {
   listRemoteDirectory(path: string): Promise<MavftpDirectoryEntry[]>
   downloadRemoteFile(path: string): Promise<Uint8Array>
+  // Burst download for arbitrary files — handles the 16 MB+ regular files
+  // (logs, terrain tiles, crash dumps) the single-read downloadRemoteFile caps
+  // out on, and falls back to a single read for size-0 @SYS virtual files.
+  downloadRemoteFileBurst(path: string): Promise<Uint8Array>
   uploadRemoteFile(path: string, bytes: Uint8Array, options?: { overwrite?: boolean }): Promise<void>
   deleteRemotePath(path: string, kind: 'file' | 'directory'): Promise<void>
 }
@@ -127,7 +131,7 @@ export function useMavftpBrowser(options: UseMavftpBrowserOptions): MavftpBrowse
       setBusyAction('files:download')
       setError(undefined)
       try {
-        const bytes = await runtime.downloadRemoteFile(entry.path)
+        const bytes = await runtime.downloadRemoteFileBurst(entry.path)
         downloadBinaryFile(entry.name, bytes)
       } catch (err) {
         setError(err instanceof Error ? `Download failed: ${err.message}` : 'Download failed.')

--- a/apps/web/src/sections/PortsSection.tsx
+++ b/apps/web/src/sections/PortsSection.tsx
@@ -24,6 +24,7 @@ import { Panel, StatusBadge, buttonStyle } from '@arduconfig/ui-kit'
 import { SERIAL_BAUD_PRESET_RATES, formatBaudRate, isPresetBaudRate, parseSerialBaudInput, selectedBaudPresetValue } from '../baud-helpers'
 import type { ParameterNotice } from '../hooks/use-parameter-feedback'
 import type { UsePortsViewResult } from '../hooks/use-ports-view'
+import { statusToneLabel } from '../status-tone'
 import { LiveGpsMapCard } from '../live-gps-map'
 import { MavlinkSigningPanel } from '../mavlink-signing-panel'
 import { normalizeBitmaskValue } from '../parameter-format'
@@ -835,7 +836,7 @@ export function PortsSection(props: PortsSectionProps): ReactElement {
 
 	            {parameterNotice ? (
 	              <div className="parameter-review__notice parameter-review__notice--inline">
-	                <StatusBadge tone={parameterNotice.tone}>{parameterNotice.tone}</StatusBadge>
+	                <StatusBadge tone={parameterNotice.tone}>{statusToneLabel(parameterNotice.tone)}</StatusBadge>
 	                <p>{parameterNotice.text}</p>
 	              </div>
 	            ) : null}

--- a/apps/web/src/sections/PresetsSection.tsx
+++ b/apps/web/src/sections/PresetsSection.tsx
@@ -17,6 +17,7 @@ import type { NormalizedFirmwareMetadataBundle, NormalizedPresetDefinition, Pres
 import type { ParameterFollowUp, ParameterNotice } from '../hooks/use-parameter-feedback'
 import { formatParameterDelta, formatParameterValue } from '../parameter-format'
 import type { SavedParameterSnapshot } from '../snapshot-library'
+import { statusToneLabel } from '../status-tone'
 import { toneForPresetApplicability } from '../tone-helpers'
 import { PresetsView, type PresetsCard, type PresetsGroup } from '../views/Presets'
 
@@ -153,7 +154,7 @@ export function PresetsSection(props: PresetsSectionProps): ReactElement {
             ? `${selectedPresetChangedEntries.length} diff`
             : `${presetDefinitions.length} presets`
       }
-      notice={presetNotice ? { tone: presetNotice.tone, toneLabel: presetNotice.tone, text: presetNotice.text } : null}
+      notice={presetNotice ? { tone: presetNotice.tone, toneLabel: statusToneLabel(presetNotice.tone), text: presetNotice.text } : null}
       followUp={parameterFollowUp ? { requiresReboot: parameterFollowUp.requiresReboot, text: parameterFollowUp.text } : null}
       familiesCount={presetGroups.length}
       totalCount={presetDefinitions.length}

--- a/apps/web/src/status-tone.ts
+++ b/apps/web/src/status-tone.ts
@@ -4,3 +4,17 @@
  * type their notices without depending back on App.
  */
 export type StatusTone = 'neutral' | 'success' | 'warning' | 'danger'
+
+const STATUS_TONE_LABELS: Record<StatusTone, string> = {
+  neutral: 'Info',
+  success: 'Success',
+  warning: 'Warning',
+  danger: 'Error'
+}
+
+/** Human-readable badge text for a tone. Notice badges historically rendered
+ *  the raw tone enum ("danger" / "success") as their own label; use this so the
+ *  pill reads as a word instead of an internal enum. */
+export function statusToneLabel(tone: StatusTone): string {
+  return STATUS_TONE_LABELS[tone]
+}

--- a/apps/web/src/tuning-control.tsx
+++ b/apps/web/src/tuning-control.tsx
@@ -16,6 +16,11 @@ export function tuningInputValue(parameter: ParameterState, editedValues: Record
     if (rawValue === undefined) {
       return String(Math.round(parameter.value / 100))
     }
+    // Operator cleared the field: applyTuningEditedValue stores '' — keep it
+    // blank instead of Number('')→0 snapping the display to "0" mid-edit.
+    if (rawValue === '') {
+      return ''
+    }
 
     const parsed = Number(rawValue)
     return Number.isFinite(parsed) ? String(Math.round(parsed / 100)) : ''

--- a/apps/web/src/view-models/onboard-log-source.test.ts
+++ b/apps/web/src/view-models/onboard-log-source.test.ts
@@ -68,4 +68,25 @@ describe('mavftpEntriesToLogItems', () => {
     ])
     expect(items.map((item) => item.path)).toEqual(['/APM/LOGS/00000001.BIN', '/APM/LOGS/00000002.BIN'])
   })
+
+  it('drops non-log files (LASTLOG.TXT etc.) instead of listing them as logs', () => {
+    const items = mavftpEntriesToLogItems([
+      entry('LASTLOG.TXT', 12),
+      entry('00000001.BIN', 600),
+      entry('README', 40)
+    ])
+    expect(items.map((item) => item.name)).toEqual(['00000001.BIN'])
+  })
+
+  it('never emits two items with the same id (would collide React keys / downloads)', () => {
+    // Before the name filter, LASTLOG.TXT fell back to id index+1, which could
+    // equal a real log's number — regression guard for that collision.
+    const items = mavftpEntriesToLogItems([
+      entry('LASTLOG.TXT'), // would have been id 1 via fallback
+      entry('00000001.BIN', 600)
+    ])
+    const ids = items.map((item) => item.log.id)
+    expect(new Set(ids).size).toBe(ids.length)
+    expect(ids).toEqual([1])
+  })
 })

--- a/apps/web/src/view-models/onboard-log-source.ts
+++ b/apps/web/src/view-models/onboard-log-source.ts
@@ -41,21 +41,38 @@ export function selectOnboardLogSource(snapshot: ConfiguratorSnapshot): OnboardL
   return snapshot.hardware.board?.ftpSupported ? 'mavftp' : 'mavlink'
 }
 
+// A real ArduPilot dataflash log file: a zero-padded log number + `.BIN`.
+// `/APM/LOGS` also holds non-log files (e.g. `LASTLOG.TXT`) which must not list
+// as downloadable "logs" — and whose index-fallback id can collide with a real
+// log's number, producing duplicate React keys and an ambiguous download.
+const DATAFLASH_LOG_NAME = /^\d+\.bin$/i
+
 /**
  * Normalize MAVFTP `/APM/LOGS` entries into shared log items, sorted by id.
- * Dedupes by path: a MAVFTP directory listing can repeat an entry across a
- * pagination boundary (observed against real SITL), which would otherwise
- * produce duplicate rows and colliding React keys.
+ * Keeps only real dataflash logs (`NNNNNNNN.BIN`), and dedupes by both path and
+ * id: a listing can repeat an entry across a pagination boundary (observed on
+ * real SITL), and — before the name filter — a non-log file's fallback id could
+ * collide with a real log's number; either would produce duplicate rows and
+ * colliding React keys.
  */
 export function mavftpEntriesToLogItems(entries: readonly MavftpDirectoryEntry[]): MavftpLogItem[] {
   const byPath = new Map<string, MavftpLogItem>()
+  const seenIds = new Set<number>()
   entries.forEach((entry, index) => {
+    if (!DATAFLASH_LOG_NAME.test(entry.name.trim())) {
+      return
+    }
     if (byPath.has(entry.path)) {
       return
     }
+    const id = parseMavftpLogId(entry.name, index)
+    if (seenIds.has(id)) {
+      return
+    }
+    seenIds.add(id)
     byPath.set(entry.path, {
       log: {
-        id: parseMavftpLogId(entry.name, index),
+        id,
         sizeBytes: entry.sizeBytes ?? 0,
         // MAVFTP directory listings carry no log timestamp; the filename
         // carries identity, so the UI shows the name rather than a date.

--- a/apps/web/src/view-models/setup-flow-sections.ts
+++ b/apps/web/src/view-models/setup-flow-sections.ts
@@ -716,7 +716,15 @@ export function buildSetupFlowSections(inputs: SetupFlowSectionsInputs): SetupFl
           }
           break
         }
-        case 'radio':
+        case 'radio': {
+          const radioDirectionAxes = ['roll', 'pitch', 'throttle', 'yaw'] as const
+          const radioDirectionsVerified = radioDirectionAxes.every((axis) => rcDirectionResults[axis] === 'correct')
+          const radioReversedAxes = radioDirectionAxes.filter((axis) => rcDirectionResults[axis] === 'reversed')
+          const radioDirectionsSummary = radioDirectionsVerified
+            ? 'all axes correct'
+            : radioReversedAxes.length > 0
+              ? `reversed: ${radioReversedAxes.join(', ')}`
+              : 'not checked yet'
           criteria = [
             {
               label: 'Live RC telemetry is present',
@@ -736,9 +744,7 @@ export function buildSetupFlowSections(inputs: SetupFlowSectionsInputs): SetupFl
             },
             {
               label: 'RC channel directions verified — no axis reads backwards',
-              met: (['roll', 'pitch', 'throttle', 'yaw'] as const).every(
-                (axis) => rcDirectionResults[axis] === 'correct'
-              )
+              met: radioDirectionsVerified
             },
             {
               label: 'Operator reviewed RC mapping and calibration values',
@@ -765,15 +771,17 @@ export function buildSetupFlowSections(inputs: SetupFlowSectionsInputs): SetupFl
                 : rcCalibrationSession.status === 'failed'
                   ? rcCalibrationSession.failureReason ?? 'RC endpoint capture failed.'
                   : 'Use the guided one-axis-at-a-time receiver mapping first, then verify stick travel, capture endpoints, and sign off the full radio review.'
+          // Include directions + review: they're the two things most likely to
+          // be the actual blocker, and the old 5-item .slice(0,4) always dropped
+          // the Review pill and never surfaced directions at all.
           evidence = [
             snapshot.liveVerification.rcInput.verified
               ? `${snapshot.liveVerification.rcInput.channelCount} RC channels live`
               : 'No live RC telemetry yet',
-            `Mapping: ${rcMappingSession.status}`,
-            `Ranges: ${rcRangeExercise.status}`,
-            `Endpoints: ${rcCalibrationSession.status}`,
+            `Mapping ${rcMappingSession.status}, ranges ${rcRangeExercise.status}, endpoints ${rcCalibrationSession.status}`,
+            `Directions: ${radioDirectionsSummary}`,
             `Review: ${radioConfirmation ? `confirmed at ${formatConfirmationTime(radioConfirmation.confirmedAtMs)}` : 'pending operator confirmation'}`
-          ].slice(0, 4)
+          ]
           actions.unshift({
             kind: 'rc-mapping-exercise',
             label: rcMappingSession.status === 'ready' ? 'Run Guided Mapping Again' : 'Begin Guided Mapping',
@@ -791,11 +799,16 @@ export function buildSetupFlowSections(inputs: SetupFlowSectionsInputs): SetupFl
             label: radioConfirmation ? 'Clear RC Review' : 'Confirm RC Review',
             tone: 'secondary',
             sectionId: 'radio',
+            // Gate on directions too: without this the operator could "Confirm RC
+            // Review" (ticking the confirmation) while the step stays incomplete
+            // because the directions criterion is unmet, with the real blocker
+            // hidden in the collapsed criteria list.
             disabled:
               !snapshot.liveVerification.rcInput.verified ||
               rcMappingSession.status !== 'ready' ||
               rcRangeExercise.status !== 'passed' ||
-              rcCalibrationSession.status !== 'ready'
+              rcCalibrationSession.status !== 'ready' ||
+              !radioDirectionsVerified
           })
           actions.splice(1, 0, {
             kind: 'scroll',
@@ -830,6 +843,7 @@ export function buildSetupFlowSections(inputs: SetupFlowSectionsInputs): SetupFl
             }
           }
           break
+        }
         case 'failsafe':
           criteria = [
             {

--- a/packages/ardupilot-core/src/runtime.ts
+++ b/packages/ardupilot-core/src/runtime.ts
@@ -1057,6 +1057,18 @@ export class ArduPilotConfiguratorRuntime {
     return this.mavftp.downloadRemoteFile(path)
   }
 
+  /** Download an arbitrary remote file via MAVFTP burst read (512 MB cap),
+   *  falling back to a single read for size-0 `@SYS` virtual files. The file
+   *  browser uses this so a regular file over the 16 MB single-read cap
+   *  (an `/APM/LOGS/*.BIN`, a terrain tile, a crash dump) downloads instead of
+   *  failing with "read exceeded the 16777216-byte cap". */
+  async downloadRemoteFileBurst(
+    path: string,
+    onProgress?: (progress: LogDownloadProgress) => void
+  ): Promise<Uint8Array> {
+    return this.mavftp.downloadRemoteFileBurst(path, { onProgress, maxBytes: MAX_MAVFTP_LOG_BYTES })
+  }
+
   /**
    * Read the VTX band/power table over MAVLink FTP (@VTX/vtxtable.dat) and
    * parse it. Returns `undefined` when the firmware doesn't expose the table


### PR DESCRIPTION
Six audit findings across the app:

- **Files browser >16 MB downloads.** The browser used the single-read `downloadRemoteFile` (16 MiB cap) — every `/APM/LOGS/*.BIN`, terrain tile, or crash dump failed. Added `runtime.downloadRemoteFileBurst` (512 MB cap, single-read fallback for size-0 `@SYS`) and routed the browser to it.
- **Onboard-log list.** Keep only real dataflash logs (`NNNNNNNN.BIN`) + dedupe by id — `/APM/LOGS` also holds `LASTLOG.TXT` etc., which listed as "logs" and (via the index-fallback id) could collide with a real log's number → colliding React keys + wrong-file download. (+2 tests)
- **Guided radio step.** "Confirm RC Review" now gates on the channel-direction check, and evidence shows directions + review — it used to confirm while the step stayed incomplete with the blocker hidden, and the 5-item evidence `.slice(0,4)` always dropped the Review pill.
- **Throttle direction baseline.** Re-running the stick-range exercise resets the captured rest-baseline — a first sample off-rest used to poison the throttle verdict with no in-app clear.
- **ANGLE_MAX** stays blank when cleared instead of snapping to "0".
- **Notice badges** (Ports/Power/Presets) render a word via shared `statusToneLabel()` instead of the raw tone enum.

**ArduCopter byte-identical** (web presentational + a read-path burst download). Gates: typecheck · web vitest (513) · full e2e (208).