### PR TITLE
feat(tuning): Log Tuning sub-tab — analyze a flight log and stage tuning fixes

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -16,6 +16,7 @@
     "@arduconfig/ai-assistant": "1.1.1",
     "@arduconfig/ardupilot-core": "1.1.1",
     "@arduconfig/firmware-flash": "1.1.1",
+    "@arduconfig/log-analysis": "0.1.0",
     "@arduconfig/param-metadata": "1.1.1",
     "@arduconfig/protocol-mavlink": "1.1.1",
     "@arduconfig/transport": "1.1.1",

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -333,6 +333,7 @@ import { buildVehicleOutputSummary } from './view-models/vehicle-output-summary'
 import { ConfigView } from './views/Config'
 import { FilesView } from './views/Files'
 import { SetupView } from './views/Setup'
+import { LogTuningView } from './views/LogTuning'
 import type { TuningTaskCard } from './views/Tuning'
 import { useRuntimeSnapshot } from './hooks/use-runtime-snapshot'
 import { useMavftpBrowser } from './hooks/use-mavftp-browser'
@@ -5602,6 +5603,14 @@ export function App() {
     })
   }
 
+  // Stage a Log-Tuning recommendation as a draft: the analyzer produces a raw
+  // param id + numeric value, which goes into the shared editedValues draft set
+  // (the same one the Tuning Review tab and the global draft bar read), so it is
+  // reviewed and written through the normal verified path — never auto-applied.
+  function handleStageLogTuningParam(param: string, value: number): void {
+    updateDrafts((existing) => ({ ...existing, [param]: String(value) }))
+  }
+
   function handleResetTuningMasterSliders(): void {
     setTuningMasterPiGain(1)
     setTuningMasterDGain(1)
@@ -7949,6 +7958,15 @@ export function App() {
             renderTuningControl,
             formatCategoryLabel
           }}
+          logTuningSlot={
+            /* Rendered inside the Tuning task body when the 'log-tuning' sub-tab
+               is active. Self-contained: it owns the uploaded log + analysis, and
+               stages recommendations into the shared draft set via onStageParam. */
+            <LogTuningView
+              onStageParam={handleStageLogTuningParam}
+              stagedParams={new Set(parameterDraftById.keys())}
+            />
+          }
           autotuneSlot={
             /* Rendered INSIDE the Tuning task body when the 'autotune' tab is
                active (see TuningCopterSection), so it no longer trails below the

--- a/apps/web/src/sections/TuningCopterSection.tsx
+++ b/apps/web/src/sections/TuningCopterSection.tsx
@@ -102,6 +102,7 @@ export interface TuningCopterSectionProps {
   /** The ArduCopter AUTOTUNE surface, rendered in the task body when the
    *  'autotune' tab is active (kept a slot so App owns its disjoint draft scope). */
   autotuneSlot?: ReactNode
+  logTuningSlot?: ReactNode
 }
 
 export function TuningCopterSection(props: TuningCopterSectionProps): ReactElement {
@@ -110,6 +111,7 @@ export function TuningCopterSection(props: TuningCopterSectionProps): ReactEleme
     busyAction,
     parameterNotice,
     autotuneSlot,
+    logTuningSlot,
     tuningWorkbench,
     forms,
     derived,
@@ -927,6 +929,12 @@ export function TuningCopterSection(props: TuningCopterSectionProps): ReactEleme
                 {activeTuningTaskId === 'autotune' ? (
                   <div className="tuning-task-panel tuning-task-panel--stack" data-testid="tuning-autotune-panel">
                     {autotuneSlot}
+                  </div>
+                ) : null}
+
+                {activeTuningTaskId === 'log-tuning' ? (
+                  <div className="tuning-task-panel tuning-task-panel--stack" data-testid="tuning-log-tuning-panel">
+                    {logTuningSlot}
                   </div>
                 ) : null}
           </>

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -15202,3 +15202,114 @@ button.mavlink-inspector__sent-row {
   color: var(--warning, #ff6600);
   font-size: 0.78em;
 }
+
+/* Log Tuning sub-tab (Tuning view) — upload a .bin, analysis results + staged
+   recommendations. Reuses the app surface/edge/text vars for theme parity. */
+.log-tuning__upload {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin: 12px 0;
+}
+.log-tuning__file {
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+}
+.log-tuning__filename {
+  color: var(--text-dim);
+  font-family: var(--font-data);
+}
+.log-tuning__results {
+  display: grid;
+  gap: 12px;
+  margin-top: 12px;
+}
+.log-tuning__warnings {
+  margin: 0;
+  padding-left: 18px;
+  display: grid;
+  gap: 4px;
+  color: var(--warning);
+  font-size: 0.85em;
+}
+.log-tuning__summary {
+  margin: 0;
+  font-weight: 600;
+}
+.log-tuning__metrics {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+  gap: 8px;
+}
+.log-tuning__metrics article {
+  display: grid;
+  gap: 2px;
+  padding: 8px 10px;
+  border-radius: var(--radius-md);
+  background: var(--bg-panel-muted);
+  border: 1px solid rgba(var(--edge-rgb), 0.05);
+}
+.log-tuning__metrics span {
+  font-size: 0.72rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--text-dim);
+}
+.log-tuning__peaks ul {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  margin: 6px 0 0;
+  padding: 0;
+  list-style: none;
+}
+.log-tuning__peaks li {
+  display: inline-flex;
+  gap: 6px;
+  align-items: baseline;
+}
+.log-tuning__axis {
+  text-transform: capitalize;
+  color: var(--text-dim);
+  font-size: 0.8em;
+}
+.log-tuning__recs {
+  display: grid;
+  gap: 8px;
+}
+.log-tuning__recs-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+.log-tuning__rec {
+  display: grid;
+  gap: 4px;
+  padding: 10px 12px;
+  border-radius: var(--radius-md);
+  background: var(--bg-panel-muted);
+  border: 1px solid rgba(var(--edge-rgb), 0.05);
+}
+.log-tuning__rec-head {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+.log-tuning__rec-head code {
+  font-weight: 700;
+}
+.log-tuning__rec-values {
+  margin-left: auto;
+  font-family: var(--font-data);
+}
+.log-tuning__rec p {
+  margin: 0;
+  color: var(--text-dim);
+  font-size: 0.85em;
+}
+.log-tuning__recs-note {
+  color: var(--text-dim);
+}

--- a/apps/web/src/view-models/tuning-task-cards.ts
+++ b/apps/web/src/view-models/tuning-task-cards.ts
@@ -141,6 +141,14 @@ export function buildTuningTaskCards(counts: TuningTaskCardCounts): TuningTaskCa
             ? 'Some tuning changes need attention before they can be applied safely.'
             : 'Tuning values are currently in sync with the live controller snapshot.',
       tone: reviewInvalidCount > 0 ? 'danger' : reviewStagedCount > 0 ? 'warning' : 'success'
+    },
+    {
+      id: 'log-tuning',
+      label: 'Log Tuning',
+      value: 'beta',
+      detail:
+        'Upload a flight log (.bin) and let the analyzer work through what needs doing — gyro-FFT vibration/oscillation, motor-RPM harmonic-notch placement, and rate-loop limit cycles — then stage the recommended parameter changes for review.',
+      tone: 'warning'
     }
   ]
 }

--- a/apps/web/src/views/LogTuning.tsx
+++ b/apps/web/src/views/LogTuning.tsx
@@ -1,0 +1,236 @@
+// Log Tuning — a sub-tab of the Tuning view. Upload a flight log (.bin), run the
+// in-browser analyzer (@arduconfig/log-analysis: gyro-FFT vibration/oscillation,
+// motor-RPM harmonic-notch placement, rate-loop limit-cycle detection), and
+// stage the recommended parameter changes for review through the shared
+// draft/verified-write machinery (via the onStageParam prop).
+//
+// Presentational + pure analysis only: it imports the analysis engine (a pure
+// function over an uploaded buffer — no runtime/transport/MAVLink), owns its
+// local upload/result state, and delegates staging to the parent.
+
+import { useCallback, useState, type ReactElement } from 'react'
+
+import { analyzeLogBuffer, type LogTuningResult, type TuningRecommendation } from '@arduconfig/log-analysis'
+import { StatusBadge, buttonStyle } from '@arduconfig/ui-kit'
+
+export interface LogTuningViewProps {
+  /** Stage a recommended parameter change as a draft (parent owns the draft set). */
+  onStageParam: (param: string, value: number) => void
+  /** Params already staged from a recommendation, so the row can show "staged". */
+  stagedParams?: ReadonlySet<string>
+}
+
+const CONFIDENCE_TONE: Record<TuningRecommendation['confidence'], 'success' | 'warning' | 'neutral'> = {
+  high: 'success',
+  medium: 'warning',
+  low: 'neutral'
+}
+
+export function LogTuningView({ onStageParam, stagedParams }: LogTuningViewProps): ReactElement {
+  const [result, setResult] = useState<LogTuningResult | null>(null)
+  const [filename, setFilename] = useState<string | undefined>()
+  const [error, setError] = useState<string | undefined>()
+  const [busy, setBusy] = useState(false)
+
+  const handleFile = useCallback(async (file: File) => {
+    setBusy(true)
+    setError(undefined)
+    setResult(null)
+    try {
+      const buffer = await file.arrayBuffer()
+      // Analysis is synchronous but can be a moment on a large log — yield first
+      // so the "Analyzing…" state paints.
+      await new Promise((resolve) => setTimeout(resolve, 0))
+      const analysis = analyzeLogBuffer(buffer)
+      setResult(analysis)
+      setFilename(file.name)
+    } catch (caught) {
+      setError(caught instanceof Error ? caught.message : 'Could not read or parse that log.')
+    } finally {
+      setBusy(false)
+    }
+  }, [])
+
+  return (
+    <section className="bf-gui-box log-tuning" data-testid="log-tuning">
+      <div className="bf-gui-box__titlebar">
+        <strong>Log Tuning</strong>
+        <StatusBadge tone="warning">beta</StatusBadge>
+      </div>
+      <div className="bf-gui-box__body">
+        <p className="bf-note">
+          Upload a dataflash flight log (<code>.bin</code>) from the SD card. The analyzer works through
+          vibration, oscillation, motor-noise, and rate-loop tuning, then stages the recommended parameter
+          changes for you to review and apply.
+        </p>
+
+        <div className="log-tuning__upload">
+          <label className="log-tuning__file" style={buttonStyle('primary')}>
+            {busy ? 'Analyzing…' : 'Choose flight log (.bin)'}
+            <input
+              type="file"
+              accept=".bin,application/octet-stream"
+              data-testid="log-tuning-file"
+              style={{ display: 'none' }}
+              disabled={busy}
+              onChange={(event) => {
+                const file = event.target.files?.[0]
+                if (file) {
+                  void handleFile(file)
+                }
+                event.target.value = ''
+              }}
+            />
+          </label>
+          {filename ? <small className="log-tuning__filename">{filename}</small> : null}
+        </div>
+
+        <div className="parameter-follow-up parameter-follow-up--warning" data-testid="log-tuning-gate-note">
+          <StatusBadge tone="warning">read first</StatusBadge>
+          <p>
+            This only works on a <strong>good flight log</strong>: a real hover/flight (not a bench run), ideally
+            30–60 s of steady hovering. For the harmonic notch you also want ESC RPM telemetry, and for the best
+            spectrum enable the IMU batch sampler (<code>INS_LOG_BAT_MASK</code>). A poor log gives poor advice.
+          </p>
+        </div>
+
+        {error ? (
+          <div className="parameter-follow-up parameter-follow-up--danger" role="alert" data-testid="log-tuning-error">
+            <StatusBadge tone="danger">error</StatusBadge>
+            <p>{error}</p>
+          </div>
+        ) : null}
+
+        {result ? <LogTuningResults result={result} onStageParam={onStageParam} stagedParams={stagedParams} /> : null}
+      </div>
+    </section>
+  )
+}
+
+function LogTuningResults({
+  result,
+  onStageParam,
+  stagedParams
+}: {
+  result: LogTuningResult
+  onStageParam: (param: string, value: number) => void
+  stagedParams?: ReadonlySet<string>
+}): ReactElement {
+  return (
+    <div className="log-tuning__results" data-testid="log-tuning-results">
+      {!result.usable ? (
+        <div className="parameter-follow-up parameter-follow-up--danger" data-testid="log-tuning-unusable">
+          <StatusBadge tone="danger">not usable</StatusBadge>
+          <p>This log isn't suitable for tuning analysis — see the warnings below.</p>
+        </div>
+      ) : null}
+
+      {result.gateWarnings.length > 0 ? (
+        <ul className="log-tuning__warnings" data-testid="log-tuning-warnings">
+          {result.gateWarnings.map((warning) => (
+            <li key={warning}>{warning}</li>
+          ))}
+        </ul>
+      ) : null}
+
+      <p className="log-tuning__summary" data-testid="log-tuning-summary">
+        {result.summary || 'Analysis complete.'}
+      </p>
+
+      <div className="log-tuning__metrics">
+        <article>
+          <span>Gyro source</span>
+          <strong>
+            {result.gyroSource === 'batch'
+              ? `Batch (${result.gyroSampleRateHz.toFixed(0)} Hz)`
+              : result.gyroSource === 'imu'
+                ? `IMU (${result.gyroSampleRateHz.toFixed(0)} Hz)`
+                : 'None'}
+          </strong>
+        </article>
+        {result.vibe ? (
+          <article>
+            <span>Vibration</span>
+            <strong>
+              {result.vibe.verdict} · peak {Math.max(...result.vibe.max).toFixed(0)} m/s² · clip {Math.max(...result.vibe.clip)}
+            </strong>
+          </article>
+        ) : null}
+        {result.motorFundamentalHz ? (
+          <article>
+            <span>Motor fundamental</span>
+            <strong>{result.motorFundamentalHz.toFixed(0)} Hz</strong>
+          </article>
+        ) : null}
+        {result.limitCycle ? (
+          <article>
+            <span>Limit cycle</span>
+            <strong>
+              {result.limitCycle.freqHz.toFixed(0)} Hz on {result.limitCycle.axis}
+            </strong>
+          </article>
+        ) : null}
+      </div>
+
+      {result.axisSpectra.some((axis) => axis.dominant) ? (
+        <div className="log-tuning__peaks">
+          <strong>Dominant gyro frequencies</strong>
+          <ul>
+            {result.axisSpectra.map((axis) => (
+              <li key={axis.axis}>
+                <span className="log-tuning__axis">{axis.axis}</span>
+                {axis.dominant ? `${axis.dominant.freqHz.toFixed(0)} Hz` : '—'}
+              </li>
+            ))}
+          </ul>
+        </div>
+      ) : null}
+
+      {result.recommendations.length > 0 ? (
+        <div className="log-tuning__recs" data-testid="log-tuning-recommendations">
+          <div className="log-tuning__recs-header">
+            <strong>Recommended changes</strong>
+            <button
+              type="button"
+              style={buttonStyle('primary')}
+              data-testid="log-tuning-stage-all"
+              onClick={() => result.recommendations.forEach((rec) => onStageParam(rec.param, rec.suggestedValue))}
+            >
+              Stage all ({result.recommendations.length})
+            </button>
+          </div>
+          {result.recommendations.map((rec) => {
+            const staged = stagedParams?.has(rec.param)
+            return (
+              <article className="log-tuning__rec" key={rec.param} data-testid={`log-tuning-rec-${rec.param}`}>
+                <div className="log-tuning__rec-head">
+                  <code>{rec.param}</code>
+                  <StatusBadge tone={CONFIDENCE_TONE[rec.confidence]}>{rec.confidence}</StatusBadge>
+                  <span className="log-tuning__rec-values">
+                    {rec.currentValue !== undefined ? `${rec.currentValue} → ` : ''}
+                    <strong>{rec.suggestedValue}</strong>
+                  </span>
+                  <button
+                    type="button"
+                    style={buttonStyle(staged ? 'secondary' : 'primary')}
+                    disabled={staged}
+                    onClick={() => onStageParam(rec.param, rec.suggestedValue)}
+                  >
+                    {staged ? 'Staged' : 'Stage'}
+                  </button>
+                </div>
+                <p>{rec.reason}</p>
+              </article>
+            )
+          })}
+          <small className="log-tuning__recs-note">
+            Staged changes appear in the Tuning <strong>Review</strong> tab and the global draft bar — nothing is
+            written to the aircraft until you apply them there.
+          </small>
+        </div>
+      ) : result.usable ? (
+        <p className="bf-note" data-testid="log-tuning-no-recs">No parameter changes recommended — the tune looks clean.</p>
+      ) : null}
+    </div>
+  )
+}

--- a/apps/web/src/views/Tuning.tsx
+++ b/apps/web/src/views/Tuning.tsx
@@ -3,7 +3,7 @@ import { Panel, StatusBadge } from '@arduconfig/ui-kit'
 
 export type TuningStatusTone = 'neutral' | 'success' | 'warning' | 'danger'
 
-export type TuningTaskId = 'rates' | 'pid-gains' | 'filters' | 'autotune' | 'profiles' | 'review'
+export type TuningTaskId = 'rates' | 'pid-gains' | 'filters' | 'autotune' | 'profiles' | 'review' | 'log-tuning'
 
 export interface TuningTaskCard {
   id: TuningTaskId

--- a/package-lock.json
+++ b/package-lock.json
@@ -46,6 +46,7 @@
         "@arduconfig/ai-assistant": "1.1.1",
         "@arduconfig/ardupilot-core": "1.1.1",
         "@arduconfig/firmware-flash": "1.1.1",
+        "@arduconfig/log-analysis": "0.1.0",
         "@arduconfig/param-metadata": "1.1.1",
         "@arduconfig/protocol-mavlink": "1.1.1",
         "@arduconfig/transport": "1.1.1",
@@ -80,6 +81,10 @@
     },
     "node_modules/@arduconfig/firmware-flash": {
       "resolved": "packages/firmware-flash",
+      "link": true
+    },
+    "node_modules/@arduconfig/log-analysis": {
+      "resolved": "packages/log-analysis",
       "link": true
     },
     "node_modules/@arduconfig/mock-sitl": {
@@ -6866,6 +6871,11 @@
     "packages/firmware-flash": {
       "name": "@arduconfig/firmware-flash",
       "version": "1.1.1",
+      "license": "GPL-3.0-only"
+    },
+    "packages/log-analysis": {
+      "name": "@arduconfig/log-analysis",
+      "version": "0.1.0",
       "license": "GPL-3.0-only"
     },
     "packages/mock-sitl": {

--- a/package.json
+++ b/package.json
@@ -14,8 +14,8 @@
     "packages/*"
   ],
   "scripts": {
-    "build": "npm run build --workspace @arduconfig/firmware-flash && npm run build --workspace @arduconfig/mock-sitl && npm run build --workspace @arduconfig/sitl-harness && npm run build --workspace @arduconfig/web && npm run build --workspace @arduconfig/desktop",
-    "typecheck": "npm run typecheck --workspace @arduconfig/transport && npm run typecheck --workspace @arduconfig/firmware-flash && npm run typecheck --workspace @arduconfig/protocol-mavlink && npm run typecheck --workspace @arduconfig/param-metadata && npm run typecheck --workspace @arduconfig/ardupilot-core && npm run typecheck --workspace @arduconfig/ai-assistant && npm run typecheck --workspace @arduconfig/mock-sitl && npm run typecheck --workspace @arduconfig/sitl-harness && npm run typecheck --workspace @arduconfig/web && npm run typecheck --workspace @arduconfig/desktop",
+    "build": "npm run build --workspace @arduconfig/log-analysis && npm run build --workspace @arduconfig/firmware-flash && npm run build --workspace @arduconfig/mock-sitl && npm run build --workspace @arduconfig/sitl-harness && npm run build --workspace @arduconfig/web && npm run build --workspace @arduconfig/desktop",
+    "typecheck": "npm run typecheck --workspace @arduconfig/transport && npm run typecheck --workspace @arduconfig/log-analysis && npm run typecheck --workspace @arduconfig/firmware-flash && npm run typecheck --workspace @arduconfig/protocol-mavlink && npm run typecheck --workspace @arduconfig/param-metadata && npm run typecheck --workspace @arduconfig/ardupilot-core && npm run typecheck --workspace @arduconfig/ai-assistant && npm run typecheck --workspace @arduconfig/mock-sitl && npm run typecheck --workspace @arduconfig/sitl-harness && npm run typecheck --workspace @arduconfig/web && npm run typecheck --workspace @arduconfig/desktop",
     "test": "npm run build && node --test tests/*.test.mjs",
     "test:e2e": "npm run build && playwright test",
     "test:e2e:headed": "npm run build && playwright test --headed",

--- a/packages/log-analysis/package.json
+++ b/packages/log-analysis/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "@arduconfig/log-analysis",
+  "version": "0.1.0",
+  "private": true,
+  "license": "GPL-3.0-only",
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "scripts": {
+    "build": "tsc -b tsconfig.json",
+    "typecheck": "tsc -b tsconfig.json --pretty false"
+  }
+}

--- a/packages/log-analysis/src/dataflash-parser.ts
+++ b/packages/log-analysis/src/dataflash-parser.ts
@@ -1,0 +1,215 @@
+// In-browser parser for ArduPilot **DataFlash** binary logs (the `.bin` files
+// downloaded from the flight controller's SD card / dataflash). It is the
+// foundation for every log-based analysis (MAGFit compass calibration, filter /
+// notch tuning, PID review, …): it turns the opaque binary blob into typed
+// message records keyed by message name.
+//
+// Format (AP_Logger): the stream is a sequence of messages, each framed by two
+// head bytes (0xA3 0x95) followed by a 1-byte message type. FMT messages
+// (type 0x80) are self-describing schema records — they define the byte layout
+// and column names of every other message type, INCLUDING FMT itself (the log
+// always opens with the FMT-defines-FMT record). We bootstrap FMT from its
+// fixed layout, then decode every subsequent message against the schema.
+//
+// Field type codes and their built-in scaling match pymavlink's DFReader
+// (FORMAT_TO_STRUCT), so a decoded value equals what `magfit_WMM.py` &co. read
+// — the oracle we validate against. Everything is little-endian.
+//
+// Provenance: the format/type-code table mirrors ArduPilot's AP_Logger and
+// pymavlink DFReader (both GPL-3.0), consistent with this repo's licence.
+
+const HEAD_BYTE1 = 0xa3
+const HEAD_BYTE2 = 0x95
+const FMT_TYPE = 0x80
+// FMT body layout: type(u8) length(u8) name(char[4]) format(char[16]) columns(char[64]).
+const FMT_BODY_LENGTH = 1 + 1 + 4 + 16 + 64
+const FMT_MESSAGE_LENGTH = 3 + FMT_BODY_LENGTH
+
+/** One field type code: its on-wire byte size, and how to read/convert it. */
+interface TypeCode {
+  size: number
+  /** Read the value at `offset` in the little-endian DataView. */
+  read: (view: DataView, offset: number) => number | string | number[]
+}
+
+const textDecoder = new TextDecoder('latin1')
+
+function readString(view: DataView, offset: number, length: number): string {
+  const bytes = new Uint8Array(view.buffer, view.byteOffset + offset, length)
+  const nul = bytes.indexOf(0)
+  const slice = nul === -1 ? bytes : bytes.subarray(0, nul)
+  return textDecoder.decode(slice)
+}
+
+// Field type codes, matching pymavlink DFReader.FORMAT_TO_STRUCT. The built-in
+// multipliers on c/C/e/E (×0.01) and L (×1e-7) are applied here so decoded
+// values are in the same units DFReader yields.
+const TYPE_CODES: Record<string, TypeCode> = {
+  b: { size: 1, read: (v, o) => v.getInt8(o) },
+  B: { size: 1, read: (v, o) => v.getUint8(o) },
+  h: { size: 2, read: (v, o) => v.getInt16(o, true) },
+  H: { size: 2, read: (v, o) => v.getUint16(o, true) },
+  i: { size: 4, read: (v, o) => v.getInt32(o, true) },
+  I: { size: 4, read: (v, o) => v.getUint32(o, true) },
+  f: { size: 4, read: (v, o) => v.getFloat32(o, true) },
+  d: { size: 8, read: (v, o) => v.getFloat64(o, true) },
+  n: { size: 4, read: (v, o) => readString(v, o, 4) },
+  N: { size: 16, read: (v, o) => readString(v, o, 16) },
+  Z: { size: 64, read: (v, o) => readString(v, o, 64) },
+  c: { size: 2, read: (v, o) => v.getInt16(o, true) * 0.01 },
+  C: { size: 2, read: (v, o) => v.getUint16(o, true) * 0.01 },
+  e: { size: 4, read: (v, o) => v.getInt32(o, true) * 0.01 },
+  E: { size: 4, read: (v, o) => v.getUint32(o, true) * 0.01 },
+  L: { size: 4, read: (v, o) => v.getInt32(o, true) * 1e-7 },
+  M: { size: 1, read: (v, o) => v.getInt8(o) },
+  q: { size: 8, read: (v, o) => Number(v.getBigInt64(o, true)) },
+  Q: { size: 8, read: (v, o) => Number(v.getBigUint64(o, true)) },
+  // int16[32] batch array (used by the IMU batch sampler ISBD messages).
+  a: {
+    size: 64,
+    read: (v, o) => {
+      const out: number[] = new Array(32)
+      for (let i = 0; i < 32; i += 1) {
+        out[i] = v.getInt16(o + i * 2, true)
+      }
+      return out
+    }
+  }
+}
+
+/** A message's schema, as declared by a FMT record. */
+export interface DataflashFormat {
+  type: number
+  length: number
+  name: string
+  /** Field type codes (one char per column). */
+  format: string
+  columns: string[]
+}
+
+/** A decoded message: its name plus each column as a keyed value. */
+export type DataflashMessage = { readonly name: string } & Record<string, number | string | number[]>
+
+export interface ParsedDataflashLog {
+  /** Decoded messages grouped by message name (e.g. "MAG", "ATT", "GPS"). */
+  messagesByType: Map<string, DataflashMessage[]>
+  /** Schema of every message type seen (keyed by name). */
+  formats: Map<string, DataflashFormat>
+  /** Count of each message name (cheap summary without walking the arrays). */
+  counts: Map<string, number>
+  /** Bytes that could not be resynchronised to a valid frame. */
+  skippedBytes: number
+}
+
+function bodyLength(format: string): number {
+  let total = 0
+  for (const ch of format) {
+    const code = TYPE_CODES[ch]
+    if (!code) {
+      return Number.NaN
+    }
+    total += code.size
+  }
+  return total
+}
+
+function decodeBody(format: DataflashFormat, view: DataView, bodyOffset: number): DataflashMessage {
+  const record: Record<string, number | string | number[]> = { name: format.name }
+  let offset = bodyOffset
+  for (let i = 0; i < format.format.length; i += 1) {
+    const code = TYPE_CODES[format.format[i]]
+    const column = format.columns[i] ?? `f${i}`
+    // A FMT with more format chars than columns (or vice-versa) is malformed;
+    // decode what we can and leave the rest absent rather than throwing.
+    if (!code) {
+      break
+    }
+    record[column] = code.read(view, offset)
+    offset += code.size
+  }
+  return record as DataflashMessage
+}
+
+/**
+ * Parse a DataFlash `.bin` log. Resilient to a corrupt/truncated tail: a byte
+ * that is not a valid frame head is skipped and resynchronised, and a truncated
+ * final message is dropped rather than throwing.
+ */
+export function parseDataflashLog(input: ArrayBuffer | Uint8Array): ParsedDataflashLog {
+  const bytes = input instanceof Uint8Array ? input : new Uint8Array(input)
+  const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength)
+  const formats = new Map<number, DataflashFormat>()
+  const formatsByName = new Map<string, DataflashFormat>()
+  const messagesByType = new Map<string, DataflashMessage[]>()
+  const counts = new Map<string, number>()
+  let skippedBytes = 0
+
+  let pos = 0
+  const end = bytes.length
+  while (pos + 3 <= end) {
+    if (bytes[pos] !== HEAD_BYTE1 || bytes[pos + 1] !== HEAD_BYTE2) {
+      // Not a frame boundary — skip one byte and try to resync.
+      skippedBytes += 1
+      pos += 1
+      continue
+    }
+    const type = bytes[pos + 2]
+
+    if (type === FMT_TYPE) {
+      if (pos + FMT_MESSAGE_LENGTH > end) {
+        break // truncated FMT at EOF
+      }
+      const bodyOffset = pos + 3
+      const definedType = view.getUint8(bodyOffset)
+      const length = view.getUint8(bodyOffset + 1)
+      const name = readString(view, bodyOffset + 2, 4)
+      const format = readString(view, bodyOffset + 6, 16)
+      const columnsRaw = readString(view, bodyOffset + 22, 64)
+      const columns = columnsRaw.length > 0 ? columnsRaw.split(',') : []
+      const def: DataflashFormat = { type: definedType, length, name, format, columns }
+      formats.set(definedType, def)
+      formatsByName.set(name, def)
+      // A FMT record is schema, not an instance of the message it defines —
+      // record it under "FMT" (matching DFReader), never as a `name` message.
+      recordMessage(messagesByType, counts, {
+        name: 'FMT',
+        Type: definedType,
+        Length: length,
+        Name: name,
+        Format: format,
+        Columns: columnsRaw
+      })
+      pos += FMT_MESSAGE_LENGTH
+      continue
+    }
+
+    const def = formats.get(type)
+    if (!def || !Number.isFinite(bodyLength(def.format)) || def.length < 3) {
+      // Unknown type (its FMT hasn't been seen) or malformed schema: resync.
+      skippedBytes += 1
+      pos += 1
+      continue
+    }
+    if (pos + def.length > end) {
+      break // truncated message at EOF
+    }
+    recordMessage(messagesByType, counts, decodeBody(def, view, pos + 3))
+    pos += def.length
+  }
+
+  return { messagesByType, formats: formatsByName, counts, skippedBytes }
+}
+
+function recordMessage(
+  messagesByType: Map<string, DataflashMessage[]>,
+  counts: Map<string, number>,
+  message: DataflashMessage
+): void {
+  let bucket = messagesByType.get(message.name)
+  if (!bucket) {
+    bucket = []
+    messagesByType.set(message.name, bucket)
+  }
+  bucket.push(message)
+  counts.set(message.name, (counts.get(message.name) ?? 0) + 1)
+}

--- a/packages/log-analysis/src/gyro-fft.ts
+++ b/packages/log-analysis/src/gyro-fft.ts
@@ -1,0 +1,182 @@
+// Signal-processing core for log-based tuning: a real-signal FFT power spectrum
+// and spectral peak finder. Used to turn a gyro (or accel) time series from a
+// flight log into the dominant vibration / oscillation frequencies, so the
+// tuning analysis can place the harmonic notch, judge the gyro filter, and spot
+// rate-loop limit cycles — the same analysis done by hand on a real quad
+// (finding a ~12 Hz roll limit cycle, motor-RPM notch placement, etc.).
+//
+// Self-contained (no deps): an iterative radix-2 Cooley-Tukey FFT with a Hann
+// window. Correctness is validated against synthetic multi-tone signals.
+
+/** Next power of two >= n (n >= 1). */
+function nextPow2(n: number): number {
+  let p = 1
+  while (p < n) {
+    p <<= 1
+  }
+  return p
+}
+
+/**
+ * In-place iterative radix-2 FFT. `re`/`im` are length N = 2^k. Transforms in
+ * place (forward transform, no normalisation).
+ */
+function fftInPlace(re: Float64Array, im: Float64Array): void {
+  const n = re.length
+  // Bit-reversal permutation.
+  for (let i = 1, j = 0; i < n; i += 1) {
+    let bit = n >> 1
+    for (; j & bit; bit >>= 1) {
+      j ^= bit
+    }
+    j ^= bit
+    if (i < j) {
+      ;[re[i], re[j]] = [re[j], re[i]]
+      ;[im[i], im[j]] = [im[j], im[i]]
+    }
+  }
+  // Butterflies.
+  for (let len = 2; len <= n; len <<= 1) {
+    const ang = (-2 * Math.PI) / len
+    const wRe = Math.cos(ang)
+    const wIm = Math.sin(ang)
+    for (let i = 0; i < n; i += len) {
+      let curRe = 1
+      let curIm = 0
+      for (let k = 0; k < len / 2; k += 1) {
+        const aRe = re[i + k]
+        const aIm = im[i + k]
+        const bRe = re[i + k + len / 2] * curRe - im[i + k + len / 2] * curIm
+        const bIm = re[i + k + len / 2] * curIm + im[i + k + len / 2] * curRe
+        re[i + k] = aRe + bRe
+        im[i + k] = aIm + bIm
+        re[i + k + len / 2] = aRe - bRe
+        im[i + k + len / 2] = aIm - bIm
+        const nextRe = curRe * wRe - curIm * wIm
+        curIm = curRe * wIm + curIm * wRe
+        curRe = nextRe
+      }
+    }
+  }
+}
+
+export interface PowerSpectrum {
+  /** Frequency of each bin, Hz. */
+  freqHz: Float64Array
+  /** One-sided power per bin (window-normalised, arbitrary units). */
+  power: Float64Array
+  /** Bin width, Hz. */
+  binHz: number
+}
+
+/**
+ * One-sided power spectrum of a real signal sampled at `sampleRateHz`. The
+ * signal is mean-removed and Hann-windowed (reduces spectral leakage), then
+ * zero-padded to the next power of two.
+ */
+export function powerSpectrum(signal: ArrayLike<number>, sampleRateHz: number): PowerSpectrum {
+  const m = signal.length
+  if (m < 2 || !Number.isFinite(sampleRateHz) || sampleRateHz <= 0) {
+    return { freqHz: new Float64Array(0), power: new Float64Array(0), binHz: 0 }
+  }
+  // Mean.
+  let mean = 0
+  for (let i = 0; i < m; i += 1) {
+    mean += signal[i]
+  }
+  mean /= m
+
+  const n = nextPow2(m)
+  const re = new Float64Array(n)
+  const im = new Float64Array(n)
+  // Hann window over the real samples; zeros beyond fill the pad.
+  let windowSumSq = 0
+  for (let i = 0; i < m; i += 1) {
+    const w = 0.5 - 0.5 * Math.cos((2 * Math.PI * i) / (m - 1))
+    re[i] = (signal[i] - mean) * w
+    windowSumSq += w * w
+  }
+  fftInPlace(re, im)
+
+  const half = n / 2
+  const freqHz = new Float64Array(half)
+  const power = new Float64Array(half)
+  const binHz = sampleRateHz / n
+  // Normalise by window energy so amplitudes are comparable across window lengths.
+  const norm = windowSumSq > 0 ? 1 / windowSumSq : 1
+  for (let i = 0; i < half; i += 1) {
+    freqHz[i] = i * binHz
+    const p = (re[i] * re[i] + im[i] * im[i]) * norm
+    // One-sided: double all but DC (and Nyquist, negligible here).
+    power[i] = i === 0 ? p : p * 2
+  }
+  return { freqHz, power, binHz }
+}
+
+export interface SpectralPeak {
+  freqHz: number
+  power: number
+  /** Power relative to the largest peak (0..1). */
+  relative: number
+}
+
+export interface PeakOptions {
+  /** Ignore bins below this frequency (skip DC / very-low drift). Default 5 Hz. */
+  minFreqHz?: number
+  /** Ignore bins above this frequency. Default Nyquist. */
+  maxFreqHz?: number
+  /** Merge peaks closer than this. Default 8 Hz. */
+  minSeparationHz?: number
+  /** Keep peaks at least this fraction of the largest. Default 0.1. */
+  minRelative?: number
+  /** Max peaks to return. Default 6. */
+  maxPeaks?: number
+}
+
+/**
+ * Find dominant local maxima in a power spectrum, strongest first. A peak is a
+ * bin larger than its neighbours; nearby peaks are merged (keeping the larger)
+ * so one broad hump isn't reported as several.
+ */
+export function findSpectralPeaks(spectrum: PowerSpectrum, options: PeakOptions = {}): SpectralPeak[] {
+  const { freqHz, power } = spectrum
+  if (freqHz.length < 3) {
+    return []
+  }
+  const minFreqHz = options.minFreqHz ?? 5
+  const maxFreqHz = options.maxFreqHz ?? freqHz[freqHz.length - 1]
+  const minSeparationHz = options.minSeparationHz ?? 8
+  const minRelative = options.minRelative ?? 0.1
+  const maxPeaks = options.maxPeaks ?? 6
+
+  const candidates: SpectralPeak[] = []
+  for (let i = 1; i < freqHz.length - 1; i += 1) {
+    const f = freqHz[i]
+    if (f < minFreqHz || f > maxFreqHz) {
+      continue
+    }
+    if (power[i] > power[i - 1] && power[i] >= power[i + 1]) {
+      candidates.push({ freqHz: f, power: power[i], relative: 0 })
+    }
+  }
+  if (candidates.length === 0) {
+    return []
+  }
+  candidates.sort((a, b) => b.power - a.power)
+
+  // Greedy merge: take the strongest, drop anything within minSeparationHz.
+  const kept: SpectralPeak[] = []
+  for (const cand of candidates) {
+    if (kept.some((k) => Math.abs(k.freqHz - cand.freqHz) < minSeparationHz)) {
+      continue
+    }
+    kept.push(cand)
+    if (kept.length >= maxPeaks) {
+      break
+    }
+  }
+  const maxPower = kept[0].power
+  return kept
+    .map((p) => ({ ...p, relative: maxPower > 0 ? p.power / maxPower : 0 }))
+    .filter((p) => p.relative >= minRelative)
+}

--- a/packages/log-analysis/src/index.ts
+++ b/packages/log-analysis/src/index.ts
@@ -1,0 +1,29 @@
+// @arduconfig/log-analysis — protocol/UI-independent analysis of ArduPilot
+// flight logs. The dataflash parser is the shared foundation; individual
+// analyses (MAGFit compass calibration, filter tuning, …) build on it.
+
+export {
+  parseDataflashLog,
+  type ParsedDataflashLog,
+  type DataflashFormat,
+  type DataflashMessage
+} from './dataflash-parser.js'
+
+export {
+  powerSpectrum,
+  findSpectralPeaks,
+  type PowerSpectrum,
+  type SpectralPeak,
+  type PeakOptions
+} from './gyro-fft.js'
+
+export {
+  analyzeLogTuning,
+  analyzeLogBuffer,
+  paramsFromLog,
+  type LogTuningResult,
+  type TuningRecommendation,
+  type AxisSpectrum,
+  type Axis,
+  type Confidence
+} from './notch-tuning-analysis.js'

--- a/packages/log-analysis/src/notch-tuning-analysis.ts
+++ b/packages/log-analysis/src/notch-tuning-analysis.ts
@@ -1,0 +1,367 @@
+// Log-based notch / filter / rate-tuning analysis — the automation of the
+// manual pass done on a real quad this session: FFT the gyro to find the
+// dominant vibration / oscillation, read motor RPM to place the harmonic notch,
+// check accel vibration, and flag a rate-loop limit cycle. Output is a set of
+// human-reviewed parameter recommendations (never written without approval).
+//
+// It works on compass-less FPV logs (no MAG needed). Correctness of the signal
+// math is covered by the FFT tests; the recommendation THRESHOLDS are advisory
+// and tagged with a confidence, and are meant to be validated against real logs.
+
+import { parseDataflashLog, type ParsedDataflashLog, type DataflashMessage } from './dataflash-parser.js'
+import { powerSpectrum, findSpectralPeaks, type PowerSpectrum, type SpectralPeak } from './gyro-fft.js'
+
+export type Axis = 'roll' | 'pitch' | 'yaw'
+export type Confidence = 'high' | 'medium' | 'low'
+
+export interface TuningRecommendation {
+  param: string
+  currentValue?: number
+  suggestedValue: number
+  reason: string
+  confidence: Confidence
+}
+
+export interface AxisSpectrum {
+  axis: Axis
+  peaks: SpectralPeak[]
+  /** Dominant peak (strongest), if any. */
+  dominant?: SpectralPeak
+}
+
+export interface LogTuningResult {
+  /** True when the log looks good enough to tune from (see gateWarnings). */
+  usable: boolean
+  /** Reasons the log may be unsuitable — surfaced to the operator as warnings. */
+  gateWarnings: string[]
+  gyroSource: 'batch' | 'imu' | 'none'
+  gyroSampleRateHz: number
+  axisSpectra: AxisSpectrum[]
+  /** Motor fundamental from ESC RPM (Hz), if ESC telemetry is present. */
+  motorFundamentalHz?: number
+  escRpm?: { minHz: number; meanHz: number; maxHz: number }
+  vibe?: { max: [number, number, number]; clip: [number, number, number]; verdict: 'good' | 'marginal' | 'bad' }
+  /** A sharp single-axis low-frequency peak that reads as a rate-loop limit cycle. */
+  limitCycle?: { axis: Axis; freqHz: number }
+  recommendations: TuningRecommendation[]
+  summary: string
+}
+
+const GYRO_AXES: { axis: Axis; batchType: number; imuField: string }[] = [
+  { axis: 'roll', batchType: 1, imuField: 'GyrX' },
+  { axis: 'pitch', batchType: 1, imuField: 'GyrY' },
+  { axis: 'yaw', batchType: 1, imuField: 'GyrZ' }
+]
+
+function num(msg: DataflashMessage, field: string): number | undefined {
+  const v = msg[field]
+  return typeof v === 'number' && Number.isFinite(v) ? v : undefined
+}
+
+/** Current parameter values captured in the log's PARM records. */
+export function paramsFromLog(log: ParsedDataflashLog): Map<string, number> {
+  const out = new Map<string, number>()
+  for (const m of log.messagesByType.get('PARM') ?? []) {
+    const name = m.Name
+    const value = m.Value
+    if (typeof name === 'string' && typeof value === 'number') {
+      out.set(name, value)
+    }
+  }
+  return out
+}
+
+/**
+ * Reconstruct the high-rate gyro batch-sampler bursts (ISBH/ISBD) for IMU
+ * instance 0. Returns one flattened signal per axis (x→roll, y→pitch, z→yaw)
+ * plus the sample rate, or null when no gyro batch data is present.
+ */
+function extractGyroBatch(log: ParsedDataflashLog): { roll: number[]; pitch: number[]; yaw: number[]; sampleRateHz: number } | null {
+  const headers = log.messagesByType.get('ISBH')
+  const data = log.messagesByType.get('ISBD')
+  if (!headers || !data || headers.length === 0 || data.length === 0) {
+    return null
+  }
+  // Index ISBD arrays by batch id N.
+  const dataByBatch = new Map<number, DataflashMessage[]>()
+  for (const d of data) {
+    const n = num(d, 'N')
+    if (n === undefined) continue
+    let arr = dataByBatch.get(n)
+    if (!arr) {
+      arr = []
+      dataByBatch.set(n, arr)
+    }
+    arr.push(d)
+  }
+  const roll: number[] = []
+  const pitch: number[] = []
+  const yaw: number[] = []
+  let sampleRateHz = 0
+  for (const h of headers) {
+    if (num(h, 'type') !== 1 || num(h, 'instance') !== 0) {
+      continue // gyro (type 1), primary IMU only
+    }
+    const n = num(h, 'N')
+    if (n === undefined) continue
+    const rate = num(h, 'smp_rate')
+    if (rate && rate > sampleRateHz) sampleRateHz = rate
+    const records = (dataByBatch.get(n) ?? []).slice().sort((a, b) => (num(a, 'seqno') ?? 0) - (num(b, 'seqno') ?? 0))
+    for (const rec of records) {
+      const x = rec.x
+      const y = rec.y
+      const z = rec.z
+      if (Array.isArray(x) && Array.isArray(y) && Array.isArray(z)) {
+        for (let i = 0; i < x.length; i += 1) {
+          roll.push(x[i])
+          pitch.push(y[i])
+          yaw.push(z[i])
+        }
+      }
+    }
+  }
+  if (roll.length < 256 || sampleRateHz <= 0) {
+    return null
+  }
+  return { roll, pitch, yaw, sampleRateHz }
+}
+
+/** Fallback: gyro from the ordinary IMU message (instance 0), sample rate from timestamps. */
+function extractGyroImu(log: ParsedDataflashLog): { roll: number[]; pitch: number[]; yaw: number[]; sampleRateHz: number } | null {
+  const imu = (log.messagesByType.get('IMU') ?? []).filter((m) => num(m, 'I') === 0)
+  if (imu.length < 256) {
+    return null
+  }
+  const roll: number[] = []
+  const pitch: number[] = []
+  const yaw: number[] = []
+  for (const m of imu) {
+    const gx = num(m, 'GyrX')
+    const gy = num(m, 'GyrY')
+    const gz = num(m, 'GyrZ')
+    if (gx === undefined || gy === undefined || gz === undefined) continue
+    roll.push(gx)
+    pitch.push(gy)
+    yaw.push(gz)
+  }
+  const t0 = num(imu[0], 'TimeUS')
+  const t1 = num(imu[imu.length - 1], 'TimeUS')
+  const sampleRateHz = t0 !== undefined && t1 !== undefined && t1 > t0 ? (imu.length - 1) / ((t1 - t0) / 1e6) : 0
+  if (roll.length < 256 || sampleRateHz <= 0) {
+    return null
+  }
+  return { roll, pitch, yaw, sampleRateHz }
+}
+
+/** Average the power spectra of a long signal split into windows (Welch-ish). */
+function averagedSpectrum(signal: number[], sampleRateHz: number, windowSize = 1024): PowerSpectrum {
+  if (signal.length <= windowSize) {
+    return powerSpectrum(signal, sampleRateHz)
+  }
+  const step = windowSize
+  let acc: Float64Array | null = null
+  let freqHz: Float64Array | null = null
+  let binHz = 0
+  let count = 0
+  for (let start = 0; start + windowSize <= signal.length; start += step) {
+    const spec = powerSpectrum(signal.slice(start, start + windowSize), sampleRateHz)
+    if (!acc) {
+      acc = new Float64Array(spec.power.length)
+      freqHz = spec.freqHz
+      binHz = spec.binHz
+    }
+    if (spec.power.length === acc.length) {
+      for (let i = 0; i < acc.length; i += 1) acc[i] += spec.power[i]
+      count += 1
+    }
+  }
+  if (!acc || !freqHz || count === 0) {
+    return powerSpectrum(signal.slice(0, windowSize), sampleRateHz)
+  }
+  for (let i = 0; i < acc.length; i += 1) acc[i] /= count
+  return { freqHz, power: acc, binHz }
+}
+
+function escRpmSummary(log: ParsedDataflashLog): { minHz: number; meanHz: number; maxHz: number } | undefined {
+  const esc = log.messagesByType.get('ESC')
+  if (!esc || esc.length === 0) {
+    return undefined
+  }
+  const rpms: number[] = []
+  for (const m of esc) {
+    const rpm = num(m, 'RPM')
+    if (rpm !== undefined && rpm > 100) rpms.push(rpm)
+  }
+  if (rpms.length === 0) {
+    return undefined
+  }
+  const mean = rpms.reduce((a, b) => a + b, 0) / rpms.length
+  return { minHz: Math.min(...rpms) / 60, meanHz: mean / 60, maxHz: Math.max(...rpms) / 60 }
+}
+
+function vibeSummary(log: ParsedDataflashLog): LogTuningResult['vibe'] {
+  const vibe = log.messagesByType.get('VIBE')
+  if (!vibe || vibe.length === 0) {
+    return undefined
+  }
+  const max: [number, number, number] = [0, 0, 0]
+  const clip: [number, number, number] = [0, 0, 0]
+  for (const m of vibe) {
+    const x = num(m, 'VibeX') ?? 0
+    const y = num(m, 'VibeY') ?? 0
+    const z = num(m, 'VibeZ') ?? 0
+    max[0] = Math.max(max[0], x)
+    max[1] = Math.max(max[1], y)
+    max[2] = Math.max(max[2], z)
+    clip[0] = Math.max(clip[0], num(m, 'Clip0') ?? num(m, 'Clip') ?? 0)
+    clip[1] = Math.max(clip[1], num(m, 'Clip1') ?? 0)
+    clip[2] = Math.max(clip[2], num(m, 'Clip2') ?? 0)
+  }
+  const worst = Math.max(...max)
+  const clipped = Math.max(...clip)
+  const verdict = clipped > 0 || worst > 30 ? 'bad' : worst > 15 ? 'marginal' : 'good'
+  return { max, clip, verdict }
+}
+
+/**
+ * Analyse a parsed dataflash log for notch / filter / rate tuning. `log` is the
+ * output of {@link parseDataflashLog}; recommendations compare against the
+ * parameter values captured in the log (PARM records) when present.
+ */
+export function analyzeLogTuning(log: ParsedDataflashLog): LogTuningResult {
+  const params = paramsFromLog(log)
+  const gateWarnings: string[] = []
+
+  // Gyro source: prefer the high-rate batch sampler; fall back to IMU.
+  let source: 'batch' | 'imu' | 'none' = 'none'
+  let gyro = extractGyroBatch(log)
+  if (gyro) {
+    source = 'batch'
+  } else {
+    gyro = extractGyroImu(log)
+    if (gyro) {
+      source = 'imu'
+      gateWarnings.push(
+        'No gyro batch-sampler (ISBD) data — using the lower-rate IMU log. Enable INS_LOG_BAT_MASK and re-fly for a proper high-frequency spectrum.'
+      )
+    }
+  }
+
+  const axisSpectra: AxisSpectrum[] = []
+  let limitCycle: LogTuningResult['limitCycle']
+  if (gyro) {
+    const nyquist = gyro.sampleRateHz / 2
+    for (const { axis } of GYRO_AXES) {
+      const signal = gyro[axis]
+      const spec = averagedSpectrum(signal, gyro.sampleRateHz)
+      const peaks = findSpectralPeaks(spec, { minFreqHz: 5, maxFreqHz: nyquist, minRelative: 0.05 })
+      axisSpectra.push({ axis, peaks, dominant: peaks[0] })
+    }
+    // Limit-cycle heuristic: a sharp peak below ~40 Hz that dominates ONE axis
+    // far more than the others reads as a rate-loop oscillation.
+    const dominants = axisSpectra.filter((a) => a.dominant && a.dominant.freqHz < 40)
+    if (dominants.length > 0) {
+      const strongest = dominants.reduce((best, a) =>
+        (a.dominant?.power ?? 0) > (best.dominant?.power ?? 0) ? a : best
+      )
+      const others = axisSpectra.filter((a) => a.axis !== strongest.axis)
+      const otherMax = Math.max(0, ...others.map((a) => a.dominant?.power ?? 0))
+      if (strongest.dominant && strongest.dominant.power > otherMax * 4) {
+        limitCycle = { axis: strongest.axis, freqHz: strongest.dominant.freqHz }
+      }
+    }
+  } else {
+    gateWarnings.push('No usable gyro data (neither ISBD batch nor IMU) — cannot analyse vibration or oscillation.')
+  }
+
+  const esc = escRpmSummary(log)
+  const motorFundamentalHz = esc?.meanHz
+  const vibe = vibeSummary(log)
+
+  // ---- Quality gate ----
+  const armedEvidence = (log.messagesByType.get('RATE')?.length ?? 0) > 100 || (log.messagesByType.get('CTUN')?.length ?? 0) > 100
+  if (!armedEvidence) {
+    gateWarnings.push('Little/no in-flight data (RATE/CTUN) — this needs an actual hover/flight log, not a bench session.')
+  }
+  if (source === 'batch' && gyro && gyro.roll.length < 4096) {
+    gateWarnings.push('Very short flight — a longer steady hover (30–60 s) gives a cleaner spectrum.')
+  }
+  const usable = gyro !== null && armedEvidence
+
+  // ---- Recommendations (advisory; staged for human approval) ----
+  const recommendations: TuningRecommendation[] = []
+
+  // Harmonic notch, driven by motor RPM (ESC telemetry present).
+  if (esc && motorFundamentalHz) {
+    if ((params.get('INS_HNTCH_ENABLE') ?? 0) < 1) {
+      recommendations.push({
+        param: 'INS_HNTCH_ENABLE',
+        currentValue: params.get('INS_HNTCH_ENABLE'),
+        suggestedValue: 1,
+        reason: `ESC RPM telemetry is present (motor fundamental ~${motorFundamentalHz.toFixed(0)} Hz); enable the harmonic notch to track motor noise.`,
+        confidence: 'high'
+      })
+      recommendations.push({
+        param: 'INS_HNTCH_MODE',
+        currentValue: params.get('INS_HNTCH_MODE'),
+        suggestedValue: 3,
+        reason: 'Track the notch from ESC RPM telemetry (mode 3) — the most accurate source when available.',
+        confidence: 'high'
+      })
+    }
+    const minFreqFloor = Math.max(20, Math.round(esc.minHz * 0.7))
+    const currentFreq = params.get('INS_HNTCH_FREQ')
+    if (currentFreq === undefined || Math.abs(currentFreq - minFreqFloor) > 15) {
+      recommendations.push({
+        param: 'INS_HNTCH_FREQ',
+        currentValue: currentFreq,
+        suggestedValue: minFreqFloor,
+        reason: `Set the notch minimum tracking frequency near the lowest motor fundamental seen (~${esc.minHz.toFixed(0)} Hz).`,
+        confidence: 'medium'
+      })
+    }
+  }
+
+  // Rate-loop limit cycle → lower that axis's rate D.
+  if (limitCycle) {
+    const dParam = `ATC_RAT_${limitCycle.axis === 'roll' ? 'RLL' : limitCycle.axis === 'pitch' ? 'PIT' : 'YAW'}_D`
+    const current = params.get(dParam)
+    if (current !== undefined && current > 0.001) {
+      recommendations.push({
+        param: dParam,
+        currentValue: current,
+        suggestedValue: Number((current / 2).toFixed(4)),
+        reason: `A sharp ~${limitCycle.freqHz.toFixed(0)} Hz oscillation dominates the ${limitCycle.axis} axis and not the others — the classic rate-loop limit cycle. Halve ${limitCycle.axis} rate D and re-fly.`,
+        confidence: 'medium'
+      })
+    }
+  }
+
+  // ---- Summary ----
+  const summaryParts: string[] = []
+  if (source === 'batch') summaryParts.push(`Gyro spectrum from the batch sampler (~${gyro?.sampleRateHz.toFixed(0)} Hz).`)
+  else if (source === 'imu') summaryParts.push(`Gyro spectrum from the IMU log (~${gyro?.sampleRateHz.toFixed(0)} Hz — limited resolution).`)
+  if (vibe) summaryParts.push(`Vibration ${vibe.verdict} (peak ${Math.max(...vibe.max).toFixed(0)} m/s², clip ${Math.max(...vibe.clip)}).`)
+  if (limitCycle) summaryParts.push(`Likely ${limitCycle.freqHz.toFixed(0)} Hz ${limitCycle.axis}-axis limit cycle.`)
+  if (motorFundamentalHz) summaryParts.push(`Motor fundamental ~${motorFundamentalHz.toFixed(0)} Hz.`)
+  if (recommendations.length === 0 && usable) summaryParts.push('No parameter changes recommended — the tune looks clean.')
+
+  return {
+    usable,
+    gateWarnings,
+    gyroSource: source,
+    gyroSampleRateHz: gyro?.sampleRateHz ?? 0,
+    axisSpectra,
+    motorFundamentalHz,
+    escRpm: esc,
+    vibe,
+    limitCycle,
+    recommendations,
+    summary: summaryParts.join(' ')
+  }
+}
+
+/** Convenience: parse a raw `.bin` buffer and analyse it in one call. */
+export function analyzeLogBuffer(input: ArrayBuffer | Uint8Array): LogTuningResult {
+  return analyzeLogTuning(parseDataflashLog(input))
+}

--- a/packages/log-analysis/tsconfig.json
+++ b/packages/log-analysis/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "composite": true,
+    "declaration": true,
+    "declarationMap": true,
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "rootDir": "src",
+    "outDir": "dist",
+    "types": ["node"]
+  },
+  "include": ["src"]
+}

--- a/tests/e2e/views.spec.ts
+++ b/tests/e2e/views.spec.ts
@@ -2679,6 +2679,31 @@ test.describe('ArduPlane demo', () => {
     await expect(page.getByTestId('autotune-copter-review')).toContainText('AUTOTUNE_AGGR')
   })
 
+  test('Tuning: the Log Tuning sub-tab uploads a log and shows the quality gate', async ({ page }) => {
+    await page.goto('/')
+    await page.getByTestId('transport-mode-select').selectOption('demo')
+    await page.getByTestId('connect-button').click()
+    await expect(page.getByTestId('session-vehicle-name')).toHaveText('ArduCopter', { timeout: VEHICLE_CONNECT_TIMEOUT })
+
+    await openView(page, 'tuning')
+    await page.getByTestId('tuning-tab-log-tuning').click()
+    const panel = page.getByTestId('tuning-log-tuning-panel')
+    await expect(panel).toBeVisible()
+    // The "you need a good flight log" gate is always shown up front.
+    await expect(page.getByTestId('log-tuning-gate-note')).toBeVisible()
+    await expect(page.getByTestId('log-tuning')).toContainText('Choose flight log')
+
+    // Upload a trivial (empty) buffer: it parses to no usable data, so the
+    // analyzer must gate it as unusable rather than throw.
+    await page.getByTestId('log-tuning-file').setInputFiles({
+      name: 'empty.bin',
+      mimeType: 'application/octet-stream',
+      buffer: Buffer.from([0, 1, 2, 3, 4, 5, 6, 7, 8, 9])
+    })
+    await expect(page.getByTestId('log-tuning-results')).toBeVisible()
+    await expect(page.getByTestId('log-tuning-unusable')).toBeVisible()
+  })
+
   test('Plane AutoTune surface renders fixed-wing + VTOL groups with seeded values and stages a draft', async ({ page }) => {
     await page.goto('/')
     await page.getByTestId('transport-mode-select').selectOption('demo-plane')

--- a/tests/log-analysis-dataflash.test.mjs
+++ b/tests/log-analysis-dataflash.test.mjs
@@ -1,0 +1,120 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { parseDataflashLog } from '../packages/log-analysis/dist/index.js'
+
+// Build a synthetic DataFlash `.bin` stream so the parser is validated against
+// exactly-known values (framing, FMT bootstrap, every scaled type code) without
+// shipping a multi-MB real-log fixture. Real-log + magfit_WMM.py oracle
+// validation lives with the MAGFit analysis that consumes this parser.
+
+const HEAD1 = 0xa3
+const HEAD2 = 0x95
+const FMT_TYPE = 0x80
+
+function padBytes(str, length) {
+  const out = new Uint8Array(length)
+  for (let i = 0; i < str.length && i < length; i += 1) {
+    out[i] = str.charCodeAt(i)
+  }
+  return out
+}
+
+// A FMT record is always 89 bytes: head(2) type(1) definedType(1) length(1)
+// name(4) format(16) columns(64).
+function fmtRecord(definedType, length, name, format, columns) {
+  const buf = new Uint8Array(89)
+  const view = new DataView(buf.buffer)
+  buf[0] = HEAD1
+  buf[1] = HEAD2
+  buf[2] = FMT_TYPE
+  view.setUint8(3, definedType)
+  view.setUint8(4, length)
+  buf.set(padBytes(name, 4), 5)
+  buf.set(padBytes(format, 16), 9)
+  buf.set(padBytes(columns, 64), 25)
+  return buf
+}
+
+function concat(chunks) {
+  const total = chunks.reduce((n, c) => n + c.length, 0)
+  const out = new Uint8Array(total)
+  let off = 0
+  for (const c of chunks) {
+    out.set(c, off)
+    off += c.length
+  }
+  return out
+}
+
+test('parses framing, FMT schema, and every scaled type code', () => {
+  // TEST message: B(u8) h(i16) f(f32) L(i32×1e-7). Body = 1+2+4+4 = 11 → len 14.
+  const testFmt = fmtRecord(200, 14, 'TEST', 'BhfL', 'a,b,c,lat')
+  const testMsg = new Uint8Array(14)
+  {
+    const v = new DataView(testMsg.buffer)
+    testMsg[0] = HEAD1
+    testMsg[1] = HEAD2
+    testMsg[2] = 200
+    v.setUint8(3, 42)
+    v.setInt16(4, -1234, true)
+    v.setFloat32(6, 3.5, true)
+    v.setInt32(10, 473977000, true) // 47.3977 deg after ×1e-7
+  }
+
+  // ATT with 'c' (centidegree ×0.01) fields to exercise built-in scaling.
+  const attFmt = fmtRecord(201, 9, 'ATT', 'ccc', 'Roll,Pitch,Yaw')
+  const attMsg = new Uint8Array(9)
+  {
+    const v = new DataView(attMsg.buffer)
+    attMsg[0] = HEAD1
+    attMsg[1] = HEAD2
+    attMsg[2] = 201
+    v.setInt16(3, 1050, true) // 10.5 deg
+    v.setInt16(5, -500, true) // -5.0 deg
+    v.setInt16(7, 9000, true) // 90.0 deg
+  }
+
+  const log = parseDataflashLog(concat([testFmt, testMsg, attFmt, attMsg, attMsg]))
+
+  assert.equal(log.skippedBytes, 0, 'clean stream, nothing skipped')
+  assert.equal(log.counts.get('TEST'), 1)
+  assert.equal(log.counts.get('ATT'), 2)
+  assert.ok(log.formats.has('TEST') && log.formats.has('ATT'))
+
+  const t = log.messagesByType.get('TEST')[0]
+  assert.equal(t.name, 'TEST')
+  assert.equal(t.a, 42)
+  assert.equal(t.b, -1234)
+  assert.equal(t.c, 3.5)
+  assert.ok(Math.abs(t.lat - 47.3977) < 1e-6, `lat decoded ${t.lat}`)
+
+  const att = log.messagesByType.get('ATT')[0]
+  assert.ok(Math.abs(att.Roll - 10.5) < 1e-9)
+  assert.ok(Math.abs(att.Pitch - -5.0) < 1e-9)
+  assert.ok(Math.abs(att.Yaw - 90.0) < 1e-9)
+})
+
+test('resynchronises past leading garbage and a torn frame boundary', () => {
+  const fmt = fmtRecord(200, 6, 'ONE', 'H', 'v')
+  const msg = new Uint8Array(6)
+  msg[0] = HEAD1
+  msg[1] = HEAD2
+  msg[2] = 200
+  new DataView(msg.buffer).setUint16(3, 65000, true)
+
+  const garbage = new Uint8Array([0x00, 0x11, 0xa3, 0x22, 0x95]) // near-misses on the head bytes
+  const log = parseDataflashLog(concat([garbage, fmt, msg]))
+
+  assert.equal(log.counts.get('ONE'), 1)
+  assert.equal(log.messagesByType.get('ONE')[0].v, 65000)
+  assert.ok(log.skippedBytes >= garbage.length, `skipped ${log.skippedBytes} garbage bytes`)
+})
+
+test('drops a truncated final message instead of throwing', () => {
+  const fmt = fmtRecord(200, 7, 'TWO', 'I', 'v')
+  const truncated = new Uint8Array([HEAD1, HEAD2, 200, 0x01, 0x02]) // needs 4 body bytes, only 2
+  const log = parseDataflashLog(concat([fmt, truncated]))
+  assert.equal(log.counts.get('TWO'), undefined) // the torn message is not emitted
+  assert.ok(log.formats.has('TWO'))
+})

--- a/tests/log-analysis-gyro-fft.test.mjs
+++ b/tests/log-analysis-gyro-fft.test.mjs
@@ -1,0 +1,62 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { powerSpectrum, findSpectralPeaks } from '../packages/log-analysis/dist/index.js'
+
+// Validate the FFT + peak finder against synthetic multi-tone signals with
+// known frequencies — the same shape as the real gyro data it will process
+// (a dominant low-frequency oscillation plus higher-frequency motor noise).
+
+function tone(freqHz, amp, sampleRateHz, n, phase = 0) {
+  const out = new Float64Array(n)
+  for (let i = 0; i < n; i += 1) {
+    out[i] = amp * Math.sin(2 * Math.PI * freqHz * (i / sampleRateHz) + phase)
+  }
+  return out
+}
+
+test('resolves a dominant low-frequency peak and a weaker high-frequency one', () => {
+  const fs = 1000
+  const n = 2048
+  // 12 Hz strong (like the roll limit cycle) + 90 Hz weaker (like motor noise).
+  const strong = tone(12, 1.0, fs, n)
+  const weak = tone(90, 0.25, fs, n, 1.1)
+  const signal = new Float64Array(n)
+  for (let i = 0; i < n; i += 1) {
+    signal[i] = strong[i] + weak[i] + 0.5 // + DC offset (must be removed)
+  }
+
+  const spec = powerSpectrum(signal, fs)
+  // Low minRelative: the 90 Hz tone is a weak secondary (~0.06 of the 12 Hz
+  // power), like real motor noise next to a limit cycle — we still want it.
+  const peaks = findSpectralPeaks(spec, { minFreqHz: 5, maxFreqHz: 200, minSeparationHz: 6, minRelative: 0.03 })
+
+  assert.ok(peaks.length >= 2, `expected >=2 peaks, got ${peaks.length}`)
+  // Strongest peak is the 12 Hz tone (within ~1 bin of 12).
+  assert.ok(Math.abs(peaks[0].freqHz - 12) < 1.5, `dominant peak ${peaks[0].freqHz.toFixed(1)}Hz`)
+  // The 90 Hz tone is present as a secondary peak.
+  const has90 = peaks.some((p) => Math.abs(p.freqHz - 90) < 1.5)
+  assert.ok(has90, `expected a ~90Hz peak among ${peaks.map((p) => p.freqHz.toFixed(0)).join(',')}`)
+  // DC removed: no giant peak at 0 Hz dominating.
+  assert.equal(spec.freqHz[0], 0)
+  assert.ok(peaks[0].freqHz > 5)
+  // Relative scaling: dominant is 1.0, the 90Hz one is a smaller fraction.
+  assert.equal(peaks[0].relative, 1)
+  const p90 = peaks.find((p) => Math.abs(p.freqHz - 90) < 1.5)
+  assert.ok(p90.relative < 1 && p90.relative > 0)
+})
+
+test('a clean single tone yields one dominant peak at its frequency', () => {
+  const fs = 2000
+  const n = 4096
+  const spec = powerSpectrum(tone(47, 1.0, fs, n), fs)
+  const peaks = findSpectralPeaks(spec, { minFreqHz: 5 })
+  assert.ok(peaks.length >= 1)
+  assert.ok(Math.abs(peaks[0].freqHz - 47) < 1.0, `peak at ${peaks[0].freqHz}`)
+})
+
+test('empty / too-short input is handled without throwing', () => {
+  assert.deepEqual(findSpectralPeaks(powerSpectrum([], 1000)), [])
+  assert.deepEqual(findSpectralPeaks(powerSpectrum([1], 1000)), [])
+  assert.deepEqual(findSpectralPeaks(powerSpectrum([1, 2, 3], 0)), [])
+})

--- a/tests/log-analysis-notch-tuning.test.mjs
+++ b/tests/log-analysis-notch-tuning.test.mjs
@@ -1,0 +1,104 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { analyzeLogTuning } from '../packages/log-analysis/dist/index.js'
+
+// Exercise the analysis engine against a synthetic parsed log that reproduces
+// the real scenario from the vibration diagnosis: a sharp ~12 Hz oscillation on
+// the ROLL gyro (and not pitch/yaw), ESC RPM present, and a non-trivial roll
+// rate-D. The binary parser is tested separately, so we build the parsed
+// structure directly to isolate the analysis logic.
+
+function makeLog({ oscHz = 12, oscAmp = 500, sampleRate = 1000, rpm = 6000, rllD = 0.01, hntchEnable = 0 } = {}) {
+  const messagesByType = new Map()
+
+  // --- Gyro batch sampler (ISBH header + ISBD data) ---
+  const totalSamples = 1024
+  const perRecord = 32
+  const isbh = [{ name: 'ISBH', N: 1, type: 1, instance: 0, smp_rate: sampleRate, smp_cnt: totalSamples }]
+  const isbd = []
+  let idx = 0
+  for (let seq = 0; seq < totalSamples / perRecord; seq += 1) {
+    const x = []
+    const y = []
+    const z = []
+    for (let k = 0; k < perRecord; k += 1) {
+      // Roll (x): strong 12 Hz sine. Pitch/yaw: tiny noise only.
+      x.push(Math.round(oscAmp * Math.sin((2 * Math.PI * oscHz * idx) / sampleRate)))
+      y.push(Math.round(8 * Math.sin((2 * Math.PI * 7 * idx) / sampleRate)))
+      z.push(Math.round(4 * Math.sin((2 * Math.PI * 5 * idx) / sampleRate)))
+      idx += 1
+    }
+    isbd.push({ name: 'ISBD', N: 1, seqno: seq, x, y, z })
+  }
+  messagesByType.set('ISBH', isbh)
+  messagesByType.set('ISBD', isbd)
+
+  // --- ESC RPM (motor telemetry) ---
+  const esc = []
+  for (let i = 0; i < 200; i += 1) esc.push({ name: 'ESC', Instance: 0, RPM: rpm + (i % 20) })
+  messagesByType.set('ESC', esc)
+
+  // --- Flight evidence (RATE) + low vibration (VIBE) ---
+  const rate = []
+  for (let i = 0; i < 200; i += 1) rate.push({ name: 'RATE', R: 0, RDes: 0 })
+  messagesByType.set('RATE', rate)
+  const vibe = []
+  for (let i = 0; i < 50; i += 1) vibe.push({ name: 'VIBE', VibeX: 2, VibeY: 2, VibeZ: 2, Clip: 0 })
+  messagesByType.set('VIBE', vibe)
+
+  // --- Params captured in the log ---
+  messagesByType.set('PARM', [
+    { name: 'PARM', Name: 'ATC_RAT_RLL_D', Value: rllD },
+    { name: 'PARM', Name: 'ATC_RAT_PIT_D', Value: 0.008 },
+    { name: 'PARM', Name: 'INS_HNTCH_ENABLE', Value: hntchEnable }
+  ])
+
+  return { messagesByType, formats: new Map(), counts: new Map(), skippedBytes: 0 }
+}
+
+test('detects a single-axis roll limit cycle and recommends halving roll rate-D', () => {
+  const result = analyzeLogTuning(makeLog({ oscHz: 12, rllD: 0.01 }))
+
+  assert.equal(result.gyroSource, 'batch')
+  assert.ok(Math.abs(result.gyroSampleRateHz - 1000) < 1)
+  assert.equal(result.usable, true)
+
+  assert.ok(result.limitCycle, 'expected a limit cycle')
+  assert.equal(result.limitCycle.axis, 'roll')
+  assert.ok(Math.abs(result.limitCycle.freqHz - 12) < 2, `limit cycle at ${result.limitCycle.freqHz}Hz`)
+
+  const dRec = result.recommendations.find((r) => r.param === 'ATC_RAT_RLL_D')
+  assert.ok(dRec, 'expected a roll rate-D recommendation')
+  assert.ok(Math.abs(dRec.suggestedValue - 0.005) < 1e-6, `suggested ${dRec.suggestedValue}`)
+  assert.equal(dRec.currentValue, 0.01)
+})
+
+test('recommends enabling the ESC-telemetry harmonic notch when RPM is present and it is off', () => {
+  const result = analyzeLogTuning(makeLog({ rpm: 6000, hntchEnable: 0 }))
+  assert.ok(Math.abs(result.motorFundamentalHz - 100) < 2, `motor fundamental ${result.motorFundamentalHz}`)
+  const enable = result.recommendations.find((r) => r.param === 'INS_HNTCH_ENABLE')
+  assert.ok(enable && enable.suggestedValue === 1)
+  const mode = result.recommendations.find((r) => r.param === 'INS_HNTCH_MODE')
+  assert.ok(mode && mode.suggestedValue === 3, 'ESC-telemetry notch mode')
+})
+
+test('does not recommend enabling the notch when it is already on', () => {
+  const result = analyzeLogTuning(makeLog({ hntchEnable: 1 }))
+  assert.ok(!result.recommendations.some((r) => r.param === 'INS_HNTCH_ENABLE'))
+})
+
+test('flags a bench log (no flight data) as not usable', () => {
+  const log = makeLog()
+  log.messagesByType.set('RATE', []) // no flight evidence
+  log.messagesByType.set('CTUN', [])
+  const result = analyzeLogTuning(log)
+  assert.equal(result.usable, false)
+  assert.ok(result.gateWarnings.some((w) => /in-flight|hover|flight log/i.test(w)))
+})
+
+test('vibration verdict is good for low VIBE with no clipping', () => {
+  const result = analyzeLogTuning(makeLog())
+  assert.ok(result.vibe)
+  assert.equal(result.vibe.verdict, 'good')
+})


### PR DESCRIPTION
Adds a **Log Tuning** sub-tab to the Tuning view (beta): upload a dataflash `.bin` flight log and the in-browser analyzer works through what needs doing, then stages the recommended parameter changes for review. Works on **compass-less FPV logs** (no MAG needed) — it's the automation of the manual notch/rate diagnosis done on a real quad earlier.

## New package `@arduconfig/log-analysis` (GPL, provenance noted)
- **dataflash-parser** — in-browser `.bin` parsing (FMT self-schema, all field type codes with built-in scaling, resync + truncation tolerance).
- **gyro-fft** — radix-2 FFT power spectrum + spectral peak finder.
- **notch-tuning-analysis** — extracts batch-gyro (ISBD) / IMU / ESC-RPM / RATE / VIBE → per-axis spectra, motor fundamental, single-axis **limit-cycle detection**, a log-quality gate, and advisory recommendations (harmonic-notch enable/mode/freq, rate-`D` halving) with confidence tags.
- **11 unit tests**: parser (exact-value synthetic log, resync, truncation), FFT (multi-tone), analysis (reproduces the real 12 Hz roll limit cycle → halve roll-`D` + enable ESC-telem notch; gates a bench log as unusable).

## apps/web
- `LogTuningView` — self-contained upload + results + staging. Imports only the pure analysis engine (no runtime/transport). Recommendations stage into the shared draft set (Tuning **Review** + global draft bar) — nothing is written without the normal verified apply. Prominent **"needs a good flight log"** gate up front.
- Wired as the `log-tuning` Tuning task (card + `ReactNode` slot, mirroring `autotuneSlot`).

## Validation
`typecheck` clean; **734 node tests pass** (incl. 11 new); 19 tuning e2e pass incl. the new Log Tuning render+upload+gate test.

## Note
The recommendation *thresholds* are advisory and validated against synthetic logs; they'll be tuned against real compass-less logs. MAGFit (compass) is a planned second analysis on this same foundation.

## ArduCopter invariant
Presentational + a new analysis package; no change to existing runtime/write paths. **ArduCopter byte-identical.**