### PR TITLE
feat(valt): log-based baro thrust-scale (VALT) calibration, Expert + rangefinder gated

### DIFF
--- a/apps/web/src/sections/CalibrationSection.tsx
+++ b/apps/web/src/sections/CalibrationSection.tsx
@@ -11,6 +11,7 @@ import { Panel, StatusBadge, buttonStyle } from '@arduconfig/ui-kit'
 import { AccelerometerPoseGuide } from '../accelerometer-pose-guide'
 import { CalibrationLocationButton } from './CalibrationLocationCard'
 import { TcalCalibrationCard } from './TcalCalibrationCard'
+import { ValtCalibrationCard } from './ValtCalibrationCard'
 import {
   accelerometerPoseFromAction,
   guidedActionBlockingReason,
@@ -690,6 +691,19 @@ export function CalibrationSection(props: CalibrationSectionProps): ReactElement
               {/* Thermal calibration (TCAL) — Expert-only advanced surface. */}
               {isExpertMode ? (
                 <TcalCalibrationCard
+                  snapshot={snapshot}
+                  canApplyDraftParameters={canApplyDraftParameters}
+                  busyAction={busyAction}
+                  setDraft={setDraft}
+                />
+              ) : null}
+
+              {/* Baro thrust calibration (VALT) — Expert-only, and only when a
+                * downward rangefinder is configured on the connected vehicle
+                * (RNGFND1_TYPE > 0). It's a log-based calibration; the card
+                * itself handles the .bin upload and the fit. */}
+              {isExpertMode && (readRoundedParameter(snapshot, 'RNGFND1_TYPE') ?? 0) > 0 ? (
+                <ValtCalibrationCard
                   snapshot={snapshot}
                   canApplyDraftParameters={canApplyDraftParameters}
                   busyAction={busyAction}

--- a/apps/web/src/sections/ValtCalibrationCard.tsx
+++ b/apps/web/src/sections/ValtCalibrationCard.tsx
@@ -1,0 +1,183 @@
+// Baro thrust-compensation (VALT) calibration card for the Calibration tab —
+// Expert-gated, and shown only when a rangefinder is detected on the connected
+// vehicle (CalibrationSection does that gating).
+//
+// A multirotor's prop wash lowers static pressure over the barometer as throttle
+// rises, so the baro reads high under load. ArduPilot corrects this with
+// BARO1_THST_SCALE (Pascals subtracted per unit throttle). We can't measure this
+// live on the bench — it needs a real hover — so this is a LOG-based calibration:
+// fly a steady hover (ideally at 2–3 heights) with a downward rangefinder, then
+// upload that .bin here. The analyzer (@arduconfig/log-analysis) fits the scale
+// from CTUN throttle/baro-altitude vs the rangefinder ground truth and stages
+// BARO1_THST_SCALE as a draft for the normal verified-write path.
+
+import { useCallback, useState, type ReactElement } from 'react'
+
+import { analyzeValtBuffer, type ValtResult } from '@arduconfig/log-analysis'
+import type { ConfiguratorSnapshot } from '@arduconfig/ardupilot-core'
+import { StatusBadge, buttonStyle } from '@arduconfig/ui-kit'
+
+import { readParameterValue } from '../selectors/parameter-read'
+
+export interface ValtCalibrationCardProps {
+  snapshot: ConfiguratorSnapshot
+  canApplyDraftParameters: boolean
+  busyAction: string | undefined
+  setDraft: (paramId: string, value: string) => void
+}
+
+export function ValtCalibrationCard({
+  snapshot,
+  canApplyDraftParameters,
+  busyAction,
+  setDraft
+}: ValtCalibrationCardProps): ReactElement {
+  const [result, setResult] = useState<ValtResult | null>(null)
+  const [filename, setFilename] = useState<string | undefined>()
+  const [error, setError] = useState<string | undefined>()
+  const [busy, setBusy] = useState(false)
+  const [staged, setStaged] = useState(false)
+
+  const currentScale = readParameterValue(snapshot, 'BARO1_THST_SCALE')
+
+  const handleFile = useCallback(async (file: File) => {
+    setBusy(true)
+    setError(undefined)
+    setResult(null)
+    setStaged(false)
+    try {
+      const buffer = await file.arrayBuffer()
+      await new Promise((resolve) => setTimeout(resolve, 0))
+      const analysis = analyzeValtBuffer(buffer)
+      setResult(analysis)
+      setFilename(file.name)
+    } catch (caught) {
+      setError(caught instanceof Error ? caught.message : 'Could not read or parse that log.')
+    } finally {
+      setBusy(false)
+    }
+  }, [])
+
+  // BARO1_THST_SCALE is compiled out on some builds (AP_BARO_THST_COMP_ENABLED).
+  // If the synced params don't include it, the firmware can't apply a scale.
+  if (currentScale === undefined) {
+    return (
+      <article className="calibration-card" data-testid="calibration-card-valt">
+        <div className="calibration-card__header">
+          <strong>Baro thrust calibration (VALT)</strong>
+          <StatusBadge tone="neutral">n/a</StatusBadge>
+        </div>
+        <p>
+          This firmware doesn't expose the baro thrust-compensation parameter (<code>BARO1_THST_SCALE</code>). It's
+          available on builds with barometer thrust compensation compiled in.
+        </p>
+      </article>
+    )
+  }
+
+  const canStage = canApplyDraftParameters && busyAction === undefined
+  const suggested = result?.suggestedScale
+
+  return (
+    <article className="calibration-card" data-testid="calibration-card-valt">
+      <div className="calibration-card__header">
+        <strong>Baro thrust calibration (VALT)</strong>
+        <StatusBadge tone="neutral">{`now ${Number(currentScale.toFixed(1))} Pa`}</StatusBadge>
+      </div>
+      <p>
+        Corrects the barometer altitude error that prop wash induces under throttle
+        (<code>BARO1_THST_SCALE</code>). This is measured from a flight log — upload a steady hover flown with a
+        downward rangefinder and the scale is fit from baro altitude vs the rangefinder ground truth.
+      </p>
+
+      <div className="log-tuning__upload">
+        <label className="log-tuning__file" style={buttonStyle('primary')}>
+          {busy ? 'Analyzing…' : 'Choose hover log (.bin)'}
+          <input
+            type="file"
+            accept=".bin,application/octet-stream"
+            data-testid="valt-file"
+            style={{ display: 'none' }}
+            disabled={busy}
+            onChange={(event) => {
+              const file = event.target.files?.[0]
+              if (file) void handleFile(file)
+              event.target.value = ''
+            }}
+          />
+        </label>
+        {filename ? <small className="log-tuning__filename">{filename}</small> : null}
+      </div>
+
+      {error ? (
+        <div className="parameter-follow-up parameter-follow-up--danger" role="alert" data-testid="valt-error">
+          <StatusBadge tone="danger">error</StatusBadge>
+          <p>{error}</p>
+        </div>
+      ) : null}
+
+      {result ? (
+        <div data-testid="valt-results">
+          {result.warnings.length > 0 ? (
+            <ul className="log-tuning__warnings" data-testid="valt-warnings">
+              {result.warnings.map((w) => (
+                <li key={w}>{w}</li>
+              ))}
+            </ul>
+          ) : null}
+
+          <p className="log-tuning__summary" data-testid="valt-summary">
+            {result.summary}
+          </p>
+
+          {result.points.length > 0 ? (
+            <div className="config-pills" data-testid="valt-points">
+              {result.points.map((p, i) => (
+                <span key={i}>
+                  {(p.throttle * 100).toFixed(0)}% · err {p.errorM >= 0 ? '+' : ''}
+                  {p.errorM.toFixed(2)} m
+                </span>
+              ))}
+            </div>
+          ) : null}
+
+          {result.usable && suggested !== undefined ? (
+            <>
+              <div className="config-pills">
+                <span>Current: {Number(currentScale.toFixed(1))} Pa</span>
+                <span data-tone="success">Suggested: {suggested} Pa</span>
+              </div>
+              <button
+                type="button"
+                style={buttonStyle(staged ? 'secondary' : 'primary')}
+                data-testid="valt-stage"
+                disabled={!canStage || staged}
+                onClick={() => {
+                  setDraft('BARO1_THST_SCALE', String(suggested))
+                  setStaged(true)
+                }}
+              >
+                {staged ? 'Staged' : `Stage BARO1_THST_SCALE = ${suggested} Pa`}
+              </button>
+              {!canApplyDraftParameters ? <small>Finish parameter sync and disarm to stage.</small> : null}
+              <small className="log-tuning__recs-note">
+                Staged changes appear in the draft bar — nothing is written to the aircraft until you apply them.
+              </small>
+            </>
+          ) : null}
+        </div>
+      ) : null}
+
+      <details className="calibration-card__howto">
+        <summary>How to calibrate baro thrust scale (VALT, from a log)</summary>
+        <ol>
+          <li>Fit a <strong>downward rangefinder</strong> and confirm it logs (RFND, orientation Down).</li>
+          <li>Hover as steadily as you can at a fixed height in a stable mode, holding throttle constant for several seconds. Repeat at 2–3 different heights for a better fit.</li>
+          <li>Download that flight's <code>.bin</code> log and upload it above.</li>
+          <li>The scale is fit from baro altitude vs the rangefinder ground truth: <code>BARO1_THST_SCALE = −(baro_error_m × 12) / throttle</code>. Review the points, then <em>Stage</em> and apply in the draft bar.</li>
+          <li>Re-fly and re-check that baro altitude holds steadier through throttle changes.</li>
+        </ol>
+      </details>
+    </article>
+  )
+}

--- a/packages/log-analysis/src/index.ts
+++ b/packages/log-analysis/src/index.ts
@@ -27,3 +27,10 @@ export {
   type Axis,
   type Confidence
 } from './notch-tuning-analysis.js'
+
+export {
+  analyzeValtLog,
+  analyzeValtBuffer,
+  type ValtResult,
+  type ValtPoint
+} from './valt-analysis.js'

--- a/packages/log-analysis/src/valt-analysis.ts
+++ b/packages/log-analysis/src/valt-analysis.ts
@@ -1,0 +1,265 @@
+// Log-based VALT (baro thrust-compensation) calibration analysis.
+//
+// A multirotor's props lower the local static pressure over the barometer as
+// throttle rises, so the baro reads a *higher* altitude the harder it works.
+// ArduPilot corrects this linearly: it subtracts `BARO1_THST_SCALE × throttle`
+// (Pascals × normalized-throttle) from the measured pressure. This module fits
+// that scale from a flight log by comparing the baro altitude against a
+// downward rangefinder (the ground-truth height) over steady-hover windows —
+// the same idea as ArduPilot's VALT WebTool, done offline in the browser.
+//
+// Data used (all from the dataflash log, no live connection):
+//   - CTUN.ThO   normalized throttle out (0..1), time-aligned with…
+//   - CTUN.BAlt  barometer-derived altitude (m)
+//   - RFND.Dist  downward rangefinder distance (m) — ground truth, Orient=25,
+//                Stat=4 (Good), instance 0
+//
+// The correction model (from libraries/AP_Baro/AP_Baro.cpp): the FC does
+//   corrected_pressure = measured_pressure − BARO1_THST_SCALE × throttle
+// A positive altitude error (baro reads high) means measured pressure is too
+// low, so the scale is NEGATIVE. In pressure terms, error_Pa = error_m × 12
+// (~12 Pa per metre near sea level), giving per point
+//   BARO1_THST_SCALE = −(error_m × 12) / throttle
+// and, across several steady hover points, a least-squares fit through the
+// origin of error_Pa against throttle.
+
+import { parseDataflashLog, type ParsedDataflashLog, type DataflashMessage } from './dataflash-parser.js'
+
+/** Pascals per metre of altitude near sea level (barometric, ~ -12 Pa/m). */
+const PA_PER_M = 12
+/** Downward rangefinder orientation (ROTATION_PITCH_270) and Good status. */
+const RFND_ORIENT_DOWN = 25
+const RFND_STATUS_GOOD = 4
+/** BARO1_THST_SCALE parameter range (AP_Baro: @Range -300 300, Pascals). */
+const SCALE_MIN = -300
+const SCALE_MAX = 300
+
+// Steady-hover window detection.
+const MIN_THROTTLE = 0.1 // below this it isn't a hover; the fit would divide by ~0
+const THROTTLE_BAND = 0.03 // ±3% throttle to count as "steady"
+const DIST_BAND = 0.25 // ±0.25 m rangefinder height to count as "steady"
+const MIN_WINDOW_S = 2.0 // a steady window must last at least this long
+const MIN_WINDOW_SAMPLES = 10
+const MAX_SAMPLE_GAP_S = 0.5 // a longer gap breaks the window
+const ALIGN_TOLERANCE_S = 0.2 // max time gap to pair a CTUN sample with an RFND sample
+
+export interface ValtPoint {
+  /** Mean normalized throttle over the window (0..1). */
+  throttle: number
+  /** Mean barometer altitude over the window (m). */
+  baroAltM: number
+  /** Mean rangefinder (true) altitude over the window (m). */
+  trueAltM: number
+  /** baroAltM − trueAltM (m) — positive means the baro reads high. */
+  errorM: number
+  /** Number of aligned samples in the window. */
+  samples: number
+  /** Window duration (s). */
+  durationS: number
+}
+
+export interface ValtResult {
+  /** True when a scale could be fit from at least one steady hover window. */
+  usable: boolean
+  /** Reasons the log can't be used, or caveats on the fit. */
+  warnings: string[]
+  /** Steady-hover points the fit was built from. */
+  points: ValtPoint[]
+  /** Fitted BARO1_THST_SCALE (Pascals), clamped to the parameter range. */
+  suggestedScale?: number
+  /** Current BARO1_THST_SCALE from the log's PARM records, if present. */
+  currentScale?: number
+  summary: string
+}
+
+function num(msg: DataflashMessage, field: string): number | undefined {
+  const v = msg[field]
+  return typeof v === 'number' && Number.isFinite(v) ? v : undefined
+}
+
+function mean(values: number[]): number {
+  return values.length === 0 ? 0 : values.reduce((a, b) => a + b, 0) / values.length
+}
+
+interface AlignedSample {
+  t: number
+  throttle: number
+  baroAlt: number
+  trueAlt: number
+}
+
+/** Pair each CTUN (throttle+baro) sample with the nearest-in-time downward
+ *  rangefinder reading, dropping pairs that are too far apart in time. */
+function alignSamples(
+  ctun: { t: number; throttle: number; baroAlt: number }[],
+  rfnd: { t: number; dist: number }[]
+): AlignedSample[] {
+  const aligned: AlignedSample[] = []
+  let j = 0
+  for (const c of ctun) {
+    // Advance the rangefinder pointer to the closest reading at or before c.t,
+    // then compare it with the next one to pick the nearer.
+    while (j + 1 < rfnd.length && rfnd[j + 1].t <= c.t) j += 1
+    let best = rfnd[j]
+    if (j + 1 < rfnd.length && Math.abs(rfnd[j + 1].t - c.t) < Math.abs(best.t - c.t)) {
+      best = rfnd[j + 1]
+    }
+    if (best && Math.abs(best.t - c.t) <= ALIGN_TOLERANCE_S) {
+      aligned.push({ t: c.t, throttle: c.throttle, baroAlt: c.baroAlt, trueAlt: best.dist })
+    }
+  }
+  return aligned
+}
+
+/** Split aligned samples into steady-hover windows (stable throttle + height). */
+function findSteadyWindows(aligned: AlignedSample[]): ValtPoint[] {
+  const points: ValtPoint[] = []
+  let cur: AlignedSample[] = []
+
+  const close = (): void => {
+    if (cur.length < MIN_WINDOW_SAMPLES) return
+    const durationS = cur[cur.length - 1].t - cur[0].t
+    if (durationS < MIN_WINDOW_S) return
+    const throttle = mean(cur.map((s) => s.throttle))
+    if (throttle < MIN_THROTTLE) return
+    const baroAltM = mean(cur.map((s) => s.baroAlt))
+    const trueAltM = mean(cur.map((s) => s.trueAlt))
+    points.push({
+      throttle,
+      baroAltM,
+      trueAltM,
+      errorM: baroAltM - trueAltM,
+      samples: cur.length,
+      durationS
+    })
+  }
+
+  for (const s of aligned) {
+    if (cur.length === 0) {
+      cur = [s]
+      continue
+    }
+    const meanThr = mean(cur.map((c) => c.throttle))
+    const meanDist = mean(cur.map((c) => c.trueAlt))
+    const withinBand = Math.abs(s.throttle - meanThr) <= THROTTLE_BAND && Math.abs(s.trueAlt - meanDist) <= DIST_BAND
+    const contiguous = s.t - cur[cur.length - 1].t <= MAX_SAMPLE_GAP_S
+    if (withinBand && contiguous) {
+      cur.push(s)
+    } else {
+      close()
+      cur = [s]
+    }
+  }
+  close()
+  return points
+}
+
+/** Fit BARO1_THST_SCALE (Pa) from steady points via least-squares through the
+ *  origin of error_Pa (= error_m × 12) against throttle. */
+function fitScale(points: ValtPoint[]): number | undefined {
+  let sxx = 0
+  let sxy = 0
+  for (const p of points) {
+    const x = p.throttle
+    const y = p.errorM * PA_PER_M
+    sxx += x * x
+    sxy += x * y
+  }
+  if (sxx <= 0) return undefined
+  const slope = sxy / sxx // = -scale
+  const scale = -slope
+  return Math.max(SCALE_MIN, Math.min(SCALE_MAX, Number(scale.toFixed(1))))
+}
+
+/** Analyse a parsed dataflash log for VALT baro thrust-scale calibration. */
+export function analyzeValtLog(log: ParsedDataflashLog): ValtResult {
+  const warnings: string[] = []
+
+  const ctunRaw = log.messagesByType.get('CTUN') ?? []
+  const ctun: { t: number; throttle: number; baroAlt: number }[] = []
+  for (const m of ctunRaw) {
+    const t = num(m, 'TimeUS')
+    const throttle = num(m, 'ThO')
+    // CTUN carries the baro-derived altitude as BAlt; fall back to the BARO
+    // message only if CTUN.BAlt is absent on this firmware.
+    const baroAlt = num(m, 'BAlt')
+    if (t !== undefined && throttle !== undefined && baroAlt !== undefined) {
+      ctun.push({ t: t / 1e6, throttle, baroAlt })
+    }
+  }
+
+  const rfndRaw = log.messagesByType.get('RFND') ?? []
+  const rfnd: { t: number; dist: number }[] = []
+  for (const m of rfndRaw) {
+    const t = num(m, 'TimeUS')
+    const dist = num(m, 'Dist')
+    const orient = num(m, 'Orient')
+    const stat = num(m, 'Stat')
+    const instance = num(m, 'Instance')
+    if (t === undefined || dist === undefined) continue
+    if (instance !== undefined && instance !== 0) continue
+    if (orient !== undefined && orient !== RFND_ORIENT_DOWN) continue
+    if (stat !== undefined && stat !== RFND_STATUS_GOOD) continue
+    rfnd.push({ t: t / 1e6, dist })
+  }
+  rfnd.sort((a, b) => a.t - b.t)
+
+  const params = new Map<string, number>()
+  for (const m of log.messagesByType.get('PARM') ?? []) {
+    if (typeof m.Name === 'string' && typeof m.Value === 'number') params.set(m.Name, m.Value)
+  }
+  const currentScale = params.get('BARO1_THST_SCALE')
+
+  if (ctun.length === 0) {
+    warnings.push('No throttle/altitude data (CTUN) in this log — it needs an actual flight log.')
+  }
+  if (rfnd.length === 0) {
+    warnings.push(
+      'No downward rangefinder data (RFND, Orient=25, status Good) in this log. VALT needs a downward-facing rangefinder logged during the hover for ground truth.'
+    )
+  }
+
+  let points: ValtPoint[] = []
+  if (ctun.length > 0 && rfnd.length > 0) {
+    const aligned = alignSamples(ctun, rfnd)
+    points = findSteadyWindows(aligned)
+    if (points.length === 0) {
+      warnings.push(
+        'No steady hover found — hold a stable throttle at a fixed height for several seconds (ideally at 2–3 different heights).'
+      )
+    } else if (points.length === 1) {
+      warnings.push(
+        'Only one steady hover point — the fit is from a single sample. Fly 2–3 steady heights for a more reliable scale.'
+      )
+    }
+  }
+
+  const suggestedScale = points.length > 0 ? fitScale(points) : undefined
+  const usable = suggestedScale !== undefined
+
+  const summaryParts: string[] = []
+  if (usable) {
+    summaryParts.push(
+      `Fitted BARO1_THST_SCALE = ${suggestedScale} Pa from ${points.length} steady hover ${points.length === 1 ? 'point' : 'points'}.`
+    )
+    if (currentScale !== undefined) summaryParts.push(`Current value is ${Number(currentScale.toFixed(1))} Pa.`)
+    const worst = points.reduce((a, b) => (Math.abs(b.errorM) > Math.abs(a.errorM) ? b : a))
+    summaryParts.push(`Largest baro error ${worst.errorM >= 0 ? '+' : ''}${worst.errorM.toFixed(2)} m at ${(worst.throttle * 100).toFixed(0)}% throttle.`)
+  } else {
+    summaryParts.push('Could not fit a baro thrust scale from this log — see the warnings.')
+  }
+
+  return {
+    usable,
+    warnings,
+    points,
+    suggestedScale,
+    currentScale,
+    summary: summaryParts.join(' ')
+  }
+}
+
+/** Convenience: parse a raw `.bin` buffer and run the VALT analysis. */
+export function analyzeValtBuffer(input: ArrayBuffer | Uint8Array): ValtResult {
+  return analyzeValtLog(parseDataflashLog(input))
+}

--- a/tests/e2e/views.spec.ts
+++ b/tests/e2e/views.spec.ts
@@ -2720,6 +2720,24 @@ test.describe('ArduPlane demo', () => {
     await expect(page.getByTestId('calibration-card-tcal')).toContainText('Thermal calibration')
   })
 
+  test('Calibration: the Baro Thrust (VALT) card is gated on Expert AND a rangefinder', async ({ page }) => {
+    await page.goto('/')
+    await page.getByTestId('transport-mode-select').selectOption('demo')
+    await page.getByTestId('connect-button').click()
+    await expect(page.getByTestId('session-vehicle-name')).toHaveText('ArduCopter', { timeout: VEHICLE_CONNECT_TIMEOUT })
+
+    await openView(page, 'calibration')
+    // Default (non-Expert): hidden.
+    await expect(page.getByTestId('calibration-card-valt')).toHaveCount(0)
+
+    // Expert mode alone is NOT enough — the demo vehicle has no rangefinder
+    // (RNGFND1_TYPE = 0), so the VALT card must still be hidden while the
+    // Expert-only TCAL card is shown.
+    await page.getByTestId('product-mode-expert').check()
+    await expect(page.getByTestId('calibration-card-tcal')).toBeVisible()
+    await expect(page.getByTestId('calibration-card-valt')).toHaveCount(0)
+  })
+
   test('Plane AutoTune surface renders fixed-wing + VTOL groups with seeded values and stages a draft', async ({ page }) => {
     await page.goto('/')
     await page.getByTestId('transport-mode-select').selectOption('demo-plane')

--- a/tests/log-analysis-valt.test.mjs
+++ b/tests/log-analysis-valt.test.mjs
@@ -1,0 +1,108 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { analyzeValtLog } from '../packages/log-analysis/dist/index.js'
+
+// Build a synthetic parsed log with steady-hover windows: CTUN carries throttle
+// (ThO) + baro altitude (BAlt), RFND carries the downward rangefinder ground
+// truth. The baro reads high by `errorM` at throttle `tho`, so the expected
+// BARO1_THST_SCALE = -(errorM * 12) / tho.
+
+const PA_PER_M = 12
+
+function hoverWindow({ startS, durS = 4, hz = 10, tho, trueAlt, baroErr }) {
+  const ctun = []
+  const rfnd = []
+  const n = Math.round(durS * hz)
+  for (let i = 0; i < n; i += 1) {
+    const t = Math.round((startS + i / hz) * 1e6)
+    ctun.push({ name: 'CTUN', TimeUS: t, ThO: tho, BAlt: trueAlt + baroErr })
+    // Rangefinder slightly offset in time to exercise alignment.
+    rfnd.push({ name: 'RFND', TimeUS: t + 5000, Instance: 0, Dist: trueAlt, Stat: 4, Orient: 25 })
+  }
+  return { ctun, rfnd }
+}
+
+function makeValtLog(windows, { currentScale, rfndOverride } = {}) {
+  const ctun = []
+  const rfnd = []
+  for (const w of windows) {
+    ctun.push(...w.ctun)
+    rfnd.push(...w.rfnd)
+  }
+  const messagesByType = new Map()
+  messagesByType.set('CTUN', ctun)
+  messagesByType.set('RFND', rfndOverride ?? rfnd)
+  const parm = []
+  if (currentScale !== undefined) parm.push({ name: 'PARM', Name: 'BARO1_THST_SCALE', Value: currentScale })
+  messagesByType.set('PARM', parm)
+  return { messagesByType, formats: new Map(), counts: new Map(), skippedBytes: 0 }
+}
+
+test('fits BARO1_THST_SCALE from a single steady hover point', () => {
+  // baro reads 0.5 m high at 40% throttle -> scale = -(0.5*12)/0.4 = -15 Pa
+  const log = makeValtLog([hoverWindow({ startS: 10, tho: 0.4, trueAlt: 2, baroErr: 0.5 })])
+  const r = analyzeValtLog(log)
+  assert.equal(r.usable, true)
+  assert.equal(r.points.length, 1)
+  assert.ok(Math.abs(r.suggestedScale - -15) < 0.6, `scale ${r.suggestedScale}`)
+  assert.ok(r.warnings.some((w) => /single/i.test(w)), 'single-point caveat')
+})
+
+test('least-squares fit through the origin across multiple hover points', () => {
+  // Consistent -20 Pa scale: errorM = -scale*tho/12 = 20*tho/12.
+  const scale = -20
+  const mk = (startS, tho, trueAlt) =>
+    hoverWindow({ startS, tho, trueAlt, baroErr: (-scale * tho) / PA_PER_M })
+  const log = makeValtLog([mk(10, 0.3, 1.5), mk(20, 0.45, 3), mk(30, 0.6, 5)])
+  const r = analyzeValtLog(log)
+  assert.equal(r.usable, true)
+  assert.equal(r.points.length, 3)
+  assert.ok(Math.abs(r.suggestedScale - scale) < 0.5, `scale ${r.suggestedScale}`)
+})
+
+test('reports the current scale from PARM and no single-point caveat for 2+ points', () => {
+  const mk = (startS, tho, trueAlt) => hoverWindow({ startS, tho, trueAlt, baroErr: 0.3 })
+  const log = makeValtLog([mk(10, 0.35, 2), mk(20, 0.5, 3.5)], { currentScale: -8 })
+  const r = analyzeValtLog(log)
+  assert.equal(r.currentScale, -8)
+  assert.ok(!r.warnings.some((w) => /single/i.test(w)))
+  assert.match(r.summary, /current value is -8/i)
+})
+
+test('warns and is unusable when there is no downward rangefinder', () => {
+  const log = makeValtLog([hoverWindow({ startS: 10, tho: 0.4, trueAlt: 2, baroErr: 0.5 })], {
+    rfndOverride: [] // no RFND at all
+  })
+  const r = analyzeValtLog(log)
+  assert.equal(r.usable, false)
+  assert.ok(r.warnings.some((w) => /rangefinder/i.test(w)))
+})
+
+test('ignores forward/upward rangefinder readings (Orient != down)', () => {
+  const w = hoverWindow({ startS: 10, tho: 0.4, trueAlt: 2, baroErr: 0.5 })
+  const forward = w.rfnd.map((m) => ({ ...m, Orient: 0 })) // forward-facing
+  const log = makeValtLog([w], { rfndOverride: forward })
+  const r = analyzeValtLog(log)
+  assert.equal(r.usable, false)
+  assert.ok(r.warnings.some((w) => /rangefinder/i.test(w)))
+})
+
+test('does not form a window from a non-steady (drifting throttle) hover', () => {
+  // Throttle ramps well beyond the steady band across the window.
+  const ctun = []
+  const rfnd = []
+  for (let i = 0; i < 40; i += 1) {
+    const t = Math.round((10 + i / 10) * 1e6)
+    ctun.push({ name: 'CTUN', TimeUS: t, ThO: 0.3 + i * 0.02, BAlt: 2.5 })
+    rfnd.push({ name: 'RFND', TimeUS: t, Instance: 0, Dist: 2, Stat: 4, Orient: 25 })
+  }
+  const messagesByType = new Map([
+    ['CTUN', ctun],
+    ['RFND', rfnd],
+    ['PARM', []]
+  ])
+  const r = analyzeValtLog({ messagesByType, formats: new Map(), counts: new Map(), skippedBytes: 0 })
+  assert.equal(r.usable, false)
+  assert.ok(r.warnings.some((w) => /steady hover/i.test(w)))
+})

--- a/wiki/first-time-setup/sensors-calibration.rst
+++ b/wiki/first-time-setup/sensors-calibration.rst
@@ -129,6 +129,46 @@ The card shows each IMU's current state (disabled / enabled / learning) and its
 ``TMIN → TMAX`` range. Live IMU-temperature progress isn't shown in the app yet —
 the firmware completes the fit on its own; you don't need to watch it.
 
+Baro thrust calibration (VALT)
+------------------------------
+
+A multirotor's prop wash lowers the static pressure over the barometer as
+throttle rises, so the baro reads a *higher* altitude the harder the motors
+work. ArduPilot compensates for this linearly with ``BARO1_THST_SCALE`` (in
+Pascals, subtracted per unit of normalized throttle). **Baro thrust calibration
+(VALT)** fits that scale from a flight log.
+
+It is an **Expert-only** card that appears only when a **downward rangefinder is
+configured** on the connected vehicle (``RNGFND1_TYPE`` set), because the
+calibration needs a rangefinder as the ground-truth height. It is **log-based**:
+the app connects on the bench, not in flight, so you fly the hover first and then
+upload that log.
+
+Steps:
+
+#. Fit a **downward-facing rangefinder** and confirm it logs (an ``RFND`` message
+   with orientation *Down*).
+#. Fly a **steady hover** at a fixed height in a stable mode, holding the throttle
+   as constant as you can for several seconds. Repeat at **2–3 different heights**
+   so the fit has more than one point.
+#. Download that flight's ``.bin`` log.
+#. In **Calibration → Baro thrust calibration (VALT)**, upload the log. The app
+   pairs the barometer altitude (``CTUN.BAlt``) with the rangefinder ground truth
+   (``RFND.Dist``) over the steady windows and fits
+
+   .. math::
+
+      \mathtt{BARO1\_THST\_SCALE} = -\frac{(\mathrm{baro\_error_m} \times 12)}{\mathrm{throttle}}
+
+   (across several points, a least-squares fit through the origin of the pressure
+   error against throttle; ~12 Pa per metre near sea level).
+#. Review the fitted points, then **Stage** and **Apply** ``BARO1_THST_SCALE`` in
+   the draft bar.
+#. Re-fly and confirm the baro altitude holds steadier through throttle changes.
+
+The card is hidden on firmware that doesn't expose ``BARO1_THST_SCALE`` (it is a
+compile-time option).
+
 See also the ArduPilot wiki: `Accelerometer Calibration
 <https://ardupilot.org/copter/docs/common-accelerometer-calibration.html>`_,
 `Compass Calibration


### PR DESCRIPTION
## What
Adds a **Baro thrust-compensation (VALT)** calibration card to the Calibration tab. Prop wash lowers static pressure over the barometer as throttle rises, so the baro reads high under load; ArduPilot corrects this with `BARO1_THST_SCALE` (Pa subtracted per unit throttle). It's **log-based** (we connect on the bench, not in flight): fly a steady hover with a downward rangefinder, upload the `.bin`, and the scale is fit from `CTUN.BAlt` vs `RFND.Dist`.

- `packages/log-analysis`: new `valt-analysis.ts` — steady-hover-window detection + least-squares fit through the origin of `error_Pa = -scale × throttle`. `BARO1_THST_SCALE = -(baro_error_m × 12) / throttle`.
- `apps/web`: `ValtCalibrationCard` (self-contained `.bin` upload + fit + stage). Shown only in **Expert** mode AND when a rangefinder is configured (`RNGFND1_TYPE > 0`); shows n/a on firmware without `BARO1_THST_SCALE` (compile-gated).
- Wiki section; 6 unit tests + an e2e gate test.

## Validation
- 6 `valt-analysis` unit tests (single-point + least-squares, no/forward-facing rangefinder, non-steady hover).
- **Validated end-to-end on a real hover log**: injected a known −25 Pa scale into a real flight's throttle/baro trace + synthetic downward rangefinder → recovered exactly −25 Pa from 5 steady windows.
- Ran across ~20 real logs (all correctly unusable — none have a rangefinder).
- Full gates: 741 node / 542 vitest / typecheck / web build / e2e 215.

## ArduCopter byte-identical
Copter default/pre-connect path unchanged; the surface is Expert- and rangefinder-gated and writes only a user-staged, approved `BARO1_THST_SCALE` draft through the existing verified-write path.