### PR TITLE
fix(test): add log-tuning to the tuning-task-cards order assertion

### DIFF
--- a/apps/web/src/view-models/tuning-task-cards.test.ts
+++ b/apps/web/src/view-models/tuning-task-cards.test.ts
@@ -32,7 +32,8 @@ describe('buildTuningTaskCards', () => {
       'filters',
       'autotune',
       'profiles',
-      'review'
+      'review',
+      'log-tuning'
     ])
   })
 


### PR DESCRIPTION
The Log Tuning sub-tab (#77) added a `log-tuning` card but this vitest order test still expected the old six-card list, so CI went red. `npm run test` runs node tests only (not vitest), so it slipped through locally — caught by CI. Fixed; full web vitest suite green (542 tests).