### PR TITLE
fix(ports): name the raw param behind Baud, Flow and Serial options

### DIFF
--- a/apps/web/src/sections/PortsSection.tsx
+++ b/apps/web/src/sections/PortsSection.tsx
@@ -388,6 +388,15 @@ export function PortsSection(props: PortsSectionProps): ReactElement {
                                         <div className="ports-matrix-row__baud">
                                           <label className="scoped-editor-field scoped-editor-field--compact">
                                             <span>Baud</span>
+                                            {/* The port matrix hand-rolls its fields instead of using the
+                                                Scoped* components, so it doesn't inherit their param-name
+                                                hint — add it here so Baud/Flow/Options aren't the only
+                                                editable knobs in the app with no visible raw param name.
+                                                aria-hidden for the same reason ScopedField does it: a
+                                                <label> folds all its text into the control's a11y name. */}
+                                            <small className="scoped-editor-field__param-id" aria-hidden="true">
+                                              {baudParameter.id}
+                                            </small>
                                             <select
                                               value={selectedBaudPresetValue(currentBaudRate)}
                                               onChange={(event) => {
@@ -455,6 +464,9 @@ export function PortsSection(props: PortsSectionProps): ReactElement {
                                       {flowControlParameter ? (
                                         <label className="scoped-editor-field scoped-editor-field--compact">
                                           <span>Flow</span>
+                                          <small className="scoped-editor-field__param-id" aria-hidden="true">
+                                            {flowControlParameter.id}
+                                          </small>
                                           <select
                                             value={editedValues[flowControlParameter.id] ?? String(port.flowControlValue ?? '')}
                                             onChange={(event) =>
@@ -478,7 +490,12 @@ export function PortsSection(props: PortsSectionProps): ReactElement {
                                     <div className="ports-matrix-row__cell">
                                       <div className="ports-matrix-row__options">
                                         <div className="ports-matrix-row__options-header">
-                                          <strong>Serial options</strong>
+                                          <strong>
+                                            Serial options
+                                            {optionsParameter ? (
+                                              <small className="scoped-editor-field__param-id">{optionsParameter.id}</small>
+                                            ) : null}
+                                          </strong>
                                           {optionsParameter ? (
                                             <button
                                               style={buttonStyle()}

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -7430,6 +7430,7 @@ textarea:focus {
   color: var(--text-dim, var(--text-muted));
   font-family: var(--font-data);
   font-size: 10px;
+  font-weight: 400;
   letter-spacing: 0.02em;
   text-transform: none;
 }

--- a/tests/e2e/views.spec.ts
+++ b/tests/e2e/views.spec.ts
@@ -361,6 +361,20 @@ test.describe('Ports view', () => {
     // The selected option now shows as a chip in the Options cell.
     await expect(page.locator('[data-testid^="serial-options-chips-"]').first()).toBeVisible()
   })
+
+  test('the port matrix names the raw param behind Baud, Flow and Serial options', async ({ page }) => {
+    // The matrix hand-rolls its fields rather than using the Scoped* components,
+    // so it does NOT inherit their param-name hint for free — these were the last
+    // editable knobs in the app showing only a generic word ("Baud", "Flow") with
+    // no way to tell which SERIALn_* parameter they write.
+    await page.goto('/')
+    await connectViaHeader(page)
+    await openView(page, 'ports')
+    const hints = page.locator('.ports-matrix .scoped-editor-field__param-id')
+    await expect(hints.filter({ hasText: /^SERIAL\d+_BAUD$/ }).first()).toBeVisible()
+    await expect(hints.filter({ hasText: /_RTSCTS$/ }).first()).toBeVisible()
+    await expect(hints.filter({ hasText: /^SERIAL\d+_OPTIONS$/ }).first()).toBeVisible()
+  })
 })
 
 test.describe('Networking view (Expert + networking-capable FC)', () => {


### PR DESCRIPTION
Audit follow-up to #9 (the param-name hint on every editable field). One surface never got it.

The port matrix hand-rolls its `<label className="scoped-editor-field">` cells instead of using the `Scoped*` components, so it doesn't inherit `ParamIdHint` — **Baud**, **Flow** and **Serial options** showed only a generic word with no way to tell which `SERIALn_*` parameter they write (the row header names `SERIALn_PROTOCOL` and nothing else).

Measured against the running demo app, hints per tab:

| tab | before | after |
|---|---|---|
| Ports | 12/37 | **35/37** |
| Failsafe | 18/18 | 18/18 |
| Modes | 6/6 | 6/6 |
| Power | 5/5 | 5/5 |
| Config | 50/55 | 50/55 |

Function is deliberately left alone — its id is already in the row header, so adding it would duplicate on the same row. The fields still without a hint are params with **no friendly label**, where the id already *is* the label text (`BRD_BOOT_DELAY`); showing it twice would be the duplicate.

- `aria-hidden` on the two inside a `<label>`, same reason `ScopedField` does it: a `<label>` folds all its text into the wrapped control's accessible name.
- `font-weight: 400` on the shared class so the options hint doesn't inherit the `<strong>` header's bold. Every other instance already renders at normal weight, so nothing else moves.

Also verified during the audit and left unchanged: **zero** fields anywhere render the hint twice, and 18 of 841 curated params have a label that normalises to their own id (`FRAME_CLASS`, `LOG_BITMASK`, `RC1_TRIM`…) so they read as a mild stutter — left as-is, since suppressing it makes the hint's presence unpredictable for 2% of params.

**ArduCopter byte-identical**: presentational only.

## Validation ladder
Rungs 1 + 3. New e2e assertion in the Ports block.
- Playwright 217 pass / 6 skipped
- `node --test` 753 pass, vitest 542 pass, typecheck clean
- Verified in the demo at desktop width in both themes and at 390px (no horizontal overflow)