### PR TITLE
fix(build): alias @arduconfig/log-analysis in vite (unbreaks CI/deploy)

### DIFF
--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -63,6 +63,7 @@ export default defineConfig({
       '@arduconfig/protocol-mavlink': fileURLToPath(new URL('packages/protocol-mavlink/src/index.ts', root)),
       '@arduconfig/ardupilot-core': fileURLToPath(new URL('packages/ardupilot-core/src/index.ts', root)),
       '@arduconfig/param-metadata': fileURLToPath(new URL('packages/param-metadata/src/index.ts', root)),
+      '@arduconfig/log-analysis': fileURLToPath(new URL('packages/log-analysis/src/index.ts', root)),
       '@arduconfig/ui-kit': fileURLToPath(new URL('packages/ui-kit/src/index.tsx', root))
     }
   },


### PR DESCRIPTION
The web build aliases every `@arduconfig/*` workspace package to its `src/` entry, and CI runs `vite build` directly (no dist pre-built). Log Tuning (#77) imported `@arduconfig/log-analysis` but it was never added to the alias map, so vite fell back to `node_modules → dist/index.js` (absent on a fresh checkout) → **`Rolldown failed to resolve import`**. This failed every web build — and every deploy — since #77, so **Log Tuning + TCAL never actually reached prod.** Adds the alias; verified by building web with the dist deleted.