### PR TITLE
feat(nav): show the Guided Setup "beta" badge in the sidebar rail

### DIFF
--- a/apps/web/src/sections/WorkspaceSidebar.tsx
+++ b/apps/web/src/sections/WorkspaceSidebar.tsx
@@ -134,6 +134,15 @@ export function WorkspaceSidebar({
               <span className="workspace-nav__item-copy">
                 <strong>{view.label}</strong>
               </span>
+              {/* Only the Guided Setup tab surfaces a nav badge (its "beta"
+                  under-development flag). Other tabs carry badges too, but we
+                  intentionally show them only in the active-view header, not the
+                  sidebar, to keep the rail clean. */}
+              {view.id === 'guided-setup' && view.badge ? (
+                <span className="workspace-nav__badge">
+                  <StatusBadge tone={view.tone}>{view.badge}</StatusBadge>
+                </span>
+              ) : null}
             </button>
           ))}
         </nav>

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -1694,6 +1694,13 @@ textarea:focus {
   flex: 1;
 }
 
+/* Guided Setup's "beta" nav badge — sits at the right of the row (item-copy
+   takes the flex space), never shrinks so it stays legible. */
+.workspace-nav__badge {
+  flex-shrink: 0;
+  display: inline-flex;
+}
+
 .workspace-nav__item-text {
   display: flex;
   align-items: center;


### PR DESCRIPTION
The sidebar rail rendered no per-tab badges — descriptor badges only appeared in the active-view header — so the Guided Setup **beta** flag was invisible in the sidebar. This renders the badge in the rail **for the Guided Setup tab only** (it sits at the right of the row and never shrinks). Other tabs keep their badges out of the rail by design.

typecheck clean. Presentational only. **ArduCopter byte-identical.**