### PR TITLE
chore(release): v1.4.0

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@arduconfig/desktop",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "private": true,
   "license": "GPL-3.0-only",
   "description": "ArduConfigurator desktop app — offline ArduPilot configuration + firmware flashing.",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@arduconfig/web",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "private": true,
   "license": "GPL-3.0-only",
   "type": "module",

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
     },
     "apps/desktop": {
       "name": "@arduconfig/desktop",
-      "version": "1.3.0",
+      "version": "1.4.0",
       "license": "GPL-3.0-only",
       "dependencies": {
         "@arduconfig/firmware-flash": "1.1.1",
@@ -40,7 +40,7 @@
     },
     "apps/web": {
       "name": "@arduconfig/web",
-      "version": "1.3.0",
+      "version": "1.4.0",
       "license": "GPL-3.0-only",
       "dependencies": {
         "@arduconfig/ai-assistant": "1.1.1",


### PR DESCRIPTION
Version bump to **1.4.0** (desktop + web, lockstep) for a new desktop release.

Since v1.3.0: log-tuning per-axis limit-cycle handling (#86), VALT baro thrust-scale calibration (#87, #90), TCAL live IMU-temp fix (#88) + compact card redesign (#91, #92), OSD message Style/Category controls (#89).

Tagging `v1.4.0` after merge triggers the Desktop Release workflow (macOS/Windows/Linux installers). Public tree grep-guarded beacon-free. Version strings only — ArduCopter byte-identical.