### PR TITLE
fix(transport): raise Web Serial read buffer to 256 KiB — unblocks param sync + log download

### DIFF
--- a/apps/web/src/runtime-factory.ts
+++ b/apps/web/src/runtime-factory.ts
@@ -33,6 +33,20 @@ import { getDesktopBridge } from './desktop-bridge'
 import { DesktopSocketTransport } from './desktop-socket-transport'
 import type { TransportMode } from './hooks/use-transport-selection'
 
+// Web Serial's SerialOptions.bufferSize defaults to a tiny 255 bytes, which
+// throttles every fast inbound burst ArduPilot sends:
+//  - PARAM_REQUEST_LIST dumps ~1300 PARAM_VALUE frames (~35 bytes) back-to-back;
+//  - a MAVFTP burst log download streams ~239-byte packets thousands deep;
+// A 255-byte OS read buffer holds only a handful of either, so the instant the
+// JS read loop can't drain fast enough the browser silently drops the overflow.
+// That surfaces as a stalled param stream (trickling in via by-index gap-fill)
+// and as a log download that crawls — every dropped packet forces a re-stream
+// from the gap (and can cost a burst-inactivity timeout). Give the read buffer
+// enough headroom to hold the whole burst while JS drains it. 256 KiB
+// comfortably covers a full 1300-param table (~45 KB) and a MAVFTP burst
+// segment (~478 KB is chunked across requests) with slack.
+const WEB_SERIAL_READ_BUFFER_BYTES = 256 * 1024
+
 // Parses the "UDP (direct)" target field into a neutral shape. "host:port"
 // connects to a fixed remote; ":port" or a bare "port" binds locally and learns
 // the peer from the first datagram (the ELRS / Mission-Planner-UDP-listen case).
@@ -79,6 +93,7 @@ export function createRuntime(
     if (mode === 'web-serial') {
       return new WebSerialTransport('browser-serial', {
         baudRate: 115200,
+        bufferSize: WEB_SERIAL_READ_BUFFER_BYTES,
         port: serialPort,
         onPortSelected: onSerialPortSelected
       })


### PR DESCRIPTION
## What
Open the Web Serial port with an explicit `bufferSize` of 256 KiB. It was unset, so the browser used the spec default of **255 bytes**.

## Why
A 255-byte OS read buffer overflows on any fast inbound burst from ArduPilot and the browser silently drops the excess once the JS read loop can't keep up:
- **Param sync** — `PARAM_REQUEST_LIST` dumps ~1300 `PARAM_VALUE` frames back-to-back. Observed on a real FC as `Parameter stream stalled at 2/1258`, then a slow by-index gap-fill crawl.
- **Log download** — the MAVFTP burst path streams thousands of 239-byte packets; each dropped packet forces a re-stream from the gap (and a lost `burst_complete` costs a ~6s inactivity timeout), so a 2.7 MB log took far longer than the link warrants.

256 KiB lets a full burst queue while JS drains it — the whole param table (~45 KB) or a MAVFTP burst segment fits with slack.

## Validation
- Root cause reproduced on real hardware (ArduPilot 4.7, web-serial USB) — the param-stall trace above.
- A headless pyserial pull of the same 2.7 MB onboard log over the **same USB** finished in ~4s, proving the link is fast and the 255-byte buffer was the throttle.
- `npm run typecheck` + `npm run test` (721 pass) green. e2e via CI.
- Not yet re-verified with the fixed build on-device (web-serial isn't exercised by the mock e2e path).

## ArduCopter invariant
Transport-layer only (a Web Serial open option); affects all vehicles equally. **ArduCopter byte-identical.**