### PR TITLE
fix(receiver): pitch direction verdict was inverted (RC2_REVERSED=0 is reversed, not correct)

### DIFF
--- a/apps/web/src/preview-components.tsx
+++ b/apps/web/src/preview-components.tsx
@@ -115,11 +115,12 @@ export function StickCraftPreview({
     }
     const reversed = readRoundedParameter(snapshot, `RC${obs.channelNumber}_REVERSED`) === 1
     const oriented = reversed ? -value : value
-    // Pitch is inverted relative to roll/yaw here — matches the same
-    // hardware-verified correction in receiver-direction-check.ts's
-    // evaluateRcDirection (see its comment for the full trace).
-    const axisOriented = axisId === 'pitch' ? -oriented : oriented
-    return Math.max(-1, Math.min(1, axisOriented))
+    // No per-axis flip — the deflection follows ArduPilot's norm_input()
+    // convention for every axis. An earlier build inverted pitch here (and in
+    // evaluateRcDirection), but a fresh on-FC re-verification (2026-07-12) showed
+    // the inversion was wrong: with RC2_REVERSED=0 a pulled-back stick pitches
+    // nose-DOWN, and the preview must show that. Both were un-inverted together.
+    return Math.max(-1, Math.min(1, oriented))
   }
   const rollNorm = axisNorm('roll')
   const pitchNorm = axisNorm('pitch')

--- a/apps/web/src/view-models/receiver-direction-check.test.ts
+++ b/apps/web/src/view-models/receiver-direction-check.test.ts
@@ -33,13 +33,13 @@ describe('evaluateRcDirection (centred axes)', () => {
     expect(evaluateRcDirection({ axisId: 'roll', pwm: 1100, ...CENTERED, reversed: true })).toBe('correct')
   })
 
-  it('pitch is inverted relative to roll/yaw (hardware-verified correction)', () => {
-    // Mode-2 TX: pulling back (pitch up) drives the wire LOW. Unlike
-    // roll/yaw, hands-on hardware testing confirmed pitch reads correctly
-    // UNREVERSED here — see evaluateRcDirection's comment for the full trace
-    // and why the source-level derivation didn't predict this.
-    expect(evaluateRcDirection({ axisId: 'pitch', pwm: 1100, ...CENTERED, reversed: false })).toBe('correct')
-    expect(evaluateRcDirection({ axisId: 'pitch', pwm: 1100, ...CENTERED, reversed: true })).toBe('reversed')
+  it('pitch follows the same sign convention as roll/yaw (no per-axis flip)', () => {
+    // Mode-2 TX: pulling the pitch stick back drives the wire LOW. On-FC
+    // re-verification (2026-07-12) confirmed RC2_REVERSED=0 pitches nose-DOWN on
+    // pull-back, so that setting reads REVERSED (needs the reverse) and is only
+    // correct once RC2_REVERSED=1 — matching ArduPilot norm_input, no pitch flip.
+    expect(evaluateRcDirection({ axisId: 'pitch', pwm: 1100, ...CENTERED, reversed: false })).toBe('reversed')
+    expect(evaluateRcDirection({ axisId: 'pitch', pwm: 1100, ...CENTERED, reversed: true })).toBe('correct')
   })
 
   it('yaw-right matches the roll sign convention', () => {

--- a/apps/web/src/view-models/receiver-direction-check.ts
+++ b/apps/web/src/view-models/receiver-direction-check.ts
@@ -85,17 +85,19 @@ export function evaluateRcDirection(input: RcDirectionAxisInput): RcDirectionRes
   }
   const rawSign = delta > 0 ? 1 : -1
   const normSign = input.reversed ? -rawSign : rawSign
-  // Pitch is inverted relative to roll/yaw here: hands-on hardware
-  // verification (toggling RCn_REVERSED on a real FC) confirmed the verdict
-  // was backwards for pitch specifically — flips to the wrong label when
-  // reversed is toggled, on both this verdict and the reactive stick-craft
-  // preview, which share this sign convention. Source-level tracing of
-  // RC_Channel::norm_input -> rc_input_to_roll_pitch_rad -> the attitude
-  // controller found no flip anywhere in that chain, so whatever the
-  // discrepancy is, it isn't in that path; empirical hardware behavior
-  // wins over the derivation here.
-  const orientedSign = input.axisId === 'pitch' ? -normSign : normSign
-  return orientedSign > 0 ? 'correct' : 'reversed'
+  // ArduPilot norm_input sign = (reversed ? -1 : 1) * sign(pwm - trim). The named
+  // direction (roll-right, pitch-back/up, yaw-right) wants a POSITIVE norm, so
+  // this is the verdict directly — no per-axis flip.
+  //
+  // Pitch is NOT special-cased. An earlier build inverted pitch here (and in the
+  // stick-craft preview) after a hardware test appeared to read it backwards, but
+  // a fresh on-FC re-verification (2026-07-12) showed the inversion was itself
+  // wrong: with RC2_REVERSED=0 a stick pulled back (wire LOW → negative norm)
+  // pitches nose-DOWN, so that setting IS reversed and the verdict must say so.
+  // The pitch inversion made it read "correct" instead. Removing it matches both
+  // the norm_input convention and the aircraft. (Keep this axis-symmetric — the
+  // preview in preview-components.tsx dropped the same inversion in lockstep.)
+  return normSign > 0 ? 'correct' : 'reversed'
 }
 
 /**


### PR DESCRIPTION
The Endpoints "Channel Direction" check reported pitch **"correct"** for `RC2_REVERSED=0`, but on-FC re-verification (operator, 2026-07-12) shows that setting pitches **nose-down** on a pulled-back stick — it's reversed and needs `RC2_REVERSED=1`.

A pitch-specific sign flip added in an earlier build (both `evaluateRcDirection` **and** the stick-craft preview's `axisNorm`) was the cause — it made pitch read backwards vs ArduPilot's `norm_input`. Removed the flip in **both** sites so pitch follows roll/yaw. Now pull-back with `RC2_REVERSED=0` reads "reversed" (offers the one-click reverse) and "correct" once `RC2_REVERSED=1`, matching both `norm_input` and the aircraft. Changed together so the verdict and visual craft stay consistent; test updated.

Safety verdict — re-verified on real hardware, not by source tracing. This reverses PR #16's flip (see the flip-flop history; the source derivation was right all along). **ArduCopter byte-identical.** Gates: typecheck · direction-check + setup-flow vitest (30) · web vitest (513).