### PR TITLE
feat(receiver/params/tuning): arm-switch red box, main-craft throttle lift, unified export picker, Acro-first pilot order

### DIFF
--- a/apps/web/src/flight-deck-preview.tsx
+++ b/apps/web/src/flight-deck-preview.tsx
@@ -25,8 +25,10 @@ interface FlightDeckPreviewProps {
   /** Bare quad only — strips the heading tape, HUD, caption, and readouts so the
    *  craft can live in a very small box (e.g. the RC direction-check corner). */
   mini?: boolean
-  /** 0..1 vertical lift for the mini quad (throttle): 0 sinks it low, 1 raises it,
-   *  0.5 is centred. Only applied in `mini` mode. */
+  /** 0..1 vertical lift from the throttle stick: 0 sinks the craft low, 1 raises
+   *  it, 0.5 is centred. Applied in both mini and full mode (full gets a larger
+   *  travel to match its size); previews that don't pass it default to 0.5 (no
+   *  movement). */
   liftNorm?: number
   testId?: string
   // Overrides the caption's source line. Defaults to the FC-attitude wording;
@@ -985,7 +987,13 @@ export function FlightDeckPreview({
           <canvas
             ref={canvasRef}
             className="flight-deck__canvas"
-            style={mini ? { transform: `translateY(${(0.5 - Math.max(0, Math.min(1, liftNorm))) * 64}px)` } : undefined}
+            // Throttle lift: raise/lower the craft with the throttle stick. Used
+            // by the Receiver endpoints mini-craft AND the main Receiver craft at
+            // the top of the tab (both StickCraftPreview) — the full model gets a
+            // larger travel to match its size. Other non-mini previews
+            // (AttitudePreview at Setup) never pass liftNorm, so it defaults to
+            // 0.5 → translateY 0 → no movement, leaving them unchanged.
+            style={{ transform: `translateY(${(0.5 - Math.max(0, Math.min(1, liftNorm))) * (mini ? 64 : 96)}px)` }}
           />
           {!mini ? (
           <div className="flight-deck__heading-tape" aria-hidden="true">

--- a/apps/web/src/rc-channel-bars.tsx
+++ b/apps/web/src/rc-channel-bars.tsx
@@ -15,6 +15,13 @@ interface RcChannelBarsProps {
   }[]
   verified: boolean
   testId?: string
+  /** Channel currently mapped as the Arm/Disarm switch (RCn_OPTION 153/154),
+   *  or undefined. When it matches a row AND armSwitchActive is true, that row
+   *  is boxed red — a live "this switch is holding the craft armed" cue. */
+  armSwitchChannel?: number
+  /** True when the vehicle is armed and the arm-switch channel is in the arm
+   *  (high) position. Drives the red box on the arm-switch row. */
+  armSwitchActive?: boolean
 }
 
 /* ------------------------------------------------------------------ */
@@ -57,6 +64,14 @@ const STYLE_BLOCK = `
 .rc-bar-row--mode {
   border-color: var(--warning, #dab254);
   background: var(--warning-weak, rgba(218, 178, 84, 0.14));
+}
+
+/* Arm-switch row while the vehicle is armed via that switch — a red box so it
+   is unmistakable which channel is holding the craft armed. Declared after the
+   mode rule so it wins the border when a channel is somehow both. */
+.rc-bar-row--armed {
+  border-color: var(--danger, #d46b62);
+  background: var(--danger-weak, rgba(212, 107, 98, 0.16));
 }
 
 /* Label column */
@@ -191,7 +206,7 @@ function clampFillPct(pct: number): number {
 /*  Component                                                          */
 /* ------------------------------------------------------------------ */
 
-export function RcChannelBars({ channels, verified, testId }: RcChannelBarsProps) {
+export function RcChannelBars({ channels, verified, testId, armSwitchChannel, armSwitchActive }: RcChannelBarsProps) {
   const styleId = useId()
 
   return (
@@ -219,12 +234,16 @@ export function RcChannelBars({ channels, verified, testId }: RcChannelBarsProps
         const trimPct = clampFillPct(ch.trimPercent)
         const color = hasData ? fillColor(ch.pwm, ch.isModeChannel) : 'transparent'
         const fillOpacity = hasData ? 0.82 : 0
+        const armHighlight =
+          Boolean(armSwitchActive) && armSwitchChannel !== undefined && ch.channelNumber === armSwitchChannel
 
         return (
           <div
             key={ch.channelNumber}
-            className={`rc-bar-row${ch.isModeChannel ? ' rc-bar-row--mode' : ''}`}
+            className={`rc-bar-row${ch.isModeChannel ? ' rc-bar-row--mode' : ''}${armHighlight ? ' rc-bar-row--armed' : ''}`}
             data-testid={testId ? `${testId}-ch${ch.channelNumber}` : undefined}
+            data-arm-switch-armed={armHighlight ? 'true' : undefined}
+            title={armHighlight ? `Armed — CH${ch.channelNumber} is the arm switch and is in the arm position.` : undefined}
           >
             {/* Label */}
             <div className="rc-bar-label">

--- a/apps/web/src/sections/ParametersSection.tsx
+++ b/apps/web/src/sections/ParametersSection.tsx
@@ -370,37 +370,31 @@ export function ParametersSection(props: ParametersSectionProps): ReactElement {
             </div>
 
             <div className="button-row">
-              <button
-                data-testid="export-parameter-backup"
-                style={buttonStyle('primary')}
-                onClick={handleExportParameterBackup}
-                disabled={busyAction !== undefined || snapshot.parameters.length === 0}
-                title="ArduConfigurator JSON backup with full metadata; round-trips through Import Backup. Use this unless another tool specifically needs a legacy format."
-              >
-                Export
-              </button>
-              {/* A third export format ("why do these exist?") collapsed into
-               *  one control: pick a legacy ground-station format here only
-               *  when you specifically need to hand the file to Mission
-               *  Planner or QGroundControl. Resets to the placeholder after
-               *  each export so it reads as a one-shot action, not a
-               *  persistent mode toggle. */}
+              {/* One Export control — pick the format on click (field request:
+               *  the old side-by-side "Export" + "Export Legacy…" read as two
+               *  competing buttons). ArduConfigurator JSON keeps full metadata
+               *  and round-trips through Import Backup; the two ground-station
+               *  formats are for handing the file to Mission Planner / QGC.
+               *  Controlled value="" resets to the placeholder after each pick
+               *  so it reads as a one-shot action, not a persistent mode. */}
               <select
-                data-testid="export-parameter-backup-legacy"
-                className="export-legacy-select"
-                style={buttonStyle()}
+                data-testid="export-parameter-backup"
+                className="export-format-select"
+                style={buttonStyle('primary')}
                 value=""
                 disabled={busyAction !== undefined || snapshot.parameters.length === 0}
-                title="Export in a legacy ground-station format for a specific tool, instead of ArduConfigurator's own JSON."
+                title="Export the current parameters — pick a format. ArduConfigurator JSON keeps full metadata and round-trips through Import Backup; Mission Planner / QGroundControl are for handing the file to those ground stations."
                 onChange={(event) => {
                   const format = event.target.value
-                  if (format === 'parm') handleExportParameterBackupAsParm()
+                  if (format === 'json') handleExportParameterBackup()
+                  else if (format === 'parm') handleExportParameterBackupAsParm()
                   else if (format === 'params') handleExportParameterBackupAsParams()
                 }}
               >
                 <option value="" disabled>
-                  Export Legacy…
+                  Export…
                 </option>
+                <option value="json">ArduConfigurator JSON</option>
                 <option value="parm">Mission Planner (.parm)</option>
                 <option value="params">QGroundControl (.params)</option>
               </select>

--- a/apps/web/src/sections/ReceiverSection.tsx
+++ b/apps/web/src/sections/ReceiverSection.tsx
@@ -26,7 +26,7 @@ import {
 import { formatArducopterFlightModeChannel, formatArducopterRssiType } from '@arduconfig/param-metadata'
 import { StatusBadge, buttonStyle } from '@arduconfig/ui-kit'
 
-import { armSwitchChannelOptions, type ArmSwitchAssignment } from '../view-models/arm-switch'
+import { armSwitchChannelOptions, isArmSwitchHighlightActive, type ArmSwitchAssignment } from '../view-models/arm-switch'
 import type { useModeSwitchDerivations } from '../hooks/use-mode-switch-derivations'
 import type { useRcCalibrationDerivations } from '../hooks/use-rc-calibration-derivations'
 import type { useRcExercises } from '../hooks/use-rc-exercises'
@@ -285,6 +285,19 @@ export function ReceiverSection(props: ReceiverSectionProps): ReactElement {
     handleSetArmSwitchChannel
   } = handlers
 
+  // Arm-switch red box: the live PWM on the assigned arm-switch channel (0xffff
+  // = the RC_CHANNELS no-data sentinel), and whether the vehicle is armed via
+  // that switch (armed + channel in the arm/high position).
+  const armSwitchChannelPwm =
+    armSwitchAssignment.channel !== undefined
+      ? snapshot.liveVerification.rcInput.channels[armSwitchAssignment.channel - 1]
+      : undefined
+  const armSwitchHighlightActive = isArmSwitchHighlightActive(
+    armSwitchAssignment,
+    Boolean(snapshot.vehicle?.armed),
+    armSwitchChannelPwm === undefined || armSwitchChannelPwm === 0xffff ? undefined : armSwitchChannelPwm
+  )
+
   return (
         <ReceiverView
           taskCards={receiverTaskCards}
@@ -357,6 +370,8 @@ export function ReceiverSection(props: ReceiverSectionProps): ReactElement {
                     channels={receiverPrimaryChannelDisplays}
                     verified={snapshot.liveVerification.rcInput.verified}
                     testId="receiver-channel-bars"
+                    armSwitchChannel={armSwitchAssignment.channel}
+                    armSwitchActive={armSwitchHighlightActive}
                   />
 
                   {rcLogicChannelClaims && rcLogicChannelClaims.size > 0 ? (

--- a/apps/web/src/sections/TuningCopterSection.tsx
+++ b/apps/web/src/sections/TuningCopterSection.tsx
@@ -217,6 +217,33 @@ export function TuningCopterSection(props: TuningCopterSectionProps): ReactEleme
                   <div className="tuning-task-panel tuning-task-panel--stack">
                     <details className="bf-gui-box">
                       <summary className="bf-gui-box__titlebar">
+                        <strong>Attitude (Acro)</strong>
+                      </summary>
+                      <div className="bf-gui-box__body">
+                        <div className="switch-exercise-card__header">
+                          <div>
+                            <span className="tuning-card-title">
+                              <strong>Rates, expo, and accel shaping</strong>
+                              <InfoDot label="About rates, expo, and accel shaping" testId="tuning-info-acro" wide>
+                                <span className="info-dot-line">Rates set maximum rotation speed. Expo softens the center without reducing full-stick authority.</span>
+                                <span className="info-dot-line">Acceleration limits control how aggressively the controller tries to reach the commanded rate.</span>
+                                <span className="info-dot-line">Keep changes small and save a known-good snapshot before pushing responsiveness higher.</span>
+                              </InfoDot>
+                            </span>
+                            <p>Curated FPV-style rate shaping backed by real ArduPilot acro-rate and angular-acceleration parameters.</p>
+                          </div>
+                          <StatusBadge tone="neutral">{acroTuningParameters.length + tuningAccelerationParameters.length} controls</StatusBadge>
+                        </div>
+
+                        <div className="tuning-control-grid">
+                          {acroTuningParameters.map((parameter) => renderTuningControl(parameter))}
+                          {tuningAccelerationParameters.map((parameter) => renderTuningControl(parameter))}
+                        </div>
+                      </div>
+                    </details>
+
+                    <details className="bf-gui-box">
+                      <summary className="bf-gui-box__titlebar">
                         <strong>Angle</strong>
                       </summary>
                       <div className="bf-gui-box__body">
@@ -239,33 +266,6 @@ export function TuningCopterSection(props: TuningCopterSectionProps): ReactEleme
 
                         <div className="tuning-control-grid">
                           {flightFeelParameters.map((parameter) => renderTuningControl(parameter))}
-                        </div>
-                      </div>
-                    </details>
-
-                    <details className="bf-gui-box">
-                      <summary className="bf-gui-box__titlebar">
-                        <strong>Attitude (Acro)</strong>
-                      </summary>
-                      <div className="bf-gui-box__body">
-                        <div className="switch-exercise-card__header">
-                          <div>
-                            <span className="tuning-card-title">
-                              <strong>Rates, expo, and accel shaping</strong>
-                              <InfoDot label="About rates, expo, and accel shaping" testId="tuning-info-acro" wide>
-                                <span className="info-dot-line">Rates set maximum rotation speed. Expo softens the center without reducing full-stick authority.</span>
-                                <span className="info-dot-line">Acceleration limits control how aggressively the controller tries to reach the commanded rate.</span>
-                                <span className="info-dot-line">Keep changes small and save a known-good snapshot before pushing responsiveness higher.</span>
-                              </InfoDot>
-                            </span>
-                            <p>Curated FPV-style rate shaping backed by real ArduPilot acro-rate and angular-acceleration parameters.</p>
-                          </div>
-                          <StatusBadge tone="neutral">{acroTuningParameters.length + tuningAccelerationParameters.length} controls</StatusBadge>
-                        </div>
-
-                        <div className="tuning-control-grid">
-                          {acroTuningParameters.map((parameter) => renderTuningControl(parameter))}
-                          {tuningAccelerationParameters.map((parameter) => renderTuningControl(parameter))}
                         </div>
                       </div>
                     </details>

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -13823,8 +13823,7 @@ details.bf-gui-box:not([open]) > summary::after {
   /* Exporting a backup file is a desktop task; on a phone keep Import Backup
    * (used for cross-vehicle migration) plus Apply/Discard, and drop the
    * export controls so the review card stops dominating the screen. */
-  [data-testid="export-parameter-backup"],
-  [data-testid="export-parameter-backup-legacy"] {
+  [data-testid="export-parameter-backup"] {
     display: none;
   }
 

--- a/apps/web/src/view-models/arm-switch.test.ts
+++ b/apps/web/src/view-models/arm-switch.test.ts
@@ -5,7 +5,9 @@ import {
   ARM_SWITCH_OPTION_VALUE,
   armSwitchAssignmentDrafts,
   armSwitchChannelOptions,
-  deriveArmSwitchAssignment
+  deriveArmSwitchAssignment,
+  isArmSwitchHighlightActive,
+  isArmSwitchInArmPosition
 } from './arm-switch'
 
 function snapshotWith(params: Record<string, number>): any {
@@ -65,6 +67,36 @@ describe('armSwitchAssignmentDrafts', () => {
   it('toggling airmode on the SAME channel only rewrites that channel', () => {
     const drafts = armSwitchAssignmentDrafts({ channel: 6, airmode: false }, 6, true)
     expect(drafts).toEqual({ RC6_OPTION: String(ARM_SWITCH_AIRMODE_OPTION_VALUE) })
+  })
+})
+
+describe('isArmSwitchInArmPosition', () => {
+  it('is true only above the 1800µs HIGH trigger', () => {
+    expect(isArmSwitchInArmPosition(1801)).toBe(true)
+    expect(isArmSwitchInArmPosition(2000)).toBe(true)
+    expect(isArmSwitchInArmPosition(1800)).toBe(false)
+    expect(isArmSwitchInArmPosition(1500)).toBe(false)
+    expect(isArmSwitchInArmPosition(1000)).toBe(false)
+  })
+
+  it('rejects undefined and the 0xffff no-data sentinel (never reads as armed)', () => {
+    expect(isArmSwitchInArmPosition(undefined)).toBe(false)
+    expect(isArmSwitchInArmPosition(0xffff)).toBe(false)
+  })
+})
+
+describe('isArmSwitchHighlightActive', () => {
+  const assigned = { channel: 7, airmode: false }
+
+  it('is active only when armed AND the assigned channel is high', () => {
+    expect(isArmSwitchHighlightActive(assigned, true, 1900)).toBe(true)
+    expect(isArmSwitchHighlightActive(assigned, false, 1900)).toBe(false) // not armed
+    expect(isArmSwitchHighlightActive(assigned, true, 1200)).toBe(false) // switch low
+    expect(isArmSwitchHighlightActive(assigned, true, undefined)).toBe(false) // no telemetry
+  })
+
+  it('is inactive when no channel is assigned, even if armed', () => {
+    expect(isArmSwitchHighlightActive({ channel: undefined, airmode: false }, true, 1900)).toBe(false)
   })
 })
 

--- a/apps/web/src/view-models/arm-switch.ts
+++ b/apps/web/src/view-models/arm-switch.ts
@@ -91,6 +91,28 @@ export function armSwitchAssignmentDrafts(
   return drafts
 }
 
+/** ArduPilot AUX_SWITCH_PWM_TRIGGER_HIGH: an aux switch reads HIGH — the arm
+ *  position for ARMDISARM (153) / ARMDISARM_AIRMODE (154) — above 1800µs. */
+export const ARM_SWITCH_HIGH_PWM_US = 1800
+
+/** True when a channel PWM puts the arm switch in the arm (HIGH) position.
+ *  Rejects undefined and the RC_CHANNELS no-data sentinel (0xffff) / other
+ *  out-of-band values so a silent or missing channel never reads as "armed". */
+export function isArmSwitchInArmPosition(pwm: number | undefined): boolean {
+  return pwm !== undefined && Number.isFinite(pwm) && pwm > ARM_SWITCH_HIGH_PWM_US && pwm < 2500
+}
+
+/** Whether the arm-switch channel row should be boxed red in the Receiver tab:
+ *  the vehicle is armed, an arm switch is assigned, and that channel is in the
+ *  arm (high) position — i.e. the switch is actively holding the craft armed. */
+export function isArmSwitchHighlightActive(
+  assignment: ArmSwitchAssignment,
+  armed: boolean,
+  armChannelPwm: number | undefined
+): boolean {
+  return armed && assignment.channel !== undefined && isArmSwitchInArmPosition(armChannelPwm)
+}
+
 export interface ArmSwitchChannelOption {
   value: number
   label: string

--- a/tests/e2e/app.spec.ts
+++ b/tests/e2e/app.spec.ts
@@ -961,11 +961,11 @@ test.describe('browser configurator regression flows', () => {
     await connectToVehicle(page, 'demo')
     await page.getByTestId('product-mode-expert').click()
     await openView(page, 'parameters')
-    const exportButton = page.getByTestId('export-parameter-backup')
-    await expect(exportButton).toBeEnabled()
+    const exportPicker = page.getByTestId('export-parameter-backup')
+    await expect(exportPicker).toBeEnabled()
     const [download] = await Promise.all([
       page.waitForEvent('download'),
-      exportButton.click()
+      exportPicker.selectOption('json')
     ])
     expect(download.suggestedFilename().length).toBeGreaterThan(0)
   })
@@ -1005,7 +1005,7 @@ test.describe('browser configurator regression flows', () => {
 
     // Exporting reports the skipped category in the notice.
     const download = page.waitForEvent('download')
-    await page.getByTestId('export-parameter-backup').click()
+    await page.getByTestId('export-parameter-backup').selectOption('json')
     await download
     await expect(page.getByTestId('parameter-notice')).toContainText('skipped calibration')
   })

--- a/tests/e2e/views.spec.ts
+++ b/tests/e2e/views.spec.ts
@@ -291,28 +291,36 @@ test.describe('Parameters tab (expert-only)', () => {
     await expect(page.getByTestId('parameter-diff-grid')).toBeInViewport()
   })
 
-  test('Export collapses to one primary button + an Export Legacy format picker', async ({ page }) => {
-    // Was three buttons (Export JSON / .parm / .params) with no explanation of
-    // why they exist. Now: one primary Export (native JSON) plus a legacy
-    // select for the two ground-station formats, used only when a specific
-    // tool needs them.
+  test('Export is one picker where you choose the format', async ({ page }) => {
+    // Was a primary "Export" button sitting next to a separate "Export Legacy…"
+    // select, which read as two competing exports. Now a single picker: pick
+    // ArduConfigurator JSON or a ground-station format from one control.
     await page.goto('/')
     await connectViaHeader(page)
     await page.getByTestId('product-mode-expert').click()
     await page.getByTestId('view-button-parameters').click()
 
-    await expect(page.getByTestId('export-parameter-backup')).toHaveText('Export')
-    const legacySelect = page.getByTestId('export-parameter-backup-legacy')
-    await expect(legacySelect).toHaveValue('')
-    const optionLabels = await legacySelect.locator('option').allTextContents()
-    expect(optionLabels).toEqual(['Export Legacy…', 'Mission Planner (.parm)', 'QGroundControl (.params)'])
+    // No separate legacy control anymore.
+    await expect(page.getByTestId('export-parameter-backup-legacy')).toHaveCount(0)
 
-    // Picking a format triggers its export and resets to the placeholder —
+    const exportPicker = page.getByTestId('export-parameter-backup')
+    await expect(exportPicker).toHaveValue('')
+    const optionLabels = await exportPicker.locator('option').allTextContents()
+    expect(optionLabels).toEqual([
+      'Export…',
+      'ArduConfigurator JSON',
+      'Mission Planner (.parm)',
+      'QGroundControl (.params)'
+    ])
+
+    // Picking any format triggers its export and resets to the placeholder —
     // reads as a one-shot action, not a persistent mode.
-    const download = page.waitForEvent('download')
-    await legacySelect.selectOption('parm')
-    await download
-    await expect(legacySelect).toHaveValue('')
+    for (const format of ['json', 'parm', 'params']) {
+      const download = page.waitForEvent('download')
+      await exportPicker.selectOption(format)
+      await download
+      await expect(exportPicker).toHaveValue('')
+    }
   })
 })
 
@@ -858,11 +866,14 @@ test.describe('Tuning tab', () => {
     await page.locator('details.bf-gui-box > summary').filter({ hasText: 'Angle' }).click()
     const input = page.getByTestId('tuning-input-ATC_INPUT_TC')
     await expect(input).toBeVisible({ timeout: 10000 })
-    // The first tuning slider is the first Flight Feel control (ATC_INPUT_TC).
-    // Dragging it (input events, no pointer-up) must update the value live but
-    // NOT commit a staged draft yet — committing on every drag tick is what
-    // made the slider stutter and "jump to staged" before you could finish.
-    const slider = page.locator('.tuning-control__range').first()
+    // Scope to the ATC_INPUT_TC control's own slider (not `.first()` — the
+    // Pilot section order isn't guaranteed, and a collapsed section's sliders
+    // are still in the DOM). Dragging it (input events, no pointer-up) must
+    // update the value live but NOT commit a staged draft yet — committing on
+    // every drag tick is what made the slider stutter and "jump to staged".
+    const slider = page
+      .locator('.tuning-control', { has: page.getByTestId('tuning-input-ATC_INPUT_TC') })
+      .locator('.tuning-control__range')
     await slider.fill('0.3')
     await expect(input).toHaveValue('0.3')
     // Mid-drag (before release) nothing is staged.


### PR DESCRIPTION
Four field-requested UI changes.

## What changed
1. **Receiver — arm-switch red box.** The mapped arm-switch channel (`RCn_OPTION` 153/154) is boxed red in the channel strip when the vehicle is **armed AND that channel is in the arm (high) position**. New tested helpers `isArmSwitchInArmPosition` / `isArmSwitchHighlightActive` (guard the `0xffff` RC_CHANNELS no-data sentinel; HIGH = >1800µs per ArduPilot `AUX_SWITCH_PWM_TRIGGER_HIGH`). Reuses the existing arm-switch assignment detection.
2. **Receiver — throttle lift on the main craft.** The top-of-tab model now rises/sinks with the throttle stick, same as the endpoints mini-craft. The lift transform was gated to `mini` mode only; now applied in full mode too (larger travel). Setup's AttitudePreview never passes `liftNorm`, so it stays put.
3. **Parameters — one Export picker.** Merged the "Export" button + "Export Legacy…" select into a single **Export…** picker: ArduConfigurator JSON / Mission Planner (.parm) / QGroundControl (.params).
4. **Tuning → Pilot — Acro first.** Attitude (Acro) now leads, ahead of Angle / Alt Hold / Loiter.

## ArduCopter byte-identical
UI-only (Receiver / Parameters / Tuning presentation). No runtime, transport, protocol, or param-metadata changes.

## Validation ladder
- Rung 1: typecheck (all workspaces); 517 web unit tests (+4 new arm-switch tests).
- Rung 3: affected Playwright e2e green — export picker, pilot-order (including a `.first()`→scoped-slider fix the reorder surfaced), receiver, snapshot.