### PR TITLE
feat(vtx): analog power-table presets + 1600 mW + 3-char-safe labels

### DIFF
--- a/apps/web/src/hooks/use-vtx-table.ts
+++ b/apps/web/src/hooks/use-vtx-table.ts
@@ -11,7 +11,8 @@
 
 import { useCallback, useEffect, useState } from 'react'
 
-import type { VtxTable } from '@arduconfig/ardupilot-core'
+import type { VtxTable, VtxTablePowerLevel } from '@arduconfig/ardupilot-core'
+import { defaultVtxPowerLabel } from '@arduconfig/ardupilot-core'
 
 // Structural runtime slice — avoids importing the whole runtime class.
 export interface VtxTableRuntime {
@@ -35,6 +36,9 @@ export interface UseVtxTableResult {
   setFrequency: (bandIndex: number, channelIndex: number, mhz: number) => void
   setPowerValue: (index: number, value: number) => void
   setPowerLabel: (index: number, label: string) => void
+  /** Replace only the power ladder (keeps the band/frequency map) — used by the
+   *  analog power-table presets. */
+  setPowerLevels: (levels: VtxTablePowerLevel[]) => void
   /** Replace the working draft wholesale (e.g. from a Betaflight import).
    *  Marks dirty; Save then uploads it. */
   loadTable: (table: VtxTable) => void
@@ -120,7 +124,29 @@ export function useVtxTable(input: {
       const level = current.powerLevels[index]
       if (!level) return current
       const next = cloneVtxTable(current)
-      next.powerLevels[index].value = Number.isFinite(value) ? Math.max(0, Math.min(0xffff, Math.round(value))) : 0
+      const nextValue = Number.isFinite(value) ? Math.max(0, Math.min(0xffff, Math.round(value))) : 0
+      next.powerLevels[index].value = nextValue
+      // Keep the 3-char label in step with the value unless the operator has
+      // given it a custom label. The firmware label is only 3 chars, so a high
+      // value can't hold its full mW as text (1600 → "1.6"); auto-deriving a
+      // fitting label beats silently truncating what the operator typed.
+      if (level.label === '' || level.label === defaultVtxPowerLabel(level.value)) {
+        next.powerLevels[index].label = defaultVtxPowerLabel(nextValue)
+      }
+      return next
+    })
+    setDirty(true)
+  }, [])
+
+  const setPowerLevels = useCallback((levels: VtxTablePowerLevel[]) => {
+    setDraft((current) => {
+      if (!current) return current
+      const next = cloneVtxTable(current)
+      // Swap only the power ladder, keeping the existing band/frequency map.
+      next.powerLevels = levels.map((level) => ({
+        value: Number.isFinite(level.value) ? Math.max(0, Math.min(0xffff, Math.round(level.value))) : 0,
+        label: level.label.slice(0, 3)
+      }))
       return next
     })
     setDirty(true)
@@ -181,6 +207,7 @@ export function useVtxTable(input: {
     setFrequency,
     setPowerValue,
     setPowerLabel,
+    setPowerLevels,
     loadTable,
     save,
     reset,

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -3358,7 +3358,9 @@ textarea:focus {
 .bf-vtx-table__power-head {
   display: flex;
   align-items: center;
+  justify-content: space-between;
   gap: 8px;
+  flex-wrap: wrap;
 }
 .bf-vtx-table__power-grid {
   border-collapse: collapse;

--- a/apps/web/src/views/Vtx.tsx
+++ b/apps/web/src/views/Vtx.tsx
@@ -1,7 +1,13 @@
 import { useRef, useState } from 'react'
 import { Panel, StatusBadge, buttonStyle } from '@arduconfig/ui-kit'
 import type { ParameterState } from '@arduconfig/ardupilot-core'
-import { parseBetaflightVtxTable, serializeBetaflightVtxTable, VTX_TABLE_PRESETS } from '@arduconfig/ardupilot-core'
+import {
+  parseBetaflightVtxTable,
+  serializeBetaflightVtxTable,
+  VTX_TABLE_PRESETS,
+  VTX_POWER_PRESETS,
+  vtxPowerPresetLevels
+} from '@arduconfig/ardupilot-core'
 
 import type { UseVtxTableResult } from '../hooks/use-vtx-table'
 import { downloadTextFile } from '../download-file'
@@ -325,6 +331,15 @@ function VtxTableEditor({ vtxTable, learned }: { vtxTable: UseVtxTableResult; le
       applyImport(preset.table)
     }
   }
+  const handlePowerPreset = (id: string): void => {
+    const preset = VTX_POWER_PRESETS.find((candidate) => candidate.id === id)
+    if (preset) {
+      // Swap only the power ladder, keeping the band/frequency map that's
+      // already loaded (from the FC or a full preset).
+      vtxTable.setPowerLevels(vtxPowerPresetLevels(preset))
+      setImportError(undefined)
+    }
+  }
 
   return (
     <div className="bf-vtx-table" data-testid="vtx-table-editor">
@@ -478,6 +493,22 @@ function VtxTableEditor({ vtxTable, learned }: { vtxTable: UseVtxTableResult; le
       <div className="bf-vtx-table__power" data-testid="vtx-table-power">
         <div className="bf-vtx-table__power-head">
           <strong>Power levels</strong>
+          {learned ? null : (
+            <select
+              className="bf-vtx-table__preset-select"
+              data-testid="vtx-table-power-preset-select"
+              aria-label="Load a VTX power-table preset"
+              value=""
+              onChange={(event) => handlePowerPreset(event.target.value)}
+            >
+              <option value="">Load a power preset…</option>
+              {VTX_POWER_PRESETS.map((preset) => (
+                <option key={preset.id} value={preset.id} title={preset.description}>
+                  {preset.label}
+                </option>
+              ))}
+            </select>
+          )}
         </div>
         <table className="bf-vtx-table__power-grid">
           <thead>

--- a/packages/ardupilot-core/src/vtx-presets.ts
+++ b/packages/ardupilot-core/src/vtx-presets.ts
@@ -49,6 +49,28 @@ const POWER_WHOOP = [
   'vtxtable powerlabels 25 100 200',
 ].join('\n')
 
+// The firmware power label is a 3-char fixed field, so a mW value ≥ 1000 can't
+// be written out in full (e.g. "1600" would truncate to a misleading "160").
+// Derive a fitting label: the mW number under 1 W, a compact watts form above
+// it (1600 → "1.6", 1000 → "1", 2000 → "2"). Shared by the power presets and
+// the editor's value→label auto-fill.
+export function defaultVtxPowerLabel(valueMw: number): string {
+  if (!Number.isFinite(valueMw) || valueMw <= 0) {
+    return '0'
+  }
+  if (valueMw < 1000) {
+    return String(Math.round(valueMw))
+  }
+  const watts = valueMw / 1000
+  return (Number.isInteger(watts) ? String(watts) : watts.toFixed(1)).slice(0, 3)
+}
+
+const POWER_25_1600 = [
+  'vtxtable powerlevels 4',
+  'vtxtable powervalues 25 400 800 1600',
+  `vtxtable powerlabels 25 400 800 ${defaultVtxPowerLabel(1600)}`,
+].join('\n')
+
 export const VTX_TABLE_PRESETS: readonly VtxTablePresetDefinition[] = [
   {
     id: 'standard-40ch-25-600',
@@ -74,9 +96,68 @@ export const VTX_TABLE_PRESETS: readonly VtxTablePresetDefinition[] = [
     ].join('\n'),
   },
   {
+    id: 'standard-40ch-25-1600',
+    label: 'Standard 40CH · 25–1600 mW (1.6 W)',
+    description: 'Full 40CH map with a 25/400/800/1600 mW ladder for high-power analog VTX (e.g. a 1.6 W whoop VTX).',
+    table: ['vtxtable bands 5', 'vtxtable channels 8', STANDARD_40CH_BANDS, POWER_25_1600].join('\n'),
+  },
+  {
     id: 'standard-40ch-whoop',
     label: 'Standard 40CH · whoop (25–200 mW)',
     description: 'Full 40CH map with a low 25/100/200 mW ladder for tiny-whoop / indoor analog VTX.',
     table: ['vtxtable bands 5', 'vtxtable channels 8', STANDARD_40CH_BANDS, POWER_WHOOP].join('\n'),
   },
 ]
+
+/**
+ * Power-only presets — the ANALOG power ladder without touching the band /
+ * frequency map. The bands are universal (and usually already loaded from the
+ * FC), but the selectable power set varies by VTX, so this lets an operator
+ * swap just the power levels. Analog only: a digital/MSP VTX provides its own
+ * table (learned from the goggles) and renders read-only.
+ */
+export interface VtxPowerPresetDefinition {
+  id: string
+  label: string
+  description: string
+  /** mW values low → high; labels are derived to fit the 3-char firmware field. */
+  valuesMw: readonly number[]
+}
+
+export const VTX_POWER_PRESETS: readonly VtxPowerPresetDefinition[] = [
+  {
+    id: 'power-25-600',
+    label: '25 / 100 / 200 / 400 / 600 mW',
+    description: 'Common 5-step analog ladder (Tramp-native).',
+    valuesMw: [25, 100, 200, 400, 600],
+  },
+  {
+    id: 'power-25-800',
+    label: '25 / 100 / 400 / 800 mW',
+    description: 'Higher 4-step analog ladder.',
+    valuesMw: [25, 100, 400, 800],
+  },
+  {
+    id: 'power-25-500',
+    label: '25 / 200 / 500 mW',
+    description: 'SmartAudio-style 3-step ladder.',
+    valuesMw: [25, 200, 500],
+  },
+  {
+    id: 'power-25-1600',
+    label: '25 / 400 / 800 / 1600 mW (1.6 W)',
+    description: 'High-power ladder for a 1.6 W analog VTX.',
+    valuesMw: [25, 400, 800, 1600],
+  },
+  {
+    id: 'power-whoop',
+    label: '25 / 100 / 200 mW (whoop)',
+    description: 'Low-power indoor / tiny-whoop ladder.',
+    valuesMw: [25, 100, 200],
+  },
+]
+
+/** Build the `VtxTablePowerLevel[]` for a power preset, deriving 3-char labels. */
+export function vtxPowerPresetLevels(preset: VtxPowerPresetDefinition): { value: number; label: string }[] {
+  return preset.valuesMw.map((value) => ({ value, label: defaultVtxPowerLabel(value) }))
+}

--- a/tests/e2e/views.spec.ts
+++ b/tests/e2e/views.spec.ts
@@ -3788,6 +3788,33 @@ test.describe('VTX band/frequency table', () => {
     await expect(page.getByTestId('vtx-table-power-value-0')).toHaveValue('25')
     await expect(page.getByTestId('vtx-table-save')).toBeEnabled()
   })
+
+  test('loads an analog power-table preset (power-only) with a 3-char-safe 1600 mW label', async ({ page }) => {
+    await page.goto('/')
+    await connectViaHeader(page)
+    await page.getByTestId('view-button-vtx').click()
+    await expect(page.getByTestId('vtx-table-editor')).toBeVisible({ timeout: 15000 })
+
+    // The power preset swaps only the ladder (bands untouched), and the 1600 mW
+    // level's label fits the firmware's 3-char field as "1.6" (not "160").
+    await page.getByTestId('vtx-table-power-preset-select').selectOption('power-25-1600')
+    await expect(page.getByTestId('vtx-table-power-value-3')).toHaveValue('1600')
+    await expect(page.getByTestId('vtx-table-power-label-3')).toHaveValue('1.6')
+    // Bands were not touched by a power-only preset.
+    await expect(page.getByTestId('vtx-table-freq-0-0')).toHaveValue('5865')
+  })
+
+  test('editing a power value auto-derives a fitting 3-char label (1600 → 1.6)', async ({ page }) => {
+    await page.goto('/')
+    await connectViaHeader(page)
+    await page.getByTestId('view-button-vtx').click()
+    await expect(page.getByTestId('vtx-table-editor')).toBeVisible({ timeout: 15000 })
+
+    // The label field can't hold "1600" (3-char firmware limit); typing the value
+    // auto-fills a fitting label instead of leaving a misleading truncated one.
+    await page.getByTestId('vtx-table-power-value-0').fill('1600')
+    await expect(page.getByTestId('vtx-table-power-label-0')).toHaveValue('1.6')
+  })
 })
 
 test.describe('Scoped write-progress bar', () => {

--- a/tests/vtx-presets.test.mjs
+++ b/tests/vtx-presets.test.mjs
@@ -3,12 +3,16 @@ import test from 'node:test'
 
 import {
   VTX_TABLE_PRESETS,
+  VTX_POWER_PRESETS,
+  vtxPowerPresetLevels,
+  defaultVtxPowerLabel,
   parseBetaflightVtxTable,
   serializeVtxTable,
   parseVtxTable,
   VTX_TABLE_MAX_BANDS,
   VTX_TABLE_MAX_CHANNELS,
-  VTX_TABLE_MAX_POWER_LEVELS
+  VTX_TABLE_MAX_POWER_LEVELS,
+  VTX_TABLE_POWER_LABEL_LEN
 } from '../packages/ardupilot-core/dist/index.js'
 
 test('every curated VTX preset parses into a firmware-valid table', () => {
@@ -48,4 +52,44 @@ test('the standard 40CH preset carries the canonical Raceband row', () => {
   // the frequency map.
   assert.equal(raceband.frequencies[0], 5658)
   assert.equal(raceband.frequencies[7], 5917)
+})
+
+test('a 1600 mW (1.6 W) high-power preset ships and fits the 3-char label field', () => {
+  const highPower = VTX_TABLE_PRESETS.find((preset) => preset.id === 'standard-40ch-25-1600')
+  assert.ok(highPower, 'high-power 40CH preset exists')
+  const table = parseBetaflightVtxTable(highPower.table)
+  const top = table.powerLevels[table.powerLevels.length - 1]
+  assert.equal(top.value, 1600, 'top power level is 1600 mW')
+  assert.ok(top.label.length <= VTX_TABLE_POWER_LABEL_LEN, 'its label fits the fixed field')
+  assert.equal(top.label, '1.6', 'labelled as 1.6 W, not a truncated "160"')
+})
+
+test('defaultVtxPowerLabel derives a 3-char-safe label', () => {
+  assert.equal(defaultVtxPowerLabel(25), '25')
+  assert.equal(defaultVtxPowerLabel(800), '800')
+  assert.equal(defaultVtxPowerLabel(1600), '1.6')
+  assert.equal(defaultVtxPowerLabel(1000), '1')
+  assert.equal(defaultVtxPowerLabel(2500), '2.5')
+  for (const mw of [25, 100, 200, 400, 600, 800, 1000, 1600, 2000, 2500]) {
+    assert.ok(defaultVtxPowerLabel(mw).length <= VTX_TABLE_POWER_LABEL_LEN, `${mw} label fits`)
+  }
+})
+
+test('every analog power preset yields firmware-valid, label-safe levels including a 1600 mW ladder', () => {
+  assert.ok(VTX_POWER_PRESETS.length >= 1)
+  const ids = new Set()
+  for (const preset of VTX_POWER_PRESETS) {
+    assert.ok(preset.id && preset.label && preset.description)
+    assert.ok(!ids.has(preset.id), `power preset id ${preset.id} unique`)
+    ids.add(preset.id)
+    const levels = vtxPowerPresetLevels(preset)
+    assert.ok(levels.length >= 1 && levels.length <= VTX_TABLE_MAX_POWER_LEVELS, `${preset.id} level count in range`)
+    for (const level of levels) {
+      assert.ok(level.value >= 0 && level.value <= 0xffff, `${preset.id} value in u16`)
+      assert.ok(level.label.length <= VTX_TABLE_POWER_LABEL_LEN, `${preset.id} label "${level.label}" fits`)
+    }
+  }
+  const highPower = VTX_POWER_PRESETS.find((preset) => preset.id === 'power-25-1600')
+  assert.ok(highPower, 'a 1600 mW power ladder ships')
+  assert.deepEqual(highPower.valuesMw, [25, 400, 800, 1600])
 })


### PR DESCRIPTION
Follow-up to the VTX table presets, addressing three requests:

- **Power-table presets (analog).** A new "Load a power preset…" picker swaps **only** the power ladder, keeping the loaded band map (the bands are universal; the power set varies by VTX). Ladders: 25/100/200/400/600, 25/100/400/800, 25/200/500, **25/400/800/1600 (1.6 W)**, 25/100/200 (whoop). Backed by a new `setPowerLevels()` on the table hook.
- **1600 mW.** Added the high-power ladder and a full "Standard 40CH · 25–1600 mW" preset the earlier set was missing.
- **Label truncation fix.** The firmware power label is a fixed **3-char** field, so "1600" truncated to a misleading "160". New `defaultVtxPowerLabel()` derives a fitting label (1600 → **"1.6"**), used by the presets and as a value→label **auto-fill** in the editor (unless you've customised the label).

**Persistence already works:** `readVtxTable()` parses the FC's full table (bands + power) into the editor on connect — verified, no change needed.

Analog only — a digital/MSP VTX learns its table from the goggles and stays read-only. Presentational + curated data — **ArduCopter byte-identical**. Gates: typecheck · node preset/metadata tests · web vitest (513) · VTX e2e (5).