### PR TITLE
fix(log-tuning): per-axis limit-cycle handling + coupling advisory

### DIFF
--- a/packages/log-analysis/src/notch-tuning-analysis.ts
+++ b/packages/log-analysis/src/notch-tuning-analysis.ts
@@ -98,6 +98,14 @@ const LIMIT_CYCLE_MIN_HZ = 8
 const LIMIT_CYCLE_MAX_HZ = 40
 const LIMIT_CYCLE_MIN_PROMINENCE = 40
 
+// Rate D at/below this is already at (or near) the ArduCopter default
+// (ATC_RAT_*_D ≈ 0.0036). An axis that still oscillates at a limit-cycle
+// frequency while its D is already this low is unlikely to be a D-term problem
+// on that axis — it's far more likely coupling from the primary (sharpest) axis,
+// or a mechanical / gyro-filter issue. Pushing D below the default in that case
+// just makes the axis mushy, so we advise instead of recommending a cut.
+const D_REDUCE_FLOOR = 0.005
+
 function median(values: number[]): number {
   if (values.length === 0) return 0
   const sorted = values.slice().sort((a, b) => a - b)
@@ -301,6 +309,12 @@ export function analyzeLogTuning(log: ParsedDataflashLog): LogTuningResult {
 
   const axisSpectra: AxisSpectrum[] = []
   let limitCycle: LogTuningResult['limitCycle']
+  // Every axis that carries the same limit-cycle-band oscillation, sharpest
+  // first. A real limit cycle commonly shows on more than one axis at the SAME
+  // frequency (roll/pitch share a tune, and one axis's oscillation couples into
+  // the other), so we keep the full set — not just the single sharpest axis —
+  // to drive per-axis recommendations vs. coupling advisories below.
+  let affectedAxes: { axis: Axis; freqHz: number; prominence: number }[] = []
   if (gyro) {
     const nyquist = gyro.sampleRateHz / 2
     for (const { axis } of GYRO_AXES) {
@@ -327,16 +341,18 @@ export function analyzeLogTuning(log: ParsedDataflashLog): LogTuningResult {
     // rate-loop oscillation signature. Cross-axis dominance is NOT required: a
     // real limit cycle can appear on roll and pitch together. Report the axis
     // where it's sharpest.
-    const candidates = axisSpectra.filter(
-      (a) =>
-        a.dominant &&
-        a.dominant.freqHz >= LIMIT_CYCLE_MIN_HZ &&
-        a.dominant.freqHz < LIMIT_CYCLE_MAX_HZ &&
-        (a.prominence ?? 0) >= LIMIT_CYCLE_MIN_PROMINENCE
-    )
-    if (candidates.length > 0) {
-      const sharpest = candidates.reduce((best, a) => ((a.prominence ?? 0) > (best.prominence ?? 0) ? a : best))
-      limitCycle = { axis: sharpest.axis, freqHz: sharpest.dominant!.freqHz }
+    affectedAxes = axisSpectra
+      .filter(
+        (a) =>
+          a.dominant &&
+          a.dominant.freqHz >= LIMIT_CYCLE_MIN_HZ &&
+          a.dominant.freqHz < LIMIT_CYCLE_MAX_HZ &&
+          (a.prominence ?? 0) >= LIMIT_CYCLE_MIN_PROMINENCE
+      )
+      .map((a) => ({ axis: a.axis, freqHz: a.dominant!.freqHz, prominence: a.prominence ?? 0 }))
+      .sort((x, y) => y.prominence - x.prominence)
+    if (affectedAxes.length > 0) {
+      limitCycle = { axis: affectedAxes[0].axis, freqHz: affectedAxes[0].freqHz }
     }
   } else {
     gateWarnings.push('No usable gyro data (neither ISBD batch nor IMU) — cannot analyse vibration or oscillation.')
@@ -358,6 +374,9 @@ export function analyzeLogTuning(log: ParsedDataflashLog): LogTuningResult {
 
   // ---- Recommendations (advisory; staged for human approval) ----
   const recommendations: TuningRecommendation[] = []
+  // Non-parameter findings the operator should act on (mechanical/coupling), built
+  // alongside the recommendations so the rate-loop block can add coupling notes.
+  const advisories: string[] = []
 
   // Harmonic notch, driven by motor RPM (ESC telemetry present).
   if (esc && motorFundamentalHz) {
@@ -382,23 +401,49 @@ export function analyzeLogTuning(log: ParsedDataflashLog): LogTuningResult {
     // low floor. The default floor works with ESC-telemetry tracking; leave it.
   }
 
-  // Rate-loop limit cycle → lower that axis's rate D.
-  if (limitCycle) {
-    const dParam = `ATC_RAT_${limitCycle.axis === 'roll' ? 'RLL' : limitCycle.axis === 'pitch' ? 'PIT' : 'YAW'}_D`
-    const current = params.get(dParam)
-    if (current !== undefined && current > 0.001) {
-      recommendations.push({
-        param: dParam,
-        currentValue: current,
-        suggestedValue: Number((current / 2).toFixed(4)),
-        reason: `A sharp ~${limitCycle.freqHz.toFixed(0)} Hz oscillation dominates the ${limitCycle.axis} axis and not the others — the classic rate-loop limit cycle. Halve ${limitCycle.axis} rate D and re-fly.`,
-        confidence: 'medium'
-      })
+  // Rate-loop limit cycle → lower rate D on each oscillating axis. A real limit
+  // cycle often shows on more than one axis at the same frequency, so we act per
+  // axis: halve D where it's still meaningfully high, but for an axis already at
+  // or below the default floor, don't push D lower — that reads as coupling from
+  // the primary axis (or mechanical), so surface an advisory instead.
+  if (affectedAxes.length > 0) {
+    const primary = affectedAxes[0]
+    const alsoAxes = affectedAxes.slice(1).map((a) => a.axis)
+    for (const affected of affectedAxes) {
+      const code = affected.axis === 'roll' ? 'RLL' : affected.axis === 'pitch' ? 'PIT' : 'YAW'
+      const dParam = `ATC_RAT_${code}_D`
+      const current = params.get(dParam)
+      if (current === undefined || current <= 0.0001) {
+        continue // e.g. yaw D is usually 0 — nothing to lower
+      }
+      if (current > D_REDUCE_FLOOR) {
+        const alsoNote =
+          affected.axis === primary.axis && alsoAxes.length > 0
+            ? ` It also appears on ${alsoAxes.join(' and ')} at the same frequency (a shared-tune / coupled oscillation).`
+            : ''
+        recommendations.push({
+          param: dParam,
+          currentValue: current,
+          suggestedValue: Number((current / 2).toFixed(4)),
+          reason: `A sharp ~${affected.freqHz.toFixed(0)} Hz oscillation stands far above the noise floor on the ${affected.axis} axis — the classic rate-loop limit cycle.${alsoNote} Halve ${affected.axis} rate D and re-fly.`,
+          confidence: affected.axis === primary.axis ? 'medium' : 'low'
+        })
+      } else if (affected.axis !== primary.axis) {
+        // Already-low D on a secondary axis → coupling from the primary axis.
+        advisories.push(
+          `The ~${affected.freqHz.toFixed(0)} Hz oscillation also shows on the ${affected.axis} axis, but its rate D (${Number(current.toFixed(4))}) is already at/near default — pushing it lower is unlikely to help. This is most likely coupling from the ${primary.axis} axis (or a mechanical / gyro-filter issue); reduce ${primary.axis} rate D first and re-fly.`
+        )
+      } else {
+        // The sharpest axis itself is already at/near default D yet still
+        // oscillating — a D cut won't fix it; point at the real causes.
+        advisories.push(
+          `A ~${affected.freqHz.toFixed(0)} Hz oscillation dominates the ${affected.axis} axis, but its rate D (${Number(current.toFixed(4))}) is already at/near default — this isn't a D-term problem. Look at gyro filtering (INS_GYRO_FILTER), the harmonic notch, or a mechanical cause (loose FC mount, prop/motor balance).`
+        )
+      }
     }
   }
 
   // ---- Advisories (non-parameter findings the operator should act on) ----
-  const advisories: string[] = []
   if (vibe && vibe.verdict !== 'good') {
     const peak = Math.max(...vibe.max)
     const clip = Math.max(...vibe.clip)
@@ -425,11 +470,12 @@ export function analyzeLogTuning(log: ParsedDataflashLog): LogTuningResult {
   if (limitCycle) summaryParts.push(`Likely ${limitCycle.freqHz.toFixed(0)} Hz ${limitCycle.axis}-axis limit cycle.`)
   if (motorFundamentalHz) summaryParts.push(`Motor fundamental ~${motorFundamentalHz.toFixed(0)} Hz.`)
   if (recommendations.length === 0 && usable) {
-    // Don't call a high-vibration log "clean" just because there's no param to
-    // stage — the vibration advisory is the actionable finding.
+    // Don't call a log "clean" just because there's no param to stage — an
+    // advisory (high vibration, or a limit cycle whose axis is already at
+    // default D) is the actionable finding.
     summaryParts.push(
-      vibe && vibe.verdict !== 'good'
-        ? 'No parameter changes to stage — the priority here is the vibration above (a mechanical fix), not PID.'
+      advisories.length > 0
+        ? 'No parameter changes to stage — the priority here is the finding above, not a PID change.'
         : 'No parameter changes recommended — the tune looks clean.'
     )
   }

--- a/tests/log-analysis-notch-tuning.test.mjs
+++ b/tests/log-analysis-notch-tuning.test.mjs
@@ -9,7 +9,17 @@ import { analyzeLogTuning } from '../packages/log-analysis/dist/index.js'
 // rate-D. The binary parser is tested separately, so we build the parsed
 // structure directly to isolate the analysis logic.
 
-function makeLog({ oscHz = 12, oscAmp = 500, sampleRate = 1000, rpm = 6000, rllD = 0.01, hntchEnable = 0 } = {}) {
+function makeLog({
+  oscHz = 12,
+  oscAmp = 500,
+  pitchOscHz = 7,
+  pitchOscAmp = 8,
+  sampleRate = 1000,
+  rpm = 6000,
+  rllD = 0.01,
+  pitD = 0.008,
+  hntchEnable = 0
+} = {}) {
   const messagesByType = new Map()
 
   // --- Gyro batch sampler (ISBH header + ISBD data) ---
@@ -23,9 +33,10 @@ function makeLog({ oscHz = 12, oscAmp = 500, sampleRate = 1000, rpm = 6000, rllD
     const y = []
     const z = []
     for (let k = 0; k < perRecord; k += 1) {
-      // Roll (x): strong 12 Hz sine. Pitch/yaw: tiny noise only.
+      // Roll (x) + pitch (y): configurable sines (defaults: strong roll, tiny
+      // sub-band pitch). Yaw (z): tiny noise only.
       x.push(Math.round(oscAmp * Math.sin((2 * Math.PI * oscHz * idx) / sampleRate)))
-      y.push(Math.round(8 * Math.sin((2 * Math.PI * 7 * idx) / sampleRate)))
+      y.push(Math.round(pitchOscAmp * Math.sin((2 * Math.PI * pitchOscHz * idx) / sampleRate)))
       z.push(Math.round(4 * Math.sin((2 * Math.PI * 5 * idx) / sampleRate)))
       idx += 1
     }
@@ -50,7 +61,7 @@ function makeLog({ oscHz = 12, oscAmp = 500, sampleRate = 1000, rpm = 6000, rllD
   // --- Params captured in the log ---
   messagesByType.set('PARM', [
     { name: 'PARM', Name: 'ATC_RAT_RLL_D', Value: rllD },
-    { name: 'PARM', Name: 'ATC_RAT_PIT_D', Value: 0.008 },
+    { name: 'PARM', Name: 'ATC_RAT_PIT_D', Value: pitD },
     { name: 'PARM', Name: 'INS_HNTCH_ENABLE', Value: hntchEnable }
   ])
 
@@ -72,6 +83,37 @@ test('detects a single-axis roll limit cycle and recommends halving roll rate-D'
   assert.ok(dRec, 'expected a roll rate-D recommendation')
   assert.ok(Math.abs(dRec.suggestedValue - 0.005) < 1e-6, `suggested ${dRec.suggestedValue}`)
   assert.equal(dRec.currentValue, 0.01)
+})
+
+test('a limit cycle on two axes with both rate-D high recommends halving BOTH', () => {
+  // Same 12 Hz oscillation strong on roll AND pitch, both D above the floor.
+  const result = analyzeLogTuning(
+    makeLog({ oscHz: 12, oscAmp: 500, pitchOscHz: 12, pitchOscAmp: 500, rllD: 0.01, pitD: 0.008 })
+  )
+  const rll = result.recommendations.find((r) => r.param === 'ATC_RAT_RLL_D')
+  const pit = result.recommendations.find((r) => r.param === 'ATC_RAT_PIT_D')
+  assert.ok(rll, 'expected a roll rate-D recommendation')
+  assert.ok(pit, 'expected a pitch rate-D recommendation')
+  assert.ok(Math.abs(rll.suggestedValue - 0.005) < 1e-6, `roll suggested ${rll.suggestedValue}`)
+  assert.ok(Math.abs(pit.suggestedValue - 0.004) < 1e-6, `pitch suggested ${pit.suggestedValue}`)
+})
+
+test('a secondary axis already at default D yields a coupling advisory, not a D cut', () => {
+  // This mirrors the real vibration log: pitch is the sharp/primary oscillator
+  // with high D, roll carries the same frequency but is already at default D.
+  const result = analyzeLogTuning(
+    makeLog({ oscHz: 12, oscAmp: 200, pitchOscHz: 12, pitchOscAmp: 500, rllD: 0.004, pitD: 0.008 })
+  )
+  // Pitch (primary, high D) → halve; roll (secondary, already low D) → no cut.
+  const pit = result.recommendations.find((r) => r.param === 'ATC_RAT_PIT_D')
+  assert.ok(pit && Math.abs(pit.suggestedValue - 0.004) < 1e-6, 'pitch D halved')
+  assert.ok(!result.recommendations.some((r) => r.param === 'ATC_RAT_RLL_D'), 'roll D not cut further')
+  assert.ok(
+    result.advisories.some((a) => /roll/i.test(a) && /coupling/i.test(a)),
+    'expected a roll coupling advisory'
+  )
+  // The primary rec should note the coupled axis.
+  assert.match(pit.reason, /also appears on roll/i)
 })
 
 test('recommends enabling the ESC-telemetry harmonic notch when RPM is present and it is off', () => {


### PR DESCRIPTION
## What

The rate-loop limit-cycle detector only ever acted on the **single sharpest axis** — silently ignoring other axes carrying the *same* oscillation, and printing "dominates the *<axis>* and not the others", which is factually wrong when the oscillation spans roll and pitch together (as it does on the real vibration log diagnosed this session).

Now it handles the oscillation **per axis**:
- Halve rate D on each affected axis whose D is still meaningfully above the ArduCopter default floor (`0.005`).
- For an affected axis already at/near default D, **don't** push D lower — that reads as coupling from the primary (sharpest) axis, or a mechanical / gyro-filter issue. Surface it as an **advisory** instead.
- Accurate multi-axis reason text; the summary no longer calls a log "clean" when a limit-cycle advisory is the actionable finding.

## Why

On the real 2012 Hz batch-sampled hover log, the 12 Hz limit cycle sits on **both** roll (prominence 6472×) and pitch (91406×). Roll is already at default D (`0.004`) yet still shows the peak → it's coupling from the pitch oscillation, not an independent roll-D problem. The old code's single-axis pick happened to give the right *param* here, but for the wrong stated reason and with no generalization. This change:
- keeps the correct `ATC_RAT_PIT_D=0.0038` recommendation,
- adds an advisory explaining roll is coupling (matching the manual on-hardware fix, which left roll at 0.004),
- generalizes correctly to the case where two axes both have high D (both get recommended).

## Validation

- Rung 1 (unit): `tests/log-analysis-notch-tuning.test.mjs` — added multi-axis-both-high and secondary-axis-coupling-advisory cases; 9/9 pass.
- Real logs: validated against the session's batch-sampled hover logs (correct pitch-D rec + roll coupling advisory; no false positives on IMU-only / clean logs).
- Full suite: 737 node / 542 vitest / typecheck / e2e 214 passed, 6 skipped.

## ArduCopter byte-identical

Analysis-only (`@arduconfig/log-analysis`) — no runtime, transport, or write-path changes.