### PR TITLE
fix(tcal): carry live IMU temperature into the snapshot (clone dropped it)

### DIFF
--- a/packages/ardupilot-core/src/runtime-helpers.ts
+++ b/packages/ardupilot-core/src/runtime-helpers.ts
@@ -335,7 +335,12 @@ export function cloneLiveVerification(liveVerification: LiveVerificationState): 
     },
     opticalFlow: {
       ...liveVerification.opticalFlow
-    }
+    },
+    // Scalar carried straight through — omitting it here silently dropped the
+    // live IMU temperature (from SCALED_IMU) out of every emitted snapshot, so
+    // the thermal-calibration readout never populated even though the runtime
+    // had decoded it. Kept last to mirror the LiveVerificationState field order.
+    imuTemperatureC: liveVerification.imuTemperatureC
   }
 }
 

--- a/packages/protocol-mavlink/src/constants.ts
+++ b/packages/protocol-mavlink/src/constants.ts
@@ -128,8 +128,10 @@ export const MAVLINK_MIN_PAYLOAD_LENGTHS: Record<number, number> = {
   [MAVLINK_MESSAGE_IDS.ATTITUDE]: 28,
   // time_boot_ms(4) + q1..q4(16) + rollspeed/pitchspeed/yawspeed(12) = 32.
   [MAVLINK_MESSAGE_IDS.ATTITUDE_QUATERNION]: 32,
-  // time_boot_ms(4) + xacc..zmag(9×2=18) + temperature(2) = 24.
-  [MAVLINK_MESSAGE_IDS.SCALED_IMU]: 24,
+  // time_boot_ms(4) + xacc..zmag(9×2=18) = 22. `temperature` is a v2 extension
+  // field, excluded from the min length (ArduPilot: SCALED_IMU_MIN_LEN = 22) — a
+  // sender may truncate it when zero, so the min must not require it.
+  [MAVLINK_MESSAGE_IDS.SCALED_IMU]: 22,
   [MAVLINK_MESSAGE_IDS.RC_CHANNELS]: 42,
   [MAVLINK_MESSAGE_IDS.FILE_TRANSFER_PROTOCOL]: 254,
   [MAVLINK_MESSAGE_IDS.COMMAND_ACK]: 3,

--- a/tests/runtime-helpers-clone.test.mjs
+++ b/tests/runtime-helpers-clone.test.mjs
@@ -1,0 +1,37 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+// Deep-import the internal helpers (not part of the package's public surface).
+import {
+  cloneLiveVerification,
+  createIdleLiveVerification
+} from '../packages/ardupilot-core/dist/runtime-helpers.js'
+
+// Regression: cloneLiveVerification is used to build every emitted snapshot's
+// liveVerification. It rebuilds the object field-by-field, so any field it
+// forgets is silently dropped out of all snapshots. imuTemperatureC (the live
+// IMU temperature from SCALED_IMU, for the thermal-calibration readout) was
+// omitted, so the runtime decoded the temperature but it never reached the UI.
+// Verified live on real hardware: the snapshot went from `undefined` to 35.62 C
+// once the clone carried the field.
+
+test('cloneLiveVerification carries imuTemperatureC through to the snapshot', () => {
+  const state = createIdleLiveVerification()
+  state.imuTemperatureC = 35.62
+  const cloned = cloneLiveVerification(state)
+  assert.equal(cloned.imuTemperatureC, 35.62)
+})
+
+test('cloneLiveVerification leaves imuTemperatureC undefined when unset', () => {
+  const cloned = cloneLiveVerification(createIdleLiveVerification())
+  assert.equal(cloned.imuTemperatureC, undefined)
+})
+
+test('cloneLiveVerification is a deep copy (mutating the clone does not touch the source)', () => {
+  const state = createIdleLiveVerification()
+  const cloned = cloneLiveVerification(state)
+  cloned.attitudeTelemetry.rollDeg = 12
+  cloned.satisfiedSignals.push('rc-input')
+  assert.notEqual(state.attitudeTelemetry.rollDeg, 12)
+  assert.equal(state.satisfiedSignals.length, 0)
+})

--- a/wiki/first-time-setup/sensors-calibration.rst
+++ b/wiki/first-time-setup/sensors-calibration.rst
@@ -126,8 +126,10 @@ Steps:
    IMU's enable flips back to ``1`` (enabled). **Reboot once more** to use it.
 
 The card shows each IMU's current state (disabled / enabled / learning) and its
-``TMIN → TMAX`` range. Live IMU-temperature progress isn't shown in the app yet —
-the firmware completes the fit on its own; you don't need to watch it.
+``TMIN → TMAX`` range. When the flight controller streams IMU temperature (from
+``SCALED_IMU``), the card also shows the live temperature and warm-up progress
+toward ``TMAX``; the firmware completes and saves the fit on its own once it
+reaches the target, so you don't need to watch it.
 
 Baro thrust calibration (VALT)
 ------------------------------


### PR DESCRIPTION
## What
The Thermal Calibration card's **live IMU-temperature readout never populated on any hardware**. Root-caused on a real FC by tracing the whole path (raw wire → codec → session → runtime → snapshot):

- The FC streams `SCALED_IMU` with a valid non-zero temperature, and the codec + session decode it correctly (verified: `temperatureCdeg` 3562 → **35.62 °C** on the wire).
- `processScaledImu` sets `this.liveVerification.imuTemperatureC`…
- …but **`cloneLiveVerification()` — which rebuilds every emitted snapshot's `liveVerification` field-by-field — never copied `imuTemperatureC`**, so it was silently dropped from every snapshot. The UI always saw `undefined`.

## Fix
- `cloneLiveVerification` now carries `imuTemperatureC`. **Verified live on a real FC: snapshot went `undefined` → 35.62 °C.**
- Correct `MAVLINK_MIN_PAYLOAD_LENGTHS[SCALED_IMU]` 24 → 22 (`temperature` is a v2 extension field; ArduPilot's `SCALED_IMU_MIN_LEN` = 22). Latent (decode zero-pads to full length) but factually wrong.
- Regression test pins that the clone carries `imuTemperatureC` (and stays a deep copy). Wiki updated.

## Validation
738 node / 542 vitest / typecheck / grep-guard clean, plus the live-hardware confirmation above.

## ArduCopter byte-identical
Transport/runtime **read-path only** — no write path or FC-facing behavior changes.