### PR TITLE
feat(ports): declutter each port row + rename Serial Options toggle to "Bitmask"

### DIFF
--- a/apps/web/src/sections/PortsSection.tsx
+++ b/apps/web/src/sections/PortsSection.tsx
@@ -346,20 +346,17 @@ export function PortsSection(props: PortsSectionProps): ReactElement {
                                             {port.protocolValue ?? '—'}
                                           </small>
                                         </div>
-                                        <StatusBadge tone={rowHasInvalid ? 'danger' : rowHasStaged ? 'warning' : port.editable ? 'neutral' : 'warning'}>
-                                          {rowHasInvalid ? 'invalid' : rowHasStaged ? 'staged' : port.editable ? 'ready' : 'read only'}
-                                        </StatusBadge>
                                       </div>
-                                      <div className="config-pills">
-                                        {/* Physical UART/USART now leads (heading); show the SERIAL number
-                                            as a secondary pill (the id the params use) plus the descriptive
-                                            connector/role. Dedupe so a connector label that just repeats the
-                                            heading isn't shown twice. */}
-                                        {port.portNumber !== 0 ? <span>{`SERIAL ${port.portNumber}`}</span> : null}
-                                        <span>{port.usageSummary}</span>
-                                        {port.label && port.label !== portHeading ? <span>{port.label}</span> : null}
-                                        {port.boardTrafficSummary ? <span>{port.boardTrafficSummary}</span> : null}
-                                      </div>
+                                      {/* Physical UART/USART leads (heading), with the SERIALn_PROTOCOL id in
+                                          the sub-line above. Only the board connector label remains as a pill
+                                          (and only when it doesn't just repeat the heading). The SERIAL-number
+                                          pill was dropped as redundant with the SERIALn_PROTOCOL sub-line, and
+                                          the role/usage, live-traffic, and status pills as redundant chrome. */}
+                                      {port.label && port.label !== portHeading ? (
+                                        <div className="config-pills">
+                                          <span>{port.label}</span>
+                                        </div>
+                                      ) : null}
                                     </div>
 
                                     <div className="ports-matrix-row__cell">
@@ -490,7 +487,7 @@ export function PortsSection(props: PortsSectionProps): ReactElement {
                                               }
                                               disabled={!port.editable}
                                             >
-                                              {expandedSerialOptionsPortNumber === port.portNumber ? 'Hide' : 'Edit'}
+                                              {expandedSerialOptionsPortNumber === port.portNumber ? 'Hide' : 'Bitmask'}
                                             </button>
                                           ) : null}
                                         </div>

--- a/tests/e2e/views.spec.ts
+++ b/tests/e2e/views.spec.ts
@@ -352,11 +352,10 @@ test.describe('Ports view', () => {
     // peripheral number (USART1,2,3 then UART4,5,6…), USB/console first.
     await expect(page.locator('.ports-matrix-row__title strong').first()).toBeVisible()
     await expect(page.locator('.ports-matrix-row__title small', { hasText: /SERIAL\d+_PROTOCOL/ }).first()).toBeVisible()
-    // Edit serial options on the first editable port, toggle one bit (clicking
-    // the click-to-highlight chip). Scope to the ports matrix:
-    // a bare hasText 'Edit' also matches the header build-info button on
-    // branches whose name contains "edit" (case-insensitive substring).
-    await page.locator('.ports-matrix button:enabled', { hasText: 'Edit' }).first().click()
+    // Open the serial-options bitmask editor on the first editable port and
+    // toggle one bit (clicking the click-to-highlight chip). The button reads
+    // "Bitmask" (collapsed) / "Hide" (expanded); scope to the ports matrix.
+    await page.locator('.ports-matrix button:enabled', { hasText: 'Bitmask' }).first().click()
     await page.locator('.ports-matrix-row__expanded .scoped-bitmask-bit').first().click()
     // The selected option now shows as a chip in the Options cell.
     await expect(page.locator('[data-testid^="serial-options-chips-"]').first()).toBeVisible()


### PR DESCRIPTION
Text/chrome cleanup on the Ports tab (from a live dev-server pass).

## Per-row declutter
Each port row carried the same identity ~4 ways. Removed the redundant bits so a row reads clean:
- **StatusBadge** (`ready` / `read only` / `staged` / `invalid`) — the row already conveys staged/invalid via its border+background and disables read-only fields.
- **Usage/role line** (`DisplayPort OSD / HD display link.`, `Telemetry / companion link.` …).
- **Live-traffic line** (`Idle in current uarts.txt snapshot` / `TX… · RX…`).
- **`SERIAL n` pill** — redundant with the `SERIALn_PROTOCOL` sub-line already shown.

A row now shows: physical UART heading → `SERIALn_PROTOCOL <value>` sub-line → board connector label (only when it isn't just the heading again; the pill strip is omitted entirely otherwise) → the Function/Baud/Flow/Options editors.

## Serial Options button
Renamed the expander from **"Edit" → "Bitmask"** (clearer what it opens), and updated the ports e2e to click by the new label.

## Validation
`typecheck` clean; no e2e asserted on any removed text; the one e2e that clicked "Edit" now clicks "Bitmask". Full e2e via CI.

## ArduCopter invariant
Presentational only — no parameter reads/writes change. **ArduCopter byte-identical.**