### PR TITLE
fix(params): survive a watchdogging board — resume the param download across link drops

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1305,7 +1305,9 @@ export function App() {
           try {
             await runtime.connect()
             await runtime.waitForVehicle({ timeoutMs: 4000 })
-            await runtime.requestParameterList()
+            // fresh: the board just rebooted on purpose — re-read every value
+            // rather than inheriting a partial table from before the reboot.
+            await runtime.requestParameterList({ fresh: true })
             // The reboot's pull is done — clear the "pull parameters again"
             // follow-up so it doesn't linger after the auto-refresh.
             setParameterFollowUp((current) => (current?.refreshRequired && !current.requiresReboot ? undefined : current))
@@ -2665,7 +2667,7 @@ export function App() {
           void (async () => {
             await new Promise((resolve) => setTimeout(resolve, 3000))
             try {
-              await runtime.requestParameterList()
+              await runtime.requestParameterList({ fresh: true })
               setParameterFollowUp((current) =>
                 current?.refreshRequired && !current.requiresReboot ? undefined : current
               )
@@ -3011,7 +3013,7 @@ export function App() {
       // first or the pull races the still-old running firmware.
       if (rebootRequiredCount === 0 && result.applied.length > 0) {
         try {
-          await runtime.requestParameterList()
+          await runtime.requestParameterList({ fresh: true })
           await runtime.waitForParameterSync()
           setParameterFollowUp((current) => (current?.refreshRequired && !current.requiresReboot ? undefined : current))
         } catch {
@@ -3138,7 +3140,7 @@ export function App() {
       // still-old running firmware.
       if (applyingRebootRequiredCount === 0 && result.applied.length > 0) {
         try {
-          await runtime.requestParameterList()
+          await runtime.requestParameterList({ fresh: true })
           await runtime.waitForParameterSync()
           setParameterFollowUp((current) => (current?.refreshRequired && !current.requiresReboot ? undefined : current))
         } catch {
@@ -5071,7 +5073,7 @@ export function App() {
       setSavedSnapshots((current) => [autoBackup, ...current.filter((entry) => entry.id !== autoBackup.id)])
       const result = await runtime.setParameters(requests, UI_PARAMETER_WRITE_OPTIONS, onProgress)
       if (result.applied.length > 0) {
-        void runtime.requestParameterList().then(() => runtime.waitForParameterSync()).catch(() => undefined)
+        void runtime.requestParameterList({ fresh: true }).then(() => runtime.waitForParameterSync()).catch(() => undefined)
       }
       return result
     },

--- a/packages/ardupilot-core/src/runtime.ts
+++ b/packages/ardupilot-core/src/runtime.ts
@@ -152,7 +152,15 @@ export interface WaitForVehicleOptions {
   timeoutMs?: number
 }
 
-export interface RequestParameterListOptions extends WaitForVehicleOptions {}
+export interface RequestParameterListOptions extends WaitForVehicleOptions {
+  /**
+   * Force a clean download, ignoring any partial table carried over from a
+   * link that dropped mid-sync. Required after anything that can change what
+   * the table holds — a firmware flash, a defaults reset, a reboot into new
+   * firmware — where inheriting the previous board state would be wrong.
+   */
+  fresh?: boolean
+}
 
 export interface WaitForParameterSyncOptions {
   timeoutMs?: number
@@ -186,7 +194,21 @@ export interface ArduPilotConfiguratorRuntimeOptions {
 const DEFAULT_HEARTBEAT_TIMEOUT_MS = 20000
 const DEFAULT_PARAMETER_SYNC_TIMEOUT_MS = 20000
 const PARAMETER_SYNC_STALL_RETRY_MS = 1500
-const MAX_PARAMETER_SYNC_RETRIES = 3
+// Consecutive no-progress stall passes before the retry interval starts backing
+// off. The retry itself is NOT capped: a board that watchdog-resets mid-download
+// is silent for far longer than a few passes, and giving up permanently left the
+// operator with a partial table and no way back short of a reconnect (field
+// repro: a 4.8-dev board resetting on every connect never delivered a single
+// full table, while a GCS that retries indefinitely pulled it off fine).
+const PARAMETER_SYNC_BACKOFF_AFTER_PASSES = 3
+// Ceiling for the backed-off stall interval. Slow enough not to spam a dead
+// link, fast enough to catch a board the moment it finishes rebooting.
+const MAX_PARAMETER_SYNC_STALL_RETRY_MS = 8000
+// How long a partial table carried over from a dropped link stays eligible for
+// resume. Long enough to cover a watchdog reboot + USB re-enumeration + the
+// operator re-connecting; short enough that it can't silently resurface hours
+// later against a board that has since been reflashed.
+const PARAMETER_CARRY_OVER_TTL_MS = 10 * 60 * 1000
 // Cap on how many PARAM_REQUEST_READ frames a single gap-fill pass emits, so a
 // pathological gap streams in bounded bursts rather than thousands at once. The
 // real-world gap is a handful of dropped frames; any remainder rolls to the
@@ -477,6 +499,27 @@ export class ArduPilotConfiguratorRuntime {
   // Test-injectable per-instance override; defaults to the
   // module constant. Production callers never set this.
   private readonly parameterSyncStallRetryMs: number
+  // Partial parameter table kept when a link drops mid-download, so the next
+  // connect resumes by index instead of restarting from zero. A board that
+  // resets every few seconds can never finish a table in one window; carrying
+  // the partial set across drops turns N short windows into one download.
+  // Deliberately NOT surfaced in the snapshot: while disconnected the UI must
+  // keep showing nothing, since these values belong to a board that is gone.
+  // Parameter count the carried-over table was captured against, while a
+  // resumed download is still unproven. The first PARAM_VALUE of the new link
+  // settles it: a different count means the table itself changed (reflash,
+  // defaults reset, different build) and the carried values must be thrown out.
+  private parameterSyncResumedTotal: number | undefined
+  private parameterCarryOver:
+    | {
+        readonly key: string
+        readonly parameters: Map<string, ParameterState>
+        readonly realIds: Set<string>
+        readonly indices: Set<number>
+        readonly total: number
+        readonly capturedAtMs: number
+      }
+    | undefined
   private autopilotVersionRequested = false
   private uartsFileRequested = false
 
@@ -857,12 +900,31 @@ export class ArduPilotConfiguratorRuntime {
       this.parameterSyncLastRetryDownloaded = 0
       this.parameterSyncGapFillActive = false
       this.clearParameterSyncRetryTimer()
+
+      // Resume a table the previous link dropped mid-download, when this is the
+      // same board and the stash is still fresh. `fresh: true` opts out — a
+      // caller that just reflashed or rebooted the board must not inherit values
+      // from the firmware that was on it before.
+      const resumed = options.fresh === true ? undefined : this.takeParameterCarryOver(vehicle)
+      if (resumed) {
+        resumed.parameters.forEach((parameter, id) => this.parameters.set(id, parameter))
+        resumed.realIds.forEach((id) => this.realParameterIdsReceived.add(id))
+        resumed.indices.forEach((index) => this.receivedParameterIndices.add(index))
+        this.totalParameters = resumed.total
+        this.parameterSyncResumedTotal = resumed.total
+        this.parameterSyncLastRetryDownloaded = resumed.realIds.size
+        this.appendStatusEntry(
+          'info',
+          `Resuming the parameter download: ${resumed.realIds.size}/${resumed.total} carried over from the previous link.`
+        )
+      }
+
       this.parameterSync = {
         status: 'requesting',
-        downloaded: 0,
-        total: 0,
+        downloaded: resumed ? resumed.realIds.size : 0,
+        total: resumed ? resumed.total : 0,
         duplicateFrames: 0,
-        progress: null,
+        progress: resumed ? Math.min(resumed.realIds.size / resumed.total, 1) : null,
         targetSystemId: vehicle.systemId,
         targetComponentId: vehicle.componentId,
         requestedAtMs: Date.now()
@@ -870,7 +932,9 @@ export class ArduPilotConfiguratorRuntime {
       this.setGuidedAction('request-parameters', {
         actionId: 'request-parameters',
         status: 'running',
-        summary: `Parameter request sent to sys=${vehicle.systemId} comp=${vehicle.componentId}.`,
+        summary: resumed
+          ? `Resuming the parameter download at ${resumed.realIds.size}/${resumed.total} (sys=${vehicle.systemId} comp=${vehicle.componentId}).`
+          : `Parameter request sent to sys=${vehicle.systemId} comp=${vehicle.componentId}.`,
         instructions: ['Waiting for the autopilot to stream the full parameter table.'],
         statusTexts: [],
         startedAtMs: this.guidedActionService.getAction('request-parameters').startedAtMs ?? Date.now(),
@@ -879,7 +943,16 @@ export class ArduPilotConfiguratorRuntime {
       })
       this.emit()
 
-      await this.requestParameterTable(vehicle.systemId, vehicle.componentId)
+      if (resumed) {
+        // Refetch only what the dropped link never delivered. A full re-stream
+        // here would re-send everything we already hold and — on a board that
+        // resets every few seconds — never get further than the last attempt.
+        this.parameterSyncGapFillActive = true
+        await this.requestMissingParameters(this.missingParameterIndices())
+        this.scheduleParameterSyncRetry()
+      } else {
+        await this.requestParameterTable(vehicle.systemId, vehicle.componentId)
+      }
     } catch (error) {
       this.failGuidedAction('request-parameters', error)
       this.emit()
@@ -1350,6 +1423,9 @@ export class ArduPilotConfiguratorRuntime {
    *  ArduPilot boards then enumerate as a DFU device on USB. Throws on
    *  REJECTED / TIMEOUT — the caller surfaces that to the operator. */
   async rebootToBootloader(): Promise<void> {
+    // Whatever is flashed next may have a different parameter table, so no
+    // partial table from this session may survive to be resumed against it.
+    this.parameterCarryOver = undefined
     await this.sendCommand(MAV_CMD.PREFLIGHT_REBOOT_SHUTDOWN, [3, 0, 0, 0, 0, 0, 0], {
       waitForAck: true,
       ackTimeoutMs: 3000
@@ -1919,6 +1995,17 @@ export class ArduPilotConfiguratorRuntime {
       this.autopilotVersionRequested = true
       void this.requestAutopilotVersion(systemId, componentId)
     }
+
+    // A heartbeat from a board that just finished rebooting is the earliest
+    // signal it can answer again. If a download is still open but no retry is
+    // armed (nothing can re-arm it once the stream went quiet at exactly the
+    // wrong moment), restart the stall timer so the recovery continues.
+    if (
+      !this.parameterSyncRetryTimer &&
+      (this.parameterSync.status === 'requesting' || this.parameterSync.status === 'streaming')
+    ) {
+      this.scheduleParameterSyncRetry()
+    }
   }
 
   /**
@@ -1944,7 +2031,47 @@ export class ArduPilotConfiguratorRuntime {
     return this.metadata
   }
 
+  /**
+   * Settle a resumed download against the first count the reconnected board
+   * reports. Same count: the carried values describe this table, keep them.
+   * Different count: the parameter table itself changed while we were away, so
+   * every carried value is suspect — drop the lot and re-stream from scratch
+   * rather than serve the operator a blend of two firmwares.
+   */
+  private reconcileResumedParameterTable(paramCount: number): void {
+    const resumedTotal = this.parameterSyncResumedTotal
+    if (resumedTotal === undefined) {
+      return
+    }
+    this.parameterSyncResumedTotal = undefined
+    if (paramCount === resumedTotal) {
+      return
+    }
+
+    this.parameters.clear()
+    this.realParameterIdsReceived.clear()
+    this.receivedParameterIndices.clear()
+    this.totalParameters = 0
+    this.parameterSyncLastRetryDownloaded = 0
+    this.parameterSyncGapFillActive = false
+    this.parameterSync = {
+      ...this.parameterSync,
+      status: 'requesting',
+      downloaded: 0,
+      total: 0,
+      progress: null
+    }
+    this.appendStatusEntry(
+      'warning',
+      `The board now reports ${paramCount} parameters (was ${resumedTotal}) — its table changed, so the carried-over values were discarded and the download restarted.`
+    )
+    if (this.vehicle) {
+      void this.requestParameterTable(this.vehicle.systemId, this.vehicle.componentId)
+    }
+  }
+
   private processParamValue(message: ParamValueMessage): void {
+    this.reconcileResumedParameterTable(message.paramCount)
     // "Known" tracks REAL arrivals (excludes alias-mirror entries) so a
     // mirrored entry placed under one id by a later message does not mark
     // an earlier real arrival under the other id as a duplicate.
@@ -2687,7 +2814,64 @@ export class ArduPilotConfiguratorRuntime {
     })
   }
 
+  /**
+   * Identity a carried-over partial table is bound to. Includes the vehicle
+   * kind and autopilot alongside the MAVLink addresses so a resume can't graft
+   * one board's parameters onto another that happens to share sys/comp ids.
+   */
+  private carryOverKey(vehicle: VehicleIdentity): string {
+    return `${vehicle.systemId}:${vehicle.componentId}:${vehicle.firmware}:${vehicle.vehicle}`
+  }
+
+  /**
+   * Stash the partial parameter table before live state is torn down, so the
+   * next connect to the same board resumes instead of restarting. Only worth
+   * keeping while a download is genuinely mid-flight: a complete table will be
+   * re-streamed cheaply anyway, and an empty one has nothing to resume.
+   */
+  private captureParameterCarryOver(): void {
+    const vehicle = this.vehicle
+    if (
+      !vehicle ||
+      this.realParameterIdsReceived.size === 0 ||
+      this.parameterSync.status === 'complete' ||
+      this.totalParameters <= 0
+    ) {
+      return
+    }
+
+    this.parameterCarryOver = {
+      key: this.carryOverKey(vehicle),
+      parameters: new Map(this.parameters),
+      realIds: new Set(this.realParameterIdsReceived),
+      indices: new Set(this.receivedParameterIndices),
+      total: this.totalParameters,
+      capturedAtMs: Date.now()
+    }
+  }
+
+  /**
+   * Consume the stashed partial table if it belongs to this board and is still
+   * fresh. Always clears the stash — a resume that turns out to be wrong (the
+   * FC reports a different parameter count, see processParamValue) restarts
+   * clean rather than half-resuming twice.
+   */
+  private takeParameterCarryOver(vehicle: VehicleIdentity):
+    | NonNullable<ArduPilotConfiguratorRuntime['parameterCarryOver']>
+    | undefined {
+    const carryOver = this.parameterCarryOver
+    this.parameterCarryOver = undefined
+    if (!carryOver || carryOver.key !== this.carryOverKey(vehicle)) {
+      return undefined
+    }
+    if (Date.now() - carryOver.capturedAtMs > PARAMETER_CARRY_OVER_TTL_MS) {
+      return undefined
+    }
+    return carryOver
+  }
+
   private resetLiveState(): void {
+    this.captureParameterCarryOver()
     this.vehicle = undefined
     this.hardwareBoard = undefined
     this.uartsFile = createIdleUartsFileState()
@@ -2699,6 +2883,7 @@ export class ArduPilotConfiguratorRuntime {
     this.parameterSyncRetryCount = 0
     this.parameterSyncLastRetryDownloaded = 0
     this.parameterSyncGapFillActive = false
+    this.parameterSyncResumedTotal = undefined
     this.parameterSync = createIdleParameterSync()
     this.guidedActionService.reset()
     this.motorTestService.reset()
@@ -2817,16 +3002,32 @@ export class ArduPilotConfiguratorRuntime {
   private scheduleParameterSyncRetry(): void {
     this.clearParameterSyncRetryTimer()
 
-    if (
-      (this.parameterSync.status !== 'requesting' && this.parameterSync.status !== 'streaming') ||
-      this.parameterSyncRetryCount >= MAX_PARAMETER_SYNC_RETRIES
-    ) {
+    if (this.parameterSync.status !== 'requesting' && this.parameterSync.status !== 'streaming') {
       return
     }
 
     this.parameterSyncRetryTimer = setTimeout(() => {
       void this.retryParameterSync()
-    }, this.parameterSyncStallRetryMs)
+    }, this.parameterSyncStallRetryDelayMs())
+  }
+
+  /**
+   * Stall interval for the next pass. Stays at the base rate while passes are
+   * still recovering parameters, then backs off exponentially once several
+   * consecutive passes have found nothing — the signature of a board that is
+   * down (rebooting) rather than a link merely dropping frames. Retries never
+   * stop while the sync is live: the board may come back at any moment, and it
+   * is the operator who decides to give up, not the runtime.
+   */
+  private parameterSyncStallRetryDelayMs(): number {
+    const overBudget = this.parameterSyncRetryCount - PARAMETER_SYNC_BACKOFF_AFTER_PASSES
+    if (overBudget <= 0) {
+      return this.parameterSyncStallRetryMs
+    }
+    const backedOff = this.parameterSyncStallRetryMs * 2 ** Math.min(overBudget, 8)
+    // Honour a test-injected fast timer: never back off past the module ceiling,
+    // and never below the caller's base interval.
+    return Math.max(this.parameterSyncStallRetryMs, Math.min(backedOff, MAX_PARAMETER_SYNC_STALL_RETRY_MS))
   }
 
   private clearParameterSyncRetryTimer(): void {
@@ -2844,10 +3045,9 @@ export class ArduPilotConfiguratorRuntime {
     // Use the alias-free count throughout (matches the completion gate and the
     // downloaded count getSnapshot() exposes).
     const downloaded = this.realParameterIdsReceived.size
-    // Refund the retry budget whenever a pass recovered params: a working link
-    // with a gap larger than MAX_RETRIES × MAX_PER_PASS must be allowed to
-    // converge over many passes rather than give up mid-recovery. Only
-    // CONSECUTIVE no-progress passes count toward the cap.
+    // A pass that recovered parameters resets the streak, which drops the
+    // interval back to the base rate. Only CONSECUTIVE no-progress passes back
+    // it off — a working link with a large gap must converge at full speed.
     const madeProgressSinceLastRetry = downloaded > this.parameterSyncLastRetryDownloaded
     if (madeProgressSinceLastRetry) {
       this.parameterSyncRetryCount = 0
@@ -2860,8 +3060,7 @@ export class ArduPilotConfiguratorRuntime {
       // Gate on realParameterIdsReceived.size, NOT parameters.size (which
       // counts alias mirrors), against the alias-free FC-reported total — same
       // source the completion gate uses.
-      (downloaded >= this.totalParameters && this.totalParameters > 0) ||
-      this.parameterSyncRetryCount >= MAX_PARAMETER_SYNC_RETRIES
+      (downloaded >= this.totalParameters && this.totalParameters > 0)
     ) {
       return
     }
@@ -2881,19 +3080,27 @@ export class ArduPilotConfiguratorRuntime {
     const canGapFill = total > 0 && downloaded > 0 && missingIndices.length > 0 && !gapFillStalled
     this.parameterSyncGapFillActive = canGapFill
 
-    this.appendStatusEntry(
-      'warning',
-      canGapFill
-        ? `Parameter stream stalled at ${downloaded}/${total}. Refetching ${missingIndices.length} missing parameter(s) by index (${this.parameterSyncRetryCount}/${MAX_PARAMETER_SYNC_RETRIES}).`
-        : `Parameter stream stalled at ${downloaded}/${total || 'unknown'}. Re-requesting the table (${this.parameterSyncRetryCount}/${MAX_PARAMETER_SYNC_RETRIES}).`
-    )
+    // Retries are unbounded, so every pass must NOT write a notice — a board
+    // that stays down would bury the log. Report the first few passes, then
+    // only every fifth, which is enough to show the retry is still alive.
+    if (this.parameterSyncRetryCount <= PARAMETER_SYNC_BACKOFF_AFTER_PASSES || this.parameterSyncRetryCount % 5 === 0) {
+      this.appendStatusEntry(
+        'warning',
+        canGapFill
+          ? `Parameter stream stalled at ${downloaded}/${total}. Refetching ${missingIndices.length} missing parameter(s) by index (attempt ${this.parameterSyncRetryCount}).`
+          : `Parameter stream stalled at ${downloaded}/${total || 'unknown'}. Re-requesting the table (attempt ${this.parameterSyncRetryCount}).`
+      )
+    }
     this.setGuidedAction('request-parameters', {
       ...this.guidedActionService.getAction('request-parameters'),
       status: 'running',
       summary: canGapFill
         ? `Parameter stream stalled at ${downloaded}/${total}. Refetching ${missingIndices.length} missing parameter(s).`
         : `Parameter stream stalled at ${downloaded}/${total || 'unknown'}. Re-requesting the full parameter table.`,
-      instructions: ['Keep the link open while the configurator retries the parameter stream.'],
+      instructions: [
+        'Keep the link open while the configurator retries the parameter stream.',
+        'If the board is resetting, leave this running (or reconnect) — the download resumes where it left off instead of restarting.'
+      ],
       updatedAtMs: Date.now(),
       completedAtMs: undefined
     })

--- a/tests/parameter-sync-watchdog-resume.test.mjs
+++ b/tests/parameter-sync-watchdog-resume.test.mjs
@@ -1,0 +1,244 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { ArduPilotConfiguratorRuntime } from '../packages/ardupilot-core/dist/index.js'
+import { arducopterMetadata } from '../packages/param-metadata/dist/index.js'
+import { MAV_PARAM_TYPE } from '../packages/protocol-mavlink/dist/index.js'
+
+// Field repro (4.8-dev board): the FC watchdog-resets a few seconds into every
+// connect, dropping the USB link. Before this coverage the runtime (a) threw
+// away every parameter already downloaded on each drop, (b) stopped retrying
+// after 3 no-progress passes and never resumed, and (c) ignored the heartbeat
+// from the board once it finished rebooting — so the operator never got a
+// complete table no matter how many times they reconnected, while a GCS that
+// retries indefinitely pulled the same board's parameters off fine.
+
+const TOTAL = 12
+
+function createResettingSession(sent, { windowSize }) {
+  let window = windowSize
+  const statusListeners = []
+  const messageListeners = []
+  let connected = false
+  let served = 0 // how many params this board has handed over across all links
+  let healthy = true
+  let total = TOTAL
+
+  const emit = (message) =>
+    messageListeners.forEach((listener) =>
+      listener({ header: { systemId: 1, componentId: 1, sequence: 0 }, message, timestampMs: Date.now() })
+    )
+
+  const heartbeat = () =>
+    emit({
+      type: 'HEARTBEAT',
+      autopilot: 3,
+      vehicleType: 2,
+      baseMode: 0,
+      customMode: 0,
+      systemStatus: 4,
+      mavlinkVersion: 3
+    })
+
+  const emitParam = (index) =>
+    emit({
+      type: 'PARAM_VALUE',
+      paramId: `P_${index}`,
+      paramValue: index,
+      paramType: MAV_PARAM_TYPE.REAL32,
+      paramCount: total,
+      paramIndex: index
+    })
+
+  return {
+    heartbeat,
+    setHealthy(value) {
+      healthy = value
+    },
+    /** Simulate a reflash between links: the table itself changes size. */
+    setTotal(value) {
+      total = value
+    },
+    /** How many params survive one link window before the watchdog bites. */
+    setWindow(value) {
+      window = value
+    },
+    /** The board watchdogs: the link drops the way Web Serial reports it. */
+    watchdogReset(reason = 'Serial read loop ended.') {
+      connected = false
+      statusListeners.forEach((listener) => listener({ kind: 'disconnected', reason }))
+    },
+    servedCount() {
+      return served
+    },
+    getTransportStatus() {
+      return connected ? { kind: 'connected' } : { kind: 'disconnected' }
+    },
+    onStatus(listener) {
+      statusListeners.push(listener)
+      return () => {}
+    },
+    onMessage(listener) {
+      messageListeners.push(listener)
+      return () => {}
+    },
+    async connect() {
+      connected = true
+      statusListeners.forEach((listener) => listener({ kind: 'connected' }))
+      heartbeat()
+    },
+    async disconnect() {
+      connected = false
+      statusListeners.forEach((listener) => listener({ kind: 'disconnected', reason: 'test' }))
+    },
+    destroy() {},
+    async send(message) {
+      sent.push(message)
+      if (!healthy) {
+        return // board is down (rebooting): total silence
+      }
+      if (message.type === 'PARAM_REQUEST_LIST') {
+        // Only `windowSize` params make it out before the watchdog bites.
+        for (let index = 0; index < Math.min(window, total); index += 1) {
+          served += 1
+          emitParam(index)
+        }
+        return
+      }
+      if (message.type === 'PARAM_REQUEST_READ' && message.paramIndex < total) {
+        served += 1
+        emitParam(message.paramIndex)
+      }
+    }
+  }
+}
+
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms))
+
+test('a partial table survives a watchdog link drop and the next connect resumes by index', async () => {
+  const sent = []
+  const session = createResettingSession(sent, { windowSize: 5 })
+  const runtime = new ArduPilotConfiguratorRuntime(session, arducopterMetadata, {
+    parameterSyncStallRetryMs: 10_000 // no stall retry interference; this tests the reconnect path
+  })
+  try {
+    await runtime.connect()
+    await runtime.requestParameterList({ timeoutMs: 500 })
+    assert.equal(runtime.getSnapshot().parameters.length, 5, 'first window delivered 5 of 12')
+
+    session.watchdogReset()
+    await sleep(20)
+    assert.equal(runtime.getSnapshot().parameters.length, 0, 'a dropped link still shows nothing while disconnected')
+
+    // Operator reconnects; the board is up long enough to answer by-index reads.
+    await runtime.connect()
+    await runtime.requestParameterList({ timeoutMs: 500 })
+    const stats = await runtime.waitForParameterSync({ timeoutMs: 2000 })
+
+    assert.equal(stats.status, 'complete', 'the resumed download completed across two links')
+    assert.equal(stats.downloaded, TOTAL)
+
+    // The resume refetched ONLY the 7 it never received — not a full re-stream.
+    const listRequests = sent.filter((m) => m.type === 'PARAM_REQUEST_LIST')
+    const readIndices = sent.filter((m) => m.type === 'PARAM_REQUEST_READ').map((m) => m.paramIndex).sort((a, b) => a - b)
+    assert.equal(listRequests.length, 1, 'the second connect resumed instead of re-streaming the table')
+    assert.deepEqual(readIndices, [5, 6, 7, 8, 9, 10, 11], 'only the missing indices were requested')
+  } finally {
+    runtime.destroy()
+  }
+})
+
+test('the sync keeps retrying while the board is down and recovers when it returns', async () => {
+  const sent = []
+  const session = createResettingSession(sent, { windowSize: 5 })
+  const runtime = new ArduPilotConfiguratorRuntime(session, arducopterMetadata, {
+    parameterSyncStallRetryMs: 20
+  })
+  try {
+    await runtime.connect()
+    await runtime.requestParameterList({ timeoutMs: 500 })
+    assert.equal(runtime.getSnapshot().parameters.length, 5)
+
+    // Board goes down (link stays nominally open — a bridge/SITL-style stall, or
+    // the window between the reset and the port dropping). Old behaviour: three
+    // no-progress passes and the runtime never asked again.
+    session.setHealthy(false)
+    await sleep(400) // >> 3 passes at 20ms
+    assert.equal(runtime.getSnapshot().parameterStats.downloaded, 5, 'still stuck while the board is down')
+
+    const requestsBefore = sent.length
+    session.setHealthy(true)
+    const stats = await runtime.waitForParameterSync({ timeoutMs: 4000 })
+
+    assert.ok(sent.length > requestsBefore, 'the runtime was still retrying when the board came back')
+    assert.equal(stats.status, 'complete', 'recovered without operator intervention')
+    assert.equal(stats.downloaded, TOTAL)
+  } finally {
+    runtime.destroy()
+  }
+})
+
+test('fresh: true refuses the carried-over table (post-reboot / post-flash pulls)', async () => {
+  const sent = []
+  const session = createResettingSession(sent, { windowSize: 5 })
+  const runtime = new ArduPilotConfiguratorRuntime(session, arducopterMetadata, {
+    parameterSyncStallRetryMs: 10_000
+  })
+  try {
+    await runtime.connect()
+    await runtime.requestParameterList({ timeoutMs: 500 })
+    session.watchdogReset()
+    await sleep(20)
+
+    await runtime.connect()
+    await runtime.requestParameterList({ timeoutMs: 500, fresh: true })
+    // A clean pull re-streams the whole table rather than gap-filling.
+    assert.equal(sent.filter((m) => m.type === 'PARAM_REQUEST_LIST').length, 2, 're-streamed instead of resuming')
+    assert.equal(sent.filter((m) => m.type === 'PARAM_REQUEST_READ').length, 0, 'no by-index resume reads')
+  } finally {
+    runtime.destroy()
+  }
+})
+
+test('a board whose parameter count changed discards the carried-over values', async () => {
+  // Reflashed between links: same board identity, different table. Resuming
+  // would blend two firmwares, so the carried values must be thrown out and the
+  // download restarted clean against the new count.
+  const sent = []
+  const session = createResettingSession(sent, { windowSize: 5 })
+  const runtime = new ArduPilotConfiguratorRuntime(session, arducopterMetadata, {
+    parameterSyncStallRetryMs: 10_000
+  })
+  try {
+    await runtime.connect()
+    await runtime.requestParameterList({ timeoutMs: 500 })
+    assert.equal(runtime.getSnapshot().parameters.length, 5, 'partial table before the drop')
+
+    session.watchdogReset()
+    await sleep(20)
+
+    // New firmware: the table grew, and the board is now stable enough to
+    // stream the whole thing in one window.
+    session.setTotal(TOTAL + 3)
+    session.setWindow(TOTAL + 3)
+    await runtime.connect()
+    await runtime.requestParameterList({ timeoutMs: 500 })
+    const stats = await runtime.waitForParameterSync({ timeoutMs: 3000 })
+
+    assert.equal(stats.total, TOTAL + 3, 'adopted the new table size')
+    assert.equal(stats.downloaded, TOTAL + 3, 'downloaded the new table in full')
+
+    const snapshot = runtime.getSnapshot()
+    assert.equal(
+      snapshot.parameters.filter((parameter) => parameter.aliasedFrom === undefined).length,
+      TOTAL + 3,
+      'no stale entries left over from the previous firmware'
+    )
+    assert.ok(
+      snapshot.statusTexts.some((entry) => /table changed/i.test(entry.text)),
+      'the operator is told the carried-over values were discarded'
+    )
+  } finally {
+    runtime.destroy()
+  }
+})


### PR DESCRIPTION
## Problem

Field repro on a 4.8-dev board that watchdog-resets on every connect: the configurator never delivered a parameter table, while Mission Planner pulled the same board's parameters off fine.

Three defects, each verified against the built runtime *before* changing anything (repro harness printed the actual numbers):

1. **Any link drop threw away every parameter already downloaded.** `resetLiveState()` clears `parameters` / `realParameterIdsReceived` / `receivedParameterIndices` and resets sync to `idle`, so each reconnect restarted from zero with a full `PARAM_REQUEST_LIST`. Measured: 6 params before the drop, 0 after, and 0 by-index resume reads on reconnect.
2. **The stall retry gave up permanently** after `MAX_PARAMETER_SYNC_RETRIES` (3) consecutive no-progress passes — ~4.5 s of no new params, far shorter than a reboot. Measured: once spent, flipping the mock board back to fully healthy produced **0** further requests for the life of the connection.
3. **A returning heartbeat triggered no re-request.** Measured: 5 heartbeats from a healthy board → 0 new requests, sync stuck at 6/10 forever.

## Fix

- **Carry the partial table across a drop.** Stashed keyed to `sysid:compid:firmware:vehicle` before teardown; the next connect to that board seeds from it and refetches **only the missing indices**. N short windows add up to one download. Not surfaced in the snapshot — while disconnected the UI still shows nothing, since those values belong to a board that is gone.
- **No retry cap.** After 3 no-progress passes the interval backs off exponentially (1.5 s base, 8 s ceiling); any recovered parameter resets it. Notices throttled (first 3, then every 5th).
- **Re-arm on heartbeat** when a download is open but no retry is scheduled.

### Guards against resuming onto a changed table
- `requestParameterList({ fresh: true })` opts out, and is now passed by every caller meaning "read current values": post-reboot re-pull, both post-write auto-refreshes, AI-assistant write path. Only connect paths resume.
- `rebootToBootloader()` drops the stash.
- 10-minute TTL.
- **Different parameter count on reconnect → discard everything and restart clean**, with a notice explaining why.

## ArduCopter byte-identical

A healthy board completes on the first pass: no carry-over is captured (it only stashes an *incomplete* sync) and no retry fires. Behaviour differs only on a link that drops or stalls — the broken case.

## Validation ladder

Rungs 1–3. 4 new runtime tests: resume-by-index across a drop, recovery after the board returns mid-stall, `fresh: true` refusing the stash, and the changed-count discard (first draft of that test passed vacuously — rewritten to actually reflash the mock mid-test).

- `node --test` 753 pass / 0 fail
- vitest 542 pass
- Playwright 217 pass / 6 skipped (visual)
- typecheck clean

**Rung 5 outstanding**: the actual watchdogging board. Auto-reconnect is deliberately *not* changed here — `App.tsx:1190` is still one-shot and still requires `connection.kind === 'idle'`, so a mid-session drop needs a manual Connect click (which now resumes instead of restarting). That loop needs the real board to validate.