### PR TITLE
fix(apply): apply/write-path audit findings (gap-fill convergence, enable-gate ordering, +3)

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1999,6 +1999,13 @@ export function App() {
   const effectivePresetChangedEntries = selectedPresetChangedEntries.filter(
     (entry) => !droppedPresetParamIds.includes(entry.id)
   )
+  // Invalid entries the operator has NOT dropped. The apply guard must use this
+  // (not the full merged invalid set), so dropping the one metadata-invalid row
+  // unblocks applying the rest — matching snapshot restore, which filters drops
+  // before its diff.
+  const effectivePresetInvalidEntries = selectedPresetInvalidEntries.filter(
+    (entry) => !droppedPresetParamIds.includes(entry.id)
+  )
   const effectivePresetDraftValues = Object.fromEntries(
     Object.entries(selectedPresetDraftValues).filter(([paramId]) => !droppedPresetParamIds.includes(paramId))
   )
@@ -3050,7 +3057,10 @@ export function App() {
 
     const appliedParamIds: string[] = []
     setBusyAction('param:apply-all')
-    const writeRequests = stagedParameterDrafts
+    // Order by enable-gate so an AP_PARAM_FLAG_ENABLE param (e.g. RCLn_FUNC) is
+    // written before its dependent sub-params — the scoped apply path does this,
+    // and the RC Mixer's RCL drafts only reach the FC through this global bar.
+    const writeRequests = orderDraftsByEnableGate(stagedParameterDrafts)
       .filter((draft) => draft.nextValue !== undefined)
       .map((draft) => ({
         paramId: draft.id,
@@ -3164,6 +3174,21 @@ export function App() {
       })
       return
     }
+
+    // Auto-backup the live config before a provisioning overwrite — the preset
+    // and AI-assisted apply paths both snapshot first, so a bulk fleet/template
+    // apply gets the same undo safety net (batch rollback only covers a mid-write
+    // failure, not a "restore what I had before" after a successful apply).
+    const provisioningBackup = createSavedSnapshot(
+      createParameterBackup(snapshot),
+      `Before provisioning — ${selectedProvisioningProfile.label}`,
+      'captured',
+      {
+        note: `Auto-saved before applying provisioning profile "${selectedProvisioningProfile.label}".`,
+        tags: ['auto-backup', 'provisioning']
+      }
+    )
+    setSavedSnapshots((current) => [provisioningBackup, ...current.filter((entry) => entry.id !== provisioningBackup.id)])
 
     await handleApplyScopedParameterDrafts(
       selectedProvisioningProfileDiffEntries,
@@ -3334,10 +3359,10 @@ export function App() {
       return
     }
 
-    if (selectedPresetInvalidEntries.length > 0) {
+    if (effectivePresetInvalidEntries.length > 0) {
       setPresetNotice({
         tone: 'danger',
-        text: `${selectedPresetsLabel} has ${selectedPresetInvalidEntries.length} invalid value(s) in the current metadata set.`
+        text: `${selectedPresetsLabel} has ${effectivePresetInvalidEntries.length} invalid value(s) in the current metadata set.`
       })
       return
     }
@@ -3370,7 +3395,9 @@ export function App() {
     try {
       const rebootRequiredCount = effectivePresetChangedEntries.filter((entry) => entry.definition?.rebootRequired).length
       const result = await runtime.setParameters(
-        effectivePresetChangedEntries
+        // Order by enable-gate so a preset that both enables a subsystem and sets
+        // its sub-params writes the ENABLE gate first (matches the scoped path).
+        orderDraftsByEnableGate(effectivePresetChangedEntries)
           .filter((entry) => entry.nextValue !== undefined)
           .map((entry) => ({
             paramId: entry.id,
@@ -5694,6 +5721,11 @@ export function App() {
 
   useEffect(() => {
     setSnapshotRestoreAcknowledged(false)
+    // Also clear the "force-write blocked values" opt-in when the selected
+    // snapshot (its diff) changes: otherwise enabling force for snapshot A then
+    // selecting B would silently force-write B's out-of-range/enum values to the
+    // live FC without the operator re-opting-in for that snapshot.
+    setSnapshotForceInvalid(false)
   }, [selectedSnapshotDiffSignature])
 
   useEffect(() => {
@@ -7769,7 +7801,7 @@ export function App() {
           selectedPresetApplicability={selectedPresetApplicability}
           selectedPresetDiffGroups={selectedPresetDiffGroups}
           selectedPresetChangedEntries={effectivePresetChangedEntries}
-          selectedPresetInvalidEntries={selectedPresetInvalidEntries}
+          selectedPresetInvalidEntries={effectivePresetInvalidEntries}
           droppedPresetParamIds={droppedPresetParamIds}
           onTogglePresetParamDrop={togglePresetParamDrop}
           savedSnapshots={savedSnapshots}

--- a/packages/ardupilot-core/src/runtime.ts
+++ b/packages/ardupilot-core/src/runtime.ts
@@ -448,6 +448,15 @@ export class ArduPilotConfiguratorRuntime {
   private preArmExpiryTimer?: ReturnType<typeof setTimeout>
   private parameterSyncRetryTimer?: ReturnType<typeof setTimeout>
   private parameterSyncRetryCount = 0
+  // Downloaded count observed at the last stall-retry, so a retry that recovered
+  // params can refund the retry budget (a working link with a large gap must be
+  // allowed to converge over many gap-fill passes, not give up at
+  // MAX_RETRIES × MAX_PER_PASS). Only CONSECUTIVE no-progress passes count.
+  private parameterSyncLastRetryDownloaded = 0
+  // Whether the previous stall-retry issued a by-index gap-fill; if it did and
+  // this pass made no progress, fall back to a full re-stream (guards an FC not
+  // honoring by-index reads).
+  private parameterSyncGapFillActive = false
   // Test-injectable per-instance override; defaults to the
   // module constant. Production callers never set this.
   private readonly parameterSyncStallRetryMs: number
@@ -816,6 +825,8 @@ export class ArduPilotConfiguratorRuntime {
       this.receivedParameterIndices.clear()
       this.totalParameters = 0
       this.parameterSyncRetryCount = 0
+      this.parameterSyncLastRetryDownloaded = 0
+      this.parameterSyncGapFillActive = false
       this.clearParameterSyncRetryTimer()
       this.parameterSync = {
         status: 'requesting',
@@ -2548,6 +2559,8 @@ export class ArduPilotConfiguratorRuntime {
     this.receivedParameterIndices.clear()
     this.totalParameters = 0
     this.parameterSyncRetryCount = 0
+    this.parameterSyncLastRetryDownloaded = 0
+    this.parameterSyncGapFillActive = false
     this.parameterSync = createIdleParameterSync()
     this.guidedActionService.reset()
     this.motorTestService.reset()
@@ -2690,31 +2703,45 @@ export class ArduPilotConfiguratorRuntime {
   private async retryParameterSync(): Promise<void> {
     this.parameterSyncRetryTimer = undefined
 
+    // Use the alias-free count throughout (matches the completion gate and the
+    // downloaded count getSnapshot() exposes).
+    const downloaded = this.realParameterIdsReceived.size
+    // Refund the retry budget whenever a pass recovered params: a working link
+    // with a gap larger than MAX_RETRIES × MAX_PER_PASS must be allowed to
+    // converge over many passes rather than give up mid-recovery. Only
+    // CONSECUTIVE no-progress passes count toward the cap.
+    const madeProgressSinceLastRetry = downloaded > this.parameterSyncLastRetryDownloaded
+    if (madeProgressSinceLastRetry) {
+      this.parameterSyncRetryCount = 0
+    }
+    this.parameterSyncLastRetryDownloaded = downloaded
+
     if (
       !this.vehicle ||
       (this.parameterSync.status !== 'requesting' && this.parameterSync.status !== 'streaming') ||
       // Gate on realParameterIdsReceived.size, NOT parameters.size (which
       // counts alias mirrors), against the alias-free FC-reported total — same
       // source the completion gate uses.
-      this.realParameterIdsReceived.size >= this.totalParameters && this.totalParameters > 0 ||
+      (downloaded >= this.totalParameters && this.totalParameters > 0) ||
       this.parameterSyncRetryCount >= MAX_PARAMETER_SYNC_RETRIES
     ) {
       return
     }
 
     this.parameterSyncRetryCount += 1
-    // Use the alias-free count for the "stalled at X/Y" label so it matches
-    // the downloaded count getSnapshot() exposes.
-    const downloaded = this.realParameterIdsReceived.size
     const total = this.totalParameters
     // Prefer targeting the exact indices the stream dropped. A full
     // PARAM_REQUEST_LIST re-stream re-runs the same fast burst that lost the
     // frames in the first place (and can re-drop them under a lossy transport);
     // PARAM_REQUEST_READ-by-index refetches only the gaps. Fall back to a full
-    // re-stream when nothing has arrived yet (no indices to target) or the FC
-    // has not reported a count.
+    // re-stream when nothing has arrived yet (no indices to target), the FC has
+    // not reported a count, OR the previous gap-fill pass recovered nothing —
+    // the last case guards an FC that isn't honoring by-index reads (or is
+    // dropping the by-index responses too), restoring the pre-gap-fill recovery.
     const missingIndices = this.missingParameterIndices()
-    const canGapFill = total > 0 && downloaded > 0 && missingIndices.length > 0
+    const gapFillStalled = this.parameterSyncGapFillActive && !madeProgressSinceLastRetry
+    const canGapFill = total > 0 && downloaded > 0 && missingIndices.length > 0 && !gapFillStalled
+    this.parameterSyncGapFillActive = canGapFill
 
     this.appendStatusEntry(
       'warning',

--- a/tests/parameter-sync-gap-fill.test.mjs
+++ b/tests/parameter-sync-gap-fill.test.mjs
@@ -167,3 +167,90 @@ test('a sync that drops the very first burst entirely falls back to a full re-st
     runtime.destroy()
   }
 })
+
+// Simple index-addressable session: the initial burst delivers `initialCount`
+// of `total` params; every PARAM_REQUEST_READ is answered by index (unless
+// answerReads is false). Used for convergence + fallback tests.
+function createIndexedSession(sentMessages, { total, initialCount, answerReads = true }) {
+  const messageListeners = []
+  const statusListeners = []
+  const value = (index) => index + 1000
+  const emitParam = (index) =>
+    messageListeners.forEach((l) =>
+      l({
+        header: { systemId: 1, componentId: 1, sequence: 0 },
+        message: { type: 'PARAM_VALUE', paramId: `P_${index}`, paramValue: value(index), paramType: 9, paramCount: total, paramIndex: index },
+        timestampMs: Date.now()
+      })
+    )
+  let firstList = true
+  return {
+    getTransportStatus: () => ({ kind: 'connected' }),
+    onStatus: (l) => (statusListeners.push(l), () => {}),
+    onMessage: (l) => (messageListeners.push(l), () => {}),
+    async connect() {
+      statusListeners.forEach((l) => l({ kind: 'connected' }))
+      messageListeners.forEach((l) =>
+        l({ header: { systemId: 1, componentId: 1, sequence: 0 }, message: { type: 'HEARTBEAT', autopilot: 3, vehicleType: 2, baseMode: 0, customMode: 0, systemStatus: 4, mavlinkVersion: 3 }, timestampMs: Date.now() })
+      )
+    },
+    async disconnect() {},
+    destroy() {},
+    async send(message) {
+      sentMessages.push(message)
+      if (message.type === 'PARAM_REQUEST_LIST') {
+        const count = firstList ? initialCount : total
+        firstList = false
+        for (let i = 0; i < count; i += 1) emitParam(i)
+      } else if (message.type === 'PARAM_REQUEST_READ' && answerReads) {
+        emitParam(message.paramIndex)
+      }
+    }
+  }
+}
+
+test('a gap larger than one gap-fill budget still converges (retry budget refunds on progress)', async () => {
+  // 1200 params, only 300 in the first burst → 900 missing, far beyond
+  // MAX_PARAMETER_GAP_FILL_PER_PASS (256) × MAX_PARAMETER_SYNC_RETRIES (3) = 768.
+  // Before the refund fix this stranded at ~1068/1200; now each pass that
+  // recovers params refunds the budget, so it converges.
+  const sentMessages = []
+  const session = createIndexedSession(sentMessages, { total: 1200, initialCount: 300 })
+  const runtime = new ArduPilotConfiguratorRuntime(session, arducopterMetadata, { parameterSyncStallRetryMs: 5 })
+  try {
+    await runtime.connect()
+    await runtime.requestParameterList({ timeoutMs: 2000 })
+    const stats = await runtime.waitForParameterSync({ timeoutMs: 5000 })
+    assert.equal(stats.status, 'complete', 'large gap converged')
+    assert.equal(stats.downloaded, 1200, 'all 1200 recovered (past the old 768 cap)')
+    const reads = sentMessages.filter((m) => m.type === 'PARAM_REQUEST_READ')
+    assert.ok(reads.length >= 900, `refetched all missing indices by gap-fill (${reads.length} reads)`)
+  } finally {
+    await runtime.disconnect().catch(() => {})
+    runtime.destroy()
+  }
+})
+
+test('gap-fill that recovers nothing falls back to a full re-stream', async () => {
+  // The initial burst drops the last index and the FC does NOT answer by-index
+  // reads (answerReads:false). The first pass gap-fills and recovers nothing, so
+  // the next pass must fall back to a full PARAM_REQUEST_LIST — which serves the
+  // whole table and completes. Guards an FC that ignores PARAM_REQUEST_READ.
+  const sentMessages = []
+  const session = createIndexedSession(sentMessages, { total: 5, initialCount: 4, answerReads: false })
+  const runtime = new ArduPilotConfiguratorRuntime(session, arducopterMetadata, { parameterSyncStallRetryMs: 5 })
+  try {
+    await runtime.connect()
+    await runtime.requestParameterList({ timeoutMs: 2000 })
+    const stats = await runtime.waitForParameterSync({ timeoutMs: 5000 })
+    assert.equal(stats.status, 'complete', 'fell back and completed')
+    assert.ok(
+      sentMessages.filter((m) => m.type === 'PARAM_REQUEST_LIST').length >= 2,
+      'issued a full re-stream after the unanswered gap-fill'
+    )
+    assert.ok(sentMessages.some((m) => m.type === 'PARAM_REQUEST_READ'), 'tried gap-fill first')
+  } finally {
+    await runtime.disconnect().catch(() => {})
+    runtime.destroy()
+  }
+})


### PR DESCRIPTION
Five apply/write-path audit findings:

- **Gap-fill convergence regression (mine).** By-index recovery was capped at ~768 missing and never fell back to a full re-stream, stranding very lossy links. Now the retry budget **refunds on forward progress** (only consecutive no-progress passes count) so any gap size converges, and a pass that recovers nothing **falls back to a full re-stream** (guards an FC not honoring by-index reads). +2 tests.
- **Enable-gate ordering on Apply-All + preset apply.** Both wrote in raw order; a set that enables a subsystem and sets its sub-params (RCL_*) could write children before the `*_FUNC`/ENABLE gate → unconfirmed/timeout. Both now use `orderDraftsByEnableGate` (RC Mixer RCL drafts only apply via the global bar).
- **"Force-write blocked values"** clears when the selected snapshot's diff changes — no more force-writing snapshot B's out-of-range values with A's opt-in.
- **Dropping the invalid preset row unblocks apply** — the guard + view use the post-drop effective invalid set (matches snapshot restore).
- **Provisioning apply auto-backs-up first**, like the preset/AI paths.

**ArduCopter byte-identical** (write ordering + recovery are transport/UI-layer; no written value changes). Gates: typecheck · node 84 · web vitest 513 · full e2e 210.