### PR TITLE
feat(osd): detection-gated Message-panel controls (OSD_MSG_ABBR + OSDn_MSG_LVL)

### DIFF
--- a/apps/web/src/hooks/use-osd-catalog.ts
+++ b/apps/web/src/hooks/use-osd-catalog.ts
@@ -16,6 +16,9 @@ export interface UseOsdCatalogResult {
   osdSwitchMethodParameter: ParameterState | undefined
   mspOptionsParameter: ParameterState | undefined
   mspOsdCellCountParameter: ParameterState | undefined
+  /** Fork-only "abbreviate MESSAGE panel" toggle — undefined when the firmware
+   *  doesn't expose OSD_MSG_ABBR, which gates the whole Message-panel control. */
+  msgAbbrParameter: ParameterState | undefined
 }
 
 /**
@@ -33,6 +36,7 @@ export function useOsdCatalog(snapshot: ConfiguratorSnapshot): UseOsdCatalogResu
   const osdSwitchMethodParameter = osdParameterById.get('OSD_SW_METHOD')
   const mspOptionsParameter = osdParameterById.get('MSP_OPTIONS')
   const mspOsdCellCountParameter = osdParameterById.get('MSP_OSD_NCELLS')
+  const msgAbbrParameter = osdParameterById.get('OSD_MSG_ABBR')
 
   return {
     osdParameterById,
@@ -40,6 +44,7 @@ export function useOsdCatalog(snapshot: ConfiguratorSnapshot): UseOsdCatalogResu
     osdChannelParameter,
     osdSwitchMethodParameter,
     mspOptionsParameter,
-    mspOsdCellCountParameter
+    mspOsdCellCountParameter,
+    msgAbbrParameter
   }
 }

--- a/apps/web/src/hooks/use-osd-editor.ts
+++ b/apps/web/src/hooks/use-osd-editor.ts
@@ -60,7 +60,13 @@ export function useOsdEditor({
         if (!parameter) {
           return []
         }
-        return [{ parameter, liveValue: parameter.value, kind: suffix === 'ENABLE' ? 'select' : 'number' }]
+        return [
+          {
+            parameter,
+            liveValue: parameter.value,
+            kind: suffix === 'ENABLE' || suffix === 'MSG_LVL' ? 'select' : 'number'
+          }
+        ]
       }),
     [osdParameterById, activeOsdScreen]
   )

--- a/apps/web/src/osd-params.ts
+++ b/apps/web/src/osd-params.ts
@@ -102,7 +102,9 @@ export const OSD_ELEMENT_Y_PARAM_IDS = OSD_SCREEN_NUMBERS.flatMap((screen) =>
 
 // Per-screen "Screen Options" (Mission Planner panel): enable, HD text
 // resolution, font, RC channel switch range, and ESC telemetry index.
-export const OSD_SCREEN_OPTION_SUFFIXES = ['ENABLE', 'TXT_RES', 'FONT', 'CHAN_MIN', 'CHAN_MAX', 'ESC_IDX'] as const
+// MSG_LVL (per-screen message severity filter) is a fork param — absent params
+// are skipped by the Screen Options loop, so it's auto-gated on firmware support.
+export const OSD_SCREEN_OPTION_SUFFIXES = ['ENABLE', 'MSG_LVL', 'TXT_RES', 'FONT', 'CHAN_MIN', 'CHAN_MAX', 'ESC_IDX'] as const
 export const OSD_SCREEN_OPTION_PARAM_IDS = OSD_SCREEN_NUMBERS.flatMap((screen) =>
   OSD_SCREEN_OPTION_SUFFIXES.map((suffix) => `OSD${screen}_${suffix}` as const)
 )
@@ -111,6 +113,7 @@ export const OSD_PARAM_IDS = [
   'OSD_TYPE',
   'OSD_CHAN',
   'OSD_SW_METHOD',
+  'OSD_MSG_ABBR',
   'MSP_OPTIONS',
   'MSP_OSD_NCELLS',
   ...OSD_SCREEN_OPTION_PARAM_IDS,

--- a/apps/web/src/sections/OsdSection.tsx
+++ b/apps/web/src/sections/OsdSection.tsx
@@ -56,12 +56,15 @@ export function OsdSection(props: OsdSectionProps) {
   const osdType = readRoundedParameter(snapshot, 'OSD_TYPE')
   const osdChannel = readRoundedParameter(snapshot, 'OSD_CHAN')
   const osdSwitchMethod = readRoundedParameter(snapshot, 'OSD_SW_METHOD')
+  const osdMsgAbbr = readRoundedParameter(snapshot, 'OSD_MSG_ABBR')
   const mspOptions = readRoundedParameter(snapshot, 'MSP_OPTIONS')
   const mspOsdCellCount = readRoundedParameter(snapshot, 'MSP_OSD_NCELLS')
 
   const osdTypeParameter = osdParameterById.get('OSD_TYPE')
   const osdChannelParameter = osdParameterById.get('OSD_CHAN')
   const osdSwitchMethodParameter = osdParameterById.get('OSD_SW_METHOD')
+  // Fork-only: gates the "abbreviate messages" toggle. Absent → not rendered.
+  const msgAbbrParameter = osdParameterById.get('OSD_MSG_ABBR')
   const mspOptionsParameter = osdParameterById.get('MSP_OPTIONS')
   const mspOsdCellCountParameter = osdParameterById.get('MSP_OSD_NCELLS')
 
@@ -83,6 +86,7 @@ export function OsdSection(props: OsdSectionProps) {
       typeField={osdTypeParameter ? { parameter: osdTypeParameter, liveValue: osdType } : undefined}
       channelField={osdChannelParameter ? { parameter: osdChannelParameter, liveValue: osdChannel } : undefined}
       switchMethodField={osdSwitchMethodParameter ? { parameter: osdSwitchMethodParameter, liveValue: osdSwitchMethod } : undefined}
+      msgAbbrField={msgAbbrParameter ? { parameter: msgAbbrParameter, liveValue: osdMsgAbbr } : undefined}
       previewToolbar={{
         backendText: `Backend ${formatArducopterOsdType(osdType)}`,
         switchingText: `Switching ${formatArducopterOsdSwitchMethod(osdSwitchMethod)}`,

--- a/apps/web/src/views/Osd.tsx
+++ b/apps/web/src/views/Osd.tsx
@@ -164,6 +164,8 @@ export interface OsdViewProps {
   typeField: OsdSelectField | undefined
   channelField: OsdSelectField | undefined
   switchMethodField: OsdSelectField | undefined
+  /** Fork-only "abbreviate MESSAGE panel" toggle; undefined hides it. */
+  msgAbbrField: OsdSelectField | undefined
   previewToolbar: OsdPreviewToolbarData
   previewElements: readonly OsdPreviewElement[]
   /** Per-element × per-screen (OSD1-4) enable matrix for the BF-style picker. */
@@ -221,6 +223,7 @@ export function OsdView(props: OsdViewProps) {
     typeField,
     channelField,
     switchMethodField,
+    msgAbbrField,
     previewToolbar,
     previewElements,
     elementMatrix,
@@ -515,6 +518,34 @@ export function OsdView(props: OsdViewProps) {
               </div>
             </div>
           </details>
+
+          {/* Fork-only MESSAGE-panel controls, gated on OSD_MSG_ABBR being
+              reported by the firmware. The per-screen severity filter
+              (OSDn_MSG_LVL) rides the Screen Options panel below. */}
+          {msgAbbrField ? (
+            <details className="bf-gui-box osd-messages-strip" data-testid="osd-messages-strip" open>
+              <summary className="bf-gui-box__titlebar">
+                <strong>Messages</strong>
+                <small>MESSAGE panel cleanliness</small>
+              </summary>
+              <div className="bf-gui-box__body">
+                <div className="bf-compact-field-grid">
+                  <ScopedSelectField
+                    parameter={msgAbbrField.parameter}
+                    liveValue={msgAbbrField.liveValue}
+                    editedValues={editedValues}
+                    onChange={onEditChange}
+                    draftStatusById={draftStatusById}
+                    layout="chips"
+                  />
+                </div>
+                <p className="bf-note">
+                  Per-screen message severity (which messages each screen shows) is under each screen&apos;s{' '}
+                  <strong>Screen Options</strong> below.
+                </p>
+              </div>
+            </details>
+          ) : null}
 
           {screenOptionFields.length > 0 ? (
             <details className="bf-gui-box osd-screen-options" data-testid="osd-screen-options" open>

--- a/packages/param-metadata/src/arducopter-enums.ts
+++ b/packages/param-metadata/src/arducopter-enums.ts
@@ -393,6 +393,20 @@ export const ARDUCOPTER_OSD_SWITCH_METHOD_LABELS: Record<number, string> = {
   2: 'Advance On High Pulse'
 }
 
+// Per-screen OSD message severity filter (OSDn_MSG_LVL). Matches MAVLink
+// SEVERITY: lower numbers are MORE severe. A screen shows messages at least
+// this severe, so 4 (Warning) is quiet and 7 (Debug) shows everything.
+export const ARDUCOPTER_OSD_MSG_LVL_LABELS: Record<number, string> = {
+  0: 'Emergency',
+  1: 'Alert',
+  2: 'Critical',
+  3: 'Error',
+  4: 'Warning',
+  5: 'Notice',
+  6: 'Info',
+  7: 'Debug'
+}
+
 export const ARDUCOPTER_MSP_OSD_CELL_COUNT_LABELS: Record<number, string> = {
   0: 'Auto',
   1: '1 cell',

--- a/packages/param-metadata/src/arducopter.ts
+++ b/packages/param-metadata/src/arducopter.ts
@@ -30,6 +30,7 @@ import {
   ARDUCOPTER_NOTIFICATION_LED_BRIGHTNESS_LABELS,
   ARDUCOPTER_NOTIFICATION_LED_OVERRIDE_LABELS,
   ARDUCOPTER_OSD_CHANNEL_LABELS,
+  ARDUCOPTER_OSD_MSG_LVL_LABELS,
   ARDUCOPTER_OSD_SWITCH_METHOD_LABELS,
   ARDUCOPTER_OSD_TYPE_LABELS,
   ARDUCOPTER_DSHOT_RATE_LABELS,
@@ -393,6 +394,15 @@ function buildOsdScreenOptionDefinitions(screenNumber: number): FirmwareMetadata
       maximum: 1,
       notes: osdElementNotes,
       options: enabledDisabledOptions
+    },
+    [`${screenLabel}_MSG_LVL`]: {
+      id: `${screenLabel}_MSG_LVL`,
+      label: `${screenLabel} Message Level`,
+      description: `Least-severe message shown in ${screenLabel}'s MESSAGE panel. Messages less severe than this are hidden (lower = more severe), so you can keep one screen quiet (Warning) and another verbose (Debug).`,
+      category: 'osd',
+      minimum: 0,
+      maximum: 7,
+      options: enumOptions(ARDUCOPTER_OSD_MSG_LVL_LABELS)
     },
     [`${screenLabel}_TXT_RES`]: {
       id: `${screenLabel}_TXT_RES`,
@@ -1519,6 +1529,16 @@ export const arducopterMetadata: FirmwareMetadataBundle = {
       maximum: 2,
       notes: osdSwitchNotes,
       options: enumOptions(ARDUCOPTER_OSD_SWITCH_METHOD_LABELS)
+    },
+    OSD_MSG_ABBR: {
+      id: 'OSD_MSG_ABBR',
+      label: 'Abbreviate Messages',
+      description:
+        'Apply a built-in shorthand dictionary to the MESSAGE panel so common text is shorter and fits without scrolling (e.g. "PreArm:" → "PA:", "Arming motors" → "ARMED").',
+      category: 'osd',
+      minimum: 0,
+      maximum: 1,
+      options: enabledDisabledOptions
     },
     ...buildOsdElementParameterDefinitions(1),
     ...buildOsdElementParameterDefinitions(2),

--- a/packages/protocol-mavlink/src/mock-scenario.ts
+++ b/packages/protocol-mavlink/src/mock-scenario.ts
@@ -229,6 +229,10 @@ const mockParameters: ParameterState = {
   OSD_TYPE: 5,
   OSD_CHAN: 8,
   OSD_SW_METHOD: 2,
+  // Fork "OSD message cleanliness" params (sfd-osd-msg): abbreviate the MESSAGE
+  // panel + per-screen severity filter (OSD1_MSG_LVL below, mirrored to 2-4).
+  // Present here so the demo shows the detection-gated Message-panel controls.
+  OSD_MSG_ABBR: 1,
   MSP_OPTIONS: 4,
   MSP_OSD_NCELLS: 0,
   VTX_ENABLE: 1,
@@ -435,6 +439,7 @@ const mockParameters: ParameterState = {
   // Per-screen "Screen Options" (mirrored to OSD2-4 below). Seed sensible
   // ArduPilot defaults so the demo's OSD Screen Options panel is populated.
   OSD1_ENABLE: 1,
+  OSD1_MSG_LVL: 4, // Warning — mirrored to OSD2-4 by the loop below
   OSD1_TXT_RES: 0,
   OSD1_FONT: 0,
   OSD1_CHAN_MIN: 900,

--- a/tests/transport.test.mjs
+++ b/tests/transport.test.mjs
@@ -714,8 +714,8 @@ test('MockTransport serializes chunked inbound frames so demo parameter sync com
     const stats = await runtime.waitForParameterSync({ timeoutMs: 120000 })
 
     assert.equal(stats.status, 'complete')
-    assert.equal(stats.downloaded, 1152)
-    assert.equal(stats.total, 1152)
+    assert.equal(stats.downloaded, 1157)
+    assert.equal(stats.total, 1157)
     assert.equal(runtime.getSnapshot().parameters.find((parameter) => parameter.id === 'FRAME_CLASS')?.value, 1)
     assert.equal(runtime.getSnapshot().parameters.find((parameter) => parameter.id === 'FRAME_TYPE')?.value, 1)
   } finally {
@@ -846,7 +846,7 @@ test('Bundled WebSocket bridge can drive runtime heartbeat and parameter sync fr
     assert.equal(runtime.getSnapshot().connection.kind, 'connected')
     assert.equal(runtime.getSnapshot().vehicle?.vehicle, 'ArduCopter')
     assert.equal(stats.status, 'complete')
-    assert.equal(stats.downloaded, 1152)
+    assert.equal(stats.downloaded, 1157)
     assert.equal(runtime.getSnapshot().parameters.find((parameter) => parameter.id === 'FRAME_CLASS')?.value, 1)
   } finally {
     await runtime.disconnect().catch(() => {})


### PR DESCRIPTION
Slice 1 of the OSD message-cleanliness support (ArduPilot fork branch `sfd-osd-msg`). Detection-gated — the controls appear only when the firmware reports the params, so mainline ArduCopter is unaffected.

## What changed
- **OSD_MSG_ABBR** (Abbreviate Messages) — whole-OSD toggle in a new, gated **Messages** sub-section of the OSD tab. Turns on the firmware's built-in shorthand dictionary for the MESSAGE panel.
- **OSDn_MSG_LVL** (per-screen severity, Emergency…Debug) — folded into the existing per-screen **Screen Options** panel via the suffix list, so it rides the same Save-OSD draft path and auto-gates on presence.
- Metadata: new `ARDUCOPTER_OSD_MSG_LVL_LABELS` + the two param definitions. `osd-params.ts` adds `MSG_LVL` to `OSD_SCREEN_OPTION_SUFFIXES` and `OSD_MSG_ABBR` to `OSD_PARAM_IDS`. Demo mock seeds the params so they're visible in demo mode; the transport param-count test bumped 1152→1157.

## ArduCopter byte-identical
Detection-gated, presentational + metadata only — no runtime/transport/protocol changes. The params are absent on mainline, so the controls never render.

## Validation ladder
- Rung 1: typecheck (all workspaces); 715 node tests; 517 web unit tests.
- Rung 3: Messages section + per-screen severity confirmed rendering via screenshot in demo mode.

Slice 2 (follow-up): the user-definable shorthand-dictionary editor (`@OSD/shorthand.dat` over MAVFTP).