### PR TITLE
feat(receiver): condense live monitor into Betaflight-style side-by-side columns

### DIFF
--- a/apps/web/src/sections/ReceiverSection.tsx
+++ b/apps/web/src/sections/ReceiverSection.tsx
@@ -315,57 +315,11 @@ export function ReceiverSection(props: ReceiverSectionProps): ReactElement {
                     </StatusBadge>
                   </div>
 
-                  <div className="receiver-stick-craft" data-testid="receiver-stick-craft-card">
-                    <StickCraftPreview
-                      observations={rcAxisObservations}
-                      snapshot={snapshot}
-                      verified={snapshot.liveVerification.rcInput.verified}
-                      vehicleType={snapshot.vehicle?.vehicle}
-                      frameClassLabel={airframe.frameClassLabel}
-                      frameTypeLabel={airframe.frameTypeLabel}
-                    />
-                  </div>
-
-                  <div className="receiver-live-primary-grid">
-                    {rcAxisObservations.map((axis) => {
-                      const channel = receiverPrimaryChannelDisplays.find((entry) => entry.channelNumber === axis.channelNumber)
-                      return (
-                        <article key={axis.axisId} className="receiver-live-card">
-                          <div className="receiver-live-card__header">
-                            <strong>{axis.label}</strong>
-                            <span>CH{axis.channelNumber}</span>
-                          </div>
-                          <div className="rc-bar" aria-hidden="true">
-                            <div className="rc-bar__trim" style={{ left: `${channel?.trimPercent ?? 50}%` }} />
-                            <div className="rc-bar__fill" style={{ width: `${channel?.fillPercent ?? 0}%` }} />
-                          </div>
-                          <div className="receiver-live-card__footer">
-                            <span>{axis.pwm !== undefined ? `${axis.pwm} µs` : 'No data'}</span>
-                            <span>{channel?.role ?? 'Primary control'}</span>
-                          </div>
-                        </article>
-                      )
-                    })}
-
-                    <article className={`receiver-live-card receiver-live-card--mode${recentModeSwitchChange ? ' receiver-live-card--attention' : ''}`}>
-                      <div className="receiver-live-card__header">
-                        <strong>Flight mode</strong>
-                        <span>{modeSwitchEstimate.channelNumber !== undefined ? `CH${modeSwitchEstimate.channelNumber}` : 'Unset'}</span>
-                      </div>
-                      <p>
-                        {modeSwitchEstimate.channelNumber === undefined
-                          ? 'Mode channel not configured yet.'
-                          : modeSwitchEstimate.estimatedSlot !== undefined
-                            ? `Slot ${modeSwitchEstimate.estimatedSlot} · ${formatModeAssignment(modeSwitchEstimate.configuredValue, snapshot.vehicle?.vehicle)}`
-                            : 'Waiting for the configured mode channel to move.'}
-                      </p>
-                      <div className="receiver-live-card__footer">
-                        <span>{modeSwitchEstimate.pwm !== undefined ? `${modeSwitchEstimate.pwm} µs` : 'No data'}</span>
-                        <span>{recentModeSwitchChange ? 'Recent movement' : 'Mode switch'}</span>
-                      </div>
-                    </article>
-                  </div>
-
+                  {/* Betaflight-style side-by-side: live RC channels on one
+                   *  side, the reactive craft model on the other. Stacks back to
+                   *  a single column on narrow/phone widths. */}
+                  <div className="receiver-live-columns">
+                    <div className="receiver-live-columns__channels">
                   <RcChannelBars
                     channels={receiverPrimaryChannelDisplays}
                     verified={snapshot.liveVerification.rcInput.verified}
@@ -373,6 +327,46 @@ export function ReceiverSection(props: ReceiverSectionProps): ReactElement {
                     armSwitchChannel={armSwitchAssignment.channel}
                     armSwitchActive={armSwitchHighlightActive}
                   />
+
+                  {/* The per-axis summary cards were dropped as redundant with
+                   *  the labeled channel bars above (CH1 · ROLL, …). The
+                   *  flight-mode estimate they carried is folded into this one
+                   *  compact line so that readout isn't lost. */}
+                  <div
+                    className={`receiver-flight-mode-line${recentModeSwitchChange ? ' is-attention' : ''}`}
+                    data-testid="receiver-flight-mode-line"
+                  >
+                    <strong>Flight mode</strong>
+                    <span className="receiver-flight-mode-line__ch">
+                      {modeSwitchEstimate.channelNumber !== undefined ? `CH${modeSwitchEstimate.channelNumber}` : 'Unset'}
+                    </span>
+                    <span className="receiver-flight-mode-line__state">
+                      {modeSwitchEstimate.channelNumber === undefined
+                        ? 'Mode channel not configured yet.'
+                        : modeSwitchEstimate.estimatedSlot !== undefined
+                          ? `Slot ${modeSwitchEstimate.estimatedSlot} · ${formatModeAssignment(modeSwitchEstimate.configuredValue, snapshot.vehicle?.vehicle)}`
+                          : 'Waiting for the configured mode channel to move.'}
+                    </span>
+                    <span className="receiver-flight-mode-line__pwm">
+                      {modeSwitchEstimate.pwm !== undefined ? `${modeSwitchEstimate.pwm} µs` : 'No data'}
+                      {recentModeSwitchChange ? ' · moved' : ''}
+                    </span>
+                  </div>
+                    </div>
+
+                    <div className="receiver-live-columns__craft">
+                      <div className="receiver-stick-craft" data-testid="receiver-stick-craft-card">
+                        <StickCraftPreview
+                          observations={rcAxisObservations}
+                          snapshot={snapshot}
+                          verified={snapshot.liveVerification.rcInput.verified}
+                          vehicleType={snapshot.vehicle?.vehicle}
+                          frameClassLabel={airframe.frameClassLabel}
+                          frameTypeLabel={airframe.frameTypeLabel}
+                        />
+                      </div>
+                    </div>
+                  </div>
 
                   {rcLogicChannelClaims && rcLogicChannelClaims.size > 0 ? (
                     <p className="receiver-rcl-summary" data-testid="receiver-rcl-summary">

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -6302,6 +6302,66 @@ textarea:focus {
   gap: 12px;
 }
 
+/* Betaflight-style live monitor: RC channels on one side, the reactive craft
+   model on the other. The channel side takes a little more width; both collapse
+   to a single stacked column on narrow/phone screens (see the phone media
+   query). align-items:start so a tall channel list doesn't stretch the craft. */
+.receiver-live-columns {
+  display: grid;
+  grid-template-columns: minmax(0, 1.15fr) minmax(0, 0.85fr);
+  gap: 12px;
+  align-items: start;
+}
+.receiver-live-columns__channels {
+  display: grid;
+  gap: 12px;
+  min-width: 0;
+}
+.receiver-live-columns__craft {
+  min-width: 0;
+}
+.receiver-live-columns__craft .receiver-stick-craft {
+  margin-bottom: 0;
+}
+
+/* Compact flight-mode readout (replaces the old per-axis summary cards' mode
+   card). One line: label · channel · estimated slot/mode · live PWM. Lifts to a
+   warning tint while the mode channel is actively moving. */
+.receiver-flight-mode-line {
+  display: flex;
+  align-items: baseline;
+  flex-wrap: wrap;
+  gap: 4px 10px;
+  padding: 6px 10px;
+  border-radius: var(--radius-sm, 4px);
+  border: 1px solid var(--border);
+  background: rgba(var(--fill-rgb, 20, 28, 40), 0.5);
+  font-size: 11px;
+  color: var(--text-muted);
+}
+.receiver-flight-mode-line strong {
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--text);
+}
+.receiver-flight-mode-line__ch {
+  font-weight: 700;
+  color: var(--text-dim, #5a7088);
+}
+.receiver-flight-mode-line__state {
+  flex: 1 1 auto;
+  min-width: 0;
+  color: var(--text);
+}
+.receiver-flight-mode-line__pwm {
+  font-variant-numeric: tabular-nums;
+}
+.receiver-flight-mode-line.is-attention {
+  border-color: var(--warning, #dab254);
+  background: var(--warning-weak, rgba(218, 178, 84, 0.14));
+}
+
 .tuning-overview__sticky {
   position: sticky;
   top: 16px;
@@ -11178,6 +11238,7 @@ details.metadata-settings-section:not([open]) > summary::after {
   .outputs-summary-grid,
   .tuning-summary-grid,
   .receiver-live-primary-grid,
+  .receiver-live-columns,
   .receiver-monitor__meta,
   .ports-workspace,
   .outputs-workspace,


### PR DESCRIPTION
The top of the Receiver tab was a tall vertical stack (craft model → per-axis summary cards → channel-bar list). Now it's two columns — **live RC channels on one side, the reactive craft model on the other** — like Betaflight's receiver tab.

## What changed
- New `.receiver-live-columns` grid (channels + craft), collapsing to a single stacked column on narrow/phone widths.
- **Dropped the redundant per-axis summary cards** (ROLL/PITCH/YAW/THROTTLE) — the channel bars already label each channel (`CH1 · ROLL`, …). The flight-mode estimate they carried is folded into one compact `FLIGHT MODE · CHn · Slot · mode · PWM` line (amber while the mode channel is moving), so no readout is lost.
- Model on the right; arm-switch red box + mode-channel highlight + throttle lift all still apply.

## ArduCopter byte-identical
Receiver-tab presentation only — no runtime, transport, protocol, or param-metadata changes.

## Validation ladder
- Rung 1: web typecheck clean.
- Rung 3: 13 receiver Playwright e2e tests green; layout verified via screenshot at 1440px and the phone single-column stack rule confirmed.