### PR TITLE
fix(metadata): correct ArduCopter rate-PID slider ranges to ArduPilot @Range

### DIFF
--- a/packages/param-metadata/src/arducopter.ts
+++ b/packages/param-metadata/src/arducopter.ts
@@ -2819,7 +2819,7 @@ export const arducopterMetadata: FirmwareMetadataBundle = {
       description: 'Roll-axis rate P gain.',
       category: 'pid',
       minimum: 0,
-      maximum: 1.5,
+      maximum: 0.5,
       step: 0.001,
       notes: pidTuningNotes
     },
@@ -2829,7 +2829,7 @@ export const arducopterMetadata: FirmwareMetadataBundle = {
       description: 'Roll-axis rate I gain.',
       category: 'pid',
       minimum: 0,
-      maximum: 1.5,
+      maximum: 2.0,
       step: 0.001,
       notes: pidTuningNotes
     },
@@ -2839,7 +2839,7 @@ export const arducopterMetadata: FirmwareMetadataBundle = {
       description: 'Roll-axis rate D gain.',
       category: 'pid',
       minimum: 0,
-      maximum: 0.1,
+      maximum: 0.05,
       step: 0.0001,
       notes: pidTuningNotes
     },
@@ -2849,7 +2849,7 @@ export const arducopterMetadata: FirmwareMetadataBundle = {
       description: 'Roll-axis rate feedforward gain.',
       category: 'pid',
       minimum: 0,
-      maximum: 1,
+      maximum: 0.5,
       step: 0.001,
       notes: pidTuningNotes
     },
@@ -2859,7 +2859,7 @@ export const arducopterMetadata: FirmwareMetadataBundle = {
       description: 'Roll-axis derivative feedforward term.',
       category: 'pid',
       minimum: 0,
-      maximum: 0.1,
+      maximum: 0.02,
       step: 0.0001,
       notes: pidTuningNotes
     },
@@ -2899,7 +2899,7 @@ export const arducopterMetadata: FirmwareMetadataBundle = {
       description: 'Pitch-axis rate P gain.',
       category: 'pid',
       minimum: 0,
-      maximum: 1.5,
+      maximum: 0.5,
       step: 0.001,
       notes: pidTuningNotes
     },
@@ -2909,7 +2909,7 @@ export const arducopterMetadata: FirmwareMetadataBundle = {
       description: 'Pitch-axis rate I gain.',
       category: 'pid',
       minimum: 0,
-      maximum: 1.5,
+      maximum: 2.0,
       step: 0.001,
       notes: pidTuningNotes
     },
@@ -2919,7 +2919,7 @@ export const arducopterMetadata: FirmwareMetadataBundle = {
       description: 'Pitch-axis rate D gain.',
       category: 'pid',
       minimum: 0,
-      maximum: 0.1,
+      maximum: 0.05,
       step: 0.0001,
       notes: pidTuningNotes
     },
@@ -2929,7 +2929,7 @@ export const arducopterMetadata: FirmwareMetadataBundle = {
       description: 'Pitch-axis rate feedforward gain.',
       category: 'pid',
       minimum: 0,
-      maximum: 1,
+      maximum: 0.5,
       step: 0.001,
       notes: pidTuningNotes
     },
@@ -2939,7 +2939,7 @@ export const arducopterMetadata: FirmwareMetadataBundle = {
       description: 'Pitch-axis derivative feedforward term.',
       category: 'pid',
       minimum: 0,
-      maximum: 0.1,
+      maximum: 0.02,
       step: 0.0001,
       notes: pidTuningNotes
     },
@@ -2979,7 +2979,7 @@ export const arducopterMetadata: FirmwareMetadataBundle = {
       description: 'Yaw-axis rate P gain.',
       category: 'pid',
       minimum: 0,
-      maximum: 1.5,
+      maximum: 2.5,
       step: 0.001,
       notes: pidTuningNotes
     },
@@ -2989,7 +2989,7 @@ export const arducopterMetadata: FirmwareMetadataBundle = {
       description: 'Yaw-axis rate I gain.',
       category: 'pid',
       minimum: 0,
-      maximum: 1.5,
+      maximum: 1.0,
       step: 0.001,
       notes: pidTuningNotes
     },
@@ -2999,7 +2999,7 @@ export const arducopterMetadata: FirmwareMetadataBundle = {
       description: 'Yaw-axis rate D gain.',
       category: 'pid',
       minimum: 0,
-      maximum: 0.1,
+      maximum: 0.02,
       step: 0.0001,
       notes: pidTuningNotes
     },
@@ -3009,7 +3009,7 @@ export const arducopterMetadata: FirmwareMetadataBundle = {
       description: 'Yaw-axis rate feedforward gain.',
       category: 'pid',
       minimum: 0,
-      maximum: 1,
+      maximum: 0.5,
       step: 0.001,
       notes: pidTuningNotes
     },
@@ -3019,7 +3019,7 @@ export const arducopterMetadata: FirmwareMetadataBundle = {
       description: 'Yaw-axis derivative feedforward term.',
       category: 'pid',
       minimum: 0,
-      maximum: 0.1,
+      maximum: 0.02,
       step: 0.0001,
       notes: pidTuningNotes
     },


### PR DESCRIPTION
## What
Fix the min/max on the ArduCopter rate-PID (`ATC_RAT_*`) tuning controls to match ArduPilot's documented `@Range`. Verified against `AC_AttitudeControl_Multi.cpp` in a local `~/ardupilot` checkout.

| Param | Was | ArduPilot @Range | New max |
|---|---|---|---|
| RLL/PIT_P | 0–1.5 | 0.01–0.5 | 0.5 |
| RLL/PIT_I | 0–1.5 | 0.01–2.0 | 2.0 |
| RLL/PIT_D | 0–0.1 | 0.0–0.05 | 0.05 |
| RLL/PIT_FF | 0–1 | 0–0.5 | 0.5 |
| RLL/PIT_D_FF | 0–0.1 | 0–0.02 | 0.02 |
| YAW_P | 0–1.5 | 0.10–2.5 | 2.5 |
| YAW_I | 0–1.5 | 0.010–1.0 | 1.0 |
| YAW_D | 0–0.1 | 0.0–0.02 | 0.02 |
| YAW_FF | 0–1 | 0–0.5 | 0.5 |
| YAW_D_FF | 0–0.1 | 0–0.02 | 0.02 |

## Why
Roll/pitch P maxed at 1.5 when a real multirotor P lives around 0.05–0.25, so ~2/3 of the slider was dead travel. Yaw P was capped *below* its valid range (couldn't reach 2.5). This came up while tuning a real 5S quad.

## Notes
- **Minimums kept at 0** so a D/FF term can still be zeroed — ArduPilot's non-zero mins (0.01, 0.10) are guidance, and clamping a valid stored `0` up to `0.01` on slider touch would be worse.
- These bounds also feed draft validation (`parameter-drafts.ts`): an out-of-range staged write is flagged `invalid`, with the existing operator "override and write anyway" carrying a deliberate value through — same pattern as `SERIAL7_BAUD`. Read-back values are never flagged.

## Validation
`npm run typecheck` + `npm run test` green (85 metadata/draft assertions incl. `firmware-overrides`, `parameter-drafts-derivation`, `metadata`). e2e via CI.

## ArduCopter invariant
Deliberate, scoped ArduCopter metadata/tuning-UX fix. No runtime, transport, or write-path change — a given value still writes the identical bytes on the wire.