### PR TITLE
feat(valt): rangefinder-free path — manual hover-height entry + relaxed gate

### DIFF
--- a/apps/web/src/sections/CalibrationSection.tsx
+++ b/apps/web/src/sections/CalibrationSection.tsx
@@ -698,11 +698,12 @@ export function CalibrationSection(props: CalibrationSectionProps): ReactElement
                 />
               ) : null}
 
-              {/* Baro thrust calibration (VALT) — Expert-only, and only when a
-                * downward rangefinder is configured on the connected vehicle
-                * (RNGFND1_TYPE > 0). It's a log-based calibration; the card
-                * itself handles the .bin upload and the fit. */}
-              {isExpertMode && (readRoundedParameter(snapshot, 'RNGFND1_TYPE') ?? 0) > 0 ? (
+              {/* Baro thrust calibration (VALT) — Expert-only, log-based. The
+                * card fits against a downward rangefinder in the log when present,
+                * and otherwise against a manually-entered hover height, so it no
+                * longer requires a rangefinder to be configured. Shows n/a on
+                * firmware without BARO1_THST_SCALE. */}
+              {isExpertMode ? (
                 <ValtCalibrationCard
                   snapshot={snapshot}
                   canApplyDraftParameters={canApplyDraftParameters}

--- a/apps/web/src/sections/ValtCalibrationCard.tsx
+++ b/apps/web/src/sections/ValtCalibrationCard.tsx
@@ -1,14 +1,15 @@
 // Baro thrust-compensation (VALT) calibration card for the Calibration tab —
-// Expert-gated, and shown only when a rangefinder is detected on the connected
-// vehicle (CalibrationSection does that gating).
+// Expert-gated (CalibrationSection). Shows the n/a state on firmware without
+// BARO1_THST_SCALE.
 //
 // A multirotor's prop wash lowers static pressure over the barometer as throttle
 // rises, so the baro reads high under load. ArduPilot corrects this with
 // BARO1_THST_SCALE (Pascals subtracted per unit throttle). We can't measure this
 // live on the bench — it needs a real hover — so this is a LOG-based calibration:
-// fly a steady hover (ideally at 2–3 heights) with a downward rangefinder, then
-// upload that .bin here. The analyzer (@arduconfig/log-analysis) fits the scale
-// from CTUN throttle/baro-altitude vs the rangefinder ground truth and stages
+// fly a steady hover, then upload that .bin here. The analyzer
+// (@arduconfig/log-analysis) fits the scale from CTUN throttle/baro-altitude vs a
+// ground-truth height — a downward rangefinder (RFND.Dist) when the log has one,
+// otherwise a manually-entered measured hover height — and stages
 // BARO1_THST_SCALE as a draft for the normal verified-write path.
 
 import { useCallback, useState, type ReactElement } from 'react'
@@ -33,30 +34,49 @@ export function ValtCalibrationCard({
   setDraft
 }: ValtCalibrationCardProps): ReactElement {
   const [result, setResult] = useState<ValtResult | null>(null)
+  // Keep the uploaded buffer so a manual-height entry can re-fit the same log
+  // without re-uploading (logs without a rangefinder need a ground-truth height).
+  const [buffer, setBuffer] = useState<ArrayBuffer | null>(null)
   const [filename, setFilename] = useState<string | undefined>()
   const [error, setError] = useState<string | undefined>()
   const [busy, setBusy] = useState(false)
   const [staged, setStaged] = useState(false)
+  const [manualHeight, setManualHeight] = useState('')
 
   const currentScale = readParameterValue(snapshot, 'BARO1_THST_SCALE')
 
-  const handleFile = useCallback(async (file: File) => {
-    setBusy(true)
-    setError(undefined)
-    setResult(null)
-    setStaged(false)
+  const runAnalysis = useCallback((buf: ArrayBuffer, manualTrueAltM?: number) => {
     try {
-      const buffer = await file.arrayBuffer()
-      await new Promise((resolve) => setTimeout(resolve, 0))
-      const analysis = analyzeValtBuffer(buffer)
+      const analysis = analyzeValtBuffer(buf, manualTrueAltM !== undefined ? { manualTrueAltM } : {})
       setResult(analysis)
-      setFilename(file.name)
+      setStaged(false)
+      setError(undefined)
     } catch (caught) {
       setError(caught instanceof Error ? caught.message : 'Could not read or parse that log.')
-    } finally {
-      setBusy(false)
     }
   }, [])
+
+  const handleFile = useCallback(
+    async (file: File) => {
+      setBusy(true)
+      setError(undefined)
+      setResult(null)
+      setStaged(false)
+      setManualHeight('')
+      try {
+        const buf = await file.arrayBuffer()
+        await new Promise((resolve) => setTimeout(resolve, 0))
+        setBuffer(buf)
+        setFilename(file.name)
+        runAnalysis(buf) // auto: uses the rangefinder if the log has one
+      } catch (caught) {
+        setError(caught instanceof Error ? caught.message : 'Could not read or parse that log.')
+      } finally {
+        setBusy(false)
+      }
+    },
+    [runAnalysis]
+  )
 
   // BARO1_THST_SCALE is compiled out on some builds (AP_BARO_THST_COMP_ENABLED).
   // If the synced params don't include it, the firmware can't apply a scale.
@@ -86,8 +106,9 @@ export function ValtCalibrationCard({
       </div>
       <p>
         Corrects the barometer altitude error that prop wash induces under throttle
-        (<code>BARO1_THST_SCALE</code>). This is measured from a flight log — upload a steady hover flown with a
-        downward rangefinder and the scale is fit from baro altitude vs the rangefinder ground truth.
+        (<code>BARO1_THST_SCALE</code>). Measured from a flight log — upload a steady hover. If the log has a
+        downward rangefinder the scale is fit automatically against it; otherwise enter the height you hovered at
+        and it's fit against that.
       </p>
 
       <div className="log-tuning__upload">
@@ -130,6 +151,39 @@ export function ValtCalibrationCard({
             {result.summary}
           </p>
 
+          {result.groundTruth !== 'rangefinder' && buffer ? (
+            <div className="valt-manual" data-testid="valt-manual">
+              <p className="bf-note">
+                {result.groundTruth === 'manual'
+                  ? 'Fit from your measured height. Adjust and re-fit if needed:'
+                  : 'No downward rangefinder in this log — enter the height you actually hovered at to fit manually (best with a single steady hover at that height):'}
+              </p>
+              <div className="valt-manual__row">
+                <label className="scoped-editor-field scoped-editor-field--compact">
+                  <span>Measured hover height (m)</span>
+                  <input
+                    type="number"
+                    step="0.1"
+                    min="0"
+                    inputMode="decimal"
+                    data-testid="valt-manual-height"
+                    value={manualHeight}
+                    onChange={(event) => setManualHeight(event.target.value)}
+                  />
+                </label>
+                <button
+                  type="button"
+                  style={buttonStyle('secondary')}
+                  data-testid="valt-manual-fit"
+                  disabled={!(Number.parseFloat(manualHeight) > 0) || busy}
+                  onClick={() => runAnalysis(buffer, Number.parseFloat(manualHeight))}
+                >
+                  Fit with manual height
+                </button>
+              </div>
+            </div>
+          ) : null}
+
           {result.points.length > 0 ? (
             <div className="config-pills" data-testid="valt-points">
               {result.points.map((p, i) => (
@@ -171,10 +225,10 @@ export function ValtCalibrationCard({
       <details className="calibration-card__howto">
         <summary>How to calibrate baro thrust scale (VALT, from a log)</summary>
         <ol>
-          <li>Fit a <strong>downward rangefinder</strong> and confirm it logs (RFND, orientation Down).</li>
-          <li>Hover as steadily as you can at a fixed height in a stable mode, holding throttle constant for several seconds. Repeat at 2–3 different heights for a better fit.</li>
-          <li>Download that flight's <code>.bin</code> log and upload it above.</li>
-          <li>The scale is fit from baro altitude vs the rangefinder ground truth: <code>BARO1_THST_SCALE = −(baro_error_m × 12) / throttle</code>. Review the points, then <em>Stage</em> and apply in the draft bar.</li>
+          <li>Hover as steadily as you can at a fixed height in a stable mode, holding throttle constant for several seconds.</li>
+          <li><strong>With a downward rangefinder</strong> (RFND, orientation Down): repeat at 2–3 heights for a better fit — it's fit automatically against the rangefinder.</li>
+          <li><strong>Without a rangefinder</strong>: hover once at a <em>measured</em> height (tape/known height), then enter that height above — it's the ground truth for the fit.</li>
+          <li>Download that flight's <code>.bin</code> log and upload it. The scale is fit as <code>BARO1_THST_SCALE = −(baro_error_m × 12) / throttle</code>. Review the points, then <em>Stage</em> and apply in the draft bar.</li>
           <li>Re-fly and re-check that baro altitude holds steadier through throttle changes.</li>
         </ol>
       </details>

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -13808,6 +13808,21 @@ details.bf-gui-box:not([open]) > summary::after {
   padding: 0 3px;
   border-radius: 3px;
 }
+.valt-manual {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  margin: 8px 0;
+}
+.valt-manual__row {
+  display: flex;
+  gap: 8px;
+  align-items: flex-end;
+  flex-wrap: wrap;
+}
+.valt-manual__row .scoped-editor-field {
+  flex: 1 1 150px;
+}
 .guided-current-cal {
   display: flex;
   flex-direction: column;

--- a/packages/log-analysis/src/index.ts
+++ b/packages/log-analysis/src/index.ts
@@ -32,5 +32,6 @@ export {
   analyzeValtLog,
   analyzeValtBuffer,
   type ValtResult,
-  type ValtPoint
+  type ValtPoint,
+  type ValtOptions
 } from './valt-analysis.js'

--- a/packages/log-analysis/src/valt-analysis.ts
+++ b/packages/log-analysis/src/valt-analysis.ts
@@ -5,8 +5,10 @@
 // ArduPilot corrects this linearly: it subtracts `BARO1_THST_SCALE × throttle`
 // (Pascals × normalized-throttle) from the measured pressure. This module fits
 // that scale from a flight log by comparing the baro altitude against a
-// downward rangefinder (the ground-truth height) over steady-hover windows —
-// the same idea as ArduPilot's VALT WebTool, done offline in the browser.
+// ground-truth height over steady-hover windows — the same idea as ArduPilot's
+// VALT WebTool, done offline in the browser. Ground truth is a downward
+// rangefinder (RFND.Dist) when present; otherwise the operator can enter a
+// measured hover height (options.manualTrueAltM) for a single steady hover.
 //
 // Data used (all from the dataflash log, no live connection):
 //   - CTUN.ThO   normalized throttle out (0..1), time-aligned with…
@@ -58,9 +60,18 @@ export interface ValtPoint {
   durationS: number
 }
 
+export interface ValtOptions {
+  /** Measured true hover height (m) for logs without a rangefinder. When set,
+   *  it's used as the ground-truth altitude instead of RFND — for a single
+   *  steady hover actually flown at this height. */
+  manualTrueAltM?: number
+}
+
 export interface ValtResult {
   /** True when a scale could be fit from at least one steady hover window. */
   usable: boolean
+  /** Which ground-truth altitude the fit used (or would need). */
+  groundTruth: 'rangefinder' | 'manual' | 'none'
   /** Reasons the log can't be used, or caveats on the fit. */
   warnings: string[]
   /** Steady-hover points the fit was built from. */
@@ -111,8 +122,12 @@ function alignSamples(
   return aligned
 }
 
-/** Split aligned samples into steady-hover windows (stable throttle + height). */
-function findSteadyWindows(aligned: AlignedSample[]): ValtPoint[] {
+/** Split aligned samples into steady-hover windows. Always requires a stable
+ *  throttle; when `requireHeightStable` is set (rangefinder mode) it also
+ *  requires the ground-truth height to hold steady, confirming the aircraft
+ *  isn't drifting. Manual mode has no per-sample height (it's one entered
+ *  constant), so it relies on throttle stability alone. */
+function findSteadyWindows(aligned: AlignedSample[], requireHeightStable: boolean): ValtPoint[] {
   const points: ValtPoint[] = []
   let cur: AlignedSample[] = []
 
@@ -139,11 +154,10 @@ function findSteadyWindows(aligned: AlignedSample[]): ValtPoint[] {
       cur = [s]
       continue
     }
-    const meanThr = mean(cur.map((c) => c.throttle))
-    const meanDist = mean(cur.map((c) => c.trueAlt))
-    const withinBand = Math.abs(s.throttle - meanThr) <= THROTTLE_BAND && Math.abs(s.trueAlt - meanDist) <= DIST_BAND
+    const throttleSteady = Math.abs(s.throttle - mean(cur.map((c) => c.throttle))) <= THROTTLE_BAND
+    const heightSteady = !requireHeightStable || Math.abs(s.trueAlt - mean(cur.map((c) => c.trueAlt))) <= DIST_BAND
     const contiguous = s.t - cur[cur.length - 1].t <= MAX_SAMPLE_GAP_S
-    if (withinBand && contiguous) {
+    if (throttleSteady && heightSteady && contiguous) {
       cur.push(s)
     } else {
       close()
@@ -171,9 +185,15 @@ function fitScale(points: ValtPoint[]): number | undefined {
   return Math.max(SCALE_MIN, Math.min(SCALE_MAX, Number(scale.toFixed(1))))
 }
 
-/** Analyse a parsed dataflash log for VALT baro thrust-scale calibration. */
-export function analyzeValtLog(log: ParsedDataflashLog): ValtResult {
+/** Analyse a parsed dataflash log for VALT baro thrust-scale calibration.
+ *  Ground truth is a downward rangefinder when present; otherwise pass
+ *  `options.manualTrueAltM` (a measured hover height) to fit without one. */
+export function analyzeValtLog(log: ParsedDataflashLog, options: ValtOptions = {}): ValtResult {
   const warnings: string[] = []
+  const manualTrueAltM =
+    typeof options.manualTrueAltM === 'number' && Number.isFinite(options.manualTrueAltM) && options.manualTrueAltM > 0
+      ? options.manualTrueAltM
+      : undefined
 
   const ctunRaw = log.messagesByType.get('CTUN') ?? []
   const ctun: { t: number; throttle: number; baroAlt: number }[] = []
@@ -213,16 +233,35 @@ export function analyzeValtLog(log: ParsedDataflashLog): ValtResult {
   if (ctun.length === 0) {
     warnings.push('No throttle/altitude data (CTUN) in this log — it needs an actual flight log.')
   }
-  if (rfnd.length === 0) {
-    warnings.push(
-      'No downward rangefinder data (RFND, Orient=25, status Good) in this log. VALT needs a downward-facing rangefinder logged during the hover for ground truth.'
-    )
-  }
 
+  // Ground truth: an entered manual height takes precedence (the operator is
+  // telling us the true height); otherwise a downward rangefinder; otherwise
+  // nothing to compare against.
+  let groundTruth: ValtResult['groundTruth'] = 'none'
   let points: ValtPoint[] = []
-  if (ctun.length > 0 && rfnd.length > 0) {
+
+  if (ctun.length > 0 && manualTrueAltM !== undefined) {
+    groundTruth = 'manual'
+    const aligned = ctun.map((c) => ({ t: c.t, throttle: c.throttle, baroAlt: c.baroAlt, trueAlt: manualTrueAltM }))
+    points = findSteadyWindows(aligned, false)
+    if (points.length === 0) {
+      warnings.push('No steady hover found — hold a stable throttle at your fixed height for several seconds.')
+    }
+    // Manual entry is a single height. If the baro altitude spans a wide range
+    // across the steady windows, the log holds more than one hover height and a
+    // single entered value can't be right for all of them.
+    if (points.length > 1) {
+      const levels = points.map((p) => p.baroAltM)
+      if (Math.max(...levels) - Math.min(...levels) > 1) {
+        warnings.push(
+          'Baro altitude varied by more than 1 m across the steady windows — that reads as more than one hover height, but a manual height applies one value to the whole log. Use manual mode for a single steady hover at the entered height, or fly with a rangefinder.'
+        )
+      }
+    }
+  } else if (ctun.length > 0 && rfnd.length > 0) {
+    groundTruth = 'rangefinder'
     const aligned = alignSamples(ctun, rfnd)
-    points = findSteadyWindows(aligned)
+    points = findSteadyWindows(aligned, true)
     if (points.length === 0) {
       warnings.push(
         'No steady hover found — hold a stable throttle at a fixed height for several seconds (ideally at 2–3 different heights).'
@@ -232,6 +271,10 @@ export function analyzeValtLog(log: ParsedDataflashLog): ValtResult {
         'Only one steady hover point — the fit is from a single sample. Fly 2–3 steady heights for a more reliable scale.'
       )
     }
+  } else if (ctun.length > 0) {
+    warnings.push(
+      'No downward rangefinder data (RFND, Orient=25, status Good) in this log. Enter the measured height you hovered at below to fit VALT manually, or fly the hover with a downward-facing rangefinder for an automatic fit.'
+    )
   }
 
   const suggestedScale = points.length > 0 ? fitScale(points) : undefined
@@ -239,8 +282,9 @@ export function analyzeValtLog(log: ParsedDataflashLog): ValtResult {
 
   const summaryParts: string[] = []
   if (usable) {
+    const source = groundTruth === 'manual' ? `your entered height (${manualTrueAltM!.toFixed(1)} m)` : 'the rangefinder'
     summaryParts.push(
-      `Fitted BARO1_THST_SCALE = ${suggestedScale} Pa from ${points.length} steady hover ${points.length === 1 ? 'point' : 'points'}.`
+      `Fitted BARO1_THST_SCALE = ${suggestedScale} Pa from ${points.length} steady hover ${points.length === 1 ? 'point' : 'points'} vs ${source}.`
     )
     if (currentScale !== undefined) summaryParts.push(`Current value is ${Number(currentScale.toFixed(1))} Pa.`)
     const worst = points.reduce((a, b) => (Math.abs(b.errorM) > Math.abs(a.errorM) ? b : a))
@@ -251,6 +295,7 @@ export function analyzeValtLog(log: ParsedDataflashLog): ValtResult {
 
   return {
     usable,
+    groundTruth,
     warnings,
     points,
     suggestedScale,
@@ -260,6 +305,6 @@ export function analyzeValtLog(log: ParsedDataflashLog): ValtResult {
 }
 
 /** Convenience: parse a raw `.bin` buffer and run the VALT analysis. */
-export function analyzeValtBuffer(input: ArrayBuffer | Uint8Array): ValtResult {
-  return analyzeValtLog(parseDataflashLog(input))
+export function analyzeValtBuffer(input: ArrayBuffer | Uint8Array, options: ValtOptions = {}): ValtResult {
+  return analyzeValtLog(parseDataflashLog(input), options)
 }

--- a/tests/e2e/views.spec.ts
+++ b/tests/e2e/views.spec.ts
@@ -2744,18 +2744,19 @@ test.describe('ArduPlane demo', () => {
     await expect(page.getByTestId('tcal-start')).toBeVisible()
   })
 
-  test('Calibration: the Baro Thrust (VALT) card is gated on Expert AND a rangefinder', async ({ page }) => {
+  test('Calibration: the Baro Thrust (VALT) card is Expert-gated (no rangefinder required)', async ({ page }) => {
     await page.goto('/')
     await page.getByTestId('transport-mode-select').selectOption('demo')
     await page.getByTestId('connect-button').click()
     await expect(page.getByTestId('session-vehicle-name')).toHaveText('ArduCopter', { timeout: VEHICLE_CONNECT_TIMEOUT })
 
     await openView(page, 'calibration')
-    // Default (non-Expert): hidden even though the demo vehicle has a rangefinder.
+    // Default (non-Expert): hidden.
     await expect(page.getByTestId('calibration-card-valt')).toHaveCount(0)
 
-    // Expert mode + a configured rangefinder (demo seeds RNGFND1_TYPE = 100)
-    // reveals the card, with its log-upload control and the current scale.
+    // Expert mode reveals the card — the gate no longer requires a rangefinder
+    // (the card fits against a rangefinder in the log if present, else a manual
+    // height). Full card shows because the demo firmware exposes BARO1_THST_SCALE.
     await page.getByTestId('product-mode-expert').check()
     const valt = page.getByTestId('calibration-card-valt')
     await valt.scrollIntoViewIfNeeded()

--- a/tests/log-analysis-valt.test.mjs
+++ b/tests/log-analysis-valt.test.mjs
@@ -70,13 +70,38 @@ test('reports the current scale from PARM and no single-point caveat for 2+ poin
   assert.match(r.summary, /current value is -8/i)
 })
 
-test('warns and is unusable when there is no downward rangefinder', () => {
+test('no rangefinder and no manual height: unusable, prompts for a manual height', () => {
   const log = makeValtLog([hoverWindow({ startS: 10, tho: 0.4, trueAlt: 2, baroErr: 0.5 })], {
     rfndOverride: [] // no RFND at all
   })
   const r = analyzeValtLog(log)
   assert.equal(r.usable, false)
-  assert.ok(r.warnings.some((w) => /rangefinder/i.test(w)))
+  assert.equal(r.groundTruth, 'none')
+  assert.ok(r.warnings.some((w) => /rangefinder/i.test(w) && /manual|measured height/i.test(w)))
+})
+
+test('fits from a MANUAL hover height when there is no rangefinder', () => {
+  // baro reads 0.6 m high at 45% throttle, true height 3 m -> scale = -(0.6*12)/0.45 ≈ -16 Pa
+  const log = makeValtLog([hoverWindow({ startS: 10, tho: 0.45, trueAlt: 3, baroErr: 0.6 })], { rfndOverride: [] })
+  const r = analyzeValtLog(log, { manualTrueAltM: 3 })
+  assert.equal(r.groundTruth, 'manual')
+  assert.equal(r.usable, true)
+  assert.ok(Math.abs(r.suggestedScale - -((0.6 * 12) / 0.45)) < 0.6, `scale ${r.suggestedScale}`)
+  assert.match(r.summary, /entered height/i)
+})
+
+test('manual mode flags a log that spans more than one hover height', () => {
+  // Two steady windows at clearly different baro-alt levels (2.5 m vs 6 m).
+  const log = makeValtLog(
+    [
+      hoverWindow({ startS: 10, tho: 0.4, trueAlt: 2, baroErr: 0.5 }),
+      hoverWindow({ startS: 30, tho: 0.4, trueAlt: 5.5, baroErr: 0.5 })
+    ],
+    { rfndOverride: [] }
+  )
+  const r = analyzeValtLog(log, { manualTrueAltM: 2 })
+  assert.equal(r.groundTruth, 'manual')
+  assert.ok(r.warnings.some((w) => /more than one hover height/i.test(w)))
 })
 
 test('ignores forward/upward rangefinder readings (Orient != down)', () => {


### PR DESCRIPTION
## What
VALT no longer requires a rangefinder. It fits `BARO1_THST_SCALE` against a ground-truth altitude — a **downward rangefinder** (`RFND.Dist`) when the log has one, otherwise a **manually-entered measured hover height**.

- **Engine** (`@arduconfig/log-analysis`): `analyzeValtLog/Buffer` take `{ manualTrueAltM }`. Manual mode detects steady windows on throttle alone (no per-sample height) and computes `error = baro_alt − manualTrueAltM`. New `groundTruth: 'rangefinder' | 'manual' | 'none'`; warns when baro altitude spans >1 m across windows (more than one hover height → a single manual value can't fit all).
- **Card**: keeps the uploaded buffer and, when the log has no rangefinder, shows a "measured hover height (m)" input + "Fit with manual height" that re-fits the same log. Gate relaxed from Expert **+** rangefinder to **Expert-only** (n/a without `BARO1_THST_SCALE`).
- **Tests**: manual-fit + multi-height-warning unit tests; VALT e2e renamed "Expert-gated (no rangefinder required)". Verified end-to-end by uploading a real no-rangefinder hover log in demo → manual section → fit.

## Validation
Node 0-fail / 542 vitest / typecheck / grep clean. Full e2e had 3 unrelated timing-flaky failures under a loaded local machine; all 3 (+ VALT/TCAL) pass in isolation — CI runs on a fresh runner.

## ArduCopter byte-identical
Analysis + Expert-gated UI only; writes a user-staged draft through the existing verified-write path.