### PR TITLE
feat(tcal): compact card redesign + reword per-IMU state (off/on)

### DIFF
--- a/apps/web/src/sections/TcalCalibrationCard.tsx
+++ b/apps/web/src/sections/TcalCalibrationCard.tsx
@@ -27,11 +27,14 @@ export interface TcalCalibrationCardProps {
 
 const IMU_INSTANCES = [1, 2, 3]
 
+// Per-IMU THERMAL-CAL state — labelled to make clear it's the calibration that's
+// off, not the IMU itself ("disabled" read as "IMU disabled"). enable: 0 = no
+// thermal cal, 1 = a learned cal is loaded, 2 = currently learning.
 function enableState(value: number | undefined): { label: string; tone: 'neutral' | 'success' | 'warning' } {
   if (value === undefined) return { label: 'n/a', tone: 'neutral' }
   if (value >= 2) return { label: 'learning', tone: 'warning' }
-  if (value >= 1) return { label: 'enabled', tone: 'success' }
-  return { label: 'disabled', tone: 'neutral' }
+  if (value >= 1) return { label: 'on', tone: 'success' }
+  return { label: 'off', tone: 'neutral' }
 }
 
 export function TcalCalibrationCard({
@@ -89,55 +92,26 @@ export function TcalCalibrationCard({
         <strong>Thermal calibration (TCAL)</strong>
         <StatusBadge tone={anyLearning ? 'warning' : 'neutral'}>{anyLearning ? 'learning' : 'idle'}</StatusBadge>
       </div>
-      <p>
-        Learns per-IMU gyro/accel offsets across temperature so the estimator stays stable from a cold boot to warm.
-        It learns online while the board heats through its temperature range.
-      </p>
+      <p>Learns per-IMU gyro/accel offsets across temperature — online, as the board warms from a cold boot.</p>
 
       <div className="config-pills">
         {imus.map((imu) => {
           const state = enableState(imu.enable)
           return (
             <span key={imu.i} data-tone={state.tone}>
-              IMU{imu.i}: {state.label}
+              IMU{imu.i} TCAL: {state.label}
               {imu.tmin !== undefined && imu.tmax !== undefined ? ` (${imu.tmin.toFixed(0)}→${imu.tmax.toFixed(0)}°C)` : ''}
             </span>
           )
         })}
-      </div>
-
-      {imuTempC !== undefined ? (
-        <div className="config-pills" data-testid="tcal-imu-temp">
-          <span>IMU temp: {imuTempC.toFixed(1)}&thinsp;°C</span>
-          {anyLearning && warmPct !== undefined && targetTmax !== undefined ? (
-            <span>warming: {warmPct.toFixed(0)}% → {targetTmax.toFixed(0)}&thinsp;°C</span>
-          ) : null}
-        </div>
-      ) : null}
-
-      <ol className="calibration-card__steps">
-        <li>
-          <strong>Start cold.</strong> Power the board off and let it cool to ambient — a genuinely cold board is
-          essential; the wider the temperature swing, the better the fit.
-        </li>
-        <li>
-          Click <strong>Prepare thermal calibration</strong> below, then <strong>Apply</strong> in the draft bar. This
-          sets each IMU to <em>learn</em> (<code>INS_TCALn_ENABLE = 2</code>).
-        </li>
-        <li>Reboot the board <strong>cold</strong>, props off, and leave it powered and still — it self-heats through the range.</li>
-        <li>
-          At the top temperature the fit is computed and saved automatically (enable flips back to <em>enabled</em>).
-          Reboot once more to use it.
-        </li>
-      </ol>
-
-      <div className="parameter-follow-up parameter-follow-up--warning">
-        <StatusBadge tone="warning">props off</StatusBadge>
-        <p>
-          Do this on the bench with props removed — the board just needs to sit still and warm up, not fly. The live
-          IMU temperature is shown above; the firmware completes and saves the fit automatically once it reaches the
-          target temperature.
-        </p>
+        {imuTempC !== undefined ? (
+          <span data-testid="tcal-imu-temp" data-tone={anyLearning ? 'warning' : 'neutral'}>
+            IMU temp: {imuTempC.toFixed(1)}&thinsp;°C
+            {anyLearning && warmPct !== undefined && targetTmax !== undefined
+              ? ` · warming ${warmPct.toFixed(0)}% → ${targetTmax.toFixed(0)}°C`
+              : ''}
+          </span>
+        ) : null}
       </div>
 
       <button
@@ -149,11 +123,23 @@ export function TcalCalibrationCard({
       >
         {anyLearning ? 'Learning already enabled' : 'Prepare thermal calibration'}
       </button>
-      {!connected ? (
-        <small>Connect to a vehicle first.</small>
-      ) : !canApplyDraftParameters ? (
-        <small>Finish parameter sync and disarm first.</small>
-      ) : null}
+      <small>
+        {!connected
+          ? 'Connect to a vehicle first.'
+          : !canApplyDraftParameters
+            ? 'Finish parameter sync and disarm first.'
+            : 'Bench only, props off — the board just sits still and warms up.'}
+      </small>
+
+      <details className="calibration-card__howto">
+        <summary>How thermal calibration works (cold boot → warm)</summary>
+        <ol>
+          <li><strong>Start cold.</strong> Power off and let the board cool to ambient — the wider the cold-to-warm swing, the better the fit.</li>
+          <li>Click <strong>Prepare thermal calibration</strong>, then <strong>Apply</strong> in the draft bar (sets <code>INS_TCALn_ENABLE = 2</code>, learn).</li>
+          <li>Reboot <strong>cold</strong>, props off, and leave it powered and still — it self-heats through the range.</li>
+          <li>At the top temperature the fit saves automatically (state flips back to <em>on</em>). Reboot once more to use it.</li>
+        </ol>
+      </details>
     </article>
   )
 }

--- a/packages/protocol-mavlink/src/mock-scenario.ts
+++ b/packages/protocol-mavlink/src/mock-scenario.ts
@@ -105,6 +105,12 @@ const mockParameters: ParameterState = {
   // Fork param (AP_BARO_THST_COMP_ENABLED build) so the VALT card shows its full
   // editor rather than the "firmware doesn't expose this" n/a state.
   BARO1_THST_SCALE: 0,
+  // Per-IMU thermal-calibration enable (INS_TCALn_ENABLE) so the Expert-only TCAL
+  // card renders its full (per-IMU state) surface in demo instead of the n/a
+  // variant. 0 = thermal cal off (the default), matching a fresh board.
+  INS_TCAL1_ENABLE: 0,
+  INS_TCAL2_ENABLE: 0,
+  INS_TCAL3_ENABLE: 0,
   RNGFND1_GNDCLR: 0.1,
   RNGFND1_ADDR: 0,
   RNGFND1_POS_X: 0,

--- a/tests/e2e/views.spec.ts
+++ b/tests/e2e/views.spec.ts
@@ -2732,10 +2732,16 @@ test.describe('ArduPlane demo', () => {
     await openView(page, 'calibration')
     await expect(page.getByTestId('calibration-card-tcal')).toHaveCount(0)
 
-    // Expert mode reveals it.
+    // Expert mode reveals the full card (demo seeds INS_TCALn_ENABLE = 0).
     await page.getByTestId('product-mode-expert').check()
-    await expect(page.getByTestId('calibration-card-tcal')).toBeVisible()
-    await expect(page.getByTestId('calibration-card-tcal')).toContainText('Thermal calibration')
+    const tcal = page.getByTestId('calibration-card-tcal')
+    await expect(tcal).toBeVisible()
+    await expect(tcal).toContainText('Thermal calibration')
+    // Per-IMU state reads "TCAL: off" (not "disabled", which read as IMU-off).
+    await expect(tcal).toContainText('IMU1 TCAL: off')
+    // The step-by-step is collapsed into a How-it-works disclosure (compact card).
+    await expect(tcal.locator('.calibration-card__howto summary')).toHaveText(/How thermal calibration works/i)
+    await expect(page.getByTestId('tcal-start')).toBeVisible()
   })
 
   test('Calibration: the Baro Thrust (VALT) card is gated on Expert AND a rangefinder', async ({ page }) => {

--- a/tests/transport.test.mjs
+++ b/tests/transport.test.mjs
@@ -714,8 +714,8 @@ test('MockTransport serializes chunked inbound frames so demo parameter sync com
     const stats = await runtime.waitForParameterSync({ timeoutMs: 120000 })
 
     assert.equal(stats.status, 'complete')
-    assert.equal(stats.downloaded, 1163)
-    assert.equal(stats.total, 1163)
+    assert.equal(stats.downloaded, 1166)
+    assert.equal(stats.total, 1166)
     assert.equal(runtime.getSnapshot().parameters.find((parameter) => parameter.id === 'FRAME_CLASS')?.value, 1)
     assert.equal(runtime.getSnapshot().parameters.find((parameter) => parameter.id === 'FRAME_TYPE')?.value, 1)
   } finally {
@@ -846,7 +846,7 @@ test('Bundled WebSocket bridge can drive runtime heartbeat and parameter sync fr
     assert.equal(runtime.getSnapshot().connection.kind, 'connected')
     assert.equal(runtime.getSnapshot().vehicle?.vehicle, 'ArduCopter')
     assert.equal(stats.status, 'complete')
-    assert.equal(stats.downloaded, 1163)
+    assert.equal(stats.downloaded, 1166)
     assert.equal(runtime.getSnapshot().parameters.find((parameter) => parameter.id === 'FRAME_CLASS')?.value, 1)
   } finally {
     await runtime.disconnect().catch(() => {})


### PR DESCRIPTION
## What
The TCAL card was very long vertically (always-open 4-step `<ol>` + a big "props off" warning box). Redesigned compact:

- **Reworded per-IMU state** to **"IMU{n} TCAL: off / on / learning"** — "disabled" read as *the IMU* being off (the source of a "my FC has all 3 IMUs disabled" report). It's the thermal calibration that's off.
- **Steps collapsed** into a "How thermal calibration works (cold boot → warm)" `<details>` (same pattern as the accel/level/compass cards); the warning box is now a one-line bench note; live IMU temp folded into the pill row.
- **Demo-viewable**: seeded `INS_TCAL1..3_ENABLE = 0` so the full card renders in demo (was the n/a variant); e2e upgraded to assert the compact card. transport param-count 1163→1166.

## Validation
Node 0-fail / 542 vitest / typecheck / full e2e 216 passed / grep clean. Screenshot-verified the compact result in demo.

## ArduCopter byte-identical
Presentational card + demo mock/tests only — no runtime, transport, or write-path changes.