### PR TITLE
fix(runtime): throttle emits during initial param sync so the stream stops stalling

### DIFF
--- a/packages/ardupilot-core/src/runtime.ts
+++ b/packages/ardupilot-core/src/runtime.ts
@@ -2520,11 +2520,16 @@ export class ArduPilotConfiguratorRuntime {
       this.cancelScheduledEmit()
       this.flushEmit()
     }
-    if (this.batchEmitMode) {
-      // Batch write: coalesce to the timer interval only (skip per-frame rAF).
-      // The full-snapshot rebuild + app re-render is expensive; doing it ~4x/s
-      // instead of ~60x/s frees the main thread to process the PARAM_VALUE
-      // readbacks that resolve each write, so the batch runs at link speed.
+    // Coalesce to the timer interval only (skip per-frame rAF) during a batch
+    // write OR the initial parameter sync. Both are a fast inbound PARAM_VALUE
+    // burst, and the full-snapshot rebuild + app re-render is expensive: doing it
+    // ~4x/s instead of ~60x/s frees the main thread to process the readbacks at
+    // link speed. Rendering per frame during the sync otherwise starves the Web
+    // Serial read loop, drops PARAM_VALUE packets, and stalls the stream —
+    // triggering repeated gap-fill retries ("parameter stream keeps stalling").
+    const syncingParameters =
+      this.parameterSync.status === 'requesting' || this.parameterSync.status === 'streaming'
+    if (this.batchEmitMode || syncingParameters) {
       this.emitTimer = setTimeout(run, EMIT_COALESCE_MAX_MS)
       return
     }


### PR DESCRIPTION
The parameter stream kept stalling (repeated gap-fill retries) on a real FC over Web Serial. **Same root cause as the log-download slowness:** the runtime emits a snapshot per inbound `PARAM_VALUE`, so the initial ~1300-param burst drove a ~60fps full-app re-render that starved the Web Serial read loop, dropped packets, and stalled the stream.

A batch write already coalesces emits to ~4×/s (`batchEmitMode`) for exactly this reason — the initial sync didn't. Apply the same throttle while `parameterSync.status` is `requesting`/`streaming`. Progress still updates ~4×/s (smooth); completion emits normally.

**ArduCopter byte-identical** (emit cadence only). Gates: typecheck · node param-sync/integration/emit tests (86). Full e2e skipped at operator request to test live; mirrors the existing batch throttle.