### PR TITLE
feat(osd): message-suggestion dropdown for the shorthand "from" field

### DIFF
--- a/apps/web/src/sections/OsdSection.tsx
+++ b/apps/web/src/sections/OsdSection.tsx
@@ -10,6 +10,7 @@ import { useMemo } from 'react'
 import type { UseOsdEditorResult } from '../hooks/use-osd-editor'
 import type { UseOsdShorthandResult } from '../hooks/use-osd-shorthand'
 import { isOsdReviewParamId } from '../param-review'
+import { buildOsdMessageSuggestions } from '../view-models/osd-message-suggestions'
 import { normalizeBitmaskValue } from '../parameter-format'
 import { readRoundedParameter } from '../selectors/parameter-read'
 import { selectViewDrafts } from '../selectors/view-drafts'
@@ -83,6 +84,13 @@ export function OsdSection(props: OsdSectionProps) {
     [parameterDraftEntries]
   )
 
+  // Datalist hints for the shorthand "from" field — curated common ArduPilot
+  // MESSAGE strings + whatever the FC has actually sent this session.
+  const osdMessageSuggestions = useMemo(
+    () => buildOsdMessageSuggestions(snapshot.statusTexts.map((entry) => entry.text)),
+    [snapshot.statusTexts]
+  )
+
   return (
     <OsdView
       linkPorts={osdLinkPorts}
@@ -91,6 +99,7 @@ export function OsdSection(props: OsdSectionProps) {
       switchMethodField={osdSwitchMethodParameter ? { parameter: osdSwitchMethodParameter, liveValue: osdSwitchMethod } : undefined}
       msgAbbrField={msgAbbrParameter ? { parameter: msgAbbrParameter, liveValue: osdMsgAbbr } : undefined}
       osdShorthand={osdShorthand}
+      osdMessageSuggestions={osdMessageSuggestions}
       previewToolbar={{
         backendText: `Backend ${formatArducopterOsdType(osdType)}`,
         switchingText: `Switching ${formatArducopterOsdSwitchMethod(osdSwitchMethod)}`,

--- a/apps/web/src/view-models/osd-message-suggestions.test.ts
+++ b/apps/web/src/view-models/osd-message-suggestions.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest'
+
+import { buildOsdMessageSuggestions, COMMON_OSD_MESSAGE_SUGGESTIONS } from './osd-message-suggestions'
+
+describe('buildOsdMessageSuggestions', () => {
+  it('lists curated fragments first, then live messages', () => {
+    const result = buildOsdMessageSuggestions(['Custom live message'], ['PreArm:', 'GPS'])
+    expect(result).toEqual(['PreArm:', 'GPS', 'Custom live message'])
+  })
+
+  it('dedupes case-insensitively across curated + live and drops blanks', () => {
+    const result = buildOsdMessageSuggestions(['gps', 'PreArm: GPS 1: not healthy', '  '], ['PreArm:', 'GPS'])
+    expect(result).toEqual(['PreArm:', 'GPS', 'PreArm: GPS 1: not healthy'])
+  })
+
+  it('defaults to the curated list when no live messages are given', () => {
+    expect(buildOsdMessageSuggestions([])).toEqual([...COMMON_OSD_MESSAGE_SUGGESTIONS])
+  })
+})

--- a/apps/web/src/view-models/osd-message-suggestions.ts
+++ b/apps/web/src/view-models/osd-message-suggestions.ts
@@ -1,0 +1,55 @@
+// Suggestions for the OSD shorthand editor's "from" field. The firmware matches
+// `from` as a case-insensitive SUBSTRING of a MESSAGE, so the most useful values
+// are short fragments/prefixes (≤15 chars) that abbreviate a whole class of
+// messages. We offer these as datalist hints while keeping the field free-text.
+
+/** Common ArduPilot MESSAGE-panel strings / prefixes worth abbreviating. Short
+ *  enough (≤15 chars) to drop straight into a `from` field. */
+export const COMMON_OSD_MESSAGE_SUGGESTIONS: readonly string[] = [
+  'PreArm:',
+  'Arm:',
+  'Arming motors',
+  'Disarm',
+  'GPS',
+  'GPS Glitch',
+  'Compass',
+  'Throttle',
+  'Battery',
+  'Low Battery',
+  'EKF',
+  'Baro',
+  'Gyro',
+  'Accel',
+  'Radio Failsafe',
+  'Fence',
+  'Mode',
+  'Calibrat',
+  'RC'
+]
+
+/**
+ * Datalist suggestions for a shorthand `from` field: the curated common
+ * fragments first (directly usable), then messages the FC has actually sent
+ * this session (so the operator can abbreviate something they just saw).
+ * Deduped case-insensitively; blanks dropped.
+ */
+export function buildOsdMessageSuggestions(
+  liveMessages: readonly string[],
+  curated: readonly string[] = COMMON_OSD_MESSAGE_SUGGESTIONS
+): string[] {
+  const seen = new Set<string>()
+  const out: string[] = []
+  for (const candidate of [...curated, ...liveMessages]) {
+    const trimmed = candidate.trim()
+    if (!trimmed) {
+      continue
+    }
+    const key = trimmed.toLowerCase()
+    if (seen.has(key)) {
+      continue
+    }
+    seen.add(key)
+    out.push(trimmed)
+  }
+  return out
+}

--- a/apps/web/src/views/Osd.tsx
+++ b/apps/web/src/views/Osd.tsx
@@ -170,6 +170,8 @@ export interface OsdViewProps {
   msgAbbrField: OsdSelectField | undefined
   /** Fork-only user shorthand dictionary editor state (@OSD/shorthand.dat). */
   osdShorthand: UseOsdShorthandResult
+  /** Datalist hints for the shorthand "from" field (common + live messages). */
+  osdMessageSuggestions: readonly string[]
   previewToolbar: OsdPreviewToolbarData
   previewElements: readonly OsdPreviewElement[]
   /** Per-element × per-screen (OSD1-4) enable matrix for the BF-style picker. */
@@ -229,6 +231,7 @@ export function OsdView(props: OsdViewProps) {
     switchMethodField,
     msgAbbrField,
     osdShorthand,
+    osdMessageSuggestions,
     previewToolbar,
     previewElements,
     elementMatrix,
@@ -551,6 +554,11 @@ export function OsdView(props: OsdViewProps) {
 
                 {osdShorthand.status === 'available' ? (
                   <div className="osd-shorthand" data-testid="osd-shorthand-editor">
+                    <datalist id="osd-shorthand-message-suggestions">
+                      {osdMessageSuggestions.map((message) => (
+                        <option key={message} value={message} />
+                      ))}
+                    </datalist>
                     <div className="osd-shorthand__header">
                       <strong>Custom abbreviations</strong>
                       <span>
@@ -566,7 +574,8 @@ export function OsdView(props: OsdViewProps) {
                             aria-label={`abbreviation ${index + 1} from`}
                             data-testid={`osd-shorthand-from-${index}`}
                             type="text"
-                            placeholder="Message text"
+                            list="osd-shorthand-message-suggestions"
+                            placeholder="Message text (or fragment)"
                             maxLength={osdShorthand.fromMax}
                             value={entry.from}
                             disabled={osdShorthand.saving}

--- a/tests/e2e/views.spec.ts
+++ b/tests/e2e/views.spec.ts
@@ -3899,6 +3899,11 @@ test.describe('OSD message shorthand editor (@OSD/shorthand.dat)', () => {
     await expect(page.getByTestId('osd-shorthand-from-0')).toHaveValue('PreArm:')
     await expect(page.getByTestId('osd-shorthand-to-0')).toHaveValue('PA:')
 
+    // The "from" field is a combobox: it references a datalist of common +
+    // live message suggestions (but stays free-text for substring fragments).
+    await expect(page.getByTestId('osd-shorthand-from-0')).toHaveAttribute('list', 'osd-shorthand-message-suggestions')
+    expect(await page.locator('#osd-shorthand-message-suggestions option').count()).toBeGreaterThan(5)
+
     // Edit a value + add a row, then save — the mock FTP write round-trips.
     await page.getByTestId('osd-shorthand-to-0').fill('PRE')
     await page.getByTestId('osd-shorthand-add').click()


### PR DESCRIPTION
Makes the OSD shorthand editor's **from** field a combobox — a datalist of suggestions so you pick the message to abbreviate, then type the short form, instead of recalling exact text. Stays free-text because the firmware matches `from` as a case-insensitive **substring**, so short fragments/prefixes are often the goal.

Suggestions = curated common ArduPilot MESSAGE strings (`PreArm:`, `GPS`, `Throttle`, `EKF`, `Fence`, `Radio Failsafe`, …) first, then messages the FC has actually sent this session (`snapshot.statusTexts`), deduped.

ArduCopter byte-identical: presentational (a datalist on an existing field).

Validation: typecheck; 538 web unit (+3 suggestion tests); OSD shorthand e2e asserts the combobox.