### PR TITLE
feat(demo): seed a rangefinder + BARO1_THST_SCALE so the VALT card renders in demo

### DIFF
--- a/packages/protocol-mavlink/src/mock-scenario.ts
+++ b/packages/protocol-mavlink/src/mock-scenario.ts
@@ -95,10 +95,16 @@ const mockParameters: ParameterState = {
   // Rangefinder / Lidar (RNGFND1) — seeded so the demo surfaces the
   // Rangefinder/Lidar config section (downward-facing, disabled by default).
   // The analog/PWM knobs are seeded too so they reveal when TYPE is changed.
-  RNGFND1_TYPE: 0,
+  // Downward rangefinder (MAVLink type, orientation Down) so the demo exercises
+  // the rangefinder-gated surfaces — including the Expert-only Baro Thrust (VALT)
+  // calibration card, which needs RNGFND1_TYPE > 0 to render.
+  RNGFND1_TYPE: 100,
   RNGFND1_ORIENT: 25,
   RNGFND1_MIN: 0.2,
   RNGFND1_MAX: 7,
+  // Fork param (AP_BARO_THST_COMP_ENABLED build) so the VALT card shows its full
+  // editor rather than the "firmware doesn't expose this" n/a state.
+  BARO1_THST_SCALE: 0,
   RNGFND1_GNDCLR: 0.1,
   RNGFND1_ADDR: 0,
   RNGFND1_POS_X: 0,

--- a/tests/e2e/views.spec.ts
+++ b/tests/e2e/views.spec.ts
@@ -2745,15 +2745,17 @@ test.describe('ArduPlane demo', () => {
     await expect(page.getByTestId('session-vehicle-name')).toHaveText('ArduCopter', { timeout: VEHICLE_CONNECT_TIMEOUT })
 
     await openView(page, 'calibration')
-    // Default (non-Expert): hidden.
+    // Default (non-Expert): hidden even though the demo vehicle has a rangefinder.
     await expect(page.getByTestId('calibration-card-valt')).toHaveCount(0)
 
-    // Expert mode alone is NOT enough — the demo vehicle has no rangefinder
-    // (RNGFND1_TYPE = 0), so the VALT card must still be hidden while the
-    // Expert-only TCAL card is shown.
+    // Expert mode + a configured rangefinder (demo seeds RNGFND1_TYPE = 100)
+    // reveals the card, with its log-upload control and the current scale.
     await page.getByTestId('product-mode-expert').check()
-    await expect(page.getByTestId('calibration-card-tcal')).toBeVisible()
-    await expect(page.getByTestId('calibration-card-valt')).toHaveCount(0)
+    const valt = page.getByTestId('calibration-card-valt')
+    await valt.scrollIntoViewIfNeeded()
+    await expect(valt).toBeVisible()
+    await expect(valt).toContainText('Baro thrust calibration')
+    await expect(page.getByTestId('valt-file')).toBeAttached()
   })
 
   test('Plane AutoTune surface renders fixed-wing + VTOL groups with seeded values and stages a draft', async ({ page }) => {

--- a/tests/transport.test.mjs
+++ b/tests/transport.test.mjs
@@ -714,8 +714,8 @@ test('MockTransport serializes chunked inbound frames so demo parameter sync com
     const stats = await runtime.waitForParameterSync({ timeoutMs: 120000 })
 
     assert.equal(stats.status, 'complete')
-    assert.equal(stats.downloaded, 1162)
-    assert.equal(stats.total, 1162)
+    assert.equal(stats.downloaded, 1163)
+    assert.equal(stats.total, 1163)
     assert.equal(runtime.getSnapshot().parameters.find((parameter) => parameter.id === 'FRAME_CLASS')?.value, 1)
     assert.equal(runtime.getSnapshot().parameters.find((parameter) => parameter.id === 'FRAME_TYPE')?.value, 1)
   } finally {
@@ -846,7 +846,7 @@ test('Bundled WebSocket bridge can drive runtime heartbeat and parameter sync fr
     assert.equal(runtime.getSnapshot().connection.kind, 'connected')
     assert.equal(runtime.getSnapshot().vehicle?.vehicle, 'ArduCopter')
     assert.equal(stats.status, 'complete')
-    assert.equal(stats.downloaded, 1162)
+    assert.equal(stats.downloaded, 1163)
     assert.equal(runtime.getSnapshot().parameters.find((parameter) => parameter.id === 'FRAME_CLASS')?.value, 1)
   } finally {
     await runtime.disconnect().catch(() => {})


### PR DESCRIPTION
## What
The Baro Thrust (VALT) calibration card is gated on Expert mode **AND** a configured rangefinder (`RNGFND1_TYPE > 0`) + firmware exposing `BARO1_THST_SCALE`, so it never rendered in demo mode. This seeds the demo scenario with a downward MAVLink rangefinder (`RNGFND1_TYPE=100`, `ORIENT=25`) and `BARO1_THST_SCALE=0` so the full card (log upload → fit → stage) is clickable in demo.

- MAVLink type (not Analog) keeps the Servos rangefinder section's "Analog Function hidden until TYPE=Analog" e2e assertion valid.
- VALT gate e2e updated: card now **shows** in Expert (with its upload control), stays hidden in non-Expert.
- transport param-count 1162 → 1163.

## Validation
Node (0 fail) / 542 vitest / web build / full e2e 216 passed / grep-guard clean. Ran the Servos-rangefinder + VALT gate tests explicitly — no ripple.

## ArduCopter byte-identical
Demo mock + tests only — no runtime, transport, or write-path changes.