### PR TITLE
feat(log-tuning): per-axis gyro spectrum charts + tighten limit-cycle band

### DIFF
--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -15325,3 +15325,48 @@ button.mavlink-inspector__sent-row {
 .calibration-card__steps li {
   line-height: 1.5;
 }
+
+/* Log Tuning per-axis gyro spectrum charts. */
+.log-tuning__spectra {
+  display: grid;
+  gap: 8px;
+}
+.log-tuning__spectrum {
+  display: grid;
+  grid-template-columns: 48px 1fr 88px;
+  align-items: center;
+  gap: 10px;
+}
+.log-tuning__spectrum-svg {
+  width: 100%;
+  height: 40px;
+  display: block;
+  border-radius: var(--radius-sm, 6px);
+  background: var(--bg-panel-muted);
+  border: 1px solid rgba(var(--edge-rgb), 0.05);
+}
+.log-tuning__spectrum-area {
+  fill: rgba(var(--accent-rgb, 90, 160, 255), 0.28);
+  stroke: var(--accent, #5aa0ff);
+  stroke-width: 1;
+  vector-effect: non-scaling-stroke;
+}
+.log-tuning__spectrum-peak {
+  stroke: var(--text-dim);
+  stroke-width: 1;
+  stroke-dasharray: 2 2;
+  vector-effect: non-scaling-stroke;
+}
+.log-tuning__spectrum-peak.is-limit-cycle {
+  stroke: var(--warning, #ff6600);
+  stroke-width: 1.5;
+  stroke-dasharray: none;
+}
+.log-tuning__spectrum small {
+  font-family: var(--font-data);
+  font-size: 0.78em;
+  color: var(--text-dim);
+}
+.log-tuning__spectrum-scale {
+  opacity: 0.6;
+}

--- a/apps/web/src/views/LogTuning.tsx
+++ b/apps/web/src/views/LogTuning.tsx
@@ -10,7 +10,7 @@
 
 import { useCallback, useState, type ReactElement } from 'react'
 
-import { analyzeLogBuffer, type LogTuningResult, type TuningRecommendation } from '@arduconfig/log-analysis'
+import { analyzeLogBuffer, type AxisSpectrum, type LogTuningResult, type TuningRecommendation } from '@arduconfig/log-analysis'
 import { StatusBadge, buttonStyle } from '@arduconfig/ui-kit'
 
 export interface LogTuningViewProps {
@@ -107,6 +107,50 @@ export function LogTuningView({ onStageParam, stagedParams }: LogTuningViewProps
   )
 }
 
+function SpectrumChart({ axis }: { axis: AxisSpectrum }): ReactElement | null {
+  const chart = axis.chart
+  if (!chart) {
+    return null
+  }
+  const width = 280
+  const height = 40
+  const n = chart.level.length
+  // Filled area under the spectrum curve.
+  const points = chart.level
+    .map((level, i) => `${((i / Math.max(1, n - 1)) * width).toFixed(1)},${(height - level * (height - 3) - 1).toFixed(1)}`)
+    .join(' ')
+  const peakX = axis.dominant ? (axis.dominant.freqHz / chart.maxFreqHz) * width : undefined
+  const isLimitCycleAxis = axis.dominant && (axis.prominence ?? 0) >= 40 && axis.dominant.freqHz >= 8 && axis.dominant.freqHz < 40
+
+  return (
+    <div className="log-tuning__spectrum" data-testid={`log-tuning-spectrum-${axis.axis}`}>
+      <span className="log-tuning__axis">{axis.axis}</span>
+      <svg
+        className="log-tuning__spectrum-svg"
+        viewBox={`0 0 ${width} ${height}`}
+        preserveAspectRatio="none"
+        role="img"
+        aria-label={`${axis.axis} gyro spectrum`}
+      >
+        <polyline className="log-tuning__spectrum-area" points={`0,${height} ${points} ${width},${height}`} />
+        {peakX !== undefined ? (
+          <line
+            className={`log-tuning__spectrum-peak${isLimitCycleAxis ? ' is-limit-cycle' : ''}`}
+            x1={peakX}
+            y1={0}
+            x2={peakX}
+            y2={height}
+          />
+        ) : null}
+      </svg>
+      <small>
+        {axis.dominant ? `${axis.dominant.freqHz.toFixed(0)} Hz` : '—'}
+        <span className="log-tuning__spectrum-scale"> · 0–{chart.maxFreqHz.toFixed(0)} Hz</span>
+      </small>
+    </div>
+  )
+}
+
 function LogTuningResults({
   result,
   onStageParam,
@@ -172,17 +216,12 @@ function LogTuningResults({
         ) : null}
       </div>
 
-      {result.axisSpectra.some((axis) => axis.dominant) ? (
-        <div className="log-tuning__peaks">
-          <strong>Dominant gyro frequencies</strong>
-          <ul>
-            {result.axisSpectra.map((axis) => (
-              <li key={axis.axis}>
-                <span className="log-tuning__axis">{axis.axis}</span>
-                {axis.dominant ? `${axis.dominant.freqHz.toFixed(0)} Hz` : '—'}
-              </li>
-            ))}
-          </ul>
+      {result.axisSpectra.some((axis) => axis.chart) ? (
+        <div className="log-tuning__spectra" data-testid="log-tuning-spectra">
+          <strong>Gyro spectrum</strong>
+          {result.axisSpectra.map((axis) => (
+            <SpectrumChart key={axis.axis} axis={axis} />
+          ))}
         </div>
       ) : null}
 

--- a/packages/log-analysis/src/notch-tuning-analysis.ts
+++ b/packages/log-analysis/src/notch-tuning-analysis.ts
@@ -29,6 +29,32 @@ export interface AxisSpectrum {
   dominant?: SpectralPeak
   /** Dominant peak power / median band power — how sharply it stands out. */
   prominence?: number
+  /** Compact spectrum for display: per-bin frequency (Hz) + power normalised to
+   *  this axis's max (0..1), downsampled to a fixed bin count over the plot band. */
+  chart?: { freqHz: number[]; level: number[]; maxFreqHz: number }
+}
+
+/** Downsample a spectrum to `bins` display bins over [0, maxFreqHz], taking the
+ *  peak power in each bin (preserves spikes) and normalising to the max. */
+function downsampleSpectrum(
+  spectrum: PowerSpectrum,
+  maxFreqHz: number,
+  bins = 120
+): { freqHz: number[]; level: number[]; maxFreqHz: number } {
+  const freqHz: number[] = new Array(bins)
+  const power: number[] = new Array(bins).fill(0)
+  const step = maxFreqHz / bins
+  for (let b = 0; b < bins; b += 1) {
+    freqHz[b] = b * step + step / 2
+  }
+  for (let i = 0; i < spectrum.freqHz.length; i += 1) {
+    const f = spectrum.freqHz[i]
+    if (f > maxFreqHz) break
+    const b = Math.min(bins - 1, Math.floor(f / step))
+    if (spectrum.power[i] > power[b]) power[b] = spectrum.power[i]
+  }
+  const max = Math.max(...power, 1e-12)
+  return { freqHz, level: power.map((p) => p / max), maxFreqHz }
 }
 
 export interface LogTuningResult {
@@ -60,6 +86,11 @@ const GYRO_AXES: { axis: Axis; batchType: number; imuField: string }[] = [
 // oscillation. Calibrated against real logs — a genuine ~12 Hz limit cycle
 // measured prominence in the thousands (5,000–90,000), while the threshold stays
 // well above ordinary flight motion, so it's caught without false positives.
+// Band for a rate-loop (D-term) limit cycle. The lower bound excludes very-low
+// frequency sharp peaks (5–7 Hz), which are more likely a slow P/attitude
+// oscillation or maneuvering than the classic rate-D buzz — mis-attributing
+// those to rate D would give bad advice.
+const LIMIT_CYCLE_MIN_HZ = 8
 const LIMIT_CYCLE_MAX_HZ = 40
 const LIMIT_CYCLE_MIN_PROMINENCE = 40
 
@@ -284,7 +315,8 @@ export function analyzeLogTuning(log: ParsedDataflashLog): LogTuningResult {
       }
       const med = median(bandPower)
       const prominence = dominant && med > 0 ? dominant.power / med : undefined
-      axisSpectra.push({ axis, peaks, dominant, prominence })
+      const chart = downsampleSpectrum(spec, Math.min(nyquist, 250))
+      axisSpectra.push({ axis, peaks, dominant, prominence, chart })
     }
     // Limit-cycle heuristic: a sharp LOW-frequency peak (below ~40 Hz) that
     // stands far above the broadband floor (high prominence) on any axis — the
@@ -292,7 +324,11 @@ export function analyzeLogTuning(log: ParsedDataflashLog): LogTuningResult {
     // real limit cycle can appear on roll and pitch together. Report the axis
     // where it's sharpest.
     const candidates = axisSpectra.filter(
-      (a) => a.dominant && a.dominant.freqHz < LIMIT_CYCLE_MAX_HZ && (a.prominence ?? 0) >= LIMIT_CYCLE_MIN_PROMINENCE
+      (a) =>
+        a.dominant &&
+        a.dominant.freqHz >= LIMIT_CYCLE_MIN_HZ &&
+        a.dominant.freqHz < LIMIT_CYCLE_MAX_HZ &&
+        (a.prominence ?? 0) >= LIMIT_CYCLE_MIN_PROMINENCE
     )
     if (candidates.length > 0) {
       const sharpest = candidates.reduce((best, a) => ((a.prominence ?? 0) > (best.prominence ?? 0) ? a : best))


### PR DESCRIPTION
Validated the analyzer against a **22-log batch** of real flights, then:

## Visualize the analysis
The result now carries a downsampled per-axis gyro spectrum (120 bins over 0–250 Hz, peak-preserving, normalised), and the Log Tuning view renders a **compact SVG spectrum per axis** with the dominant peak marked — highlighted (orange) when it's a detected limit cycle. You can now *see* the vibration/oscillation, not just read the peak frequency.

## Tighten limit-cycle band → 8–40 Hz
The batch surfaced a couple of very-low-frequency (6 Hz) sharp peaks. A rate-**D** limit cycle wouldn't produce those — they're more likely a slow P/attitude oscillation or maneuvering — so excluding <8 Hz avoids mis-attributing them to rate D. Genuine ~12–23 Hz limit cycles still detect (`log_36` roll@23 Hz, prominence 3331; the earlier 11.8 Hz roll/pitch cases from your own logs).

Result across 24 real logs: flags only clear rate-D limit cycles, no false positives on clean/IMU-only/rangefinder logs.

## Validation
11 unit tests pass; Log Tuning e2e passes; typecheck clean.

**ArduCopter byte-identical** (analysis package + presentational).