### PR TITLE
fix(log-tuning): surface high-vibration as an advisory (don't call a bad log "clean")

### DIFF
--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -15370,3 +15370,8 @@ button.mavlink-inspector__sent-row {
 .log-tuning__spectrum-scale {
   opacity: 0.6;
 }
+
+.log-tuning__advisories {
+  display: grid;
+  gap: 8px;
+}

--- a/apps/web/src/views/LogTuning.tsx
+++ b/apps/web/src/views/LogTuning.tsx
@@ -216,6 +216,17 @@ function LogTuningResults({
         ) : null}
       </div>
 
+      {result.advisories.length > 0 ? (
+        <div className="log-tuning__advisories" data-testid="log-tuning-advisories">
+          {result.advisories.map((advisory) => (
+            <div key={advisory} className="parameter-follow-up parameter-follow-up--warning">
+              <StatusBadge tone="warning">action needed</StatusBadge>
+              <p>{advisory}</p>
+            </div>
+          ))}
+        </div>
+      ) : null}
+
       {result.axisSpectra.some((axis) => axis.chart) ? (
         <div className="log-tuning__spectra" data-testid="log-tuning-spectra">
           <strong>Gyro spectrum</strong>
@@ -268,7 +279,11 @@ function LogTuningResults({
           </small>
         </div>
       ) : result.usable ? (
-        <p className="bf-note" data-testid="log-tuning-no-recs">No parameter changes recommended — the tune looks clean.</p>
+        <p className="bf-note" data-testid="log-tuning-no-recs">
+          {result.advisories.length > 0
+            ? 'No parameter changes to stage — address the finding above first.'
+            : 'No parameter changes recommended — the tune looks clean.'}
+        </p>
       ) : null}
     </div>
   )

--- a/packages/log-analysis/src/notch-tuning-analysis.ts
+++ b/packages/log-analysis/src/notch-tuning-analysis.ts
@@ -72,6 +72,10 @@ export interface LogTuningResult {
   /** A sharp single-axis low-frequency peak that reads as a rate-loop limit cycle. */
   limitCycle?: { axis: Axis; freqHz: number }
   recommendations: TuningRecommendation[]
+  /** Non-parameter findings the operator should act on (e.g. high vibration is a
+   *  mechanical fix, not a PID change) — surfaced even when there are no param
+   *  recommendations so a bad log is never called "clean". */
+  advisories: string[]
   summary: string
 }
 
@@ -393,6 +397,26 @@ export function analyzeLogTuning(log: ParsedDataflashLog): LogTuningResult {
     }
   }
 
+  // ---- Advisories (non-parameter findings the operator should act on) ----
+  const advisories: string[] = []
+  if (vibe && vibe.verdict !== 'good') {
+    const peak = Math.max(...vibe.max)
+    const clip = Math.max(...vibe.clip)
+    if (clip > 0) {
+      advisories.push(
+        `IMU clipping detected (${clip}) — the accelerometer is saturating, which corrupts the state estimate and makes any tuning unreliable. Fix this mechanically first: balance or replace props, check motor bearings, and secure or re-damp the flight-controller mount.`
+      )
+    } else if (vibe.verdict === 'bad') {
+      advisories.push(
+        `High vibration (peak ${peak.toFixed(0)} m/s²) — this is a mechanical problem, not a PID fix. Balance props, check motor and frame mounts, and the FC soft-mount. High vibration also makes the harmonic-notch and rate-tuning advice below less reliable.`
+      )
+    } else {
+      advisories.push(
+        `Moderate vibration (peak ${peak.toFixed(0)} m/s²) — not critical, but worth reducing (prop balance, mounts) for a cleaner tune and spectrum.`
+      )
+    }
+  }
+
   // ---- Summary ----
   const summaryParts: string[] = []
   if (source === 'batch') summaryParts.push(`Gyro spectrum from the batch sampler (~${gyro?.sampleRateHz.toFixed(0)} Hz).`)
@@ -400,7 +424,15 @@ export function analyzeLogTuning(log: ParsedDataflashLog): LogTuningResult {
   if (vibe) summaryParts.push(`Vibration ${vibe.verdict} (peak ${Math.max(...vibe.max).toFixed(0)} m/s², clip ${Math.max(...vibe.clip)}).`)
   if (limitCycle) summaryParts.push(`Likely ${limitCycle.freqHz.toFixed(0)} Hz ${limitCycle.axis}-axis limit cycle.`)
   if (motorFundamentalHz) summaryParts.push(`Motor fundamental ~${motorFundamentalHz.toFixed(0)} Hz.`)
-  if (recommendations.length === 0 && usable) summaryParts.push('No parameter changes recommended — the tune looks clean.')
+  if (recommendations.length === 0 && usable) {
+    // Don't call a high-vibration log "clean" just because there's no param to
+    // stage — the vibration advisory is the actionable finding.
+    summaryParts.push(
+      vibe && vibe.verdict !== 'good'
+        ? 'No parameter changes to stage — the priority here is the vibration above (a mechanical fix), not PID.'
+        : 'No parameter changes recommended — the tune looks clean.'
+    )
+  }
 
   return {
     usable,
@@ -413,6 +445,7 @@ export function analyzeLogTuning(log: ParsedDataflashLog): LogTuningResult {
     vibe,
     limitCycle,
     recommendations,
+    advisories,
     summary: summaryParts.join(' ')
   }
 }

--- a/tests/log-analysis-notch-tuning.test.mjs
+++ b/tests/log-analysis-notch-tuning.test.mjs
@@ -102,3 +102,25 @@ test('vibration verdict is good for low VIBE with no clipping', () => {
   assert.ok(result.vibe)
   assert.equal(result.vibe.verdict, 'good')
 })
+
+test('high vibration produces a mechanical advisory and is NOT called "clean"', () => {
+  // No oscillation + notch already on => zero parameter recommendations, but
+  // high VIBE must still surface as an advisory (the reported real-log bug).
+  const log = makeLog({ oscAmp: 0, hntchEnable: 1 })
+  log.messagesByType.set('VIBE', Array.from({ length: 50 }, () => ({ name: 'VIBE', VibeX: 40, VibeY: 10, VibeZ: 10, Clip: 0 })))
+  const r = analyzeLogTuning(log)
+
+  assert.equal(r.vibe.verdict, 'bad')
+  assert.equal(r.recommendations.length, 0, 'no param changes for a purely mechanical vibration problem')
+  assert.ok(r.advisories.length >= 1, 'expected a vibration advisory')
+  assert.match(r.advisories[0], /vibration/i)
+  assert.doesNotMatch(r.summary, /looks clean/i)
+})
+
+test('IMU clipping produces a clipping-specific advisory', () => {
+  const log = makeLog({ oscAmp: 0, hntchEnable: 1 })
+  log.messagesByType.set('VIBE', Array.from({ length: 50 }, () => ({ name: 'VIBE', VibeX: 25, VibeY: 10, VibeZ: 10, Clip: 9 })))
+  const r = analyzeLogTuning(log)
+  assert.equal(r.vibe.verdict, 'bad')
+  assert.match(r.advisories[0], /clipping/i)
+})


### PR DESCRIPTION
**Reported from a real log:** the analyzer showed *"Vibration bad (peak 35 m/s²)"* then *"No parameter changes recommended — the tune looks clean."* Contradictory — high vibration is **mechanical** (props/mounts/soft-mount) with no param to auto-stage, so it produced no recommendation and got mislabeled clean.

- Adds a non-parameter **`advisories`** list: marginal/bad vibration → actionable mechanical guidance, with a distinct **clipping** message when the accelerometer saturates.
- Summary + no-recs line no longer say "clean" when vibration is bad — they point at the advisory as the priority.
- The Log Tuning view renders advisories prominently (warning card) above the spectrum.

Validated on your real **T25 logs**: torture-test (peak 35, clip 0) → high-vibration advisory; alt-jumps (peak 41, clip 9) → clipping advisory. 2 new unit tests; web vitest (542) + dist-less build green. **ArduCopter byte-identical.**