### PR TITLE
feat(ui): Parameters editor polish + move Config tab up one step

### DIFF
--- a/apps/web/src/sections/ParametersSection.tsx
+++ b/apps/web/src/sections/ParametersSection.tsx
@@ -11,12 +11,10 @@ import { Panel, StatusBadge, buttonStyle } from '@arduconfig/ui-kit'
 
 import {
   formatParameterDelta,
-  formatParameterRange,
-  formatParameterStep,
   formatParameterValue,
   formatParameterDraftValue
 } from '../parameter-format'
-import { ScopedBitmaskPopover, ScopedField } from '../views/ScopedField'
+import { ScopedBitmaskPopover } from '../views/ScopedField'
 import { parameterApplyBlockedReason } from '../apply-gate'
 import { applyDraftSelectionClick, pruneDraftSelection } from '../view-models/draft-selection'
 import { parameterSearchPredicate } from '../view-models/filtered-parameters'
@@ -256,22 +254,12 @@ export function ParametersSection(props: ParametersSectionProps): ReactElement {
     [parameterDraftById]
   )
 
-  // The parameter inspector auto-selects the first param (FRAME_CLASS), which on
-  // a phone renders a tall box wedged above the editable table. Start it
-  // collapsed on phones (the operator taps "Show details" or any row to expand);
-  // desktop is unaffected — it initialises expanded and the toggle is CSS-hidden.
-  const [parameterDetailsCollapsed, setParameterDetailsCollapsed] = useState(
-    () => typeof window !== 'undefined' && typeof window.matchMedia === 'function' && window.matchMedia('(max-width: 600px)').matches
-  )
-
-  // Selected-parameter derived state — small enough to recompute here rather
-  // than thread through the props.
+  // Row selection is kept only to highlight the last-clicked row in the table;
+  // the standalone detail/inspector card was removed (it wasted vertical space
+  // and duplicated the inline per-row editor). Editing happens directly in the
+  // row now.
   const selectedParameter =
     displayedParameters.find((parameter) => parameter.id === selectedParameterId) ?? displayedParameters[0]
-  const selectedParameterDefinition = selectedParameter
-    ? metadataCatalog.parameters[selectedParameter.id] ?? selectedParameter.definition
-    : undefined
-  const selectedParameterDraft = selectedParameter ? parameterDraftById.get(selectedParameter.id) : undefined
 
   return (
 
@@ -766,75 +754,6 @@ export function ParametersSection(props: ParametersSectionProps): ReactElement {
             </small>
           ) : null}
         </div>
-
-        {selectedParameter ? (
-          <div className={`parameter-details${parameterDetailsCollapsed ? ' parameter-details--collapsed' : ''}`}>
-            <div className="parameter-details__header">
-              <div>
-                <h3>{selectedParameterDefinition?.label ?? selectedParameter.id}</h3>
-                <p>{selectedParameterDefinition?.description ?? 'Metadata coverage for this parameter is still limited.'}</p>
-              </div>
-              <StatusBadge tone={toneForParameterDraftStatus(selectedParameterDraft?.status ?? 'unchanged')}>
-                {selectedParameterDraft?.status ?? 'unchanged'}
-              </StatusBadge>
-              <button
-                type="button"
-                className="parameter-details__toggle"
-                data-testid="parameter-details-toggle"
-                onClick={() => setParameterDetailsCollapsed((collapsed) => !collapsed)}
-                aria-expanded={!parameterDetailsCollapsed}
-              >
-                {parameterDetailsCollapsed ? 'Show details' : 'Hide details'}
-              </button>
-            </div>
-
-            {parameterDetailsCollapsed ? null : (
-              <>
-            {/* Editable value: click to change here (stages a draft) instead of
-                scrolling to the row. Shows current + staged via the field. */}
-            <div className="parameter-details__value-editor" data-testid="parameter-details-editor">
-              <small>Value</small>
-              <ScopedField
-                parameter={{ ...selectedParameter, definition: selectedParameterDefinition ?? undefined }}
-                liveValue={selectedParameter.value}
-                editedValues={editedValues}
-                onChange={setDraft}
-                draftStatusById={draftStatusMap}
-                compact={false}
-              />
-            </div>
-            <div className="parameter-details__grid">
-              <div className="parameter-details__metric">
-                <small>Category</small>
-                <strong>{formatCategoryLabel(selectedParameterDefinition?.category)}</strong>
-              </div>
-              <div className="parameter-details__metric">
-                <small>Range / Step</small>
-                <strong>
-                  {formatParameterRange(selectedParameterDefinition)}
-                  {selectedParameterDefinition?.step !== undefined ? ` · ${formatParameterStep(selectedParameterDefinition)}` : ''}
-                </strong>
-              </div>
-              <div className="parameter-details__metric">
-                <small>Reboot</small>
-                <strong>{selectedParameterDefinition?.rebootRequired ? 'Required' : 'Not required'}</strong>
-              </div>
-            </div>
-
-            {/* Active enum label + the enum option-list boxes are gone — the
-                inline editor above (select / bitmask chips) already surfaces the
-                value and the available options. */}
-            {selectedParameterDefinition?.notes && selectedParameterDefinition.notes.length > 0 ? (
-              <ul className="notes">
-                {selectedParameterDefinition.notes.map((note) => (
-                  <li key={note}>{note}</li>
-                ))}
-              </ul>
-            ) : null}
-              </>
-            )}
-          </div>
-        ) : null}
 
         <div className="parameter-table">
           <div className="parameter-row parameter-row--header">

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -7588,6 +7588,25 @@ textarea:focus {
   flex-wrap: nowrap;
 }
 
+/* Raw numeric entry beneath the per-bit boxes: type/paste a bitmask value
+   directly (the checkboxes track it). */
+.scoped-bitmask-raw {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  margin-top: 6px;
+}
+
+.scoped-bitmask-raw span {
+  font-size: 0.72rem;
+  opacity: 0.7;
+}
+
+.scoped-bitmask-raw input {
+  width: 8rem;
+  max-width: 100%;
+}
+
 .scoped-bitmask-bit,
 .scoped-option-chip {
   padding: 3px 8px;
@@ -10627,7 +10646,16 @@ details.metadata-settings-section:not([open]) > summary::after {
 }
 
 .parameter-toolbar {
-  margin-bottom: 20px;
+  /* Freeze the search + filters at the top of the Parameter Editor so they stay
+     reachable while the (long) parameter table scrolls underneath, instead of
+     scrolling away. Solid panel background + z-index so rows pass cleanly under. */
+  position: sticky;
+  top: 0;
+  z-index: 5;
+  background: var(--bg-panel);
+  padding-top: 12px;
+  padding-bottom: 12px;
+  margin-bottom: 8px;
 }
 
 .parameter-review {

--- a/apps/web/src/view-models/visible-app-views.ts
+++ b/apps/web/src/view-models/visible-app-views.ts
@@ -182,7 +182,7 @@ export function buildVisibleAppViews(inputs: VisibleAppViewsInputs): AppViewDesc
   // follow a setup -> tuning -> tools flow. Views not listed fall to the
   // end in their original order.
   const CANONICAL_VIEW_ORDER = [
-    'setup', 'calibration', 'config', 'ports', 'receiver', 'modes', 'motors',
+    'setup', 'config', 'calibration', 'ports', 'receiver', 'modes', 'motors',
     'servos', 'power', 'failsafe', 'vtx', 'osd', 'tuning', 'presets',
     'snapshots', 'logs', 'parameters', 'can', 'networking', 'files', 'lua', 'flash', 'elrs-flash', 'rc-mixer',
     'mavlink-inspector', 'dronecan-inspector', 'ai-assistant'

--- a/apps/web/src/views/ScopedField.tsx
+++ b/apps/web/src/views/ScopedField.tsx
@@ -352,6 +352,20 @@ export function ScopedBitmaskField(props: CommonScopedFieldProps) {
           )
         })}
       </div>
+      {/* Raw value entry: paste/type a bitmask number directly (e.g. copying a
+          value out of another param file). Shares the same edited value as the
+          checkboxes above, so they stay in sync automatically. */}
+      <label className="scoped-bitmask-raw">
+        <span>Value</span>
+        <input
+          type="number"
+          min={0}
+          step={1}
+          aria-label={`${parameter.id} raw bitmask value`}
+          value={edited ?? String(safeCurrent)}
+          onChange={(event) => onChange(parameter.id, event.target.value)}
+        />
+      </label>
       <StagedWasLine status={status} liveValue={liveValue} />
     </div>
   )
@@ -449,6 +463,19 @@ export function ScopedBitmaskPopover(props: CommonScopedFieldProps) {
             )
           })}
         </div>
+        {/* Raw value entry: paste/type a bitmask number directly (e.g. copying a
+            value out of another param file) — the checkboxes track it. */}
+        <label className="scoped-bitmask-raw">
+          <span>Value</span>
+          <input
+            type="number"
+            min={0}
+            step={1}
+            aria-label={`${parameter.id} raw bitmask value`}
+            value={edited ?? String(safeCurrent)}
+            onChange={(event) => onChange(parameter.id, event.target.value)}
+          />
+        </label>
       </div>
       <StagedWasLine status={status} liveValue={liveValue} />
     </details>

--- a/tests/e2e/views.spec.ts
+++ b/tests/e2e/views.spec.ts
@@ -80,11 +80,9 @@ test.describe('Phone layout', () => {
     // Import (cross-vehicle migration) stays available on phone.
     await expect(page.getByTestId('import-parameter-backup')).toBeVisible()
 
-    // The inspector auto-defaults to the first param (FRAME_CLASS); on phone its
-    // tall body is collapsed by default and reachable via the toggle.
-    await expect(page.locator('.parameter-details__grid')).toBeHidden()
-    await page.getByTestId('parameter-details-toggle').click()
-    await expect(page.locator('.parameter-details__grid')).toBeVisible()
+    // The search/filter toolbar is frozen at the top of the editor so it stays
+    // reachable while the long parameter table scrolls under it.
+    await expect(page.getByTestId('parameter-search-input')).toBeVisible()
   })
 
   test('keeps the baseline panel on desktop width', async ({ page }) => {


### PR DESCRIPTION
Batch of small UI improvements from a live-testing session.

## Parameters editor (Expert)
- **Freeze the search/filter toolbar at the top** (`position: sticky`) so it stays reachable while the long parameter table scrolls under it.
- **Remove the standalone selected-parameter detail card** — it wasted vertical space and duplicated the inline per-row editor. Row selection is kept only to highlight the last-clicked row; editing happens in the row (number field / bitmask popover + Apply).
- **Raw-value entry for bitmask params** — added a numeric "Value" field to both bitmask editors (the compact table popover and the inline field used by Receiver options, failsafe options, etc.). Paste/type a bitmask number from another param file and the per-bit checkboxes track it (shared edited value → same draft path as clicking bits).

## Nav
- **Move the Config tab up one step**: `Status & Info → Config → Calibration → …`

## Tests
- Updated the phone-layout e2e (`views.spec.ts`) to assert the frozen search toolbar instead of the removed detail-card toggle.
- `npm run typecheck` + web unit tests (541 pass) green. e2e via CI.

## ArduCopter invariant
Presentational + nav-order only — no runtime/transport/write-path change. A given value stages and writes the identical bytes. **ArduCopter byte-identical.**