### PR TITLE
fix(elrs): keep image flash mode/freq — don't force DIO (bricks ESP8285)

### DIFF
--- a/apps/web/src/firmware/web-serial-esptool.ts
+++ b/apps/web/src/firmware/web-serial-esptool.ts
@@ -113,12 +113,13 @@ export async function flashElrsReceiver(input: ElrsFlashInput): Promise<{ chipNa
     onProgress?.({ phase: 'flash', message: `Flashing ${chipName}…`, written: 0, total: firmware.length })
     await loader.writeFlash({
       fileArray: [{ data: firmware, address }],
-      // ExpressLRS's own esptool params (binary_flash.py). 'keep' for flashSize
-      // left esptool without the size it needs to set up the erase, so the first
-      // compressed block failed with "status 193" — 'detect' fixes it. Verified
-      // on hardware (ESP8285 through an ArduPilot SERIAL_PASS bridge).
-      flashMode: 'dio',
-      flashFreq: '40m',
+      // 'keep' for flashSize left esptool without the size it needs to set up the
+      // erase, so the first compressed block failed with "status 193" — 'detect'
+      // fixes it (verified on hardware). flashMode/flashFreq stay 'keep' so the
+      // image header's own values are preserved: ESP8285 embedded flash requires
+      // DOUT, and overriding to DIO makes the app unbootable (hang / solid LED).
+      flashMode: 'keep',
+      flashFreq: 'keep',
       flashSize: 'detect',
       eraseAll: false,
       compress: true,


### PR DESCRIPTION
Correction to #65. The `status 193` write failure was **only** about `flashSize` ('keep' gave esptool no size for the erase → 'detect' fixes it). I also wrongly forced `flashMode: 'dio'` (copied from ExpressLRS's **ESP32** args). **ESP8285 embedded flash requires DOUT** — overriding the header to DIO makes the flashed app unable to read flash at boot → hang (solid LED) → won't enter its bootloader. Confirmed on hardware.

Fix: `flashMode: 'keep'` + `flashFreq: 'keep'` (preserve the .bin's correct per-target values) + `flashSize: 'detect'` (the real 193 fix). Correct for ESP8285 (DOUT) and ESP32 alike.