### PR TITLE
feat(setup): promote Guided Setup to its own left-nav tab

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1482,7 +1482,7 @@ export function App() {
   }, [activeViewId])
 
   useEffect(() => {
-    if (activeViewId !== 'setup' || setupMode !== 'wizard' || !selectedSetupSectionId) {
+    if (activeViewId !== 'guided-setup' || setupMode !== 'wizard' || !selectedSetupSectionId) {
       previousGuidedSectionRef.current = undefined
       return
     }
@@ -1599,7 +1599,7 @@ export function App() {
       modeSwitchExercise.status === 'passed' ||
       rcMappingSession.status === 'ready'
     if (exercisePassed && !returnedFromExerciseRef.current && activeViewId === 'receiver') {
-      setActiveViewId('setup')
+      setActiveViewId('guided-setup')
       setSetupMode('wizard')
     }
     returnedFromExerciseRef.current = exercisePassed
@@ -2778,13 +2778,18 @@ export function App() {
       setSelectedSetupSectionId(recommendedSetupSection.id)
     }
     setPendingSetupWizardFocusId(focusTargetId)
-    setActiveViewId('setup')
+    // The wizard now lives on its own 'guided-setup' tab (not the 'setup'
+    // overview). setupMode stays the "flow active" flag so a detour into an
+    // exercise view (receiver/motors) can bounce back here.
+    setActiveViewId('guided-setup')
     setSetupMode('wizard')
   }
 
   function closeSetupWizard(): void {
     setPendingSetupWizardFocusId(undefined)
     setSetupMode('overview')
+    // "Back to Setup" returns to the Status & Info dashboard tab.
+    setActiveViewId('setup')
   }
 
   function focusOutputsTarget(targetElementId: string): void {
@@ -2800,7 +2805,7 @@ export function App() {
   }
 
   useEffect(() => {
-    if (activeViewId !== 'setup' || setupMode !== 'wizard' || !pendingSetupWizardFocusId) {
+    if (activeViewId !== 'guided-setup' || setupMode !== 'wizard' || !pendingSetupWizardFocusId) {
       return
     }
 
@@ -2830,7 +2835,7 @@ export function App() {
 
     guidedSetupShortcutAppliedRef.current = true
     setSelectedSetupSectionId(guidedSetupShortcutSectionId)
-    setActiveViewId('setup')
+    setActiveViewId('guided-setup')
     setSetupMode('wizard')
   }, [guidedSetupShortcutSectionId])
 
@@ -5694,6 +5699,20 @@ export function App() {
     }
   }, [guidedSetupTestingShortcutActive, recommendedSetupSection, selectedSetupSectionCandidate])
 
+  // Keep the "flow active" flag (setupMode) synced to the tab. The Guided Setup
+  // tab always shows the wizard, so mark the flow active when it's open — this
+  // matters when the operator reaches the tab via the nav (not openSetupWizard),
+  // so the exercise-return effect still bounces them back after an RC/motor
+  // exercise. The Status & Info tab is always the overview. setupMode is NOT
+  // reset while on a detour view (receiver/motors), so the flow survives it.
+  useEffect(() => {
+    if (activeViewId === 'guided-setup' && setupMode !== 'wizard') {
+      setSetupMode('wizard')
+    } else if (activeViewId === 'setup' && setupMode !== 'overview') {
+      setSetupMode('overview')
+    }
+  }, [activeViewId, setupMode])
+
   // Auto-return to guided setup wizard when an exercise completes while on another page
   const exerciseReturnRef = useRef<{
     rcRange: string
@@ -5727,7 +5746,7 @@ export function App() {
       motorVerification: motorVerification.status
     }
 
-    if (setupMode !== 'wizard' || activeViewId === 'setup') {
+    if (setupMode !== 'wizard' || activeViewId === 'guided-setup') {
       return
     }
 
@@ -6224,7 +6243,7 @@ export function App() {
     }
   ] as const
 
-  const showLanding = activeViewId === 'setup' && snapshot.connection.kind !== 'connected'
+  const showLanding = (activeViewId === 'setup' || activeViewId === 'guided-setup') && snapshot.connection.kind !== 'connected'
 
   return (
     <>
@@ -6377,11 +6396,16 @@ export function App() {
               onConnect={() => void handleConnect()}
               connectDisabled={busyAction !== undefined || snapshot.connection.kind === 'connected'}
             />
-          ) : activeViewId === 'setup' ? (
+          ) : activeViewId === 'setup' || activeViewId === 'guided-setup' ? (
             <SetupView
-              mode={setupMode}
+              // The tab decides the surface: Status & Info ('setup') shows the
+              // health/status dashboard (overviewSlot); Guided Setup shows the
+              // wizard (wizardSlot). setupMode remains the "flow active" flag for
+              // effects, but the rendered surface is tab-driven so they can't
+              // desync.
+              mode={activeViewId === 'guided-setup' ? 'wizard' : 'overview'}
               actionsSlot={
-                setupMode === 'wizard' ? (
+                activeViewId === 'guided-setup' ? (
                   <div className="button-row">
                     {selectedSetupSection ? (
                       <StatusBadge tone={toneForSetup(selectedSetupSection.status)}>

--- a/apps/web/src/setup-flow-helpers.ts
+++ b/apps/web/src/setup-flow-helpers.ts
@@ -112,8 +112,11 @@ export function setupPanelActionForSection(
 export function appViewForPanel(panelId: string): AppViewId {
   switch (panelId) {
     case 'setup-panel-link':
-    case 'setup-panel-guided':
       return 'setup'
+    // The guided wizard lives on its own 'guided-setup' tab now, so a jump to
+    // the guided panel routes there (the 'setup' tab is the status dashboard).
+    case 'setup-panel-guided':
+      return 'guided-setup'
     case 'setup-panel-ports':
       return 'ports'
     case 'setup-panel-rc':

--- a/apps/web/src/view-models/visible-app-views.test.ts
+++ b/apps/web/src/view-models/visible-app-views.test.ts
@@ -39,11 +39,17 @@ const byId = (views: AppViewDescriptor[], id: string): AppViewDescriptor => {
 }
 
 describe('buildVisibleAppViews', () => {
-  it('appends the non-metadata descriptors (calibration, can, flash, files)', () => {
+  it('appends the non-metadata descriptors (guided-setup, calibration, can, flash, files)', () => {
     const result = ids(buildVisibleAppViews(baseInputs()))
-    for (const extra of ['calibration', 'can', 'flash', 'files']) {
+    for (const extra of ['guided-setup', 'calibration', 'can', 'flash', 'files']) {
       expect(result).toContain(extra)
     }
+  })
+
+  it('places the Guided Setup tab immediately after Status & Info', () => {
+    const result = ids(buildVisibleAppViews(baseInputs({ appViews: [view('setup')] })))
+    expect(result[0]).toBe('setup')
+    expect(result[1]).toBe('guided-setup')
   })
 
   it('gates the RC Mixer view behind Expert mode', () => {
@@ -95,9 +101,11 @@ describe('buildVisibleAppViews', () => {
     const result = ids(
       buildVisibleAppViews(baseInputs({ appViews: [view('modes'), view('setup'), view('mystery-view')] }))
     )
-    // setup leads, calibration second, modes before the tools cluster, unknown id last.
+    // setup leads, guided-setup second, calibration third, modes before the
+    // tools cluster, unknown id last.
     expect(result[0]).toBe('setup')
-    expect(result[1]).toBe('calibration')
+    expect(result[1]).toBe('guided-setup')
+    expect(result[2]).toBe('calibration')
     expect(result.indexOf('modes')).toBeLessThan(result.indexOf('can'))
     expect(result[result.length - 1]).toBe('mystery-view')
   })

--- a/apps/web/src/view-models/visible-app-views.ts
+++ b/apps/web/src/view-models/visible-app-views.ts
@@ -119,6 +119,17 @@ export function buildVisibleAppViews(inputs: VisibleAppViewsInputs): AppViewDesc
     badge: connectionKind === 'connected' ? 'live' : 'idle',
     tone: 'neutral'
   }
+  // Guided Setup — the step-by-step wizard, promoted out of the Status & Info
+  // tab into its own nav tab (just below Status & Info). Status & Info keeps the
+  // health/status/info dashboard; this tab hosts the wizard. Always visible so
+  // the guided flow is a first-class entry point, not a button buried in a card.
+  const guidedSetupDescriptor: AppViewDescriptor = {
+    id: 'guided-setup',
+    label: 'Guided Setup',
+    description: 'Step-by-step ArduPilot setup — walk the checklist one stage at a time, with verification at each step.',
+    badge: connectionKind === 'connected' ? 'ready' : 'idle',
+    tone: 'neutral'
+  }
   // Dedicated Calibration surface — the accelerometer / level / compass
   // guided-action flow gathered into one tab (same actions as Setup).
   const calibrationDescriptor: AppViewDescriptor = {
@@ -182,7 +193,7 @@ export function buildVisibleAppViews(inputs: VisibleAppViewsInputs): AppViewDesc
   // follow a setup -> tuning -> tools flow. Views not listed fall to the
   // end in their original order.
   const CANONICAL_VIEW_ORDER = [
-    'setup', 'config', 'calibration', 'ports', 'receiver', 'modes', 'motors',
+    'setup', 'guided-setup', 'config', 'calibration', 'ports', 'receiver', 'modes', 'motors',
     'servos', 'power', 'failsafe', 'vtx', 'osd', 'tuning', 'presets',
     'snapshots', 'logs', 'parameters', 'can', 'networking', 'files', 'lua', 'flash', 'elrs-flash', 'rc-mixer',
     'mavlink-inspector', 'dronecan-inspector', 'ai-assistant'
@@ -201,6 +212,7 @@ export function buildVisibleAppViews(inputs: VisibleAppViewsInputs): AppViewDesc
   const ELRS_FLASH_ENABLED = false
   const combined = [
     ...relabelled,
+    guidedSetupDescriptor,
     calibrationDescriptor,
     canBusDescriptor,
     flashDescriptor,

--- a/packages/param-metadata/src/types.ts
+++ b/packages/param-metadata/src/types.ts
@@ -13,6 +13,11 @@ export type GuidedActionId =
 export type LiveSignalId = 'rc-input' | 'battery-telemetry'
 export type AppViewId =
   | 'setup'
+  // Guided Setup is its own top-level tab (the step-by-step wizard), sitting
+  // just below Status & Info. The 'setup' tab keeps the health/status/info
+  // dashboard; the wizard renders here. Injected as a nav descriptor at render
+  // time (like 'calibration'), not sourced from the metadata catalogs.
+  | 'guided-setup'
   | 'ports'
   | 'vtx'
   | 'osd'

--- a/tests/e2e/app.spec.ts
+++ b/tests/e2e/app.spec.ts
@@ -552,7 +552,9 @@ test.describe('browser configurator regression flows', () => {
     // copy flips to "Retry…".
     await page.getByRole('button', { name: 'Mark Failed' }).first().click()
     await expect(page.getByTestId('wizard-orientation-primary')).toContainText('Retry Orientation Check')
-    await expect(page.getByTestId('workspace-view-title')).toHaveText('Status & Info')
+    // The guided wizard is now its own tab, so the nav title reads "Guided
+    // Setup" while in it (the Status & Info dashboard is a separate tab).
+    await expect(page.getByTestId('workspace-view-title')).toHaveText('Guided Setup')
 
     await openView(page, 'ports')
     await expect(page.getByRole('heading', { name: 'Ports & Peripherals' })).toBeVisible()

--- a/tests/e2e/views.spec.ts
+++ b/tests/e2e/views.spec.ts
@@ -326,14 +326,15 @@ test.describe('Parameters tab (expert-only)', () => {
 })
 
 test.describe('tab order', () => {
-  test('nav leads with Status & Info, then Calibration, Config, Ports', async ({ page }) => {
+  test('nav leads with Status & Info, then Guided Setup, Config, Calibration', async ({ page }) => {
     await page.goto('/')
     await connectViaHeader(page)
-    // The first four nav buttons follow the requested order.
+    // The first four nav buttons follow the canonical order (Status & Info,
+    // then the Guided Setup wizard tab, then Config and Calibration).
     const navIds = await page.locator('[data-testid^="view-button-"]').evaluateAll((els) =>
       els.map((el) => (el.getAttribute('data-testid') || '').replace('view-button-', ''))
     )
-    expect(navIds.slice(0, 4)).toEqual(['setup', 'calibration', 'config', 'ports'])
+    expect(navIds.slice(0, 4)).toEqual(['setup', 'guided-setup', 'config', 'calibration'])
     // The Setup tab is now labelled "Status & Info".
     await expect(page.getByTestId('view-button-setup')).toContainText('Status & Info')
   })
@@ -2664,8 +2665,9 @@ test.describe('ArduPlane demo', () => {
 
     // MOCK==REAL: the demo Copter seeds AUTOTUNE_AGGR=0.075, so the first numeric
     // field shows the seeded live value (not an empty box). Editing it stages a
-    // draft through the shared setDraft -> scoped-apply machinery.
-    const aggr = configGroup.locator('input[type="number"]').first()
+    // draft through the shared setDraft -> scoped-apply machinery. Exclude the
+    // bitmask raw-value inputs (e.g. AUTOTUNE_AXES) which are also type=number.
+    const aggr = configGroup.locator('input[type="number"]:not([aria-label*="raw bitmask"])').first()
     await aggr.scrollIntoViewIfNeeded()
     await expect(aggr).not.toHaveValue('')
     await expect(aggr).toHaveValue(/^0?\.0?7/)


### PR DESCRIPTION
Guided setup was a `wizard` *mode* of the Status & Info (`setup`) tab, launched from an in-card button. This promotes it to a first-class nav tab, **just below Status & Info**. Status & Info keeps the health/status/info dashboard; the step-by-step wizard renders on the new `guided-setup` tab.

## Changes
- Add `guided-setup` to `AppViewId` + an always-visible nav descriptor, ordered right after `setup`.
- Render `SetupView` on both tabs with **mode driven by the tab** (guided-setup → wizard, setup → overview) so the surface can't desync from state.
- Repoint every wizard entry/exit at the new tab: `openSetupWizard`, `closeSetupWizard` ("Back to Setup" → dashboard), the `?guidedSetupStep=` dev shortcut, the RC-exercise "bounce back" jump, `appViewForPanel`'s `setup-panel-guided` route, and the connect-landing gate.
- Keep `setupMode` as the "flow active" flag (it must persist across detours to Receiver/Motors exercises) + a small effect that syncs it to the tab so the exercise-return still fires when the tab is reached via the nav.
- Repoint the three gating effects (guided-step pageview, wizard focus, exercise-return) from `activeViewId === 'setup'` to `'guided-setup'`.

## Validation
- `typecheck` clean; `visible-app-views` unit tests updated (12 pass).
- **Full `app.spec.ts` + `views.spec.ts` e2e green.** Also fixed three pre-existing/consequent e2e issues: the nav-order assertion, the nav-sweep title check (reads "Guided Setup" in the wizard now), and an AutoTune selector that was colliding with the bitmask raw-value input added in #70.

## ArduCopter invariant
Presentational + nav routing only — no runtime/transport/param-write change. **ArduCopter byte-identical.**