### PR TITLE
feat(elrs): flash ExpressLRS receivers through the FC (Expert + SERIAL_PASS2 gated)

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -20,6 +20,7 @@
     "@arduconfig/protocol-mavlink": "1.1.1",
     "@arduconfig/transport": "1.1.1",
     "@arduconfig/ui-kit": "1.1.1",
+    "esptool-js": "^0.6.0",
     "leaflet": "^1.9.4",
     "react": "^19.2.6",
     "react-dom": "^19.2.6",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -21,6 +21,7 @@
     "@arduconfig/transport": "1.1.1",
     "@arduconfig/ui-kit": "1.1.1",
     "esptool-js": "^0.6.0",
+    "js-md5": "^0.8.3",
     "leaflet": "^1.9.4",
     "react": "^19.2.6",
     "react-dom": "^19.2.6",

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -259,6 +259,7 @@ import { DisconnectedLanding } from './disconnected-landing'
 import { FirmwareFlasher } from './firmware/FirmwareFlasher'
 import { ElrsFlasher, type ElrsFlasherNotice } from './firmware/ElrsFlasher'
 import { flashElrsReceiver, type ElrsFlashProgress } from './firmware/web-serial-esptool'
+import { patchElrsFirmwareOptions } from './view-models/elrs-firmware-options'
 import { MavlinkInspectorView } from './views/MavlinkInspector'
 import { intervalUsForRate } from './view-models/mavlink-inspector'
 import { MAX_MAVLINK_PLOTS, useMavlinkInspector } from './hooks/use-mavlink-inspector'
@@ -4940,7 +4941,12 @@ export function App() {
       setElrsFlasherBusy(false)
     }
   }
-  async function handleFlashElrs(input: { firmware: Uint8Array; baudRate: number; fileName: string }): Promise<void> {
+  async function handleFlashElrs(input: {
+    firmware: Uint8Array
+    baudRate: number
+    fileName: string
+    bindPhrase?: string
+  }): Promise<void> {
     const port = selectedSerialPortRef.current
     if (!port) {
       setElrsFlasherNotice({
@@ -4948,6 +4954,20 @@ export function App() {
         text: 'Receiver flashing needs a direct Web Serial connection (not demo/bridge). Reconnect over USB serial first.'
       })
       return
+    }
+    // Patch the options region (bind phrase → UID) before flashing, if requested.
+    // A non-unified .bin throws here so we never write a corrupted image.
+    let firmwareToFlash = input.firmware
+    if (input.bindPhrase) {
+      try {
+        firmwareToFlash = patchElrsFirmwareOptions(input.firmware, { bindPhrase: input.bindPhrase })
+      } catch (error) {
+        setElrsFlasherNotice({
+          tone: 'danger',
+          text: `Could not set the bind phrase: ${error instanceof Error ? error.message : String(error)}`
+        })
+        return
+      }
     }
     setElrsFlasherBusy(true)
     setElrsFlashProgress({ phase: 'bootloader', message: 'Preparing…' })
@@ -4957,7 +4977,7 @@ export function App() {
       await runtime.disconnect().catch(() => {})
       const result = await flashElrsReceiver({
         port,
-        firmware: input.firmware,
+        firmware: firmwareToFlash,
         baudRate: input.baudRate,
         onProgress: (progress) => setElrsFlashProgress(progress)
       })

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -258,6 +258,7 @@ import { LiveGpsMapCard } from './live-gps-map'
 import { DisconnectedLanding } from './disconnected-landing'
 import { FirmwareFlasher } from './firmware/FirmwareFlasher'
 import { ElrsFlasher, type ElrsFlasherNotice } from './firmware/ElrsFlasher'
+import { flashElrsReceiver, type ElrsFlashProgress } from './firmware/web-serial-esptool'
 import { MavlinkInspectorView } from './views/MavlinkInspector'
 import { intervalUsForRate } from './view-models/mavlink-inspector'
 import { MAX_MAVLINK_PLOTS, useMavlinkInspector } from './hooks/use-mavlink-inspector'
@@ -4900,6 +4901,7 @@ export function App() {
   const [elrsFlasherBusy, setElrsFlasherBusy] = useState(false)
   const [elrsBridgeArmed, setElrsBridgeArmed] = useState(false)
   const [elrsFlasherNotice, setElrsFlasherNotice] = useState<ElrsFlasherNotice | undefined>(undefined)
+  const [elrsFlashProgress, setElrsFlashProgress] = useState<ElrsFlashProgress | undefined>(undefined)
   async function handleArmElrsPassthrough(input: {
     destinationPort: number
     timeoutSeconds: number
@@ -4912,7 +4914,7 @@ export function App() {
       setElrsBridgeArmed(true)
       setElrsFlasherNotice({
         tone: 'warning',
-        text: `Passthru enabled on Serial${input.destinationPort}. The bridge is open at ${input.baudRate.toLocaleString()} baud; receiver flashing lands in the next update.`
+        text: `Passthru enabled on Serial${input.destinationPort}. The bridge is open at ${input.baudRate.toLocaleString()} baud — choose the ELRS firmware .bin and flash the receiver below.`
       })
     } catch (error) {
       setElrsFlasherNotice({
@@ -4935,6 +4937,42 @@ export function App() {
       })
     } finally {
       setElrsBridgeArmed(false)
+      setElrsFlasherBusy(false)
+    }
+  }
+  async function handleFlashElrs(input: { firmware: Uint8Array; baudRate: number; fileName: string }): Promise<void> {
+    const port = selectedSerialPortRef.current
+    if (!port) {
+      setElrsFlasherNotice({
+        tone: 'warning',
+        text: 'Receiver flashing needs a direct Web Serial connection (not demo/bridge). Reconnect over USB serial first.'
+      })
+      return
+    }
+    setElrsFlasherBusy(true)
+    setElrsFlashProgress({ phase: 'bootloader', message: 'Preparing…' })
+    try {
+      // Release the MAVLink transport so esptool owns the raw port. The FC's
+      // pass-through bridge stays up (armed above) until SERIAL_PASSTIMO.
+      await runtime.disconnect().catch(() => {})
+      const result = await flashElrsReceiver({
+        port,
+        firmware: input.firmware,
+        baudRate: input.baudRate,
+        onProgress: (progress) => setElrsFlashProgress(progress)
+      })
+      setElrsFlasherNotice({
+        tone: 'success',
+        text: `Flashed ${result.chipName} with ${input.fileName}. Power-cycle the receiver, then reconnect to the flight controller.`
+      })
+      setElrsBridgeArmed(false)
+    } catch (error) {
+      setElrsFlasherNotice({
+        tone: 'danger',
+        text: `Flashing failed: ${error instanceof Error ? error.message : String(error)}. Power-cycle the receiver and reconnect before retrying.`
+      })
+    } finally {
+      setElrsFlashProgress(undefined)
       setElrsFlasherBusy(false)
     }
   }
@@ -8090,6 +8128,8 @@ export function App() {
           notice={elrsFlasherNotice}
           onArmPassthrough={handleArmElrsPassthrough}
           onCancel={handleCancelElrsPassthrough}
+          onFlash={handleFlashElrs}
+          flashProgress={elrsFlashProgress}
         />
       ) : null}
 

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -257,6 +257,7 @@ import { invertGuidedReorderMapping, pickedReorderPositions } from './view-model
 import { LiveGpsMapCard } from './live-gps-map'
 import { DisconnectedLanding } from './disconnected-landing'
 import { FirmwareFlasher } from './firmware/FirmwareFlasher'
+import { ElrsFlasher, type ElrsFlasherNotice } from './firmware/ElrsFlasher'
 import { MavlinkInspectorView } from './views/MavlinkInspector'
 import { intervalUsForRate } from './view-models/mavlink-inspector'
 import { MAX_MAVLINK_PLOTS, useMavlinkInspector } from './hooks/use-mavlink-inspector'
@@ -4885,6 +4886,58 @@ export function App() {
     () => snapshot.parameters.some((parameter) => parameter.id === 'SCR_ENABLE'),
     [snapshot.parameters]
   )
+  // SERIAL_PASS2 is the AP_SerialManager transparent USB↔UART bridge param —
+  // its presence is the "this FC can passthru-flash an ELRS RX" sentinel that
+  // gates the Expert-only ELRS Flash tab.
+  const hasSerialPassthrough = useMemo(
+    () => snapshot.parameters.some((parameter) => parameter.id === 'SERIAL_PASS2'),
+    [snapshot.parameters]
+  )
+
+  // ELRS passthrough flasher (Expert + SERIAL_PASS2-gated tab). Slice A wires the
+  // SERIAL_PASS bridge arm/teardown; esptool flashing over the reopened port is
+  // the next slice.
+  const [elrsFlasherBusy, setElrsFlasherBusy] = useState(false)
+  const [elrsBridgeArmed, setElrsBridgeArmed] = useState(false)
+  const [elrsFlasherNotice, setElrsFlasherNotice] = useState<ElrsFlasherNotice | undefined>(undefined)
+  async function handleArmElrsPassthrough(input: {
+    destinationPort: number
+    timeoutSeconds: number
+    baudRate: number
+  }): Promise<void> {
+    setElrsFlasherBusy(true)
+    setElrsFlasherNotice(undefined)
+    try {
+      await runtime.enableSerialPassthrough(input.destinationPort, { timeoutSeconds: input.timeoutSeconds })
+      setElrsBridgeArmed(true)
+      setElrsFlasherNotice({
+        tone: 'warning',
+        text: `Passthru enabled on Serial${input.destinationPort}. The bridge is open at ${input.baudRate.toLocaleString()} baud; receiver flashing lands in the next update.`
+      })
+    } catch (error) {
+      setElrsFlasherNotice({
+        tone: 'danger',
+        text: `Could not arm the pass-through bridge: ${error instanceof Error ? error.message : String(error)}`
+      })
+    } finally {
+      setElrsFlasherBusy(false)
+    }
+  }
+  async function handleCancelElrsPassthrough(): Promise<void> {
+    setElrsFlasherBusy(true)
+    try {
+      await runtime.setParameter('SERIAL_PASS2', -1)
+      setElrsFlasherNotice({ tone: 'neutral', text: 'Bridge closed — SERIAL_PASS2 reset to disabled; MAVLink restored.' })
+    } catch {
+      setElrsFlasherNotice({
+        tone: 'warning',
+        text: 'Could not reset SERIAL_PASS2 over the link; the bridge auto-restores after the timeout.'
+      })
+    } finally {
+      setElrsBridgeArmed(false)
+      setElrsFlasherBusy(false)
+    }
+  }
   // Lua Scripts view-model: scripting-capability gate + per-applet sanity, plus
   // the installed-file state machine (MAVFTP against /APM/scripts). The catalog
   // + capability logic is a pure builder (unit-tested); the hook owns the async
@@ -5200,7 +5253,8 @@ export function App() {
         connectionKind: snapshot.connection.kind,
         hasNetworkingParams,
         hasRcLogicParams,
-        hasScriptingParams
+        hasScriptingParams,
+        hasSerialPassthrough
       }),
     [
       appViews,
@@ -5210,7 +5264,8 @@ export function App() {
       snapshot.connection.kind,
       hasNetworkingParams,
       hasRcLogicParams,
-      hasScriptingParams
+      hasScriptingParams,
+      hasSerialPassthrough
     ]
   )
   const activeViewDescriptor = visibleAppViews.find((view) => view.id === activeViewId) ?? visibleAppViews[0]
@@ -8023,6 +8078,18 @@ export function App() {
                 : undefined
           }
           connectedVehicle={snapshot.vehicle?.vehicle}
+        />
+      ) : null}
+
+      {activeViewId === 'elrs-flash' ? (
+        <ElrsFlasher
+          snapshot={snapshot}
+          isConnected={snapshot.connection.kind === 'connected'}
+          busy={elrsFlasherBusy}
+          bridgeArmed={elrsBridgeArmed}
+          notice={elrsFlasherNotice}
+          onArmPassthrough={handleArmElrsPassthrough}
+          onCancel={handleCancelElrsPassthrough}
         />
       ) : null}
 

--- a/apps/web/src/firmware/ElrsFlasher.tsx
+++ b/apps/web/src/firmware/ElrsFlasher.tsx
@@ -1,0 +1,173 @@
+import { useMemo, useState } from 'react'
+import type { ReactElement } from 'react'
+
+import type { ConfiguratorSnapshot } from '@arduconfig/ardupilot-core'
+import { Panel, StatusBadge } from '@arduconfig/ui-kit'
+
+import {
+  detectElrsSerialPorts,
+  ELRS_DEFAULT_FLASH_BAUD,
+  ELRS_FLASH_BAUD_RATES
+} from '../view-models/elrs-flash'
+
+export interface ElrsFlasherNotice {
+  tone: 'neutral' | 'success' | 'warning' | 'danger'
+  text: string
+}
+
+export interface ElrsFlasherProps {
+  snapshot: ConfiguratorSnapshot
+  isConnected: boolean
+  /** True while an arm/flash step is in flight (disables the controls). */
+  busy: boolean
+  /** Set once the passthru bridge has been armed and the port reopened. */
+  bridgeArmed: boolean
+  notice: ElrsFlasherNotice | undefined
+  /**
+   * Arm ArduPilot's SERIAL_PASS bridge on the chosen destination port, then
+   * (in the app) release MAVLink and reopen the port at the flashing baud.
+   */
+  onArmPassthrough: (input: { destinationPort: number; timeoutSeconds: number; baudRate: number }) => void | Promise<void>
+  /** Tear the bridge back down (close the raw port; the FC auto-restores MAVLink). */
+  onCancel: () => void | Promise<void>
+}
+
+const DEFAULT_TIMEOUT_SECONDS = 30
+
+export function ElrsFlasher(props: ElrsFlasherProps): ReactElement {
+  const { snapshot, isConnected, busy, bridgeArmed, notice, onArmPassthrough, onCancel } = props
+
+  const candidates = useMemo(() => detectElrsSerialPorts(snapshot), [snapshot])
+  const [destinationPort, setDestinationPort] = useState<number | undefined>(undefined)
+  const [baudRate, setBaudRate] = useState<number>(ELRS_DEFAULT_FLASH_BAUD)
+  const [timeoutSeconds, setTimeoutSeconds] = useState<number>(DEFAULT_TIMEOUT_SECONDS)
+
+  // Default the selection to the first detected ELRS port once we have one.
+  const effectivePort = destinationPort ?? candidates[0]?.portNumber
+
+  return (
+    <Panel title="ELRS Flash">
+      <div className="elrs-flasher" data-testid="elrs-flasher">
+        <div className="telemetry-header">
+          <div>
+            <h3>Flash an ExpressLRS receiver</h3>
+            <p>
+              Flashes an ESP-based ELRS receiver through the flight controller&apos;s transparent serial bridge — no
+              Betaflight CLI or external ELRS Configurator. The FC becomes a dumb USB↔UART pipe while flashing, then
+              auto-restores MAVLink.
+            </p>
+          </div>
+          <StatusBadge tone={bridgeArmed ? 'warning' : isConnected ? 'success' : 'neutral'}>
+            {bridgeArmed ? 'bridge open' : isConnected ? 'connected' : 'no link'}
+          </StatusBadge>
+        </div>
+
+        {notice ? (
+          <div className={`parameter-review__notice`} data-testid="elrs-flasher-notice">
+            <StatusBadge tone={notice.tone}>{notice.tone}</StatusBadge>
+            <p>{notice.text}</p>
+          </div>
+        ) : null}
+
+        {!isConnected ? (
+          <p className="switch-exercise-warning" data-testid="elrs-flasher-disconnected">
+            Connect to the flight controller over MAVLink first — the bridge is armed over the live link.
+          </p>
+        ) : candidates.length === 0 ? (
+          <p className="switch-exercise-warning" data-testid="elrs-flasher-no-port">
+            No serial port is set to RC Input (RCIN, protocol 23) or CRSF (protocol 29). Set the UART wired to your ELRS
+            receiver to one of those in the Ports tab, then come back.
+          </p>
+        ) : (
+          <div className="elrs-flasher__form" data-testid="elrs-flasher-form">
+            <label className="scoped-editor-field">
+              <span>Receiver serial port</span>
+              <select
+                data-testid="elrs-flasher-port"
+                value={effectivePort ?? ''}
+                disabled={busy || bridgeArmed}
+                onChange={(event) => setDestinationPort(Number(event.target.value))}
+              >
+                {candidates.map((candidate) => (
+                  <option key={candidate.portNumber} value={candidate.portNumber}>
+                    Serial{candidate.portNumber} · {candidate.protocolLabel}
+                  </option>
+                ))}
+              </select>
+            </label>
+
+            <label className="scoped-editor-field">
+              <span>Flashing baud</span>
+              <select
+                data-testid="elrs-flasher-baud"
+                value={baudRate}
+                disabled={busy || bridgeArmed}
+                onChange={(event) => setBaudRate(Number(event.target.value))}
+              >
+                {ELRS_FLASH_BAUD_RATES.map((rate) => (
+                  <option key={rate} value={rate}>
+                    {rate.toLocaleString()} baud
+                  </option>
+                ))}
+              </select>
+            </label>
+
+            <label className="scoped-editor-field">
+              <span>Bridge timeout (s)</span>
+              <input
+                data-testid="elrs-flasher-timeout"
+                type="number"
+                min={5}
+                max={120}
+                value={timeoutSeconds}
+                disabled={busy || bridgeArmed}
+                onChange={(event) => setTimeoutSeconds(Number(event.target.value))}
+              />
+            </label>
+          </div>
+        )}
+
+        <div className="parameter-follow-up parameter-follow-up--warning">
+          <StatusBadge tone="warning">bench only</StatusBadge>
+          <p>
+            Arming the bridge writes SERIAL_PASS2 and drops the MAVLink connection. The receiver is flashed over the raw
+            serial link; if flashing is interrupted the RX may need a re-flash. Do this on the bench with the craft
+            disarmed and props off.
+          </p>
+        </div>
+
+        <div className="snapshots-action-row snapshots-action-row--detail">
+          <button
+            data-testid="elrs-flasher-arm"
+            className="snapshots-button snapshots-button--primary"
+            disabled={busy || bridgeArmed || !isConnected || effectivePort === undefined}
+            onClick={() =>
+              effectivePort !== undefined
+                ? void onArmPassthrough({ destinationPort: effectivePort, timeoutSeconds, baudRate })
+                : undefined
+            }
+          >
+            {busy ? 'Arming…' : 'Arm passthrough bridge'}
+          </button>
+          {bridgeArmed ? (
+            <button
+              data-testid="elrs-flasher-cancel"
+              className="snapshots-button snapshots-button--secondary"
+              disabled={busy}
+              onClick={() => void onCancel()}
+            >
+              Close bridge
+            </button>
+          ) : null}
+        </div>
+
+        {bridgeArmed ? (
+          <p className="telemetry-note" data-testid="elrs-flasher-armed-note">
+            Bridge is open at {baudRate.toLocaleString()} baud. Receiver flashing (esptool sync + firmware write) lands in
+            the next update — for now, close the bridge to restore MAVLink.
+          </p>
+        ) : null}
+      </div>
+    </Panel>
+  )
+}

--- a/apps/web/src/firmware/ElrsFlasher.tsx
+++ b/apps/web/src/firmware/ElrsFlasher.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react'
+import { useMemo, useRef, useState } from 'react'
 import type { ReactElement } from 'react'
 
 import type { ConfiguratorSnapshot } from '@arduconfig/ardupilot-core'
@@ -9,6 +9,7 @@ import {
   ELRS_DEFAULT_FLASH_BAUD,
   ELRS_FLASH_BAUD_RATES
 } from '../view-models/elrs-flash'
+import type { ElrsFlashProgress } from './web-serial-esptool'
 
 export interface ElrsFlasherNotice {
   tone: 'neutral' | 'success' | 'warning' | 'danger'
@@ -30,17 +31,38 @@ export interface ElrsFlasherProps {
   onArmPassthrough: (input: { destinationPort: number; timeoutSeconds: number; baudRate: number }) => void | Promise<void>
   /** Tear the bridge back down (close the raw port; the FC auto-restores MAVLink). */
   onCancel: () => void | Promise<void>
+  /** Flash the chosen firmware over the armed bridge (reopen port + esptool). */
+  onFlash: (input: { firmware: Uint8Array; baudRate: number; fileName: string }) => void | Promise<void>
+  /** Live flashing progress, or undefined when no flash is in flight. */
+  flashProgress: ElrsFlashProgress | undefined
 }
 
 const DEFAULT_TIMEOUT_SECONDS = 30
 
 export function ElrsFlasher(props: ElrsFlasherProps): ReactElement {
-  const { snapshot, isConnected, busy, bridgeArmed, notice, onArmPassthrough, onCancel } = props
+  const { snapshot, isConnected, busy, bridgeArmed, notice, onArmPassthrough, onCancel, onFlash, flashProgress } = props
 
   const candidates = useMemo(() => detectElrsSerialPorts(snapshot), [snapshot])
   const [destinationPort, setDestinationPort] = useState<number | undefined>(undefined)
   const [baudRate, setBaudRate] = useState<number>(ELRS_DEFAULT_FLASH_BAUD)
   const [timeoutSeconds, setTimeoutSeconds] = useState<number>(DEFAULT_TIMEOUT_SECONDS)
+  const [firmware, setFirmware] = useState<{ bytes: Uint8Array; name: string } | undefined>(undefined)
+  const fileInputRef = useRef<HTMLInputElement>(null)
+
+  async function handleFirmwareFile(file: File | undefined): Promise<void> {
+    if (!file) {
+      setFirmware(undefined)
+      return
+    }
+    const buffer = await file.arrayBuffer()
+    setFirmware({ bytes: new Uint8Array(buffer), name: file.name })
+  }
+
+  const flashing = flashProgress !== undefined && flashProgress.phase !== 'done'
+  const flashPercent =
+    flashProgress?.total && flashProgress.total > 0
+      ? Math.round(((flashProgress.written ?? 0) / flashProgress.total) * 100)
+      : undefined
 
   // Default the selection to the first detected ELRS port once we have one.
   const effectivePort = destinationPort ?? candidates[0]?.portNumber
@@ -162,10 +184,55 @@ export function ElrsFlasher(props: ElrsFlasherProps): ReactElement {
         </div>
 
         {bridgeArmed ? (
-          <p className="telemetry-note" data-testid="elrs-flasher-armed-note">
-            Bridge is open at {baudRate.toLocaleString()} baud. Receiver flashing (esptool sync + firmware write) lands in
-            the next update — for now, close the bridge to restore MAVLink.
-          </p>
+          <div className="elrs-flasher__flash" data-testid="elrs-flasher-armed-note">
+            <p className="telemetry-note">
+              Bridge is open at {baudRate.toLocaleString()} baud. Choose the ELRS firmware <code>.bin</code> and flash the
+              receiver, or close the bridge to restore MAVLink.
+            </p>
+            <label className="scoped-editor-field">
+              <span>ELRS firmware (.bin)</span>
+              <input
+                ref={fileInputRef}
+                data-testid="elrs-flasher-firmware"
+                type="file"
+                accept=".bin,application/octet-stream"
+                disabled={flashing}
+                onChange={(event) => void handleFirmwareFile(event.target.files?.[0])}
+              />
+            </label>
+            {firmware ? (
+              <p className="telemetry-note">
+                {firmware.name} · {(firmware.bytes.length / 1024).toFixed(0)} KB
+              </p>
+            ) : null}
+
+            {flashProgress ? (
+              <div className="elrs-flasher__progress" data-testid="elrs-flasher-progress">
+                <div className="rc-bar" aria-hidden="true">
+                  <div className="rc-bar__fill" style={{ width: `${flashPercent ?? 0}%` }} />
+                </div>
+                <span>
+                  {flashProgress.message ??
+                    (flashPercent !== undefined ? `Flashing… ${flashPercent}%` : 'Flashing…')}
+                </span>
+              </div>
+            ) : null}
+
+            <div className="snapshots-action-row snapshots-action-row--detail">
+              <button
+                data-testid="elrs-flasher-flash"
+                className="snapshots-button snapshots-button--primary"
+                disabled={flashing || firmware === undefined}
+                onClick={() =>
+                  firmware
+                    ? void onFlash({ firmware: firmware.bytes, baudRate, fileName: firmware.name })
+                    : undefined
+                }
+              >
+                {flashing ? 'Flashing…' : 'Flash receiver'}
+              </button>
+            </div>
+          </div>
         ) : null}
       </div>
     </Panel>

--- a/apps/web/src/firmware/ElrsFlasher.tsx
+++ b/apps/web/src/firmware/ElrsFlasher.tsx
@@ -31,8 +31,14 @@ export interface ElrsFlasherProps {
   onArmPassthrough: (input: { destinationPort: number; timeoutSeconds: number; baudRate: number }) => void | Promise<void>
   /** Tear the bridge back down (close the raw port; the FC auto-restores MAVLink). */
   onCancel: () => void | Promise<void>
-  /** Flash the chosen firmware over the armed bridge (reopen port + esptool). */
-  onFlash: (input: { firmware: Uint8Array; baudRate: number; fileName: string }) => void | Promise<void>
+  /** Flash the chosen firmware over the armed bridge (reopen port + esptool).
+   *  A non-empty bindPhrase patches the .bin's options region before flashing. */
+  onFlash: (input: {
+    firmware: Uint8Array
+    baudRate: number
+    fileName: string
+    bindPhrase?: string
+  }) => void | Promise<void>
   /** Live flashing progress, or undefined when no flash is in flight. */
   flashProgress: ElrsFlashProgress | undefined
 }
@@ -47,6 +53,7 @@ export function ElrsFlasher(props: ElrsFlasherProps): ReactElement {
   const [baudRate, setBaudRate] = useState<number>(ELRS_DEFAULT_FLASH_BAUD)
   const [timeoutSeconds, setTimeoutSeconds] = useState<number>(DEFAULT_TIMEOUT_SECONDS)
   const [firmware, setFirmware] = useState<{ bytes: Uint8Array; name: string } | undefined>(undefined)
+  const [bindPhrase, setBindPhrase] = useState('')
   const fileInputRef = useRef<HTMLInputElement>(null)
 
   async function handleFirmwareFile(file: File | undefined): Promise<void> {
@@ -206,6 +213,24 @@ export function ElrsFlasher(props: ElrsFlasherProps): ReactElement {
               </p>
             ) : null}
 
+            <label className="scoped-editor-field">
+              <span>Bind phrase (optional)</span>
+              <input
+                data-testid="elrs-flasher-bind-phrase"
+                type="text"
+                placeholder="Leave blank to keep the .bin's bind phrase"
+                value={bindPhrase}
+                disabled={flashing}
+                onChange={(event) => setBindPhrase(event.target.value)}
+              />
+            </label>
+            {bindPhrase.trim() ? (
+              <p className="telemetry-note">
+                The firmware&apos;s options region will be patched with this bind phrase before flashing (requires a unified
+                ELRS release .bin).
+              </p>
+            ) : null}
+
             {flashProgress ? (
               <div className="elrs-flasher__progress" data-testid="elrs-flasher-progress">
                 <div className="rc-bar" aria-hidden="true">
@@ -225,7 +250,12 @@ export function ElrsFlasher(props: ElrsFlasherProps): ReactElement {
                 disabled={flashing || firmware === undefined}
                 onClick={() =>
                   firmware
-                    ? void onFlash({ firmware: firmware.bytes, baudRate, fileName: firmware.name })
+                    ? void onFlash({
+                        firmware: firmware.bytes,
+                        baudRate,
+                        fileName: firmware.name,
+                        bindPhrase: bindPhrase.trim() || undefined
+                      })
                     : undefined
                 }
               >

--- a/apps/web/src/firmware/web-serial-esptool.ts
+++ b/apps/web/src/firmware/web-serial-esptool.ts
@@ -1,0 +1,117 @@
+// ELRS receiver flashing over the FC's transparent SERIAL_PASS bridge, using
+// Espressif's browser esptool (esptool-js). The FC forwards the host USB-CDC
+// baud onto the RC UART, so we open the SAME Web Serial port at the flashing
+// baud and drive the ESP directly.
+//
+// HARDWARE-UNVALIDATED: the byte sequences + esptool wiring follow ExpressLRS's
+// BFinitPassthrough and esptool-js's API, but the end-to-end flash can only be
+// confirmed on a real ESP-based RX. Kept behind the Expert + detection gate and
+// unshipped until bench-verified (validation ladder rung 5).
+
+import { ESPLoader, Transport } from 'esptool-js'
+
+import type { WebSerialPortLike } from '@arduconfig/transport'
+
+import { buildElrsBootloaderCommand, espSyncTraining } from '../view-models/elrs-bootloader'
+
+// esptool-js's Transport is typed against the DOM `SerialPort`; the app carries
+// the structurally-compatible `WebSerialPortLike`. Cast at the boundary.
+type EsptoolSerialPort = ConstructorParameters<typeof Transport>[0]
+
+export interface ElrsFlashProgress {
+  phase: 'bootloader' | 'connect' | 'flash' | 'done'
+  written?: number
+  total?: number
+  message?: string
+}
+
+export interface ElrsFlashInput {
+  /** The live Web Serial port (already released by the MAVLink transport). */
+  port: WebSerialPortLike
+  /** The ELRS firmware image to write. */
+  firmware: Uint8Array
+  /** Flashing baud — the FC forwards this from USB onto the RC UART. */
+  baudRate: number
+  onProgress?: (progress: ElrsFlashProgress) => void
+  onLog?: (line: string) => void
+}
+
+/**
+ * Put the RX into its ESP ROM bootloader by sending the CRSF "enter bootloader"
+ * command + the ROM autobaud training over the bridge, then close the port. The
+ * ESP stays in its bootloader across a host-side close (the FC bridge holds),
+ * so esptool can reopen and sync.
+ */
+async function sendElrsBootloaderJump(port: WebSerialPortLike, baudRate: number): Promise<void> {
+  await port.open({ baudRate })
+  try {
+    const writer = port.writable?.getWriter()
+    if (!writer) {
+      throw new Error('serial port is not writable for the bootloader jump')
+    }
+    try {
+      await writer.write(buildElrsBootloaderCommand())
+      await writer.write(espSyncTraining())
+    } finally {
+      writer.releaseLock()
+    }
+    // Give the RX firmware a moment to reboot into the ROM bootloader.
+    await new Promise((resolve) => setTimeout(resolve, 500))
+  } finally {
+    await port.close().catch(() => undefined)
+  }
+}
+
+/**
+ * Flash an ESP-based ExpressLRS receiver through the (already-open) FC serial
+ * pass-through bridge. The caller must have armed the bridge (SERIAL_PASS2) and
+ * released the MAVLink transport first, so this owns the port exclusively.
+ */
+export async function flashElrsReceiver(input: ElrsFlashInput): Promise<{ chipName: string }> {
+  const { port, firmware, baudRate, onProgress, onLog } = input
+
+  onProgress?.({ phase: 'bootloader', message: 'Sending ELRS bootloader command…' })
+  await sendElrsBootloaderJump(port, baudRate)
+
+  // no_reset: DTR/RTS can't reach the ESP through the FC bridge, and the RX is
+  // already in its bootloader from the CRSF jump above. romBaudrate === baudrate
+  // so esptool doesn't try to renegotiate (the FC pins the UART to USB's baud).
+  onProgress?.({ phase: 'connect', message: 'Syncing with the ESP bootloader…' })
+  const transport = new Transport(port as unknown as EsptoolSerialPort, false)
+  const loader = new ESPLoader({
+    transport,
+    baudrate: baudRate,
+    enableTracing: false,
+    terminal: onLog
+      ? {
+          clean: () => undefined,
+          writeLine: (data: string) => onLog(data),
+          write: (data: string) => onLog(data)
+        }
+      : undefined
+  })
+
+  try {
+    await loader.main('no_reset')
+    const chipName = loader.chip.CHIP_NAME
+    // ESP8266/ESP8285 app image starts at 0x0; ESP32-family at 0x10000.
+    const address = chipName.includes('8266') || chipName.includes('8285') ? 0x0 : 0x10000
+    onProgress?.({ phase: 'flash', message: `Flashing ${chipName}…`, written: 0, total: firmware.length })
+    await loader.writeFlash({
+      fileArray: [{ data: firmware, address }],
+      // 'keep' preserves the flash mode/freq/size baked into the ELRS release
+      // image header rather than overriding it.
+      flashMode: 'keep',
+      flashFreq: 'keep',
+      flashSize: 'keep',
+      eraseAll: false,
+      compress: true,
+      reportProgress: (_fileIndex: number, written: number, total: number) =>
+        onProgress?.({ phase: 'flash', written, total })
+    })
+    onProgress?.({ phase: 'done', message: `Flashed ${chipName}.` })
+    return { chipName }
+  } finally {
+    await transport.disconnect().catch(() => undefined)
+  }
+}

--- a/apps/web/src/view-models/elrs-bootloader.test.ts
+++ b/apps/web/src/view-models/elrs-bootloader.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest'
+
+import { buildElrsBootloaderCommand, crsfCrc8, espSyncTraining } from './elrs-bootloader'
+
+describe('crsfCrc8', () => {
+  it('matches known CRSF CRC8 (poly 0xD5) vectors', () => {
+    expect(crsfCrc8(Uint8Array.from([0x00]))).toBe(0x00)
+    expect(crsfCrc8(Uint8Array.from([0x18, 0x2a]))).toBe(0x1a)
+    expect(crsfCrc8(Uint8Array.from([0x32, 0x62, 0x6c]))).toBe(0x0a)
+  })
+})
+
+describe('buildElrsBootloaderCommand', () => {
+  it('builds the ELRS init frame [0xEC,0x04,0x32,bl,crc] with no key (matches bootloader.py INIT_SEQ)', () => {
+    expect([...buildElrsBootloaderCommand()]).toEqual([0xec, 0x04, 0x32, 0x62, 0x6c, 0x0a])
+  })
+
+  it('grows the length byte and re-CRCs when a bind key is supplied', () => {
+    const key = Uint8Array.from([1, 2, 3, 4, 5, 6])
+    const frame = buildElrsBootloaderCommand(key)
+    // [0xEC][len][0x32]['b']['l'][6 key bytes][crc] — len = type+bl+key+crc = 1+2+6+1 = 10
+    expect(frame[0]).toBe(0xec)
+    expect(frame[1]).toBe(0x0a)
+    expect([...frame.slice(2, 5)]).toEqual([0x32, 0x62, 0x6c])
+    expect([...frame.slice(5, 11)]).toEqual([1, 2, 3, 4, 5, 6])
+    expect(frame[frame.length - 1]).toBe(crsfCrc8(frame.slice(2, frame.length - 1)))
+    expect(frame.length).toBe(12)
+  })
+})
+
+describe('espSyncTraining', () => {
+  it('is 0x07 0x07 0x12 0x20 then 32x 0x55', () => {
+    const seq = espSyncTraining()
+    expect(seq.length).toBe(36)
+    expect([...seq.slice(0, 4)]).toEqual([0x07, 0x07, 0x12, 0x20])
+    expect([...seq.slice(4)].every((b) => b === 0x55)).toBe(true)
+  })
+})

--- a/apps/web/src/view-models/elrs-bootloader.ts
+++ b/apps/web/src/view-models/elrs-bootloader.ts
@@ -1,0 +1,55 @@
+// Byte sequences that put a running ExpressLRS receiver into its ESP ROM
+// bootloader over the (now transparent) CRSF UART, mirroring ExpressLRS's
+// BFinitPassthrough / bootloader.get_init_seq. Once the FC's SERIAL_PASS bridge
+// is open and the port reopened at the flashing baud, sending the CRSF command
+// below makes the RX firmware jump to the ROM bootloader; esptool then syncs.
+//
+// Verified against ExpressLRS src/python/bootloader.py:
+//   INIT_SEQ = [0xEC, 0x04, 0x32, ord('b'), ord('l')]
+//   get_init_seq() = get_telemetry_seq(INIT_SEQ, key) — sets payload length at
+//   [1], appends the optional key, then a CRC8 (poly 0xD5) over bytes[2:].
+
+/** CRSF sync/address byte for the receiver. */
+const CRSF_RX_ADDRESS = 0xec
+/** CRSF frame type "command". */
+const CRSF_FRAMETYPE_COMMAND = 0x32
+/** The "bl" (bootloader) command payload. */
+const BOOTLOADER_COMMAND = [0x62, 0x6c] // 'b', 'l'
+
+/**
+ * CRSF's CRC8 (DVB-S2, polynomial 0xD5, init 0x00) over `data`. This is the
+ * checksum ExpressLRS/CRSF appends to every frame.
+ */
+export function crsfCrc8(data: Uint8Array): number {
+  let crc = 0
+  for (const byte of data) {
+    crc ^= byte
+    for (let bit = 0; bit < 8; bit += 1) {
+      crc = (crc & 0x80) !== 0 ? ((crc << 1) ^ 0xd5) & 0xff : (crc << 1) & 0xff
+    }
+  }
+  return crc
+}
+
+/**
+ * The CRSF "enter bootloader" command frame. Chip-agnostic (same for
+ * ESP8266/8285/ESP32). `key` is the optional bind-derived key bytes for a bound
+ * receiver — omit for an unbound/default RX. Frame layout:
+ *   [0xEC][len][0x32]['b']['l'][...key][crc8]
+ * where len counts the type byte through the CRC, and crc8 covers bytes[2:].
+ */
+export function buildElrsBootloaderCommand(key: Uint8Array = new Uint8Array(0)): Uint8Array {
+  const payload = [CRSF_FRAMETYPE_COMMAND, ...BOOTLOADER_COMMAND, ...key]
+  const length = payload.length + 1 // payload (incl. type) + the CRC byte
+  const crc = crsfCrc8(Uint8Array.from(payload))
+  return Uint8Array.from([CRSF_RX_ADDRESS, length, ...payload, crc])
+}
+
+/**
+ * The ESP ROM bootloader auto-baud training sequence esptool prefixes to its
+ * sync: 0x07 0x07 0x12 0x20 then 32×0x55. Sent right after the bootloader jump
+ * so the ROM locks onto the flashing baud.
+ */
+export function espSyncTraining(): Uint8Array {
+  return Uint8Array.from([0x07, 0x07, 0x12, 0x20, ...new Array(32).fill(0x55)])
+}

--- a/apps/web/src/view-models/elrs-firmware-options.test.ts
+++ b/apps/web/src/view-models/elrs-firmware-options.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  buildElrsDefinesJson,
+  findElrsFirmwareEnd,
+  generateElrsUid,
+  patchElrsFirmwareOptions
+} from './elrs-firmware-options'
+
+// Build a minimal synthetic ESP32 image: 8-byte header (magic 0xE9, N segments),
+// 16-byte extended header (→ segments start at 24), then N segment headers
+// (<II> addr+size) each followed by `size` data bytes.
+function esp32Image(segments: { size: number }[], trailerBytes = 0): Uint8Array {
+  const body: number[] = []
+  for (const seg of segments) {
+    // addr (unused) + size, little-endian uint32 each
+    body.push(0, 0, 0, 0)
+    body.push(seg.size & 0xff, (seg.size >> 8) & 0xff, (seg.size >> 16) & 0xff, (seg.size >> 24) & 0xff)
+    body.push(...new Array(seg.size).fill(0xaa))
+  }
+  const header = [0xe9, segments.length, 0, 0, 0, 0, 0, 0, ...new Array(16).fill(0)] // 24 bytes
+  return Uint8Array.from([...header, ...body, ...new Array(trailerBytes).fill(0)])
+}
+
+describe('findElrsFirmwareEnd', () => {
+  it('rejects a non-ESP image', () => {
+    expect(() => findElrsFirmwareEnd(Uint8Array.from([0x00, 0x01, 0x02]))).toThrow(/magic/)
+  })
+
+  it('computes the aligned end of an ESP32 image (segments from offset 24, +32)', () => {
+    // 1 segment of 16 bytes: pos = 24 + 8 + 16 = 48 → align(48)=64 → +32 = 96.
+    expect(findElrsFirmwareEnd(esp32Image([{ size: 16 }]))).toBe(96)
+    // 3 segments (8/24/16 — NOT 2, which is the ESP8285 sentinel): pos =
+    // 24 + (8+8) + (8+24) + (8+16) = 96 → align(96)=112 → +32 = 144.
+    expect(findElrsFirmwareEnd(esp32Image([{ size: 8 }, { size: 24 }, { size: 16 }]))).toBe(144)
+  })
+
+  it('handles an ESP8285 image (outer segment count 2 → real image at 0x1000, no +32)', () => {
+    const inner = esp32Image([{ size: 16 }]) // reuse as the 0x1000 image
+    const outer = new Uint8Array(0x1000 + inner.length)
+    outer[0] = 0xe9
+    outer[1] = 2 // triggers the 8285 path
+    outer.set(inner, 0x1000)
+    // inner header/segments start at 0x1000; segments read from 0x1001 = 1.
+    // pos = 0x1008 + 8 + 16 = 0x1020 (4128) → align(4128)=4128 → no +32.
+    expect(findElrsFirmwareEnd(outer)).toBe(0x1020)
+  })
+})
+
+describe('generateElrsUid', () => {
+  it('uses a comma-separated integer list directly, zero-padded to 6', () => {
+    expect(generateElrsUid('1,2,3,4')).toEqual([0, 0, 1, 2, 3, 4])
+    expect(generateElrsUid('10,20,30,40,50,60')).toEqual([10, 20, 30, 40, 50, 60])
+  })
+
+  it('falls back to the first 6 bytes of MD5 for a text phrase', () => {
+    expect(generateElrsUid('test')).toEqual([79, 4, 253, 130, 33, 85])
+  })
+
+  it('treats an out-of-range int list as a phrase (MD5)', () => {
+    expect(generateElrsUid('1,2,3,999').length).toBe(6)
+    expect(generateElrsUid('1,2,3,999')).not.toEqual([0, 0, 1, 2, 3, 999])
+  })
+})
+
+describe('buildElrsDefinesJson', () => {
+  it('emits only the set flags plus a flash-discriminator, with uid from the phrase', () => {
+    const json = buildElrsDefinesJson({ bindPhrase: 'test', domain: 1, flashDiscriminator: 42 })
+    expect(JSON.parse(json)).toEqual({ uid: [79, 4, 253, 130, 33, 85], domain: 1, 'flash-discriminator': 42 })
+  })
+
+  it('prefers an explicit uid over the bind phrase', () => {
+    const json = buildElrsDefinesJson({ bindPhrase: 'test', uid: [1, 2, 3, 4, 5, 6], flashDiscriminator: 1 })
+    expect(JSON.parse(json).uid).toEqual([1, 2, 3, 4, 5, 6])
+  })
+})
+
+describe('patchElrsFirmwareOptions', () => {
+  it('overwrites the 512-byte defines region in place and leaves the rest intact', () => {
+    // ESP32 image with end=96 → defines at 96+144 = 240; need >= 752 bytes.
+    const image = esp32Image([{ size: 16 }], 800)
+    const patched = patchElrsFirmwareOptions(image, { bindPhrase: 'test', domain: 1, flashDiscriminator: 42 })
+    expect(patched.length).toBe(image.length)
+    expect(patched).not.toBe(image) // a copy, not mutated in place
+    const definesOffset = 240
+    const json = new TextDecoder().decode(patched.slice(definesOffset, definesOffset + 512)).replace(/\0+$/, '')
+    expect(JSON.parse(json)).toEqual({ uid: [79, 4, 253, 130, 33, 85], domain: 1, 'flash-discriminator': 42 })
+    // Bytes before the defines region are untouched.
+    expect([...patched.slice(0, 96)]).toEqual([...image.slice(0, 96)])
+  })
+
+  it('refuses an image with no options region rather than writing past the end', () => {
+    const tooSmall = esp32Image([{ size: 16 }]) // ~52 bytes, no appended regions
+    expect(() => patchElrsFirmwareOptions(tooSmall, { bindPhrase: 'x' })).toThrow(/options region/)
+  })
+})

--- a/apps/web/src/view-models/elrs-firmware-options.ts
+++ b/apps/web/src/view-models/elrs-firmware-options.ts
@@ -1,0 +1,143 @@
+// Port of ExpressLRS's binary_configurator / UnifiedConfiguration options
+// patching: inject the user's bind phrase, regulatory domain, wifi, etc. into a
+// prebuilt "unified" ELRS release .bin. The release appends fixed null-padded
+// regions after the ESP firmware image — product name (128B), lua/device name
+// (16B), a 512B "defines" JSON (the options), a 2048B hardware-layout JSON, a
+// logo, and a trailing 0xBEEFCAFE + prior-target-name. Configuring rewrites only
+// the 512B defines region in place.
+//
+// BRICK-CRITICAL: a wrong offset writes garbage into the firmware. findElrsFirmwareEnd
+// is ported byte-for-byte from UnifiedConfiguration.findFirmwareEnd and unit-tested.
+
+import { md5 } from 'js-md5'
+
+const ESP_IMAGE_MAGIC = 0xe9
+const PRODUCT_NAME_BYTES = 128
+const DEVICE_NAME_BYTES = 16
+const DEFINES_BYTES = 512
+
+/**
+ * Byte offset in an ESP firmware image where the appended unified regions begin,
+ * ported from ExpressLRS UnifiedConfiguration.findFirmwareEnd. ESP32 images have
+ * a 24-byte header before their segments; ESP8285 images place the real image at
+ * 0x1000 (detected by segment count 2 in the outer header).
+ */
+export function findElrsFirmwareEnd(firmware: Uint8Array): number {
+  const view = new DataView(firmware.buffer, firmware.byteOffset, firmware.byteLength)
+  const magic = view.getUint8(0)
+  if (magic !== ESP_IMAGE_MAGIC) {
+    throw new Error('Not an ESP firmware image (bad magic byte) — is this an ELRS receiver .bin?')
+  }
+  let segments = view.getUint8(1)
+  let is8285 = false
+  let pos: number
+  if (segments === 2) {
+    // ESP8266/8285: the real application image starts at 0x1000.
+    segments = view.getUint8(0x1001)
+    is8285 = true
+    pos = 0x1000 + 8
+  } else {
+    // ESP32-family: skip the 8-byte image header + 16-byte extended header.
+    pos = 24
+  }
+  for (let segment = 0; segment < segments; segment += 1) {
+    // Each segment header is <II> = load address (skipped) + data size.
+    const size = view.getUint32(pos + 4, true)
+    pos += 8 + size
+  }
+  pos = (pos + 16) & ~15
+  if (!is8285) {
+    pos += 32
+  }
+  return pos
+}
+
+/**
+ * ELRS UID (6 bytes) from a bind phrase, matching binary_configurator.generateUID:
+ * a comma-separated list of 4–6 integers (0–255) is used directly (zero-padded to
+ * 6); anything else is the first 6 bytes of MD5(`-DMY_BINDING_PHRASE="<phrase>"`).
+ */
+export function generateElrsUid(bindPhrase: string): number[] {
+  const parts = bindPhrase.split(',').map((part) => part.trim())
+  const asInts = parts.map((part) => (/^\d+$/.test(part) ? Number(part) : -1))
+  if (asInts.length >= 4 && asInts.length <= 6 && asInts.every((value) => value >= 0 && value < 256)) {
+    return [...new Array(6 - asInts.length).fill(0), ...asInts]
+  }
+  const digest = new Uint8Array(md5.arrayBuffer(`-DMY_BINDING_PHRASE="${bindPhrase}"`))
+  return [...digest.slice(0, 6)]
+}
+
+export interface ElrsFirmwareOptions {
+  /** Bind phrase (→ UID). Overridden by an explicit `uid`. */
+  bindPhrase?: string
+  /** Explicit 6-byte UID (wins over bindPhrase). */
+  uid?: number[]
+  /** Regulatory domain number (firmware-defined; e.g. 0=AU915, 1=FCC915…). */
+  domain?: number
+  wifiSsid?: string
+  wifiPassword?: string
+  wifiOnInterval?: number
+  tlmInterval?: number
+  rxUartBaud?: number
+  lockOnFirstConnection?: boolean
+  /** Random cache-buster the firmware stores; supply for deterministic tests. */
+  flashDiscriminator?: number
+}
+
+/** The `defines` JSON string ELRS writes into the options region. */
+export function buildElrsDefinesJson(options: ElrsFirmwareOptions): string {
+  const flags: Record<string, unknown> = {}
+  const uid = options.uid ?? (options.bindPhrase ? generateElrsUid(options.bindPhrase) : undefined)
+  if (uid) {
+    flags.uid = uid
+  }
+  if (options.domain !== undefined) {
+    flags.domain = options.domain
+  }
+  if (options.wifiSsid !== undefined) {
+    flags['wifi-ssid'] = options.wifiSsid
+  }
+  if (options.wifiPassword !== undefined) {
+    flags['wifi-password'] = options.wifiPassword
+  }
+  if (options.wifiOnInterval !== undefined) {
+    flags['wifi-on-interval'] = options.wifiOnInterval
+  }
+  if (options.tlmInterval !== undefined) {
+    flags['tlm-interval'] = options.tlmInterval
+  }
+  if (options.rxUartBaud !== undefined) {
+    flags['rcvr-uart-baud'] = options.rxUartBaud
+  }
+  if (options.lockOnFirstConnection !== undefined) {
+    flags['lock-on-first-connection'] = options.lockOnFirstConnection
+  }
+  flags['flash-discriminator'] =
+    options.flashDiscriminator ?? Math.floor(Math.random() * 0xffffffff) + 1
+  return JSON.stringify(flags)
+}
+
+/**
+ * Return a new firmware image with the 512-byte options (`defines`) region
+ * overwritten with the user's config. The image must already carry the unified
+ * regions (a real ELRS release .bin) — otherwise we throw rather than write past
+ * the end and corrupt it.
+ */
+export function patchElrsFirmwareOptions(firmware: Uint8Array, options: ElrsFirmwareOptions): Uint8Array {
+  const end = findElrsFirmwareEnd(firmware)
+  const definesOffset = end + PRODUCT_NAME_BYTES + DEVICE_NAME_BYTES
+  if (definesOffset + DEFINES_BYTES > firmware.length) {
+    throw new Error(
+      'This .bin has no ELRS options region — use a "unified" ELRS release image, or flash it as-is without configuring.'
+    )
+  }
+  const json = buildElrsDefinesJson(options)
+  const jsonBytes = new TextEncoder().encode(json)
+  if (jsonBytes.length > DEFINES_BYTES) {
+    throw new Error(`ELRS options JSON is ${jsonBytes.length} bytes, over the ${DEFINES_BYTES}-byte limit.`)
+  }
+  const patched = new Uint8Array(firmware)
+  patched.fill(0, definesOffset, definesOffset + DEFINES_BYTES)
+  patched.set(jsonBytes, definesOffset)
+  return patched
+}

--- a/apps/web/src/view-models/elrs-flash.test.ts
+++ b/apps/web/src/view-models/elrs-flash.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest'
+
+import { detectElrsSerialPorts, ELRS_CRSF_PROTOCOL, ELRS_RCIN_PROTOCOL } from './elrs-flash'
+
+function snapshotWith(protocols: Record<string, number>): any {
+  return {
+    parameters: Object.entries(protocols).map(([id, value]) => ({ id, value, definition: undefined }))
+  }
+}
+
+describe('detectElrsSerialPorts', () => {
+  it('finds RCIN (23) and CRSF (29) ports, sorted by port number', () => {
+    const snapshot = snapshotWith({
+      SERIAL5_PROTOCOL: ELRS_CRSF_PROTOCOL,
+      SERIAL2_PROTOCOL: ELRS_RCIN_PROTOCOL,
+      SERIAL1_PROTOCOL: 2 // MAVLink — ignored
+    })
+    expect(detectElrsSerialPorts(snapshot)).toEqual([
+      { portNumber: 2, protocolValue: 23, protocolLabel: 'RC Input (CRSF/ELRS)' },
+      { portNumber: 5, protocolValue: 29, protocolLabel: 'CRSF' }
+    ])
+  })
+
+  it('is empty when no UART carries an ELRS-capable protocol', () => {
+    expect(detectElrsSerialPorts(snapshotWith({ SERIAL1_PROTOCOL: 2, SERIAL3_PROTOCOL: 5 }))).toEqual([])
+  })
+
+  it('rounds float-widened protocol values and ignores non-PROTOCOL params', () => {
+    const snapshot = snapshotWith({ SERIAL6_PROTOCOL: 23.0000001, SERIAL6_BAUD: 23 })
+    expect(detectElrsSerialPorts(snapshot)).toEqual([
+      { portNumber: 6, protocolValue: 23, protocolLabel: 'RC Input (CRSF/ELRS)' }
+    ])
+  })
+})

--- a/apps/web/src/view-models/elrs-flash.ts
+++ b/apps/web/src/view-models/elrs-flash.ts
@@ -1,0 +1,46 @@
+// Pure helpers for the ELRS receiver flasher. The FC exposes an ExpressLRS RX
+// on a UART whose SERIALn_PROTOCOL is either RCIN (23, RC input — CRSF is the
+// wire format) or CRSF (29, full CRSF incl. telemetry). We surface those ports
+// as flash candidates; the operator confirms which one carries the RX before we
+// bridge it with SERIAL_PASS. Protocol numbers verified against
+// AP_SerialManager.h (SerialProtocol_RCIN = 23, SerialProtocol_CRSF = 29).
+
+import type { ConfiguratorSnapshot } from '@arduconfig/ardupilot-core'
+
+export const ELRS_RCIN_PROTOCOL = 23
+export const ELRS_CRSF_PROTOCOL = 29
+
+/** Common ESP flashing baud rates ELRS uses over the passthru bridge. */
+export const ELRS_FLASH_BAUD_RATES = [420000, 460800, 230400, 115200] as const
+export const ELRS_DEFAULT_FLASH_BAUD = 420000
+
+export interface ElrsPortCandidate {
+  /** Serial port index N (the value to write to SERIAL_PASS2). */
+  portNumber: number
+  protocolValue: number
+  protocolLabel: string
+}
+
+/**
+ * Serial ports currently carrying an ELRS-capable RC link (RCIN or CRSF),
+ * sorted by port number. Empty when none is configured — the flasher then tells
+ * the operator to set a UART to RCIN/CRSF first.
+ */
+export function detectElrsSerialPorts(snapshot: ConfiguratorSnapshot): ElrsPortCandidate[] {
+  const candidates: ElrsPortCandidate[] = []
+  for (const parameter of snapshot.parameters) {
+    const match = /^SERIAL(\d+)_PROTOCOL$/.exec(parameter.id)
+    if (!match) {
+      continue
+    }
+    const value = Math.round(parameter.value ?? Number.NaN)
+    if (value === ELRS_RCIN_PROTOCOL || value === ELRS_CRSF_PROTOCOL) {
+      candidates.push({
+        portNumber: Number(match[1]),
+        protocolValue: value,
+        protocolLabel: value === ELRS_CRSF_PROTOCOL ? 'CRSF' : 'RC Input (CRSF/ELRS)'
+      })
+    }
+  }
+  return candidates.sort((left, right) => left.portNumber - right.portNumber)
+}

--- a/apps/web/src/view-models/visible-app-views.test.ts
+++ b/apps/web/src/view-models/visible-app-views.test.ts
@@ -24,6 +24,7 @@ function baseInputs(overrides: Partial<VisibleAppViewsInputs> = {}): VisibleAppV
     hasNetworkingParams: false,
     hasRcLogicParams: false,
     hasScriptingParams: false,
+    hasSerialPassthrough: false,
     ...overrides
   }
 }
@@ -74,6 +75,12 @@ describe('buildVisibleAppViews', () => {
     expect(ids(buildVisibleAppViews(baseInputs({ isExpertMode: true, hasScriptingParams: true })))).toContain('lua')
     expect(ids(buildVisibleAppViews(baseInputs({ isExpertMode: false, hasScriptingParams: true })))).not.toContain('lua')
     expect(ids(buildVisibleAppViews(baseInputs({ isExpertMode: true, hasScriptingParams: false })))).not.toContain('lua')
+  })
+
+  it('shows ELRS Flash only in Expert mode AND when the FC reports SERIAL_PASS2', () => {
+    expect(ids(buildVisibleAppViews(baseInputs({ isExpertMode: true, hasSerialPassthrough: true })))).toContain('elrs-flash')
+    expect(ids(buildVisibleAppViews(baseInputs({ isExpertMode: false, hasSerialPassthrough: true })))).not.toContain('elrs-flash')
+    expect(ids(buildVisibleAppViews(baseInputs({ isExpertMode: true, hasSerialPassthrough: false })))).not.toContain('elrs-flash')
   })
 
   it('relabels the Setup tab as Status & Info', () => {

--- a/apps/web/src/view-models/visible-app-views.ts
+++ b/apps/web/src/view-models/visible-app-views.ts
@@ -28,6 +28,10 @@ export interface VisibleAppViewsInputs {
   /** The FC reports the Lua scripting engine (SCR_ENABLE present) — the board's
    *  build has the VM compiled in, so it can run scripts. Gates the Lua tab. */
   hasScriptingParams: boolean
+  /** The FC reports the AP_SerialManager pass-through bridge (SERIAL_PASS2
+   *  present) — required to flash an ELRS receiver through the FC. Gates the
+   *  ELRS-flash tab. */
+  hasSerialPassthrough: boolean
 }
 
 export function buildVisibleAppViews(inputs: VisibleAppViewsInputs): AppViewDescriptor[] {
@@ -38,6 +42,7 @@ export function buildVisibleAppViews(inputs: VisibleAppViewsInputs): AppViewDesc
     canBusBus,
     connectionKind,
     hasNetworkingParams,
+    hasSerialPassthrough,
     hasRcLogicParams,
     hasScriptingParams
   } = inputs
@@ -92,6 +97,16 @@ export function buildVisibleAppViews(inputs: VisibleAppViewsInputs): AppViewDesc
     id: 'flash',
     label: 'Flash',
     description: 'Firmware flasher — pick an ArduPilot release or point at a custom build server, enter DFU bootloader, or drop a .apj for guided flashing.',
+    badge: 'tools',
+    tone: 'neutral'
+  }
+  // ELRS receiver flasher — flashes an ExpressLRS RX through the FC's transparent
+  // SERIAL_PASS bridge. Expert-only AND only when the FC advertises the bridge
+  // (SERIAL_PASS2), since it needs both a live link and the passthru capability.
+  const elrsFlashDescriptor: AppViewDescriptor = {
+    id: 'elrs-flash',
+    label: 'ELRS Flash',
+    description: 'Flash an ExpressLRS receiver through the flight controller — no Betaflight CLI or external ELRS Configurator needed.',
     badge: 'tools',
     tone: 'neutral'
   }
@@ -169,7 +184,7 @@ export function buildVisibleAppViews(inputs: VisibleAppViewsInputs): AppViewDesc
   const CANONICAL_VIEW_ORDER = [
     'setup', 'calibration', 'config', 'ports', 'receiver', 'modes', 'motors',
     'servos', 'power', 'failsafe', 'vtx', 'osd', 'tuning', 'presets',
-    'snapshots', 'logs', 'parameters', 'can', 'networking', 'files', 'lua', 'flash', 'rc-mixer',
+    'snapshots', 'logs', 'parameters', 'can', 'networking', 'files', 'lua', 'flash', 'elrs-flash', 'rc-mixer',
     'mavlink-inspector', 'dronecan-inspector', 'ai-assistant'
   ]
   const relabelled = base.map((view) =>
@@ -187,6 +202,8 @@ export function buildVisibleAppViews(inputs: VisibleAppViewsInputs): AppViewDesc
     ...(isExpertMode && hasNetworkingParams ? [networkingDescriptor] : []),
     // Lua Scripts — Expert-only AND only when the FC advertises scripting (SCR_).
     ...(isExpertMode && hasScriptingParams ? [luaDescriptor] : []),
+    // ELRS Flash — Expert-only AND only when the FC advertises the SERIAL_PASS bridge.
+    ...(isExpertMode && hasSerialPassthrough ? [elrsFlashDescriptor] : []),
     // Expert-only views — only surfaced when Expert mode is on.
     ...(isExpertMode
       ? [rcMixerDescriptor, mavlinkInspectorDescriptor, dronecanInspectorDescriptor, aiAssistantDescriptor]

--- a/package-lock.json
+++ b/package-lock.json
@@ -51,6 +51,7 @@
         "@arduconfig/transport": "1.1.1",
         "@arduconfig/ui-kit": "1.1.1",
         "esptool-js": "^0.6.0",
+        "js-md5": "^0.8.3",
         "leaflet": "^1.9.4",
         "react": "^19.2.6",
         "react-dom": "^19.2.6",
@@ -4381,6 +4382,12 @@
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
       }
+    },
+    "node_modules/js-md5": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/js-md5/-/js-md5-0.8.3.tgz",
+      "integrity": "sha512-qR0HB5uP6wCuRMrWPTrkMaev7MJZwJuuw4fnwAzRgP4J4/F8RwtodOKpGp4XpqsLBFzzgqIO42efFAyz2Et6KQ==",
+      "license": "MIT"
     },
     "node_modules/js-tokens": {
       "version": "9.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -50,6 +50,7 @@
         "@arduconfig/protocol-mavlink": "1.1.1",
         "@arduconfig/transport": "1.1.1",
         "@arduconfig/ui-kit": "1.1.1",
+        "esptool-js": "^0.6.0",
         "leaflet": "^1.9.4",
         "react": "^19.2.6",
         "react-dom": "^19.2.6",
@@ -2618,6 +2619,12 @@
         "node": ">= 4.0.0"
       }
     },
+    "node_modules/atob-lite": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/atob-lite/-/atob-lite-2.0.0.tgz",
+      "integrity": "sha512-LEeSAWeh2Gfa2FtlQE1shxQ8zi5F9GHarrGKz08TMdODD5T4eH6BMsvtnhbWZ+XQn+Gb6om/917ucvRu7l7ukw==",
+      "license": "MIT"
+    },
     "node_modules/balanced-match": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
@@ -3680,6 +3687,17 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/esptool-js": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/esptool-js/-/esptool-js-0.6.0.tgz",
+      "integrity": "sha512-ZyuSBXvmS+4DRKM6GrDHfCscnq3YSNlRfM+Zw0DoS7uC3SdkyC262s/ji4MjDYVmMH8SE2BiYx3/dZ1J23Xiew==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "atob-lite": "^2.0.0",
+        "pako": "^2.1.0",
+        "tslib": "^2.4.1"
       }
     },
     "node_modules/estree-walker": {
@@ -5140,6 +5158,22 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/pako": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-2.2.0.tgz",
+      "integrity": "sha512-zJq6RP/5q+TO2OpFV3FHzlPnFjmkb7Nc99a5SNjJE+uu/PkpChs+NIZSSzbBoD+6kjiISXjfYdwj1ZRQ81dz/w==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
+      "license": "(MIT AND Zlib)"
+    },
     "node_modules/path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
@@ -6153,9 +6187,7 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "dev": true,
-      "license": "0BSD",
-      "optional": true
+      "license": "0BSD"
     },
     "node_modules/type-fest": {
       "version": "0.13.1",

--- a/packages/ardupilot-core/src/runtime.ts
+++ b/packages/ardupilot-core/src/runtime.ts
@@ -393,6 +393,9 @@ export class ArduPilotConfiguratorRuntime {
   private readonly receivedParameterIndices = new Set<number>()
   private readonly preArmIssues = new Map<string, PreArmIssueState>()
   private readonly statusTexts: StatusTextEntry[] = []
+  // One-shot waiters for a specific STATUSTEXT substring (e.g. "Passthru
+  // enabled"), resolved by emitStatusText when a matching message arrives.
+  private readonly statusTextWaiters: Array<{ substring: string; resolve: () => void }> = []
   // STATUSTEXT chunked-reassembly buffers. ArduPilot splits messages longer
   // than the 50-char v2 payload into frames sharing a `statusId` with an
   // incrementing `chunkSequence`; concatenate in sequence order into one
@@ -1343,6 +1346,61 @@ export class ArduPilotConfiguratorRuntime {
     this.emit()
   }
 
+  /**
+   * Resolve once a STATUSTEXT whose text CONTAINS `substring` arrives (matching
+   * any already in the recent history first), or reject on timeout. Used to gate
+   * on autopilot banners like "Passthru enabled" that have no MAVLink ACK.
+   */
+  waitForStatusText(substring: string, timeoutMs: number): Promise<void> {
+    if (this.statusTexts.some((entry) => entry.text.includes(substring))) {
+      return Promise.resolve()
+    }
+    return new Promise((resolve, reject) => {
+      const waiter = {
+        substring,
+        resolve: () => {
+          clearTimeout(timer)
+          resolve()
+        }
+      }
+      const timer = setTimeout(() => {
+        const index = this.statusTextWaiters.indexOf(waiter)
+        if (index >= 0) {
+          this.statusTextWaiters.splice(index, 1)
+        }
+        reject(new Error(`Timed out after ${timeoutMs}ms waiting for STATUSTEXT containing "${substring}".`))
+      }, timeoutMs)
+      this.statusTextWaiters.push(waiter)
+    })
+  }
+
+  /**
+   * Enable ArduPilot's transparent USB↔UART pass-through bridge so a host tool
+   * (e.g. esptool flashing an ELRS receiver) can talk to a UART-attached device
+   * through the FC. Sets SERIAL_PASS1 (source, default 0 = USB console),
+   * SERIAL_PASSTIMO (auto-restore timeout), then SERIAL_PASS2 (destination UART)
+   * LAST so the bridge only arms once the timeout is configured — each write is
+   * verified against the echoed PARAM_VALUE. Resolves when the FC reports
+   * "Passthru enabled". The caller must then release the transport (disconnect)
+   * and reopen the port at the flashing baud, since the FC forwards USB-CDC baud
+   * changes onto the target UART.
+   */
+  async enableSerialPassthrough(
+    destinationPort: number,
+    options: { timeoutSeconds?: number; sourcePort?: number; statusTextTimeoutMs?: number } = {}
+  ): Promise<void> {
+    const { timeoutSeconds = 15, sourcePort = 0, statusTextTimeoutMs = 5000 } = options
+    await this.setParameter('SERIAL_PASS1', sourcePort)
+    await this.setParameter('SERIAL_PASSTIMO', timeoutSeconds)
+    await this.setParameter('SERIAL_PASS2', destinationPort)
+    await this.waitForStatusText('Passthru enabled', statusTextTimeoutMs)
+    this.appendStatusEntry(
+      'info',
+      `Serial pass-through enabled (Serial${sourcePort} ↔ Serial${destinationPort}, ${timeoutSeconds}s timeout).`
+    )
+    this.emit()
+  }
+
   /** Start CompassMot (compass/motor interference) calibration via
    *  MAV_CMD_PREFLIGHT_CALIBRATION param6=1. The vehicle must be disarmed,
    *  restrained, and have its props removed — running it spins the motors.
@@ -2035,6 +2093,19 @@ export class ArduPilotConfiguratorRuntime {
       receivedAtMs: Date.now()
     })
     this.statusTexts.splice(STATUS_TEXT_HISTORY_LIMIT)
+    // Resolve any one-shot substring waiters (e.g. the passthru-enabled gate).
+    if (this.statusTextWaiters.length > 0) {
+      const remaining: typeof this.statusTextWaiters = []
+      for (const waiter of this.statusTextWaiters) {
+        if (text.includes(waiter.substring)) {
+          waiter.resolve()
+        } else {
+          remaining.push(waiter)
+        }
+      }
+      this.statusTextWaiters.length = 0
+      this.statusTextWaiters.push(...remaining)
+    }
     this.recordPreArmIssue(text, severity)
     this.guidedActionService.processStatusText(text)
     // Capture the physical PWM output count from the boot banner. Only the

--- a/packages/param-metadata/src/arducopter.ts
+++ b/packages/param-metadata/src/arducopter.ts
@@ -63,6 +63,13 @@ const enabledDisabledOptions: ParameterValueOption[] = [
   { value: 1, label: 'Enabled' }
 ]
 
+// SERIAL_PASS1/PASS2 port selector — -1 disables, 0..6 pick a serial port
+// (Serial0 = USB/console). Matches AP_SerialManager.cpp @Values.
+const serialPassPortOptions: ParameterValueOption[] = [
+  { value: -1, label: 'Disabled' },
+  ...Array.from({ length: 7 }, (_unused, index) => ({ value: index, label: `Serial${index}` }))
+]
+
 const rcEndpointNotes = [
   'Receiver endpoint changes should be followed by another live RC range verification pass.'
 ]
@@ -1308,6 +1315,43 @@ export const arducopterMetadata: FirmwareMetadataBundle = {
       step: 1
     },
     ...buildSerialPortParameterDefinitions(8),
+    // AP_SerialManager transparent USB↔UART passthru bridge (SERIAL_PASS1/PASS2/
+    // PASSTIMO). Setting both PASS1 (source, default 0=USB console) and PASS2
+    // (destination UART) pumps raw bytes both ways, detaching that UART's normal
+    // driver — used to flash an ELRS receiver through the FC. Verbatim from
+    // AP_SerialManager.cpp @Param blocks (PASS2 default -1, PASSTIMO default 15).
+    SERIAL_PASS1: {
+      id: 'SERIAL_PASS1',
+      label: 'Serial Passthru First Port',
+      description:
+        'One side of a transparent pass-through between two serial ports. Once both PASS1 and PASS2 are set, all data on either port is forwarded to the other. Normally the USB/console side (0).',
+      category: 'ports',
+      minimum: -1,
+      maximum: 6,
+      step: 1,
+      options: serialPassPortOptions
+    },
+    SERIAL_PASS2: {
+      id: 'SERIAL_PASS2',
+      label: 'Serial Passthru Second Port',
+      description:
+        'The other side of the pass-through. Reset to -1 (disabled) on reboot unless SERIAL_PASSTIMO is -1. Set this to the UART carrying the RC/ELRS receiver to bridge it to USB.',
+      category: 'ports',
+      minimum: -1,
+      maximum: 6,
+      step: 1,
+      options: serialPassPortOptions
+    },
+    SERIAL_PASSTIMO: {
+      id: 'SERIAL_PASSTIMO',
+      label: 'Serial Passthru Timeout',
+      description:
+        'Seconds of silence on the first port after which pass-through ends and the port reverts to normal use (e.g. MAVLink). 0 = no timeout; -1 = no timeout and SERIAL_PASS2 is not reset on reboot.',
+      category: 'ports',
+      minimum: -1,
+      maximum: 120,
+      step: 1
+    },
     // AP_Networking NET_* family (Ethernet/PPP IP setup + network serial
     // endpoints). Surfaced in the Expert-only Networking view, and only when the
     // FC actually reports these params (Ethernet/PPP-capable boards).

--- a/packages/param-metadata/src/types.ts
+++ b/packages/param-metadata/src/types.ts
@@ -57,6 +57,10 @@ export type AppViewId =
   // Injected at render time (no metadata-driven category) since
   // firmware management is orthogonal to vehicle catalogs.
   | 'flash'
+  // 'elrs-flash' flashes an ExpressLRS receiver through the FC's transparent
+  // SERIAL_PASS bridge (no Betaflight CLI / external ELRS Configurator).
+  // Expert + detection-gated (SERIAL_PASS2 present); injected at render time.
+  | 'elrs-flash'
   // 'files' is the MAVFTP file browser — lists/downloads/uploads/deletes
   // files on the FC filesystem (@SYS virtual files, /APM, scripts) over
   // the MAVLink FTP service. Injected at render time; request/response

--- a/packages/protocol-mavlink/src/mock-scenario.ts
+++ b/packages/protocol-mavlink/src/mock-scenario.ts
@@ -1548,6 +1548,22 @@ function buildMockScenario(profile: MockVehicleProfile, options: MockScenarioOpt
               })
             )
           )
+          // Serial passthru: a real FC emits "Passthru enabled" (then locks the
+          // bridge) once SERIAL_PASS2 is set to a valid port. Mirror that so the
+          // ELRS-flash arm flow's STATUSTEXT gate resolves in demo/tests.
+          if (paramSet.paramId === 'SERIAL_PASS2' && paramSet.paramValue >= 0) {
+            responses.push(
+              codec.encode(
+                envelope(103, {
+                  type: 'STATUSTEXT',
+                  severity: MAV_SEVERITY.INFO,
+                  text: 'Passthru enabled',
+                  statusId: 0,
+                  chunkSequence: 0
+                })
+              )
+            )
+          }
           break
         }
         case 'COMMAND_LONG':

--- a/packages/protocol-mavlink/src/mock-scenario.ts
+++ b/packages/protocol-mavlink/src/mock-scenario.ts
@@ -190,6 +190,12 @@ const mockParameters: ParameterState = {
   SERIAL8_PROTOCOL: 16,
   SERIAL8_BAUD: 115,
   SERIAL8_OPTIONS: 0,
+  // AP_SerialManager transparent passthru bridge (SERIAL_PASS*). Present so the
+  // Expert-only ELRS Flash tab is gated on (SERIAL_PASS2) and can target the
+  // RCIN receiver on Serial1 above. PASS2 defaults to -1 (bridge disabled).
+  SERIAL_PASS1: 0,
+  SERIAL_PASS2: -1,
+  SERIAL_PASSTIMO: 15,
   // AP_Networking (NET_*) — a native-Ethernet demo config so the Expert-only
   // Networking view is populated. NET_ENABLE present = the FC supports networking.
   NET_ENABLE: 1,

--- a/tests/e2e/views.spec.ts
+++ b/tests/e2e/views.spec.ts
@@ -3854,3 +3854,31 @@ test.describe('Scoped write-progress bar', () => {
     await expect(banner).toHaveCount(0)
   })
 })
+
+test.describe('ELRS Flash (Expert + SERIAL_PASS2 gated)', () => {
+  test('detects the RCIN receiver port and arms the passthru bridge', async ({ page }) => {
+    await page.goto('/')
+    await connectViaHeader(page)
+    // Passthru arm writes params, which are blocked until the initial sync
+    // completes (on hardware it's long done before you reach this tab).
+    await expectParameterSyncComplete(page)
+    await page.getByTestId('product-mode-expert').check()
+
+    // Tab is gated on Expert + SERIAL_PASS2 (both true in the demo mock).
+    await page.getByTestId('view-button-elrs-flash').click()
+    await expect(page.getByTestId('elrs-flasher')).toBeVisible()
+
+    // The demo FC has Serial1 = RCIN (protocol 23) — detected as the RX port.
+    await expect(page.getByTestId('elrs-flasher-port')).toContainText('Serial1')
+
+    // Arm the bridge — the mock emits "Passthru enabled" on the SERIAL_PASS2
+    // write, which resolves the runtime's STATUSTEXT gate.
+    await page.getByTestId('elrs-flasher-arm').click()
+    await expect(page.getByTestId('elrs-flasher-armed-note')).toBeVisible()
+    await expect(page.getByTestId('elrs-flasher-notice')).toContainText('Passthru enabled')
+
+    // Close the bridge to restore MAVLink.
+    await page.getByTestId('elrs-flasher-cancel').click()
+    await expect(page.getByTestId('elrs-flasher-armed-note')).toHaveCount(0)
+  })
+})

--- a/tests/e2e/views.spec.ts
+++ b/tests/e2e/views.spec.ts
@@ -250,6 +250,9 @@ test.describe('Parameters tab (expert-only)', () => {
     await page.setViewportSize({ width: 1280, height: 900 })
     await page.goto('/')
     await connectViaHeader(page)
+    // Wait for the full param sync before counting rows — the table populates as
+    // params stream in, so an early count races the sync (and empties out).
+    await expectParameterSyncComplete(page)
     await page.getByTestId('product-mode-expert').click()
     await page.getByTestId('view-button-parameters').click()
 

--- a/tests/transport.test.mjs
+++ b/tests/transport.test.mjs
@@ -714,8 +714,8 @@ test('MockTransport serializes chunked inbound frames so demo parameter sync com
     const stats = await runtime.waitForParameterSync({ timeoutMs: 120000 })
 
     assert.equal(stats.status, 'complete')
-    assert.equal(stats.downloaded, 1157)
-    assert.equal(stats.total, 1157)
+    assert.equal(stats.downloaded, 1160)
+    assert.equal(stats.total, 1160)
     assert.equal(runtime.getSnapshot().parameters.find((parameter) => parameter.id === 'FRAME_CLASS')?.value, 1)
     assert.equal(runtime.getSnapshot().parameters.find((parameter) => parameter.id === 'FRAME_TYPE')?.value, 1)
   } finally {
@@ -846,7 +846,7 @@ test('Bundled WebSocket bridge can drive runtime heartbeat and parameter sync fr
     assert.equal(runtime.getSnapshot().connection.kind, 'connected')
     assert.equal(runtime.getSnapshot().vehicle?.vehicle, 'ArduCopter')
     assert.equal(stats.status, 'complete')
-    assert.equal(stats.downloaded, 1157)
+    assert.equal(stats.downloaded, 1160)
     assert.equal(runtime.getSnapshot().parameters.find((parameter) => parameter.id === 'FRAME_CLASS')?.value, 1)
   } finally {
     await runtime.disconnect().catch(() => {})


### PR DESCRIPTION
Native ELRS receiver flashing through ArduPilot's transparent SERIAL_PASS bridge — no Betaflight CLI or external ELRS Configurator. **Expert-mode + SERIAL_PASS2-gated.**

## Slices
- **A** — SERIAL_PASS1/PASS2/PASSTIMO metadata (verbatim from AP_SerialManager.cpp), `runtime.enableSerialPassthrough` + a "Passthru enabled" STATUSTEXT gate, the gated ELRS Flash tab, RX-UART detection (SERIALn_PROTOCOL 23/29).
- **B** — esptool-js flashing: CRSF bootloader-jump (`EC 04 32 'b' 'l' <crc8>`) + ESP training → `ESPLoader.main('no_reset')` → chip detect → `writeFlash` (0x0/0x10000), with a `.bin` picker + progress.
- **C core** — bind-phrase → UID firmware options patching (`findElrsFirmwareEnd`, MD5 UID, rewrite the 512B defines region; refuses a non-unified .bin). Adds js-md5.

## Gating / safety
Only visible with **Expert mode ON and the FC reporting SERIAL_PASS2** (mainline ArduPilot, so effectively any ArduPilot FC in Expert mode). Prominent "bench only / RX may need re-flash" warnings. Detection + Expert gated; no existing behavior changed (ArduCopter byte-identical — SERIAL_PASS* are real params, metadata is presentational).

## ⚠️ Hardware-unvalidated (validation ladder rung 5)
The byte sequences and esptool wiring follow ExpressLRS's own tools + esptool-js's API, but the real sync + write and the baud handshake through the FC bridge are only confirmable on a bench with an ESP-based RX. ESP-only (STM32 ELRS needs BOOT0); full-duplex CRSF only. In-app release fetch is deferred (browser CORS).

## Validation
- Rung 1: typecheck (all workspaces); 715 node; 535 web unit (CRSF vectors, firmware-options patching, port detection, tab gating).
- Rung 3: ELRS arm-flow e2e (detect → arm → "Passthru enabled" → close) green through the demo mock; both UI states screenshot-verified.