### PR TITLE
fix(flash/dronecan): two brick-adjacent audit findings

### DIFF
--- a/packages/ardupilot-core/src/runtime-can-bus-service.ts
+++ b/packages/ardupilot-core/src/runtime-can-bus-service.ts
@@ -768,7 +768,7 @@ export class CanBusService {
     if (!update || update.nodeId !== sourceNodeId) {
       return
     }
-    if (update.status === 'completed' || update.status === 'error') {
+    if (update.status === 'error') {
       return
     }
     const request = decodeDronecanFileReadRequest(payload)
@@ -784,14 +784,27 @@ export class CanBusService {
     if (node) {
       node.lastSeenAtMs = Date.now()
     }
+
+    // Always answer a read from the node under update — including AFTER the
+    // transfer is 'completed'. The final short/EOF response can be lost on the
+    // best-effort CAN tunnel, in which case the node re-Reads the same offset;
+    // ignoring it would strand the node in its bootloader while the UI already
+    // shows Complete. Re-serving the (short/empty) tail chunk re-runs the EOF
+    // handshake idempotently.
+    void this.sendFileReadResponse(sourceNodeId, transferId, chunk)
+
+    if (update.status === 'completed') {
+      // Already finished — this was just an EOF re-handshake for a dropped final
+      // response. Don't re-log completion or churn state.
+      return
+    }
+
     if (!update.readingStarted) {
       update.readingStarted = true
       update.status = 'in_progress'
     }
     update.bytesServed = Math.max(update.bytesServed, offset + chunk.length)
     update.updatedAtMs = Date.now()
-
-    void this.sendFileReadResponse(sourceNodeId, transferId, chunk)
 
     // A chunk shorter than the 256-byte capacity is the EOF handshake: the node
     // flashes it and boots the new app (AP_Bootloader/can.cpp). The whole image

--- a/packages/firmware-flash/src/dfu.ts
+++ b/packages/firmware-flash/src/dfu.ts
@@ -268,9 +268,18 @@ export class DfuSeDevice {
         await this.massErase()
         onProgress?.({ phase: 'erase', ratio: 1, label: 'Full chip erase' })
       }
+    } else if (this.memory.length === 0) {
+      // No parseable sector map (the DFU alt exposed no memory layout), so we
+      // can't compute which sectors the image overlaps. Erasing nothing and then
+      // programming leaves stale bits set — STM32 flash only clears on erase — so
+      // the written image is corrupt and fails verify. Fall back to a mass-erase
+      // (same as the full-erase-without-a-layout path) rather than silently
+      // programming onto un-erased flash.
+      await this.massErase()
+      onProgress?.({ phase: 'erase', ratio: 1, label: 'Full chip erase (no sector map)' })
     } else {
       const eraseTargets = sectorsToErase(this.memory, segments)
-      if (this.memory.length > 0 && eraseTargets.length === 0) {
+      if (eraseTargets.length === 0) {
         throw new Error('Firmware image lies outside the device flash memory map — refusing to flash')
       }
       for (let i = 0; i < eraseTargets.length; i += 1) {

--- a/tests/firmware-dfu.test.mjs
+++ b/tests/firmware-dfu.test.mjs
@@ -243,6 +243,17 @@ test('DfuSeDevice.flash: full erase falls back to a mass-erase when the layout i
   assert.equal(erases[0].data.length, 1, 'mass erase carries no address')
 })
 
+test('DfuSeDevice.flash: a partial erase with no sector map falls back to a mass-erase (never programs un-erased flash)', async () => {
+  const mock = mockDfu()
+  const device = new DfuSeDevice(mock.iface, [], 2048) // no memory layout
+  // Default (partial) erase path — no fullErase. Without a sector map the old
+  // code erased nothing and then programmed onto un-erased flash (corrupt image).
+  await device.flash([{ address: 0x08000000, data: new Uint8Array(64).fill(0xab) }])
+  const erases = mock.out.filter((o) => o.request === 1 && o.value === 0 && o.data[0] === 0x41)
+  assert.equal(erases.length, 1, 'a mass-erase ran instead of erasing nothing')
+  assert.equal(erases[0].data.length, 1, 'mass erase carries no address')
+})
+
 test('DfuSeDevice.flash: refuses an image outside the device memory map', async () => {
   const mock = mockDfu()
   const memory = parseDfuSeMemoryLayout('@Internal Flash  /0x08000000/16*128Kg')


### PR DESCRIPTION
- **DFU partial erase with no sector map programmed onto un-erased flash.** The non-full erase path ran `sectorsToErase()` against an empty memory layout → `[]`, which skipped the "outside the flash map" refusal (that only fires when a layout exists), so it erased **nothing** then programmed. STM32 flash only clears on erase → corrupt image, failed verify. Now falls back to a **mass-erase** when there's no sector map (matching the full-erase path). +1 test.
- **DroneCAN update could strand a node on a dropped EOF frame.** A re-Read after `completed` was ignored, so a lost final short/EOF `file.Read` response left the node in its bootloader while the UI showed Complete. Now keeps answering the node under update after completion — re-serving the tail chunk re-runs the EOF handshake idempotently (no re-logging/state churn).

**Declined (documented):** the DroneCAN GetSet request index is a single byte **on purpose** — byte-aligned is what real nodes decode (bench-verified vs a Here4; the uint13 bit-packed DSDL form is rejected). The 256-param ceiling is a node-side reality, not an encoder bug.

**Deferred (documented):** a package-level board-match net inside `flash()` — the serial path's board-match already runs at its only caller, threading `board_id` through `flash()` risks that working path, and STM32 DFU reports no board id to match. Defense-in-depth, not a live brick.

**ArduCopter byte-identical** (flash + CAN peripheral paths only). Gates: typecheck · firmware + DroneCAN node tests (96).