### PR TITLE
fix(tcal): make the how-to inline code readable (was a washed-out block)

### DIFF
--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -13800,9 +13800,13 @@ details.bf-gui-box:not([open]) > summary::after {
 .calibration-card__howto code {
   font-family: var(--font-data);
   font-size: 10px;
-  background: var(--surface-800);
+  /* Theme-safe tint + readable text. --surface-800 is a light mid-tone in dark
+     mode (#7f8aa0), so with the inherited light step text the code read as a
+     washed-out solid block ("redacted"). Match the config-pills treatment. */
+  background: rgba(var(--edge-rgb), 0.08);
+  color: var(--text);
   padding: 0 3px;
-  border-radius: 2px;
+  border-radius: 3px;
 }
 .guided-current-cal {
   display: flex;


### PR DESCRIPTION
The redesigned TCAL card's How-it-works disclosure rendered `INS_TCALn_ENABLE = 2` as a solid highlighted block that looked redacted — `.calibration-card__howto code` used `background: var(--surface-800)` with no `color`, and --surface-800 is a light mid-tone in dark mode (#7f8aa0), so the inherited light step text washed out. Switched to the theme-safe config-pills treatment (translucent `rgba(var(--edge-rgb), …)` tint + `color: var(--text)`). Screenshot-verified legible in dark mode; TCAL e2e still passes. CSS only — ArduCopter byte-identical.