### PR TITLE
fix(elrs): ExpressLRS flash params (dio/40m/detect) — fixes the write failure

### DIFF
--- a/apps/web/src/firmware/web-serial-esptool.ts
+++ b/apps/web/src/firmware/web-serial-esptool.ts
@@ -113,11 +113,13 @@ export async function flashElrsReceiver(input: ElrsFlashInput): Promise<{ chipNa
     onProgress?.({ phase: 'flash', message: `Flashing ${chipName}…`, written: 0, total: firmware.length })
     await loader.writeFlash({
       fileArray: [{ data: firmware, address }],
-      // 'keep' preserves the flash mode/freq/size baked into the ELRS release
-      // image header rather than overriding it.
-      flashMode: 'keep',
-      flashFreq: 'keep',
-      flashSize: 'keep',
+      // ExpressLRS's own esptool params (binary_flash.py). 'keep' for flashSize
+      // left esptool without the size it needs to set up the erase, so the first
+      // compressed block failed with "status 193" — 'detect' fixes it. Verified
+      // on hardware (ESP8285 through an ArduPilot SERIAL_PASS bridge).
+      flashMode: 'dio',
+      flashFreq: '40m',
+      flashSize: 'detect',
       eraseAll: false,
       compress: true,
       reportProgress: (_fileIndex: number, written: number, total: number) =>


### PR DESCRIPTION
Second bench-found fix (after the baud decouple). With `flashSize: 'keep'`, esptool couldn't determine the flash size for the erase, so the first compressed block failed: `Failed to write compressed data to flash after seq 0 failed with status 193,0`. Switching to esptool's detected size + ExpressLRS's own params (`binary_flash.py`: `--flash_mode dio --flash_freq 40m --flash_size detect`) fixes it. Compression kept (works + faster).

**Verified end-to-end on hardware** (iFlight ESP8285 900 nano through an ArduPilot SERIAL_PASS bridge): jump @420000 → esptool sync @115200 → stub → compressed write with dio/40m/detect → `Wrote 4096 bytes ... Hash of data verified` (rc 0).

ArduCopter byte-identical: ELRS-flash path only, Expert + SERIAL_PASS2 gated.