### PR TITLE
chore(elrs): hide ELRS Flash tab in prod pending a reliable flasher

### DIFF
--- a/apps/web/src/view-models/visible-app-views.test.ts
+++ b/apps/web/src/view-models/visible-app-views.test.ts
@@ -77,8 +77,10 @@ describe('buildVisibleAppViews', () => {
     expect(ids(buildVisibleAppViews(baseInputs({ isExpertMode: true, hasScriptingParams: false })))).not.toContain('lua')
   })
 
-  it('shows ELRS Flash only in Expert mode AND when the FC reports SERIAL_PASS2', () => {
-    expect(ids(buildVisibleAppViews(baseInputs({ isExpertMode: true, hasSerialPassthrough: true })))).toContain('elrs-flash')
+  it('keeps ELRS Flash hidden (temporarily disabled in prod pending a reliable chunked flasher)', () => {
+    // Even with Expert mode + SERIAL_PASS2 advertised, the tab stays hidden while
+    // ELRS_FLASH_ENABLED is off (the single-shot flash corrupts through the bridge).
+    expect(ids(buildVisibleAppViews(baseInputs({ isExpertMode: true, hasSerialPassthrough: true })))).not.toContain('elrs-flash')
     expect(ids(buildVisibleAppViews(baseInputs({ isExpertMode: false, hasSerialPassthrough: true })))).not.toContain('elrs-flash')
     expect(ids(buildVisibleAppViews(baseInputs({ isExpertMode: true, hasSerialPassthrough: false })))).not.toContain('elrs-flash')
   })

--- a/apps/web/src/view-models/visible-app-views.ts
+++ b/apps/web/src/view-models/visible-app-views.ts
@@ -192,6 +192,13 @@ export function buildVisibleAppViews(inputs: VisibleAppViewsInputs): AppViewDesc
       ? { ...view, label: 'Status & Info', description: 'Vehicle health, live status, system info, and guided setup.' }
       : view
   )
+  // ELRS Flash is TEMPORARILY DISABLED in prod (2026-07-14). Bench testing on a
+  // real iFlight ESP8285 RX showed the single-shot esptool-js writeFlash corrupts
+  // through the ArduPilot SERIAL_PASS bridge — the bridge can't sustain the stub
+  // upload or a full-image erase; only small (~4KB) --no-stub chunked writes get
+  // through. The tab is hidden until the flasher is reworked to chunk the write
+  // (see the feature-elrs-passthrough-flash notes). Flip this to re-enable.
+  const ELRS_FLASH_ENABLED = false
   const combined = [
     ...relabelled,
     calibrationDescriptor,
@@ -202,8 +209,9 @@ export function buildVisibleAppViews(inputs: VisibleAppViewsInputs): AppViewDesc
     ...(isExpertMode && hasNetworkingParams ? [networkingDescriptor] : []),
     // Lua Scripts — Expert-only AND only when the FC advertises scripting (SCR_).
     ...(isExpertMode && hasScriptingParams ? [luaDescriptor] : []),
-    // ELRS Flash — Expert-only AND only when the FC advertises the SERIAL_PASS bridge.
-    ...(isExpertMode && hasSerialPassthrough ? [elrsFlashDescriptor] : []),
+    // ELRS Flash — Expert-only AND only when the FC advertises the SERIAL_PASS
+    // bridge. Gated OFF via ELRS_FLASH_ENABLED above until the chunked flasher lands.
+    ...(ELRS_FLASH_ENABLED && isExpertMode && hasSerialPassthrough ? [elrsFlashDescriptor] : []),
     // Expert-only views — only surfaced when Expert mode is on.
     ...(isExpertMode
       ? [rcMixerDescriptor, mavlinkInspectorDescriptor, dronecanInspectorDescriptor, aiAssistantDescriptor]

--- a/tests/e2e/views.spec.ts
+++ b/tests/e2e/views.spec.ts
@@ -3858,31 +3858,18 @@ test.describe('Scoped write-progress bar', () => {
   })
 })
 
-test.describe('ELRS Flash (Expert + SERIAL_PASS2 gated)', () => {
-  test('detects the RCIN receiver port and arms the passthru bridge', async ({ page }) => {
+test.describe('ELRS Flash (temporarily disabled in prod)', () => {
+  test('stays hidden even in Expert mode with SERIAL_PASS2 advertised', async ({ page }) => {
     await page.goto('/')
     await connectViaHeader(page)
-    // Passthru arm writes params, which are blocked until the initial sync
-    // completes (on hardware it's long done before you reach this tab).
     await expectParameterSyncComplete(page)
     await page.getByTestId('product-mode-expert').check()
 
-    // Tab is gated on Expert + SERIAL_PASS2 (both true in the demo mock).
-    await page.getByTestId('view-button-elrs-flash').click()
-    await expect(page.getByTestId('elrs-flasher')).toBeVisible()
-
-    // The demo FC has Serial1 = RCIN (protocol 23) — detected as the RX port.
-    await expect(page.getByTestId('elrs-flasher-port')).toContainText('Serial1')
-
-    // Arm the bridge — the mock emits "Passthru enabled" on the SERIAL_PASS2
-    // write, which resolves the runtime's STATUSTEXT gate.
-    await page.getByTestId('elrs-flasher-arm').click()
-    await expect(page.getByTestId('elrs-flasher-armed-note')).toBeVisible()
-    await expect(page.getByTestId('elrs-flasher-notice')).toContainText('Passthru enabled')
-
-    // Close the bridge to restore MAVLink.
-    await page.getByTestId('elrs-flasher-cancel').click()
-    await expect(page.getByTestId('elrs-flasher-armed-note')).toHaveCount(0)
+    // The demo FC advertises Expert + SERIAL_PASS2, which used to surface the ELRS
+    // Flash tab. It is now gated OFF (ELRS_FLASH_ENABLED=false) because the
+    // single-shot flash corrupts through the ArduPilot bridge on real hardware —
+    // the tab must not be reachable until the chunked flasher lands.
+    await expect(page.getByTestId('view-button-elrs-flash')).toHaveCount(0)
   })
 })
 


### PR DESCRIPTION
## Why

Bench testing on a real iFlight ESP8285 900 nano RX (flashed through the ArduPilot `SERIAL_PASS` bridge) showed the **shipped single-shot flash path is unreliable on real hardware**:

- The bridge **cannot sustain a long esptool stream** — the esptool-js **stub upload** ("Serial data stream stopped") and the **full-image bulk erase** ("Invalid head of packet") both corrupt at 115200.
- Only small, independent operations survive: `flash_id` reads and **≤4 KB `--no-stub` chunked writes**.
- The current `flashElrsReceiver` does one `main()` (loads the stub) + one `writeFlash` of the whole image — exactly the two operations that always fail.

A full 556 KB image *was* recovered on the bench, but only via ~4 KB chunked `--no-stub` writes with retries, `SERIAL_PASSTIMO=0`, and the BOOT button held. That's a substantial rework of the flasher, not a quick fix.

## What

Gate the **ELRS Flash** tab OFF (`ELRS_FLASH_ENABLED = false` in `visible-app-views.ts`) so it isn't reachable in prod until the flasher is reworked to chunk the write. All flasher code (`web-serial-esptool.ts`, `ElrsFlasher.tsx`, `elrs-flash` view models) is left in place — **re-enabling is a one-line flip**.

- Unit test updated: tab stays hidden even with Expert + `SERIAL_PASS2`.
- E2E updated: asserts `view-button-elrs-flash` is absent.

## Validation
- `npm run typecheck` ✓
- `visible-app-views` unit tests ✓ (11 passed)
- e2e `ELRS Flash (temporarily disabled in prod)` ✓

**ArduCopter byte-identical** — UI-nav-only, no runtime/transport/param changes.