### PR TITLE
docs(wiki): sync with the current app (Guided Setup tab, Parameters editor, Ports)

### DIFF
--- a/wiki/first-time-setup/ports-serial.rst
+++ b/wiki/first-time-setup/ports-serial.rst
@@ -21,7 +21,8 @@ label, with five columns:
 - **Flow** — hardware flow control, editing ``BRD_SERn_RTSCTS`` (Disabled,
   Enabled, Auto, RS-485 RTS) on ports 1–6.
 - **Options** — a per-bit editor for ``SERIALn_OPTIONS`` (invert RX/TX, half
-  duplex, swap RX/TX, pull-ups, no-DMA, and so on).
+  duplex, swap RX/TX, pull-ups, no-DMA, and so on), opened with the **Bitmask**
+  button on the row.
 
 .. note::
 
@@ -55,7 +56,7 @@ DisplayPort, SmartAudio), among ArduPilot's full set of serial protocols.
 
 .. note::
 
-   The tab shows per-port draft status (in sync / staged / invalid) but does
+   The tab highlights staged and invalid changes on each port row, but does
    **not** detect two ports configured for the same role — assign each device to
    exactly one UART yourself.
 

--- a/wiki/guided-setup.rst
+++ b/wiki/guided-setup.rst
@@ -7,6 +7,10 @@ step against the **live vehicle** rather than just telling you what to do. Steps
 unlock in sequence: you can't sign off a later step until the ones it depends on
 are satisfied.
 
+Open it from the **Guided Setup** tab in the left navigation (just below
+**Status & Info**). The Status & Info tab is the health and live-status
+dashboard; the step-by-step wizard runs on its own Guided Setup tab.
+
 How it works
 ------------
 

--- a/wiki/parameters.rst
+++ b/wiki/parameters.rst
@@ -16,12 +16,14 @@ enriched with labels, descriptions, units, ranges, and categories from the
 metadata catalog, which is firmware-version-aware — a 4.7 (or newer) controller
 gets the 4.7 labels, ranges, and enum values, while older firmware and the
 pre-connect view keep the stable set, so each value's options and limits match
-the running firmware. A **search** box filters by name with wildcards (for example
-``ARMING_*`` or ``*VOLT*``), and a **category** dropdown narrows to a single
-group such as rangefinder, gimbal, or serial. A **Refresh** button pulls the
-tree fresh from the controller, bypassing the auto-refresh, and selecting any
-row opens a detail card with the parameter's description, range/step, and whether
-it is reboot-required.
+the running firmware. A **search** box — pinned to the top of the editor so it stays in reach while you
+scroll the table — filters by name with wildcards (for example ``ARMING_*`` or
+``*VOLT*``), and a **category** dropdown narrows to a single group such as
+rangefinder, gimbal, or serial. A **Refresh** button pulls the tree fresh from
+the controller, bypassing the auto-refresh. Each row shows the parameter's
+name, description, unit, and current value alongside an inline editor: a number
+field, or — for bitmask parameters — a grid of per-bit checkboxes with a
+raw-value box so you can paste a mask straight from another configuration.
 
 Editing and staged drafts
 -------------------------


### PR DESCRIPTION
Refresh the wiki so it matches recently shipped UI changes.

- **guided-setup.rst** — Guided Setup is now its own left-nav tab (just below Status & Info); Status & Info is the health/status dashboard. Added where-to-find-it.
- **parameters.rst** — the search bar is pinned to the top of the editor; removed the stale "detail card" description (that card was removed); documented the inline per-row editor and the bitmask per-bit checkboxes + raw-value entry.
- **ports-serial.rst** — the Serial Options editor opens via the **Bitmask** button; rows highlight staged/invalid inline instead of a status badge.

Checked the rest (introduction, getting-connected, tuning, index, reference) — no stale content from this session's changes (the Config nav reorder and rate-PID slider ranges aren't documented at that granularity). Sphinx build verified locally.

Docs only — no code/app change.