### PR TITLE
feat(calibration): Expert-gated Thermal Calibration (TCAL) card

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -8292,6 +8292,7 @@ export function App() {
           canApplyDraftParameters={canApplyDraftParameters}
           airframe={airframe}
           isCopterVehicle={isCopterVehicle}
+          isExpertMode={isExpertMode}
           uiParameterWriteOptions={UI_PARAMETER_WRITE_OPTIONS}
           editedValues={editedValues}
           calibrationNotices={calibrationNotices}

--- a/apps/web/src/sections/CalibrationSection.tsx
+++ b/apps/web/src/sections/CalibrationSection.tsx
@@ -10,6 +10,7 @@ import { Panel, StatusBadge, buttonStyle } from '@arduconfig/ui-kit'
 
 import { AccelerometerPoseGuide } from '../accelerometer-pose-guide'
 import { CalibrationLocationButton } from './CalibrationLocationCard'
+import { TcalCalibrationCard } from './TcalCalibrationCard'
 import {
   accelerometerPoseFromAction,
   guidedActionBlockingReason,
@@ -29,6 +30,8 @@ export interface CalibrationSectionProps {
   canApplyDraftParameters: boolean
   airframe: AirframeSummary
   isCopterVehicle: boolean
+  /** Expert product-mode — gates the advanced Thermal Calibration (TCAL) card. */
+  isExpertMode: boolean
   uiParameterWriteOptions: ParameterWriteOptions
   editedValues: Record<string, string>
   calibrationNotices: UseCalibrationNoticesResult
@@ -48,6 +51,7 @@ export function CalibrationSection(props: CalibrationSectionProps): ReactElement
     canApplyDraftParameters,
     airframe,
     isCopterVehicle,
+    isExpertMode,
     uiParameterWriteOptions: UI_PARAMETER_WRITE_OPTIONS,
     editedValues,
     calibrationNotices,
@@ -682,6 +686,16 @@ export function CalibrationSection(props: CalibrationSectionProps): ReactElement
                   </>
                 )
               })()}
+
+              {/* Thermal calibration (TCAL) — Expert-only advanced surface. */}
+              {isExpertMode ? (
+                <TcalCalibrationCard
+                  snapshot={snapshot}
+                  canApplyDraftParameters={canApplyDraftParameters}
+                  busyAction={busyAction}
+                  setDraft={setDraft}
+                />
+              ) : null}
             </div>
           </Panel>
         </section>

--- a/apps/web/src/sections/TcalCalibrationCard.tsx
+++ b/apps/web/src/sections/TcalCalibrationCard.tsx
@@ -1,0 +1,138 @@
+// Thermal calibration (TCAL) card for the Calibration tab — Expert-gated.
+//
+// ArduPilot per-IMU thermal calibration (INS_TCALn_*) learns gyro/accel offsets
+// across temperature so the estimator stays stable from a cold boot to warm.
+// It learns ONLINE: set each IMU to "learn", reboot cold, and let the board heat
+// through its range — the firmware computes and saves the fit at the top
+// temperature on its own. This card reads the current TCAL state from the synced
+// parameters and stages the "learn" enable (INS_TCALn_ENABLE=2) as a draft; the
+// operator applies it through the normal verified-write path, then reboots cold.
+//
+// Live IMU-temperature progress isn't surfaced yet (the FC IMU temperature isn't
+// in the telemetry snapshot) — that's a follow-up; the firmware self-completes.
+
+import type { ReactElement } from 'react'
+
+import type { ConfiguratorSnapshot } from '@arduconfig/ardupilot-core'
+import { StatusBadge, buttonStyle } from '@arduconfig/ui-kit'
+
+import { readParameterValue } from '../selectors/parameter-read'
+
+export interface TcalCalibrationCardProps {
+  snapshot: ConfiguratorSnapshot
+  canApplyDraftParameters: boolean
+  busyAction: string | undefined
+  setDraft: (paramId: string, value: string) => void
+}
+
+const IMU_INSTANCES = [1, 2, 3]
+
+function enableState(value: number | undefined): { label: string; tone: 'neutral' | 'success' | 'warning' } {
+  if (value === undefined) return { label: 'n/a', tone: 'neutral' }
+  if (value >= 2) return { label: 'learning', tone: 'warning' }
+  if (value >= 1) return { label: 'enabled', tone: 'success' }
+  return { label: 'disabled', tone: 'neutral' }
+}
+
+export function TcalCalibrationCard({
+  snapshot,
+  canApplyDraftParameters,
+  busyAction,
+  setDraft
+}: TcalCalibrationCardProps): ReactElement {
+  const imus = IMU_INSTANCES.map((i) => ({
+    i,
+    enable: readParameterValue(snapshot, `INS_TCAL${i}_ENABLE`),
+    tmin: readParameterValue(snapshot, `INS_TCAL${i}_TMIN`),
+    tmax: readParameterValue(snapshot, `INS_TCAL${i}_TMAX`)
+  })).filter((imu) => imu.enable !== undefined)
+
+  if (imus.length === 0) {
+    return (
+      <article className="calibration-card" data-testid="calibration-card-tcal">
+        <div className="calibration-card__header">
+          <strong>Thermal calibration (TCAL)</strong>
+          <StatusBadge tone="neutral">n/a</StatusBadge>
+        </div>
+        <p>
+          This firmware doesn't expose thermal-calibration parameters (<code>INS_TCALn_*</code>). Thermal cal is
+          available on builds with per-IMU temperature compensation compiled in.
+        </p>
+      </article>
+    )
+  }
+
+  const anyLearning = imus.some((imu) => (imu.enable ?? 0) >= 2)
+  const connected = snapshot.connection.kind === 'connected'
+  const canStart = connected && canApplyDraftParameters && busyAction === undefined && !anyLearning
+
+  const startLearning = (): void => {
+    for (const imu of imus) {
+      setDraft(`INS_TCAL${imu.i}_ENABLE`, '2')
+    }
+  }
+
+  return (
+    <article className="calibration-card" data-testid="calibration-card-tcal">
+      <div className="calibration-card__header">
+        <strong>Thermal calibration (TCAL)</strong>
+        <StatusBadge tone={anyLearning ? 'warning' : 'neutral'}>{anyLearning ? 'learning' : 'idle'}</StatusBadge>
+      </div>
+      <p>
+        Learns per-IMU gyro/accel offsets across temperature so the estimator stays stable from a cold boot to warm.
+        It learns online while the board heats through its temperature range.
+      </p>
+
+      <div className="config-pills">
+        {imus.map((imu) => {
+          const state = enableState(imu.enable)
+          return (
+            <span key={imu.i} data-tone={state.tone}>
+              IMU{imu.i}: {state.label}
+              {imu.tmin !== undefined && imu.tmax !== undefined ? ` (${imu.tmin.toFixed(0)}→${imu.tmax.toFixed(0)}°C)` : ''}
+            </span>
+          )
+        })}
+      </div>
+
+      <ol className="calibration-card__steps">
+        <li>
+          <strong>Start cold.</strong> Power the board off and let it cool to ambient — a genuinely cold board is
+          essential; the wider the temperature swing, the better the fit.
+        </li>
+        <li>
+          Click <strong>Prepare thermal calibration</strong> below, then <strong>Apply</strong> in the draft bar. This
+          sets each IMU to <em>learn</em> (<code>INS_TCALn_ENABLE = 2</code>).
+        </li>
+        <li>Reboot the board <strong>cold</strong>, props off, and leave it powered and still — it self-heats through the range.</li>
+        <li>
+          At the top temperature the fit is computed and saved automatically (enable flips back to <em>enabled</em>).
+          Reboot once more to use it.
+        </li>
+      </ol>
+
+      <div className="parameter-follow-up parameter-follow-up--warning">
+        <StatusBadge tone="warning">props off</StatusBadge>
+        <p>
+          Do this on the bench with props removed — the board just needs to sit still and warm up, not fly. Live
+          IMU-temperature progress isn't shown here yet; the firmware completes the fit at the max temperature on its own.
+        </p>
+      </div>
+
+      <button
+        type="button"
+        style={buttonStyle('primary')}
+        disabled={!canStart}
+        data-testid="tcal-start"
+        onClick={startLearning}
+      >
+        {anyLearning ? 'Learning already enabled' : 'Prepare thermal calibration'}
+      </button>
+      {!connected ? (
+        <small>Connect to a vehicle first.</small>
+      ) : !canApplyDraftParameters ? (
+        <small>Finish parameter sync and disarm first.</small>
+      ) : null}
+    </article>
+  )
+}

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -15313,3 +15313,15 @@ button.mavlink-inspector__sent-row {
 .log-tuning__recs-note {
   color: var(--text-dim);
 }
+
+/* TCAL card ordered-step guidance (Calibration tab). */
+.calibration-card__steps {
+  margin: 8px 0;
+  padding-left: 20px;
+  display: grid;
+  gap: 6px;
+  font-size: 0.88em;
+}
+.calibration-card__steps li {
+  line-height: 1.5;
+}

--- a/tests/e2e/views.spec.ts
+++ b/tests/e2e/views.spec.ts
@@ -2704,6 +2704,22 @@ test.describe('ArduPlane demo', () => {
     await expect(page.getByTestId('log-tuning-unusable')).toBeVisible()
   })
 
+  test('Calibration: the Thermal Calibration (TCAL) card is Expert-gated', async ({ page }) => {
+    await page.goto('/')
+    await page.getByTestId('transport-mode-select').selectOption('demo')
+    await page.getByTestId('connect-button').click()
+    await expect(page.getByTestId('session-vehicle-name')).toHaveText('ArduCopter', { timeout: VEHICLE_CONNECT_TIMEOUT })
+
+    // Default (non-Expert): the TCAL card is hidden.
+    await openView(page, 'calibration')
+    await expect(page.getByTestId('calibration-card-tcal')).toHaveCount(0)
+
+    // Expert mode reveals it.
+    await page.getByTestId('product-mode-expert').check()
+    await expect(page.getByTestId('calibration-card-tcal')).toBeVisible()
+    await expect(page.getByTestId('calibration-card-tcal')).toContainText('Thermal calibration')
+  })
+
   test('Plane AutoTune surface renders fixed-wing + VTOL groups with seeded values and stages a draft', async ({ page }) => {
     await page.goto('/')
     await page.getByTestId('transport-mode-select').selectOption('demo-plane')


### PR DESCRIPTION
Adds a **Thermal Calibration** card to the Calibration tab, shown **only in Expert mode**.

- Reads the per-IMU TCAL state from the synced parameters (`INS_TCALn_ENABLE` / `TMIN` / `TMAX`).
- Explains the cold-soak learning process (start cold → learn → reboot cold, props off → firmware self-completes the fit at the top temperature).
- **Prepare thermal calibration** stages `INS_TCALn_ENABLE = 2` (learn) for each present IMU as drafts — applied through the normal verified-write path, never auto-written.
- Falls back to an "n/a" note on builds without `INS_TCALn_*`.

Self-contained card (reads params via the `parameter-read` selector, stages via `setDraft`); `CalibrationSection` gains an `isExpertMode` prop to gate it.

**Follow-up noted in code:** live IMU-temperature progress isn't shown yet (the FC IMU temperature isn't in the telemetry snapshot) — the firmware completes the fit on its own.

## Validation
typecheck clean; e2e covers the Expert gate (hidden by default, visible in Expert); the other calibration e2e still pass.

## ArduCopter invariant
Presentational — stages existing params through the existing draft path; no runtime/write-path change. **ArduCopter byte-identical.**