### PR TITLE
fix(elrs): decouple the CRSF-jump baud from the esptool baud (hardware-verified)

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -4923,7 +4923,7 @@ export function App() {
       setElrsBridgeArmed(true)
       setElrsFlasherNotice({
         tone: 'warning',
-        text: `Passthru enabled on Serial${input.destinationPort}. The bridge is open at ${input.baudRate.toLocaleString()} baud — choose the ELRS firmware .bin and flash the receiver below.`
+        text: `Passthru enabled on Serial${input.destinationPort}. The bridge is open — choose the ELRS firmware .bin and flash the receiver below.`
       })
     } catch (error) {
       setElrsFlasherNotice({
@@ -4986,7 +4986,7 @@ export function App() {
       const result = await flashElrsReceiver({
         port,
         firmware: firmwareToFlash,
-        baudRate: input.baudRate,
+        crsfBaud: input.baudRate,
         onProgress: (progress) => setElrsFlashProgress(progress)
       })
       setElrsFlasherNotice({

--- a/apps/web/src/firmware/ElrsFlasher.tsx
+++ b/apps/web/src/firmware/ElrsFlasher.tsx
@@ -6,8 +6,8 @@ import { Panel, StatusBadge } from '@arduconfig/ui-kit'
 
 import {
   detectElrsSerialPorts,
-  ELRS_DEFAULT_FLASH_BAUD,
-  ELRS_FLASH_BAUD_RATES
+  ELRS_DEFAULT_CRSF_BAUD,
+  ELRS_CRSF_BAUD_RATES
 } from '../view-models/elrs-flash'
 import type { ElrsFlashProgress } from './web-serial-esptool'
 
@@ -50,7 +50,7 @@ export function ElrsFlasher(props: ElrsFlasherProps): ReactElement {
 
   const candidates = useMemo(() => detectElrsSerialPorts(snapshot), [snapshot])
   const [destinationPort, setDestinationPort] = useState<number | undefined>(undefined)
-  const [baudRate, setBaudRate] = useState<number>(ELRS_DEFAULT_FLASH_BAUD)
+  const [baudRate, setBaudRate] = useState<number>(ELRS_DEFAULT_CRSF_BAUD)
   const [timeoutSeconds, setTimeoutSeconds] = useState<number>(DEFAULT_TIMEOUT_SECONDS)
   const [firmware, setFirmware] = useState<{ bytes: Uint8Array; name: string } | undefined>(undefined)
   const [bindPhrase, setBindPhrase] = useState('')
@@ -126,14 +126,14 @@ export function ElrsFlasher(props: ElrsFlasherProps): ReactElement {
             </label>
 
             <label className="scoped-editor-field">
-              <span>Flashing baud</span>
+              <span>Receiver CRSF baud</span>
               <select
                 data-testid="elrs-flasher-baud"
                 value={baudRate}
                 disabled={busy || bridgeArmed}
                 onChange={(event) => setBaudRate(Number(event.target.value))}
               >
-                {ELRS_FLASH_BAUD_RATES.map((rate) => (
+                {ELRS_CRSF_BAUD_RATES.map((rate) => (
                   <option key={rate} value={rate}>
                     {rate.toLocaleString()} baud
                   </option>
@@ -193,8 +193,9 @@ export function ElrsFlasher(props: ElrsFlasherProps): ReactElement {
         {bridgeArmed ? (
           <div className="elrs-flasher__flash" data-testid="elrs-flasher-armed-note">
             <p className="telemetry-note">
-              Bridge is open at {baudRate.toLocaleString()} baud. Choose the ELRS firmware <code>.bin</code> and flash the
-              receiver, or close the bridge to restore MAVLink.
+              Bridge is open. Choose the ELRS firmware <code>.bin</code> and flash the receiver, or close the bridge to
+              restore MAVLink. (The bootloader command is sent at {baudRate.toLocaleString()} baud; esptool then flashes at
+              115200.)
             </p>
             <label className="scoped-editor-field">
               <span>ELRS firmware (.bin)</span>

--- a/apps/web/src/firmware/web-serial-esptool.ts
+++ b/apps/web/src/firmware/web-serial-esptool.ts
@@ -25,13 +25,25 @@ export interface ElrsFlashProgress {
   message?: string
 }
 
+// The two bauds are DIFFERENT and must be decoupled (verified on real hardware,
+// iFlight ESP8285 nano through an ArduPilot SERIAL_PASS bridge):
+//  - the CRSF "enter bootloader" command is parsed by the RUNNING ELRS firmware,
+//    so it must go at the RC link's CRSF baud (420000 default);
+//  - esptool then syncs+flashes the ESP ROM bootloader at 115200. Higher bauds
+//    (esptool's changeBaud to 230400/420000) fail through the FC bridge with
+//    "No serial data received"; 115200 works reliably.
+export const ELRS_CRSF_BOOTLOADER_BAUD = 420000
+export const ELRS_ESPTOOL_BAUD = 115200
+
 export interface ElrsFlashInput {
   /** The live Web Serial port (already released by the MAVLink transport). */
   port: WebSerialPortLike
   /** The ELRS firmware image to write. */
   firmware: Uint8Array
-  /** Flashing baud — the FC forwards this from USB onto the RC UART. */
-  baudRate: number
+  /** The receiver's CRSF link baud for the bootloader-jump command (the running
+   *  firmware parses it at this baud). Defaults to 420000. esptool always runs
+   *  at 115200 regardless. */
+  crsfBaud?: number
   onProgress?: (progress: ElrsFlashProgress) => void
   onLog?: (line: string) => void
 }
@@ -68,19 +80,21 @@ async function sendElrsBootloaderJump(port: WebSerialPortLike, baudRate: number)
  * released the MAVLink transport first, so this owns the port exclusively.
  */
 export async function flashElrsReceiver(input: ElrsFlashInput): Promise<{ chipName: string }> {
-  const { port, firmware, baudRate, onProgress, onLog } = input
+  const { port, firmware, onProgress, onLog } = input
+  const crsfBaud = input.crsfBaud ?? ELRS_CRSF_BOOTLOADER_BAUD
 
+  // Jump at the CRSF baud so the running firmware parses the command.
   onProgress?.({ phase: 'bootloader', message: 'Sending ELRS bootloader command…' })
-  await sendElrsBootloaderJump(port, baudRate)
+  await sendElrsBootloaderJump(port, crsfBaud)
 
-  // no_reset: DTR/RTS can't reach the ESP through the FC bridge, and the RX is
-  // already in its bootloader from the CRSF jump above. romBaudrate === baudrate
-  // so esptool doesn't try to renegotiate (the FC pins the UART to USB's baud).
+  // esptool at 115200 (== esptool-js's fixed romBaudrate, so main() does NO
+  // changeBaud). no_reset: DTR/RTS can't reach the ESP through the FC bridge,
+  // and the RX is already in its bootloader from the CRSF jump above.
   onProgress?.({ phase: 'connect', message: 'Syncing with the ESP bootloader…' })
   const transport = new Transport(port as unknown as EsptoolSerialPort, false)
   const loader = new ESPLoader({
     transport,
-    baudrate: baudRate,
+    baudrate: ELRS_ESPTOOL_BAUD,
     enableTracing: false,
     terminal: onLog
       ? {

--- a/apps/web/src/view-models/elrs-flash.ts
+++ b/apps/web/src/view-models/elrs-flash.ts
@@ -10,9 +10,12 @@ import type { ConfiguratorSnapshot } from '@arduconfig/ardupilot-core'
 export const ELRS_RCIN_PROTOCOL = 23
 export const ELRS_CRSF_PROTOCOL = 29
 
-/** Common ESP flashing baud rates ELRS uses over the passthru bridge. */
-export const ELRS_FLASH_BAUD_RATES = [420000, 460800, 230400, 115200] as const
-export const ELRS_DEFAULT_FLASH_BAUD = 420000
+// The receiver's CRSF link baud, used ONLY for the bootloader-jump command (the
+// running firmware parses it at this baud). esptool always flashes at 115200 —
+// higher bauds fail through the FC bridge (verified on hardware). 420000 is the
+// ELRS default; 400000/115200 cover non-standard link rates.
+export const ELRS_CRSF_BAUD_RATES = [420000, 400000, 115200] as const
+export const ELRS_DEFAULT_CRSF_BAUD = 420000
 
 export interface ElrsPortCandidate {
   /** Serial port index N (the value to write to SERIAL_PASS2). */


### PR DESCRIPTION
Bench test on real hardware (iFlight ESP8285 900 nano through an ArduPilot SERIAL_PASS bridge) found the flash failure and the fix.

**Root cause:** the flasher used one baud for both the CRSF "enter bootloader" command *and* esptool, but they must differ:
- the jump is parsed by the **running ELRS firmware** → must go at the CRSF link baud (420000 default);
- esptool syncs+flashes the ESP ROM bootloader at **115200** — higher rates (230400/420000) fail through the FC bridge with `No serial data received`.

So 420000 sent the jump fine but esptool couldn't sync; 230400 lined up neither. **Verified working sequence on hardware:** jump @420000 → esptool @115200 (detected `ESP8285N08`, uploaded stub, read flash).

- `flashElrsReceiver`: jump at `crsfBaud` (default 420000); esptool `baudrate = 115200` (== esptool-js's fixed `romBaudrate`, so `main()` does no changeBaud).
- UI: the baud select is now **Receiver CRSF baud** (jump only); flashing is always 115200.
- Also confirmed on hardware: the RX enters the bootloader **keyless even when bound**, and it's full-duplex — so no bind-key / half-duplex handling needed.

ArduCopter byte-identical: ELRS-flash path only, Expert + SERIAL_PASS2 gated. Validation: typecheck; ELRS arm e2e green; flash path proven on real hardware.