### PR TITLE
feat(setup): mark the Guided Setup tab "beta"

### DIFF
--- a/apps/web/src/view-models/visible-app-views.ts
+++ b/apps/web/src/view-models/visible-app-views.ts
@@ -127,8 +127,10 @@ export function buildVisibleAppViews(inputs: VisibleAppViewsInputs): AppViewDesc
     id: 'guided-setup',
     label: 'Guided Setup',
     description: 'Step-by-step ArduPilot setup — walk the checklist one stage at a time, with verification at each step.',
-    badge: connectionKind === 'connected' ? 'ready' : 'idle',
-    tone: 'neutral'
+    // 'beta' flags the tab as still under active development (not a
+    // setup-progress indicator) — the guided flow is being built out.
+    badge: 'beta',
+    tone: 'warning'
   }
   // Dedicated Calibration surface — the accelerometer / level / compass
   // guided-action flow gathered into one tab (same actions as Setup).


### PR DESCRIPTION
Static **beta** badge (warning tone) on the Guided Setup nav tab to flag it as still under active development — replaces the connection-derived ready/idle badge. Not a setup-progress indicator.

Presentational (nav badge string/tone). typecheck + visible-app-views unit tests green. **ArduCopter byte-identical.**