### PR TITLE
fix(logs): stop per-packet re-render storm crippling downloads + show log dates

### DIFF
--- a/apps/web/src/hooks/use-onboard-logs.ts
+++ b/apps/web/src/hooks/use-onboard-logs.ts
@@ -84,7 +84,18 @@ export function useOnboardLogs(runtime: OnboardLogCapableRuntime | undefined): O
       if (source === 'mavftp') {
         const items = mavftpEntriesToLogItems(await runtime.listMavftpLogs())
         mavftpItemsRef.current = new Map(items.map((item) => [item.log.id, item]))
-        logs = items.map((item) => item.log)
+        // MAVFTP directory listings carry no timestamp, so the rows showed
+        // "Unknown date". The LOG_ENTRY list does carry time_utc — fetch it and
+        // merge by log id. Best-effort: if it fails (or a log predates a GPS
+        // time fix, time_utc = 0) that row simply stays "Unknown date".
+        let timeUtcById = new Map<number, number>()
+        try {
+          const entries = await runtime.listOnboardLogs()
+          timeUtcById = new Map(entries.map((entry) => [entry.id, entry.timeUtc]))
+        } catch {
+          // dates are optional — keep the MAVFTP list without them
+        }
+        logs = items.map((item) => ({ ...item.log, timeUtc: timeUtcById.get(item.log.id) ?? item.log.timeUtc }))
         logNamesById = new Map(items.map((item) => [item.log.id, item.name]))
       } else {
         mavftpItemsRef.current = new Map()

--- a/packages/ardupilot-core/src/runtime.ts
+++ b/packages/ardupilot-core/src/runtime.ts
@@ -535,7 +535,19 @@ export class ArduPilotConfiguratorRuntime {
         for (const listener of this.inspectorListeners) {
           listener(envelope)
         }
-        this.emit()
+        // MAVFTP burst packets and LOG_DATA chunks arrive by the thousand during
+        // a file/log download and do NOT change the snapshot — their progress is
+        // surfaced through the download callbacks, and processEnvelope routes
+        // them to the mavftp / logDownload services rather than snapshot state.
+        // Emitting a snapshot per packet drove a continuous full-app re-render
+        // that starved the Web Serial read loop and collapsed download
+        // throughput to ~130x slower than a headless client. Skip the per-packet
+        // emit for those two high-rate types; any status/state change they make
+        // flushes on the next telemetry message, and completion emits explicitly.
+        const messageType = envelope.message.type
+        if (messageType !== 'FILE_TRANSFER_PROTOCOL' && messageType !== 'LOG_DATA') {
+          this.emit()
+        }
       })
     ]
   }

--- a/tests/download-emit-throttle.test.mjs
+++ b/tests/download-emit-throttle.test.mjs
@@ -1,0 +1,71 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { ArduPilotConfiguratorRuntime } from '../packages/ardupilot-core/dist/index.js'
+import { arducopterMetadata } from '../packages/param-metadata/dist/index.js'
+
+// Regression: the runtime emitted a snapshot for EVERY inbound message. During a
+// MAVFTP burst / LOG_DATA download that is thousands of packets a second, each
+// firing a full-app re-render — which starved the Web Serial read loop and
+// collapsed download throughput to ~130x slower than a headless client (94 KB/s
+// vs ~0.7 KB/s in the browser). File-download packets don't change the snapshot
+// (progress rides their own callbacks), so they must NOT emit per packet.
+function createSession() {
+  const statusListeners = []
+  const messageListeners = []
+  const emit = (message) =>
+    messageListeners.forEach((listener) =>
+      listener({ header: { systemId: 1, componentId: 1, sequence: 0 }, message, timestampMs: Date.now() })
+    )
+  return {
+    getTransportStatus: () => ({ kind: 'connected' }),
+    onStatus: (l) => (statusListeners.push(l), () => {}),
+    onMessage: (l) => (messageListeners.push(l), () => {}),
+    async connect() {
+      statusListeners.forEach((l) => l({ kind: 'connected' }))
+      emit({ type: 'HEARTBEAT', autopilot: 3, vehicleType: 2, baseMode: 0, customMode: 0, systemStatus: 4, mavlinkVersion: 3 })
+    },
+    async disconnect() {},
+    destroy() {},
+    async send() {},
+    _emit: emit
+  }
+}
+
+test('MAVFTP + LOG_DATA download packets do not each trigger a snapshot emit', async () => {
+  const session = createSession()
+  const runtime = new ArduPilotConfiguratorRuntime(session, arducopterMetadata)
+  try {
+    await runtime.connect()
+
+    let emits = 0
+    const unsubscribe = runtime.subscribe(() => {
+      emits += 1
+    })
+    // subscribe() may replay the current snapshot once; measure deltas from here.
+    const baseline = emits
+
+    // A flood of file-download packets — these route to the mavftp/logDownload
+    // services and must not churn the snapshot.
+    for (let i = 0; i < 500; i += 1) {
+      session._emit({
+        type: 'FILE_TRANSFER_PROTOCOL',
+        targetNetwork: 0,
+        targetSystem: 1,
+        targetComponent: 1,
+        payload: new Uint8Array(251)
+      })
+      session._emit({ type: 'LOG_DATA', id: 1, ofs: i * 90, count: 90, data: new Uint8Array(90) })
+    }
+    assert.equal(emits - baseline, 0, '1000 download packets triggered zero snapshot emits')
+
+    // A real state-changing message still emits.
+    session._emit({ type: 'HEARTBEAT', autopilot: 3, vehicleType: 2, baseMode: 0, customMode: 0, systemStatus: 4, mavlinkVersion: 3 })
+    assert.ok(emits - baseline >= 1, 'a heartbeat still emits a snapshot')
+
+    unsubscribe()
+  } finally {
+    await runtime.disconnect().catch(() => {})
+    runtime.destroy()
+  }
+})


### PR DESCRIPTION
## Slow downloads

Log/file downloads crawled — **~0.7 KB/s in the browser vs 93.8 KB/s headless** over the same FC/link (I probed the FC with pymavlink; the link is healthy). Root cause: the runtime emitted a full snapshot for **every** inbound message, so the thousands of MAVFTP burst packets / `LOG_DATA` chunks per second each triggered a full-app re-render, starving the Web Serial read loop so the FC's burst backed up.

Those packets don't change the snapshot (progress rides the download callbacks; `processEnvelope` routes them to the mavftp/logDownload services), so **skip the per-packet snapshot emit for `FILE_TRANSFER_PROTOCOL` and `LOG_DATA`**. Everything else still emits; status changes flush on the next telemetry message and completion emits explicitly. **+1 regression test** (1000 download packets → 0 emits; a heartbeat still emits).

## Missing dates

MAVFTP directory listings carry no timestamp ("Unknown date"), but the `LOG_ENTRY` list has `time_utc` — fetch it and merge dates by log id. Best-effort: a failed fetch or a pre-GPS-time log stays "Unknown date".

**ArduCopter byte-identical** (message-loop emit gating + a read-side listing merge). Gates: typecheck · node 714 · web vitest · Logs + full e2e (210).