### PR TITLE
feat(snapshots): stage-not-write restore, drop-all, and new-vs-old missing breakout

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1804,6 +1804,29 @@ export function App() {
       next.add(paramId)
       return next
     })
+    // Snapshot "Apply" now stages a draft rather than writing, so dropping a row
+    // must also discard any draft it staged — otherwise the entry lingers in the
+    // global draft bar after being dropped from the restore diff.
+    clearDraft(paramId)
+  }
+  function handleDropAllSnapshotRestoreEntries(): void {
+    const ids = [
+      ...selectedSnapshotChangedEntries.map((entry) => entry.id),
+      ...selectedSnapshotInvalidEntries.map((entry) => entry.id)
+    ]
+    if (ids.length === 0) {
+      return
+    }
+    setSnapshotRestoreDroppedParamIds((current) => {
+      const next = new Set(current)
+      ids.forEach((id) => next.add(id))
+      return next
+    })
+    clearDrafts(ids)
+    setSnapshotNotice({
+      tone: 'neutral',
+      text: `Dropped ${ids.length} row(s) from this restore and un-staged any drafts. The live FC values are unchanged.`
+    })
   }
   function handleClearSnapshotRestoreDrops(): void {
     setSnapshotRestoreDroppedParamIds(new Set())
@@ -3223,7 +3246,11 @@ export function App() {
     })
   }
 
-  async function handleApplySelectedSnapshotRestore(): Promise<void> {
+  // "Stage All" — snapshot restore now STAGES the diff into the shared draft
+  // set (matching the Parameters tab) rather than writing straight to the FC.
+  // The write happens from the global draft bar's "Write all", the one verified,
+  // readback-checked, rollback-on-failure path the whole app shares.
+  function handleApplySelectedSnapshotRestore(): void {
     if (!selectedSnapshot) {
       return
     }
@@ -3231,36 +3258,45 @@ export function App() {
     if (!snapshotRestoreAcknowledged) {
       setSnapshotNotice({
         tone: 'warning',
-        text: 'Acknowledge the overwrite warning before applying a snapshot restore.'
+        text: 'Acknowledge the overwrite warning before staging a snapshot restore.'
       })
       return
     }
 
-    // Force-write path: reclassify the blocked (out-of-doc-range / outside-enum)
-    // entries as staged so they're written as-is. Common on a cross-board restore
-    // where a value valid on the source FC trips this app's documented range/enum;
-    // runtime.setParameters still verifies readback and tolerates FC clamping.
-    const forcedInvalidEntries: ParameterDraftEntry[] = snapshotForceInvalid
-      ? selectedSnapshotInvalidEntries
-          .map((entry): ParameterDraftEntry | null => {
-            const value = entry.nextValue ?? Number(entry.rawValue)
-            return Number.isFinite(value)
-              ? { ...entry, status: 'staged', nextValue: value, override: true, reason: undefined }
-              : null
-          })
-          .filter((entry): entry is ParameterDraftEntry => entry !== null)
-      : []
-    const entriesToWrite = [
-      ...selectedSnapshotDiffEntries.filter((entry) => entry.status === 'staged'),
-      ...forcedInvalidEntries
-    ]
+    // Force-invalid path: also stage the blocked (out-of-doc-range / outside-enum)
+    // raw values as drafts. They land as INVALID drafts the operator completes
+    // from the Parameters tab ("Override and write anyway") — same escape hatch
+    // the raw editor uses — instead of a snapshot-local force-write.
+    const forcedInvalidDraftValues: Record<string, string> = snapshotForceInvalid
+      ? Object.fromEntries(
+          selectedSnapshotInvalidEntries
+            .map((entry): [string, string] | null => {
+              const raw = entry.rawValue ?? (entry.nextValue !== undefined ? String(entry.nextValue) : undefined)
+              return raw !== undefined && raw !== '' ? [entry.id, raw] : null
+            })
+            .filter((pair): pair is [string, string] => pair !== null)
+        )
+      : {}
+    const stagedValues = { ...filteredSnapshotRestoreDraftValues, ...forcedInvalidDraftValues }
+    const stagedCount = Object.keys(stagedValues).length
+    if (stagedCount === 0) {
+      setSnapshotNotice({
+        tone: 'neutral',
+        text: `Snapshot "${selectedSnapshot.label}" already matches the live controller values.`
+      })
+      return
+    }
 
-    await handleApplyScopedParameterDrafts(entriesToWrite, 'snapshots:apply', `Snapshot restore: ${selectedSnapshot.label}`)
+    mergeDrafts(stagedValues)
     setSnapshotRestoreAcknowledged(false)
     setSnapshotForceInvalid(false)
-    trackAppEvent('Snapshot Restore Applied', {
-      changedCount: entriesToWrite.length,
-      forcedCount: forcedInvalidEntries.length
+    setSnapshotNotice({
+      tone: 'warning',
+      text: `Staged ${stagedCount} snapshot change(s) as drafts. Review and Write all from the draft bar to apply them.`
+    })
+    trackAppEvent('Snapshot Restore Staged', {
+      changedCount: stagedCount,
+      forcedCount: Object.keys(forcedInvalidDraftValues).length
     })
   }
 
@@ -7555,15 +7591,22 @@ export function App() {
           handlers={{
             handleApplySelectedProvisioningProfile,
             handleApplySelectedSnapshotRestore,
-            handleApplySnapshotEntry: (entry) =>
-              handleApplyScopedParameterDrafts(
-                [entry],
-                'snapshots:apply',
-                `Snapshot restore (single): ${entry.id}`
-              ),
+            // Per-row Apply STAGES the single change as a draft (like the
+            // Parameters tab) — the write happens from the global draft bar.
+            handleApplySnapshotEntry: (entry) => {
+              if (entry.nextValue === undefined) {
+                return
+              }
+              mergeDrafts({ [entry.id]: String(entry.nextValue) })
+              setSnapshotNotice({
+                tone: 'warning',
+                text: `Staged ${entry.id} as a draft. Write all from the draft bar to apply it.`
+              })
+            },
             handleCaptureLiveSnapshot,
             handleOverwriteSelectedSnapshot,
             handleDropSnapshotRestoreEntry,
+            handleDropAllSnapshotRestoreEntries,
             handleClearSnapshotRestoreDrops,
             setSnapshotImportCalibration,
             handleCreateProvisioningProfile,

--- a/apps/web/src/sections/SnapshotsSection.tsx
+++ b/apps/web/src/sections/SnapshotsSection.tsx
@@ -56,6 +56,18 @@ function formatUsbId(vendorId: number, productId: number): string {
   return `${v}:${p}`
 }
 
+/**
+ * Compact preview of a missing-parameter-id list — first few ids inline with a
+ * "+N more" tail so the two directional "does not exist" notes stay readable
+ * even when a cross-version snapshot has dozens of one-sided params.
+ */
+function formatMissingParamList(ids: readonly string[], limit = 12): string {
+  if (ids.length <= limit) {
+    return ids.join(', ')
+  }
+  return `${ids.slice(0, limit).join(', ')} +${ids.length - limit} more`
+}
+
 export interface SnapshotsSectionDerived {
   selectedSnapshot: SavedParameterSnapshot | undefined
   selectedSnapshotRestore: ParameterBackupImportResult | undefined
@@ -99,8 +111,11 @@ export interface SnapshotsSectionHandlers {
    *  in place (same id) instead of creating a new saved entry. */
   handleOverwriteSelectedSnapshot: () => void | Promise<void>
   /** Per-row Drop for the restore diff — like Parameters, excludes one
-   *  param from the restore without leaving this view. */
+   *  param from the restore (and un-stages its draft) without leaving this view. */
   handleDropSnapshotRestoreEntry: (paramId: string) => void
+  /** Bulk Drop — clears every row from the restore diff and un-stages any
+   *  drafts it staged. Mirrors the Parameters tab's "Discard All". */
+  handleDropAllSnapshotRestoreEntries: () => void
   /** Restores every row dropped via handleDropSnapshotRestoreEntry for the
    *  selected snapshot. */
   handleClearSnapshotRestoreDrops: () => void
@@ -256,6 +271,7 @@ export function SnapshotsSection(props: SnapshotsSectionProps): ReactElement {
     handleCaptureLiveSnapshot,
     handleOverwriteSelectedSnapshot,
     handleDropSnapshotRestoreEntry,
+    handleDropAllSnapshotRestoreEntries,
     handleClearSnapshotRestoreDrops,
     setSnapshotImportCalibration,
     handleCreateProvisioningProfile,
@@ -631,9 +647,17 @@ export function SnapshotsSection(props: SnapshotsSectionProps): ReactElement {
                     <span>Matched live</span>
                     <strong>{selectedSnapshotRestore?.unchangedCount ?? 0}</strong>
                   </article>
-                  <article className="telemetry-metric-card snapshots-metric-card">
-                    <span>Unknown on live</span>
+                  <article className="telemetry-metric-card snapshots-metric-card" data-testid="snapshot-missing-old">
+                    <span title="Present in the saved snapshot (old side) but absent from this FC's parameters — skipped on restore.">
+                      In snapshot, not on FC
+                    </span>
                     <strong>{selectedSnapshotRestore?.unknownParameterIds.length ?? 0}</strong>
+                  </article>
+                  <article className="telemetry-metric-card snapshots-metric-card" data-testid="snapshot-missing-new">
+                    <span title="Present on this FC (new side) but absent from the saved snapshot — typically params a newer firmware added since capture. Informational; a restore never removes params.">
+                      On FC, not in snapshot
+                    </span>
+                    <strong>{selectedSnapshotRestore?.newParameterIds.length ?? 0}</strong>
                   </article>
                   <article className="telemetry-metric-card snapshots-metric-card">
                     <span>Restore writes</span>
@@ -710,11 +734,24 @@ export function SnapshotsSection(props: SnapshotsSectionProps): ReactElement {
                 ) : null}
 
                 {selectedSnapshotRestore && selectedSnapshotRestore.unknownParameterIds.length > 0 ? (
-                  <div className="parameter-follow-up parameter-follow-up--warning">
-                    <StatusBadge tone="warning">partial</StatusBadge>
+                  <div className="parameter-follow-up parameter-follow-up--warning" data-testid="snapshot-missing-old-note">
+                    <StatusBadge tone="warning">in snapshot, not on FC</StatusBadge>
                     <p>
-                      {selectedSnapshotRestore.unknownParameterIds.length} snapshot parameter(s) do not exist in the current live metadata set and will
-                      be ignored during restore.
+                      {selectedSnapshotRestore.unknownParameterIds.length} parameter(s) exist in this saved snapshot (the old side) but not on the
+                      connected FC (the new side), so they can&apos;t be restored and are skipped:{' '}
+                      <span className="snapshot-missing-list">{formatMissingParamList(selectedSnapshotRestore.unknownParameterIds)}</span>
+                    </p>
+                  </div>
+                ) : null}
+
+                {selectedSnapshotRestore && selectedSnapshotRestore.newParameterIds.length > 0 ? (
+                  <div className="parameter-follow-up" data-testid="snapshot-missing-new-note">
+                    <StatusBadge tone="neutral">on FC, not in snapshot</StatusBadge>
+                    <p>
+                      {selectedSnapshotRestore.newParameterIds.length} parameter(s) exist on the connected FC (the new side) but not in this saved
+                      snapshot (the old side) — usually params a newer firmware added after this snapshot was captured. A restore never removes them; this
+                      is informational:{' '}
+                      <span className="snapshot-missing-list">{formatMissingParamList(selectedSnapshotRestore.newParameterIds)}</span>
                     </p>
                   </div>
                 ) : null}
@@ -791,9 +828,12 @@ export function SnapshotsSection(props: SnapshotsSectionProps): ReactElement {
                               ) : null}
                             </span>
                             <span className="parameter-diff-delta">{formatParameterDelta(draft.delta, draft.definition?.unit)}</span>
-                            {/* Per-row apply (field request: like the
-                             *  Parameters tab). Same overwrite ack gates it
-                             *  as the full restore. */}
+                            {/* Per-row Apply — like the Parameters tab, this
+                             *  STAGES the single change as a draft (it does not
+                             *  write). The write happens from the global draft
+                             *  bar's "Write all". Gated on the same ack as the
+                             *  bulk stage so a deliberate overwrite set is
+                             *  confirmed before it enters the write queue. */}
                             <button
                               type="button"
                               style={buttonStyle()}
@@ -802,7 +842,7 @@ export function SnapshotsSection(props: SnapshotsSectionProps): ReactElement {
                               disabled={busyAction !== undefined || !snapshotRestoreAcknowledged}
                               title={
                                 snapshotRestoreAcknowledged
-                                  ? `Write only ${draft.id} from this snapshot to the controller.`
+                                  ? `Stage ${draft.id} from this snapshot as a draft — write it from the draft bar.`
                                   : 'Acknowledge the overwrite warning below first.'
                               }
                             >
@@ -885,9 +925,9 @@ export function SnapshotsSection(props: SnapshotsSectionProps): ReactElement {
                       disabled={busyAction !== undefined}
                     />
                     <span>
-                      Force-write these {selectedSnapshotInvalidEntries.length} blocked value(s) anyway. They exceed this
-                      app&apos;s documented range/enum (common on a cross-board restore) — the flight controller may
-                      still accept them, or clamp/reject on write-back. Use when you know they&apos;re valid on this FC.
+                      Also stage these {selectedSnapshotInvalidEntries.length} blocked value(s). They exceed this
+                      app&apos;s documented range/enum (common on a cross-board restore) — staging them as drafts lets you
+                      complete the override from the Parameters tab (&ldquo;Override and write anyway&rdquo;) before writing.
                     </span>
                   </label>
                   </>
@@ -895,15 +935,16 @@ export function SnapshotsSection(props: SnapshotsSectionProps): ReactElement {
 
                 <div className="snapshots-detail-section-heading snapshots-detail-section-heading--compact">
                   <div>
-                    <h4>Apply restore</h4>
+                    <h4>Stage restore</h4>
                   </div>
                 </div>
 
                 <div className="parameter-follow-up parameter-follow-up--warning">
                   <StatusBadge tone="warning">overwrite</StatusBadge>
                   <p>
-                    Snapshot restore writes only the diff against the current live controller, verifies readback, and rolls back earlier writes if a later
-                    write fails. It still overwrites the current live values for every changed parameter listed above.
+                    Staging loads the diff against the current live controller into the shared draft set — nothing is written yet. Review it, then
+                    <strong> Write all</strong> from the draft bar (the same verified, readback-checked, rollback-on-failure path the Parameters tab uses).
+                    Writing overwrites the current live values for every changed parameter listed above.
                   </p>
                 </div>
 
@@ -919,7 +960,7 @@ export function SnapshotsSection(props: SnapshotsSectionProps): ReactElement {
                         !(snapshotForceInvalid && selectedSnapshotInvalidEntries.length > 0))
                     }
                   />
-                  <span>I understand that applying this restore will overwrite the current live values shown in the diff above.</span>
+                  <span>I understand these staged changes will overwrite the current live values shown above when I write them.</span>
                 </label>
 
                 <div className="snapshots-action-row snapshots-action-row--detail">
@@ -931,14 +972,26 @@ export function SnapshotsSection(props: SnapshotsSectionProps): ReactElement {
                       busyAction !== undefined ||
                       (selectedSnapshotChangedEntries.length === 0 &&
                         !(snapshotForceInvalid && selectedSnapshotInvalidEntries.length > 0)) ||
-                      (selectedSnapshotInvalidEntries.length > 0 && !snapshotForceInvalid) ||
-                      !snapshotRestoreAcknowledged ||
-                      !canApplyDraftParameters
+                      !snapshotRestoreAcknowledged
                     }
+                    title="Stage every changed parameter as a draft, then Write all from the draft bar to apply."
                   >
-                    {busyAction === 'snapshots:apply'
-                      ? 'Applying…'
-                      : `Apply Snapshot Restore (${selectedSnapshotChangedEntries.length + (snapshotForceInvalid ? selectedSnapshotInvalidEntries.length : 0)})`}
+                    {`Stage All (${selectedSnapshotChangedEntries.length + (snapshotForceInvalid ? selectedSnapshotInvalidEntries.length : 0)})`}
+                  </button>
+                  {/* Drop next to Stage (field request) — clears every row from
+                   *  the restore diff and un-stages any drafts it already
+                   *  staged, mirroring the Parameters tab's "Discard All". */}
+                  <button
+                    data-testid="drop-all-snapshot-restore-button"
+                    className="snapshots-button snapshots-button--secondary"
+                    onClick={handleDropAllSnapshotRestoreEntries}
+                    disabled={
+                      busyAction !== undefined ||
+                      (selectedSnapshotChangedEntries.length === 0 && selectedSnapshotInvalidEntries.length === 0)
+                    }
+                    title="Drop every row from this restore diff (and un-stage any staged drafts). Keeps the live FC values as-is."
+                  >
+                    Drop All
                   </button>
                   {isExpertMode ? (
                     <button
@@ -1307,9 +1360,17 @@ export function SnapshotsSection(props: SnapshotsSectionProps): ReactElement {
                     <span>Matched live</span>
                     <strong>{selectedProvisioningProfileRestore?.unchangedCount ?? 0}</strong>
                   </article>
-                  <article className="telemetry-metric-card snapshots-metric-card">
-                    <span>Unknown on live</span>
+                  <article className="telemetry-metric-card snapshots-metric-card" data-testid="provisioning-missing-old">
+                    <span title="Present in this profile (old side) but absent from this FC's parameters — skipped on apply.">
+                      In profile, not on FC
+                    </span>
                     <strong>{selectedProvisioningProfileRestore?.unknownParameterIds.length ?? 0}</strong>
+                  </article>
+                  <article className="telemetry-metric-card snapshots-metric-card" data-testid="provisioning-missing-new">
+                    <span title="Present on this FC (new side) but absent from this profile — usually params a newer firmware added. Informational.">
+                      On FC, not in profile
+                    </span>
+                    <strong>{selectedProvisioningProfileRestore?.newParameterIds.length ?? 0}</strong>
                   </article>
                   <article className="telemetry-metric-card snapshots-metric-card">
                     <span>Provisioning writes</span>
@@ -1355,11 +1416,23 @@ export function SnapshotsSection(props: SnapshotsSectionProps): ReactElement {
                 </div>
 
                 {selectedProvisioningProfileRestore && selectedProvisioningProfileRestore.unknownParameterIds.length > 0 ? (
-                  <div className="parameter-follow-up parameter-follow-up--warning">
-                    <StatusBadge tone="warning">partial</StatusBadge>
+                  <div className="parameter-follow-up parameter-follow-up--warning" data-testid="provisioning-missing-old-note">
+                    <StatusBadge tone="warning">in profile, not on FC</StatusBadge>
                     <p>
-                      {selectedProvisioningProfileRestore.unknownParameterIds.length} profile parameter(s) do not exist in the current live metadata
-                      set and will be ignored during apply.
+                      {selectedProvisioningProfileRestore.unknownParameterIds.length} parameter(s) exist in this profile (the old side) but not on the
+                      connected FC (the new side), so they can&apos;t be applied and are skipped:{' '}
+                      <span className="snapshot-missing-list">{formatMissingParamList(selectedProvisioningProfileRestore.unknownParameterIds)}</span>
+                    </p>
+                  </div>
+                ) : null}
+
+                {selectedProvisioningProfileRestore && selectedProvisioningProfileRestore.newParameterIds.length > 0 ? (
+                  <div className="parameter-follow-up" data-testid="provisioning-missing-new-note">
+                    <StatusBadge tone="neutral">on FC, not in profile</StatusBadge>
+                    <p>
+                      {selectedProvisioningProfileRestore.newParameterIds.length} parameter(s) exist on the connected FC (the new side) but not in this
+                      profile (the old side) — usually params a newer firmware added. Apply never removes them; this is informational:{' '}
+                      <span className="snapshot-missing-list">{formatMissingParamList(selectedProvisioningProfileRestore.newParameterIds)}</span>
                     </p>
                   </div>
                 ) : null}

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -10314,6 +10314,16 @@ details.metadata-settings-section:not([open]) > summary::after {
   font-size: 11px;
 }
 
+/* The two directional "does not exist" notes list the affected param ids —
+   monospace + word-break so a long cross-version list stays readable and never
+   overflows the note width. */
+.snapshot-missing-list {
+  font-family: var(--font-mono, ui-monospace, monospace);
+  font-size: 11px;
+  word-break: break-word;
+  color: var(--text-muted);
+}
+
 .motor-test-card {
   display: grid;
   gap: 14px;

--- a/packages/ardupilot-core/src/parameter-backups.ts
+++ b/packages/ardupilot-core/src/parameter-backups.ts
@@ -122,7 +122,20 @@ export interface ParameterBackupImportResult {
   matchedCount: number
   changedCount: number
   unchangedCount: number
+  /**
+   * Params that exist in the saved snapshot (the "old" side) but are absent from
+   * the live parameter set (the "new" side) — they can't be restored and are
+   * skipped. Directionally: present in snapshot, missing on the FC.
+   */
   unknownParameterIds: string[]
+  /**
+   * The reverse direction: params present on the live FC (the "new" side) but
+   * absent from the saved snapshot (the "old" side) — typically params a newer
+   * firmware added since the snapshot was captured. Informational only (a
+   * restore never removes params); internal-use-only / snapshot-excluded live
+   * params are filtered out so this reflects genuine new configuration.
+   */
+  newParameterIds: string[]
   /** Entries skipped because they matched an opt-in exclusion category. */
   excludedCount: number
 }
@@ -417,9 +430,11 @@ export function deriveDraftValuesFromParameterBackup(
   options?: ParameterBackupImportOptions
 ): ParameterBackupImportResult {
   const parameterById = new Map(parameters.map((parameter) => [parameter.id, parameter]))
+  const backupIds = new Set(backup.parameters.map((entry) => entry.id))
   const excludeCategories = new Set(options?.excludeCategories ?? [])
   const draftValues: Record<string, string> = {}
   const unknownParameterIds: string[] = []
+  const newParameterIds: string[] = []
   let matchedCount = 0
   let changedCount = 0
   let unchangedCount = 0
@@ -466,12 +481,26 @@ export function deriveDraftValuesFromParameterBackup(
     changedCount += 1
   })
 
+  // Reverse direction — params live on the FC (new side) but not in the saved
+  // snapshot (old side). Mirror the snapshot-side exclusions so firmware-managed
+  // / snapshot-excluded params never masquerade as genuinely new configuration.
+  parameters.forEach((parameter) => {
+    if (backupIds.has(parameter.id)) {
+      return
+    }
+    if (isSnapshotExcludedParameterState(parameter) || isInternalUseOnlyParameter(parameter.id)) {
+      return
+    }
+    newParameterIds.push(parameter.id)
+  })
+
   return {
     draftValues,
     matchedCount,
     changedCount,
     unchangedCount,
     unknownParameterIds: unknownParameterIds.sort((left, right) => left.localeCompare(right)),
+    newParameterIds: newParameterIds.sort((left, right) => left.localeCompare(right)),
     excludedCount
   }
 }

--- a/tests/e2e/app.spec.ts
+++ b/tests/e2e/app.spec.ts
@@ -692,15 +692,20 @@ test.describe('browser configurator regression flows', () => {
 
     await expect(page.getByTestId('snapshot-restore-ack')).not.toBeChecked()
     await page.getByTestId('snapshot-restore-ack').check()
-    // A previous write no longer blocks restore — writes self-verify against a
-    // live readback, so the post-write refresh follow-up is advisory, not a
-    // gate. Apply path also auto-refreshes (PR introducing auto-refresh),
-    // so the manual "pull resets the ack" step the old test ran here is now
-    // unreachable from this flow — the auto-refresh fired before the ack
-    // was set, so there's no further refresh to drive a reset.
+    // Snapshot "Apply" now STAGES the diff into the shared draft set (mirroring
+    // the Parameters tab) rather than writing straight to the FC — "Stage All".
     await expect(page.getByTestId('apply-snapshot-restore-button')).toBeEnabled()
     await page.getByTestId('apply-snapshot-restore-button').click()
 
+    // The write happens from the global draft bar, the one shared write path.
+    const draftBar = page.getByTestId('global-draft-bar')
+    await expect(draftBar).toBeVisible()
+    const writeAll = page.getByTestId('global-draft-write')
+    await expect(writeAll).toBeEnabled()
+    await writeAll.click()
+    await expect(draftBar).toHaveCount(0, { timeout: COMMAND_ACK_TIMEOUT })
+
+    // Once written, live matches the snapshot again.
     await expect(page.getByText('already matched')).toBeVisible()
     await expect(page.getByTestId('active-baseline-label')).toHaveText('E2E baseline')
   })

--- a/tests/parameter-import-exclusions.test.mjs
+++ b/tests/parameter-import-exclusions.test.mjs
@@ -121,6 +121,23 @@ test('internal-use-only params (BAROn_GND_PRESS) are ALWAYS dropped on import �
   assert.equal(result.changedCount, 1)
 })
 
+test('newParameterIds captures params live on the FC but absent from the saved snapshot (the reverse direction)', () => {
+  // "New vs old" breakout: the snapshot detail surfaces BOTH directions.
+  //   unknownParameterIds = in the saved snapshot (old side), missing on the FC.
+  //   newParameterIds     = on the FC (new side), missing from the snapshot.
+  const live = [
+    { id: 'ATC_RAT_RLL_P', value: 0.135 },
+    { id: 'NEW_47_PARAM', value: 3 }, // added by newer firmware; not in the old snapshot
+    { id: 'BARO1_GND_PRESS', value: 101000 } // internal-use-only — must NOT count as new
+  ]
+  const backup = backupOf({ ATC_RAT_RLL_P: 0.135, OLD_ONLY_PARAM: 7 })
+  const result = deriveDraftValuesFromParameterBackup(live, backup)
+  assert.deepEqual(result.unknownParameterIds, ['OLD_ONLY_PARAM'])
+  assert.deepEqual(result.newParameterIds, ['NEW_47_PARAM'])
+  // The reverse direction is informational only — nothing about it is staged.
+  assert.equal('NEW_47_PARAM' in result.draftValues, false)
+})
+
 test('excluded entries never count as unknown even when absent from the live table', () => {
   // SR7_* / MIS_* not present in the baseline at all: without exclusion they
   // would land in unknownParameterIds; excluded, they vanish cleanly.


### PR DESCRIPTION
Aligns the Snapshot restore flow with the Parameters tab and answers four field asks.

## What changed
1. **Apply stages, not writes.** Per-row **Apply** and the main button (now **Stage All (N)**) merge the diff into the shared draft set (`mergeDrafts`) instead of calling `runtime.setParameters`. The write happens from the global draft bar's **Write all** — the one verified, readback-checked, rollback-on-failure path the app shares. Force-invalid entries stage as drafts (override completes in the Parameters tab).
2. **New-vs-old missing breakout.** New `newParameterIds` (live on the FC, absent from the snapshot) alongside `unknownParameterIds` (in the snapshot, absent on the FC), same internal-use-only / snapshot-excluded filtering. Two tiles + two notes on both the snapshot and provisioning-profile detail.
3. **Drop next to Apply.** Added **Drop All** beside Stage All (clears every row + un-stages its drafts, like the Parameters tab's Discard All). Per-row Drop now also un-stages the draft it staged.
4. **Verbiage aligned** — Stage All / Drop All / Write all, staging-framed copy.

## ArduCopter byte-identical
UI/diff-layer only. The diff-engine addition (`newParameterIds`) is additive/informational; the write path is unchanged (`runtime.setParameters` via the shared draft-apply handlers).

## Validation ladder
- Rung 1 (mock runtime): `npm run test` — 715 node tests pass (+1 `newParameterIds` assertion), 513 web unit tests pass, typecheck clean across all workspaces.
- Rung 3 (Playwright e2e): 9 snapshot specs pass, including the reworked restore round-trip (stage → Write all → matched) and the drop/undo flow.