### PR TITLE
feat(link): keep the last data on a dropped link, and auto-resume through watchdog resets

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -66,6 +66,7 @@ import { StatusBadge, buttonStyle } from '@arduconfig/ui-kit'
 import { describeConnectionError } from './connection-error-help'
 import { getDesktopBridge } from './desktop-bridge'
 import { createRuntime } from './runtime-factory'
+import { attemptSerialPortReconnect } from './serial-reconnect'
 import { useOsdEditor } from './hooks/use-osd-editor'
 import { useRcMixer } from './hooks/use-rc-mixer'
 import { useVtxTable } from './hooks/use-vtx-table'
@@ -955,6 +956,15 @@ export function App() {
   // stale-handle reacquire, which the first attempt at this feature was missing.
   const expectRebootReconnectRef = useRef(false)
   const rebootReconnectingRef = useRef(false)
+  // Owns the watchdog auto-resume loop (below): true while it is cycling
+  // reconnects to finish a parameter download a resetting board keeps cutting
+  // short. Separate from the reboot reconnect so the two can never both drive
+  // the port.
+  const watchdogResumingRef = useRef(false)
+  // Set by the Disconnect button. Any auto-reconnect loop must stand down when
+  // the operator closes the link on purpose — re-opening a port someone just
+  // closed is the one thing an automatic retry must never do.
+  const intentionalDisconnectRef = useRef(false)
   const previousConnectionKindRef = useRef(snapshot.connection.kind)
   const previousGuidedSectionRef = useRef<string | undefined>(undefined)
   const boardCatalogEntry = useMemo(() => findBoardCatalogEntry(snapshot.hardware.board?.boardType), [snapshot.hardware.board?.boardType])
@@ -1278,48 +1288,25 @@ export function App() {
       // interface / a bootloader just times out and we move on. Returns true
       // once a heartbeating vehicle is synced.
       const targetInfo = getWebSerialPortInfo(selectedSerialPortRef.current)
-      const attempt = async (): Promise<boolean> => {
-        let ports: WebSerialPortLike[]
-        try {
-          ports = await getAvailableWebSerialPorts()
-        } catch {
-          return false
-        }
-        const matching = ports.filter((port) => {
-          const info = getWebSerialPortInfo(port)
-          return (
-            targetInfo !== undefined &&
-            info !== undefined &&
-            info.usbVendorId === targetInfo.usbVendorId &&
-            info.usbProductId === targetInfo.usbProductId
-          )
-        })
-        const candidates = matching.length > 0 ? matching : ports
-        for (const candidate of candidates) {
-          if (!rebootReconnectingRef.current) {
-            return false
-          }
+      const attempt = async (): Promise<boolean> =>
+        attemptSerialPortReconnect({
+          runtime,
+          targetInfo,
           // Point the transport resolver at this handle synchronously; the
           // setSelectedSerialPort state update lags a render.
-          selectedSerialPortRef.current = candidate
-          try {
-            await runtime.connect()
-            await runtime.waitForVehicle({ timeoutMs: 4000 })
-            // fresh: the board just rebooted on purpose — re-read every value
-            // rather than inheriting a partial table from before the reboot.
-            await runtime.requestParameterList({ fresh: true })
-            // The reboot's pull is done — clear the "pull parameters again"
-            // follow-up so it doesn't linger after the auto-refresh.
+          setActivePort: (port) => {
+            selectedSerialPortRef.current = port
+          },
+          rememberPort: rememberSelectedSerialPort,
+          isCancelled: () => !rebootReconnectingRef.current,
+          // fresh: the board just rebooted on purpose — re-read every value
+          // rather than inheriting a partial table from before the reboot.
+          fresh: true,
+          // The reboot's pull is done — clear the "pull parameters again"
+          // follow-up so it doesn't linger after the auto-refresh.
+          onConnected: () =>
             setParameterFollowUp((current) => (current?.refreshRequired && !current.requiresReboot ? undefined : current))
-            // This interface heartbeats — remember it as the live port.
-            rememberSelectedSerialPort(candidate)
-            return true
-          } catch {
-            await runtime.disconnect().catch(() => {})
-          }
-        }
-        return false
-      }
+        })
       setSessionNotice({ tone: 'neutral', text: 'Rebooting — waiting for the flight controller to reconnect…' })
       // Give the board time to drop off USB and start re-enumerating.
       await wait(2500)
@@ -1346,6 +1333,109 @@ export function App() {
       }
     })()
   }, [snapshot.connection.kind, transportMode, selectedSerialPort, runtime, rememberSelectedSerialPort])
+
+  // Auto-resume a parameter download that a resetting board keeps interrupting.
+  // Field case: a watchdogging FC drops the USB link a few seconds into every
+  // connect, delivering ~120 of 1320 parameters per window — finishing by hand
+  // would take a dozen manual reconnects. Each cycle resumes where the last one
+  // stopped (runtime keeps the partial table), so the count climbs across
+  // attempts until the table is complete. Deliberately narrow: web-serial only,
+  // only while a genuinely incomplete download is outstanding, never when the
+  // operator disconnected on purpose or a reboot reconnect owns the link.
+  useEffect(() => {
+    if (transportMode !== 'web-serial' || !selectedSerialPort) {
+      return
+    }
+    if (snapshot.connection.kind !== 'disconnected' && snapshot.connection.kind !== 'error') {
+      return
+    }
+    if (
+      expectRebootReconnectRef.current ||
+      rebootReconnectingRef.current ||
+      watchdogResumingRef.current ||
+      intentionalDisconnectRef.current ||
+      busyAction !== undefined
+    ) {
+      return
+    }
+    const stale = snapshot.staleLink
+    if (!stale || stale.total <= 0 || stale.downloaded >= stale.total) {
+      return
+    }
+
+    watchdogResumingRef.current = true
+    void (async () => {
+      const wait = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms))
+      const targetInfo = getWebSerialPortInfo(selectedSerialPortRef.current)
+      // Bounded so a board that never comes back can't reconnect forever; the
+      // operator can start another run with Connect.
+      const deadlineMs = Date.now() + 5 * 60_000
+      let cycles = 0
+      try {
+        while (watchdogResumingRef.current && !intentionalDisconnectRef.current && Date.now() < deadlineMs) {
+          cycles += 1
+          const before = runtime.getSnapshot().staleLink?.downloaded ?? 0
+          setSessionNotice({
+            tone: 'neutral',
+            text: `Board reset with the parameter download incomplete (${before}/${stale.total}). Reconnecting to resume — attempt ${cycles}.`
+          })
+          // Let the board finish dropping off USB and re-enumerate.
+          await wait(2000)
+          if (!watchdogResumingRef.current || intentionalDisconnectRef.current) {
+            return
+          }
+          await attemptSerialPortReconnect({
+            runtime,
+            targetInfo,
+            setActivePort: (port) => {
+              selectedSerialPortRef.current = port
+            },
+            rememberPort: rememberSelectedSerialPort,
+            isCancelled: () => !watchdogResumingRef.current || intentionalDisconnectRef.current,
+            // NOT fresh: resuming is the whole point.
+            fresh: false
+          })
+
+          // Give the reconnected board a window to stream before judging it.
+          const streamDeadline = Date.now() + 20_000
+          while (Date.now() < streamDeadline && watchdogResumingRef.current) {
+            const current = runtime.getSnapshot()
+            if (current.parameterStats.status === 'complete') {
+              setSessionNotice({
+                tone: 'success',
+                text: `Parameter download finished across ${cycles} reconnect${cycles === 1 ? '' : 's'} — ${current.parameterStats.downloaded}/${current.parameterStats.total} values.`
+              })
+              return
+            }
+            if (current.connection.kind === 'disconnected' || current.connection.kind === 'error') {
+              break // reset again: go round for another window
+            }
+            await wait(500)
+          }
+          if (runtime.getSnapshot().connection.kind === 'connected') {
+            return // link is up and streaming; leave it alone
+          }
+        }
+        if (watchdogResumingRef.current && !intentionalDisconnectRef.current) {
+          const current = runtime.getSnapshot()
+          setSessionNotice({
+            tone: 'warning',
+            text: `Gave up auto-reconnecting after ${cycles} attempt${cycles === 1 ? '' : 's'} (${current.staleLink?.downloaded ?? 0}/${stale.total} parameters). The values on screen are from the last link — click Connect to keep trying.`
+          })
+        }
+      } finally {
+        watchdogResumingRef.current = false
+      }
+    })()
+  }, [
+    snapshot.connection.kind,
+    snapshot.staleLink,
+    transportMode,
+    selectedSerialPort,
+    busyAction,
+    runtime,
+    rememberSelectedSerialPort
+  ])
 
   useEffect(() => {
     if (typeof window === 'undefined') {
@@ -2526,6 +2616,9 @@ export function App() {
   }
 
   async function handleConnect(): Promise<void> {
+    // Connecting again re-arms the auto-resume loop that a deliberate
+    // disconnect stood down.
+    intentionalDisconnectRef.current = false
     setBusyAction('connect')
     try {
       setSessionNotice(undefined)
@@ -2627,10 +2720,16 @@ export function App() {
     // loop can't fight the operator by re-opening the link they just closed.
     expectRebootReconnectRef.current = false
     rebootReconnectingRef.current = false
+    watchdogResumingRef.current = false
+    intentionalDisconnectRef.current = true
     setBusyAction('disconnect')
     try {
       setSessionNotice(undefined)
       await runtime.disconnect()
+      // Closing the link on purpose means a clean slate: the retained table and
+      // its "link lost" banner only make sense for a link that went away on its
+      // own (a watchdog reset), not one the operator just closed.
+      runtime.discardRetainedParameters()
     } finally {
       setBusyAction(undefined)
     }
@@ -6368,6 +6467,7 @@ export function App() {
           <WorkspaceNotes
             snapshot={snapshot}
             sessionNotice={sessionNotice}
+            onReconnect={() => void handleConnect()}
             parameterFollowUp={parameterFollowUp}
             isExpertMode={isExpertMode}
             stagedParameterDraftCount={stagedParameterDrafts.length}

--- a/apps/web/src/sections/WorkspaceNotes.tsx
+++ b/apps/web/src/sections/WorkspaceNotes.tsx
@@ -13,10 +13,13 @@ import { buttonStyle } from '@arduconfig/ui-kit'
 
 import { canRunGuidedAction } from '../guided-action-helpers'
 import type { ParameterFollowUp, ParameterNotice } from '../hooks/use-parameter-feedback'
+import { buildStaleLinkNotice } from '../view-models/stale-link-notice'
 
 export interface WorkspaceNotesProps {
   snapshot: ConfiguratorSnapshot
   sessionNotice: ParameterNotice | undefined
+  /** Reconnect action for the stale-link banner. */
+  onReconnect?: () => void
   parameterFollowUp: ParameterFollowUp | undefined
   isExpertMode: boolean
   stagedParameterDraftCount: number
@@ -28,6 +31,7 @@ export interface WorkspaceNotesProps {
 export function WorkspaceNotes({
   snapshot,
   sessionNotice,
+  onReconnect,
   parameterFollowUp,
   isExpertMode,
   stagedParameterDraftCount,
@@ -35,12 +39,44 @@ export function WorkspaceNotes({
   onRebootAutopilot,
   onPullParameters
 }: WorkspaceNotesProps) {
-  if (!sessionNotice && !parameterFollowUp && !(!isExpertMode && stagedParameterDraftCount > 0)) {
+  const staleLink = snapshot.staleLink
+
+  if (!staleLink && !sessionNotice && !parameterFollowUp && !(!isExpertMode && stagedParameterDraftCount > 0)) {
     return null
   }
 
   return (
     <div className="workspace-main__notes">
+      {/* Everything below the banner is a snapshot of a link that has dropped.
+          It has to be unmissable: values that look live but are minutes old are
+          how someone flies a stale config. */}
+      {staleLink ? (
+        (() => {
+          const notice = buildStaleLinkNotice(staleLink)
+          return (
+            <div className="workspace-note workspace-note--stale" data-testid="stale-link-banner" role="status">
+              <div className="workspace-note--stale__headline">
+                <span className="workspace-note--stale__dot" aria-hidden="true" />
+                <strong>{notice.headline}</strong>
+              </div>
+              <p>{notice.detail}</p>
+              <small>{notice.hint}</small>
+              {onReconnect ? (
+                <div className="button-row">
+                  <button
+                    type="button"
+                    style={buttonStyle('primary')}
+                    data-testid="stale-link-reconnect"
+                    onClick={onReconnect}
+                  >
+                    Reconnect
+                  </button>
+                </div>
+              ) : null}
+            </div>
+          )
+        })()
+      ) : null}
       {sessionNotice ? (
         <div className="workspace-note workspace-note--danger" data-testid="session-connection-notice">
           <strong>Connection issue</strong>

--- a/apps/web/src/serial-reconnect.ts
+++ b/apps/web/src/serial-reconnect.ts
@@ -1,0 +1,106 @@
+// One attempt at reacquiring a flight controller's serial port after the link
+// went away, extracted from App.tsx's post-reboot reconnect so the watchdog
+// auto-resume can reuse it verbatim rather than growing a second, subtly
+// different copy.
+//
+// It handles both USB quirks a reconnect runs into:
+//  - bootloader-first: a rebooting board enumerates as the bootloader (no
+//    MAVLink heartbeat) before the firmware re-enumerates;
+//  - composite device: ArduPilot FCs expose TWO CDC serial interfaces on the
+//    same VID/PID and only one carries MAVLink, and nothing in the port info
+//    distinguishes them.
+// So it tries every currently-granted port sharing the target's VID/PID and
+// keeps the first that actually answers a heartbeat; the wrong interface or a
+// bootloader simply times out and it moves on.
+
+import {
+  getAvailableWebSerialPorts,
+  getWebSerialPortInfo,
+  type WebSerialPortLike
+} from '@arduconfig/transport'
+
+/** The slice of the runtime this needs — keeps the helper testable. */
+export interface SerialReconnectRuntime {
+  connect(): Promise<void>
+  disconnect(): Promise<void>
+  waitForVehicle(options: { timeoutMs: number }): Promise<unknown>
+  requestParameterList(options?: { fresh?: boolean }): Promise<void>
+}
+
+export interface SerialReconnectAttemptOptions {
+  runtime: SerialReconnectRuntime
+  /** VID/PID of the port the operator originally chose, if known. */
+  targetInfo: ReturnType<typeof getWebSerialPortInfo>
+  /**
+   * Point the transport resolver at a candidate handle. Must take effect
+   * synchronously — a React state update lags a render, and the connect below
+   * would then open the previous (dead) handle.
+   */
+  setActivePort: (port: WebSerialPortLike) => void
+  /** Remember the port that actually heartbeated, for later auto-reconnects. */
+  rememberPort: (port: WebSerialPortLike) => void
+  /** Checked between candidates so a cancelled loop stops promptly. */
+  isCancelled: () => boolean
+  /**
+   * `true` re-reads the whole table (post-reboot / post-flash, where inheriting
+   * the previous firmware's values would be wrong). `false` resumes a download a
+   * dropped link left incomplete — the watchdog case, where restarting from zero
+   * every time is exactly what never converges.
+   */
+  fresh: boolean
+  /** Bound on how long to wait for a heartbeat from each candidate. */
+  heartbeatTimeoutMs?: number
+  /** Called after a candidate syncs, so the caller can clear follow-up state. */
+  onConnected?: () => void
+}
+
+/**
+ * Try every plausible port once. Resolves true as soon as one connects and its
+ * parameter pull has been issued, false if none answered.
+ */
+export async function attemptSerialPortReconnect({
+  runtime,
+  targetInfo,
+  setActivePort,
+  rememberPort,
+  isCancelled,
+  fresh,
+  heartbeatTimeoutMs = 4000,
+  onConnected
+}: SerialReconnectAttemptOptions): Promise<boolean> {
+  let ports: WebSerialPortLike[]
+  try {
+    ports = await getAvailableWebSerialPorts()
+  } catch {
+    return false
+  }
+
+  const matching = ports.filter((port) => {
+    const info = getWebSerialPortInfo(port)
+    return (
+      targetInfo !== undefined &&
+      info !== undefined &&
+      info.usbVendorId === targetInfo.usbVendorId &&
+      info.usbProductId === targetInfo.usbProductId
+    )
+  })
+
+  for (const candidate of matching.length > 0 ? matching : ports) {
+    if (isCancelled()) {
+      return false
+    }
+    setActivePort(candidate)
+    try {
+      await runtime.connect()
+      await runtime.waitForVehicle({ timeoutMs: heartbeatTimeoutMs })
+      await runtime.requestParameterList({ fresh })
+      onConnected?.()
+      rememberPort(candidate)
+      return true
+    } catch {
+      await runtime.disconnect().catch(() => {})
+    }
+  }
+
+  return false
+}

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -15395,3 +15395,49 @@ button.mavlink-inspector__sent-row {
   display: grid;
   gap: 8px;
 }
+
+/* Stale-link banner: the values on screen came from a link that has dropped
+ * (a watchdogging board resets every few seconds, and blanking the app each
+ * time helps nobody). Sized and coloured to be impossible to skim past —
+ * mistaking retained values for live ones is the failure mode this prevents. */
+.workspace-note--stale {
+  border-color: color-mix(in srgb, var(--warning) 55%, transparent);
+  background: var(--warning-weak);
+  box-shadow: inset 3px 0 0 var(--warning);
+}
+
+.workspace-note--stale__headline {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.workspace-note--stale__headline strong {
+  font-size: 15px;
+  letter-spacing: 0.01em;
+}
+
+.workspace-note--stale__dot {
+  width: 9px;
+  height: 9px;
+  border-radius: 50%;
+  background: var(--warning);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--warning) 25%, transparent);
+  animation: stale-link-pulse 1.8s ease-in-out infinite;
+}
+
+@keyframes stale-link-pulse {
+  0%,
+  100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.35;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .workspace-note--stale__dot {
+    animation: none;
+  }
+}

--- a/apps/web/src/view-models/stale-link-notice.test.ts
+++ b/apps/web/src/view-models/stale-link-notice.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest'
+
+import { buildStaleLinkNotice } from './stale-link-notice'
+
+const vehicle = {
+  firmware: 'ArduPilot' as const,
+  vehicle: 'ArduCopter' as const,
+  systemId: 1,
+  componentId: 1,
+  armed: false,
+  flightMode: 'Stabilize',
+  systemStatus: 'standby' as const
+}
+
+const at = Date.UTC(2026, 6, 24, 12, 0, 0)
+
+describe('buildStaleLinkNotice', () => {
+  it('names the vehicle and flags an unfinished download as resumable', () => {
+    const notice = buildStaleLinkNotice({ sinceMs: at, vehicle, downloaded: 120, total: 1320 })
+    expect(notice.headline).toBe('Link lost — showing the last data received')
+    expect(notice.detail).toContain('ArduCopter · 120/1320 parameters received (incomplete)')
+    expect(notice.resumable).toBe(true)
+    expect(notice.hint).toContain('resumes the download where it stopped')
+  })
+
+  it('does not promise a resume when the table had already finished', () => {
+    const notice = buildStaleLinkNotice({ sinceMs: at, vehicle, downloaded: 1320, total: 1320 })
+    expect(notice.detail).toContain('1320/1320 parameters received')
+    expect(notice.detail).not.toContain('incomplete')
+    expect(notice.resumable).toBe(false)
+    expect(notice.hint).not.toContain('resumes the download')
+  })
+
+  it('omits an unknown vehicle rather than printing "Unknown"', () => {
+    const notice = buildStaleLinkNotice({
+      sinceMs: at,
+      vehicle: { ...vehicle, vehicle: 'Unknown' },
+      downloaded: 3,
+      total: 10
+    })
+    expect(notice.detail).not.toContain('Unknown')
+    expect(notice.detail).toMatch(/^3\/10 parameters received/)
+  })
+
+  it('avoids a bogus "0/0" when the FC never reported a count', () => {
+    const notice = buildStaleLinkNotice({ sinceMs: at, vehicle, downloaded: 7, total: 0 })
+    expect(notice.detail).toContain('7 parameters received')
+    expect(notice.detail).not.toContain('/0')
+    expect(notice.resumable).toBe(false)
+  })
+
+  it('singularises a lone parameter and survives a bogus timestamp', () => {
+    const notice = buildStaleLinkNotice({ sinceMs: Number.NaN, vehicle, downloaded: 1, total: 0 })
+    expect(notice.detail).toContain('1 parameter received')
+    expect(notice.detail).toContain('link lost')
+  })
+})

--- a/apps/web/src/view-models/stale-link-notice.ts
+++ b/apps/web/src/view-models/stale-link-notice.ts
@@ -1,0 +1,49 @@
+// Text for the "link lost — showing the last data received" banner.
+//
+// Pure builder (the established view-models pattern) so the wording and the
+// edge cases — unknown vehicle, a table that had finished downloading, a bogus
+// timestamp — are unit-testable without rendering anything.
+
+import type { StaleLinkState } from '@arduconfig/ardupilot-core'
+
+export interface StaleLinkNotice {
+  headline: string
+  /** Vehicle + parameter counts + when the link dropped. */
+  detail: string
+  /** Why it matters and what reconnecting does. */
+  hint: string
+  /** True when the download never finished, so reconnecting resumes it. */
+  resumable: boolean
+}
+
+function formatClock(sinceMs: number): string {
+  if (!Number.isFinite(sinceMs)) {
+    return 'link lost'
+  }
+  try {
+    return `lost at ${new Date(sinceMs).toLocaleTimeString()}`
+  } catch {
+    return 'link lost'
+  }
+}
+
+export function buildStaleLinkNotice(stale: StaleLinkState): StaleLinkNotice {
+  const vehicle = stale.vehicle?.vehicle
+  const vehiclePrefix = vehicle && vehicle !== 'Unknown' ? `${vehicle} · ` : ''
+  const resumable = stale.total > 0 && stale.downloaded < stale.total
+  // A count of 0 total means the FC never reported one — claiming "0/0
+  // parameters" would read as a failure that did not happen.
+  const counts =
+    stale.total > 0
+      ? `${stale.downloaded}/${stale.total} parameters received${resumable ? ' (incomplete)' : ''}`
+      : `${stale.downloaded} parameter${stale.downloaded === 1 ? '' : 's'} received`
+
+  return {
+    headline: 'Link lost — showing the last data received',
+    detail: `${vehiclePrefix}${counts} · ${formatClock(stale.sinceMs)}`,
+    hint: resumable
+      ? 'These values are not live and nothing can be written until the vehicle reconnects. Reconnecting resumes the download where it stopped.'
+      : 'These values are not live and nothing can be written until the vehicle reconnects.',
+    resumable
+  }
+}

--- a/packages/ardupilot-core/src/runtime.ts
+++ b/packages/ardupilot-core/src/runtime.ts
@@ -499,25 +499,26 @@ export class ArduPilotConfiguratorRuntime {
   // Test-injectable per-instance override; defaults to the
   // module constant. Production callers never set this.
   private readonly parameterSyncStallRetryMs: number
-  // Partial parameter table kept when a link drops mid-download, so the next
-  // connect resumes by index instead of restarting from zero. A board that
-  // resets every few seconds can never finish a table in one window; carrying
-  // the partial set across drops turns N short windows into one download.
-  // Deliberately NOT surfaced in the snapshot: while disconnected the UI must
-  // keep showing nothing, since these values belong to a board that is gone.
-  // Parameter count the carried-over table was captured against, while a
-  // resumed download is still unproven. The first PARAM_VALUE of the new link
-  // settles it: a different count means the table itself changed (reflash,
-  // defaults reset, different build) and the carried values must be thrown out.
+  // Parameter count the retained table was captured against, while a resumed
+  // download is still unproven. The first PARAM_VALUE of the new link settles
+  // it: a different count means the table itself changed (reflash, defaults
+  // reset, different build) and the retained values must be thrown out.
   private parameterSyncResumedTotal: number | undefined
-  private parameterCarryOver:
+  // Set when a link drops with parameters in hand. The table itself STAYS in
+  // `this.parameters`: a board that watchdog-resets every few seconds would
+  // otherwise blank the whole app on each reset, and those values are still the
+  // last truth we had. This marks them as no longer live — the UI says so
+  // loudly, and everything that can act on the vehicle stays gated on
+  // `connection.kind === 'connected'`, which a retained table cannot satisfy.
+  // It also carries the identity + timestamp that decide whether the next
+  // connect may resume the download instead of restarting from zero.
+  private staleLink:
     | {
         readonly key: string
-        readonly parameters: Map<string, ParameterState>
-        readonly realIds: Set<string>
-        readonly indices: Set<number>
+        readonly sinceMs: number
+        readonly vehicle: VehicleIdentity
+        readonly downloaded: number
         readonly total: number
-        readonly capturedAtMs: number
       }
     | undefined
   private autopilotVersionRequested = false
@@ -656,6 +657,17 @@ export class ArduPilotConfiguratorRuntime {
     return {
       connection: this.connection,
       vehicle: this.vehicle,
+      // Retained-table marker. Present only while the values on screen came
+      // from a link that has since dropped; cleared the moment a live download
+      // resumes or restarts.
+      staleLink: this.staleLink
+        ? {
+            sinceMs: this.staleLink.sinceMs,
+            vehicle: this.staleLink.vehicle,
+            downloaded: this.staleLink.downloaded,
+            total: this.staleLink.total
+          }
+        : undefined,
       hardware: cloneHardwareState({
         board: this.hardwareBoard ? { ...this.hardwareBoard } : undefined,
         uartsFile: cloneBoardFileState(this.uartsFile),
@@ -892,39 +904,37 @@ export class ArduPilotConfiguratorRuntime {
 
     try {
       const vehicle = await this.waitForVehicle(options)
-      this.parameters.clear()
-      this.realParameterIdsReceived.clear()
-      this.receivedParameterIndices.clear()
-      this.totalParameters = 0
+
+      // Resume the table the previous link dropped mid-download, when this is
+      // the same board and it is still fresh. `fresh: true` opts out — a caller
+      // that just reflashed or rebooted the board must not inherit values from
+      // the firmware that was on it before.
+      const resuming = options.fresh !== true && this.canResumeStaleLink(vehicle)
+      if (!resuming) {
+        this.discardStaleLink()
+      }
+      const resumedFrom = resuming ? this.staleLink : undefined
+      this.staleLink = undefined
+
       this.parameterSyncRetryCount = 0
-      this.parameterSyncLastRetryDownloaded = 0
+      this.parameterSyncLastRetryDownloaded = resumedFrom ? resumedFrom.downloaded : 0
       this.parameterSyncGapFillActive = false
+      this.parameterSyncResumedTotal = resumedFrom?.total
       this.clearParameterSyncRetryTimer()
 
-      // Resume a table the previous link dropped mid-download, when this is the
-      // same board and the stash is still fresh. `fresh: true` opts out — a
-      // caller that just reflashed or rebooted the board must not inherit values
-      // from the firmware that was on it before.
-      const resumed = options.fresh === true ? undefined : this.takeParameterCarryOver(vehicle)
-      if (resumed) {
-        resumed.parameters.forEach((parameter, id) => this.parameters.set(id, parameter))
-        resumed.realIds.forEach((id) => this.realParameterIdsReceived.add(id))
-        resumed.indices.forEach((index) => this.receivedParameterIndices.add(index))
-        this.totalParameters = resumed.total
-        this.parameterSyncResumedTotal = resumed.total
-        this.parameterSyncLastRetryDownloaded = resumed.realIds.size
+      if (resumedFrom) {
         this.appendStatusEntry(
           'info',
-          `Resuming the parameter download: ${resumed.realIds.size}/${resumed.total} carried over from the previous link.`
+          `Resuming the parameter download: ${resumedFrom.downloaded}/${resumedFrom.total} kept from the previous link.`
         )
       }
 
       this.parameterSync = {
         status: 'requesting',
-        downloaded: resumed ? resumed.realIds.size : 0,
-        total: resumed ? resumed.total : 0,
+        downloaded: resumedFrom ? resumedFrom.downloaded : 0,
+        total: resumedFrom ? resumedFrom.total : 0,
         duplicateFrames: 0,
-        progress: resumed ? Math.min(resumed.realIds.size / resumed.total, 1) : null,
+        progress: resumedFrom ? Math.min(resumedFrom.downloaded / resumedFrom.total, 1) : null,
         targetSystemId: vehicle.systemId,
         targetComponentId: vehicle.componentId,
         requestedAtMs: Date.now()
@@ -932,8 +942,8 @@ export class ArduPilotConfiguratorRuntime {
       this.setGuidedAction('request-parameters', {
         actionId: 'request-parameters',
         status: 'running',
-        summary: resumed
-          ? `Resuming the parameter download at ${resumed.realIds.size}/${resumed.total} (sys=${vehicle.systemId} comp=${vehicle.componentId}).`
+        summary: resumedFrom
+          ? `Resuming the parameter download at ${resumedFrom.downloaded}/${resumedFrom.total} (sys=${vehicle.systemId} comp=${vehicle.componentId}).`
           : `Parameter request sent to sys=${vehicle.systemId} comp=${vehicle.componentId}.`,
         instructions: ['Waiting for the autopilot to stream the full parameter table.'],
         statusTexts: [],
@@ -943,7 +953,7 @@ export class ArduPilotConfiguratorRuntime {
       })
       this.emit()
 
-      if (resumed) {
+      if (resumedFrom) {
         // Refetch only what the dropped link never delivered. A full re-stream
         // here would re-send everything we already hold and — on a board that
         // resets every few seconds — never get further than the last attempt.
@@ -958,6 +968,21 @@ export class ArduPilotConfiguratorRuntime {
       this.emit()
       throw error
     }
+  }
+
+  /**
+   * Drop the retained parameter table from a dropped link. The operator closing
+   * the link on purpose expects a clean slate — "link lost, showing the last
+   * data" is only honest about a link that went away on its own. NOT called on
+   * the internal disconnect()s inside a reconnect attempt, which must leave the
+   * retained table intact for the resume.
+   */
+  discardRetainedParameters(): void {
+    if (!this.staleLink && this.parameters.size === 0) {
+      return
+    }
+    this.discardStaleLink()
+    this.emit()
   }
 
   async waitForParameterSync(options: WaitForParameterSyncOptions = {}): Promise<ConfiguratorSnapshot['parameterStats']> {
@@ -1424,8 +1449,8 @@ export class ArduPilotConfiguratorRuntime {
    *  REJECTED / TIMEOUT — the caller surfaces that to the operator. */
   async rebootToBootloader(): Promise<void> {
     // Whatever is flashed next may have a different parameter table, so no
-    // partial table from this session may survive to be resumed against it.
-    this.parameterCarryOver = undefined
+    // table from this session may survive to be resumed against it.
+    this.discardStaleLink()
     await this.sendCommand(MAV_CMD.PREFLIGHT_REBOOT_SHUTDOWN, [3, 0, 0, 0, 0, 0, 0], {
       waitForAck: true,
       ackTimeoutMs: 3000
@@ -1980,6 +2005,13 @@ export class ArduPilotConfiguratorRuntime {
 
     this.vehicle = createVehicleIdentity(message, systemId, componentId)
     this.applyFirmwareMetadata(this.vehicle.vehicle)
+
+    // Retained values from a different board must never linger once this one
+    // announces itself — better an empty screen than another vehicle's config
+    // shown against this heartbeat.
+    if (this.staleLink && this.staleLink.key !== this.staleLinkKey(this.vehicle)) {
+      this.discardStaleLink()
+    }
 
     if (this.parameterSync.status === 'awaiting-vehicle') {
       this.parameterSync = createIdleParameterSync()
@@ -2815,71 +2847,76 @@ export class ArduPilotConfiguratorRuntime {
   }
 
   /**
-   * Identity a carried-over partial table is bound to. Includes the vehicle
-   * kind and autopilot alongside the MAVLink addresses so a resume can't graft
-   * one board's parameters onto another that happens to share sys/comp ids.
+   * Identity the retained table is bound to. Includes the vehicle kind and
+   * firmware alongside the MAVLink addresses so a resume can't graft one
+   * board's parameters onto another that happens to share sys/comp ids.
    */
-  private carryOverKey(vehicle: VehicleIdentity): string {
+  private staleLinkKey(vehicle: VehicleIdentity): string {
     return `${vehicle.systemId}:${vehicle.componentId}:${vehicle.firmware}:${vehicle.vehicle}`
   }
 
   /**
-   * Stash the partial parameter table before live state is torn down, so the
-   * next connect to the same board resumes instead of restarting. Only worth
-   * keeping while a download is genuinely mid-flight: a complete table will be
-   * re-streamed cheaply anyway, and an empty one has nothing to resume.
+   * Mark the parameters left on screen as belonging to a link that has gone
+   * away. Called as live state is torn down, BEFORE `this.vehicle` is cleared.
+   * Nothing to mark when the table is empty — there is no stale data to warn
+   * about, and no partial download worth resuming.
    */
-  private captureParameterCarryOver(): void {
+  private markStaleLink(): void {
     const vehicle = this.vehicle
-    if (
-      !vehicle ||
-      this.realParameterIdsReceived.size === 0 ||
-      this.parameterSync.status === 'complete' ||
-      this.totalParameters <= 0
-    ) {
+    if (!vehicle || this.parameters.size === 0) {
+      // Nothing new to record — and crucially, do NOT clear an existing marker.
+      // resetLiveState() runs again on connect(), by which point the vehicle is
+      // already gone; clearing here would destroy the marker moments before the
+      // reconnect that needs it. Retained values are dropped explicitly, via
+      // discardStaleLink().
       return
     }
 
-    this.parameterCarryOver = {
-      key: this.carryOverKey(vehicle),
-      parameters: new Map(this.parameters),
-      realIds: new Set(this.realParameterIdsReceived),
-      indices: new Set(this.receivedParameterIndices),
-      total: this.totalParameters,
-      capturedAtMs: Date.now()
+    this.staleLink = {
+      key: this.staleLinkKey(vehicle),
+      sinceMs: Date.now(),
+      vehicle,
+      downloaded: this.realParameterIdsReceived.size,
+      total: this.totalParameters
     }
   }
 
-  /**
-   * Consume the stashed partial table if it belongs to this board and is still
-   * fresh. Always clears the stash — a resume that turns out to be wrong (the
-   * FC reports a different parameter count, see processParamValue) restarts
-   * clean rather than half-resuming twice.
-   */
-  private takeParameterCarryOver(vehicle: VehicleIdentity):
-    | NonNullable<ArduPilotConfiguratorRuntime['parameterCarryOver']>
-    | undefined {
-    const carryOver = this.parameterCarryOver
-    this.parameterCarryOver = undefined
-    if (!carryOver || carryOver.key !== this.carryOverKey(vehicle)) {
-      return undefined
-    }
-    if (Date.now() - carryOver.capturedAtMs > PARAMETER_CARRY_OVER_TTL_MS) {
-      return undefined
-    }
-    return carryOver
-  }
-
-  private resetLiveState(): void {
-    this.captureParameterCarryOver()
-    this.vehicle = undefined
-    this.hardwareBoard = undefined
-    this.uartsFile = createIdleUartsFileState()
-    this.pwmOutputCount = undefined
+  /** Drop the retained table and the stale marker together. */
+  private discardStaleLink(): void {
+    this.staleLink = undefined
     this.parameters.clear()
     this.realParameterIdsReceived.clear()
     this.receivedParameterIndices.clear()
     this.totalParameters = 0
+  }
+
+  /**
+   * Whether the retained table may be resumed against the vehicle that just
+   * identified itself: same board, still within the freshness window, and the
+   * download was actually incomplete (a complete table is re-pulled normally).
+   */
+  private canResumeStaleLink(vehicle: VehicleIdentity): boolean {
+    const stale = this.staleLink
+    return (
+      stale !== undefined &&
+      stale.key === this.staleLinkKey(vehicle) &&
+      stale.total > 0 &&
+      stale.downloaded < stale.total &&
+      Date.now() - stale.sinceMs <= PARAMETER_CARRY_OVER_TTL_MS
+    )
+  }
+
+  private resetLiveState(): void {
+    // Retain the parameter table (see `staleLink`) — it is the last data we
+    // had, and blanking the app on every watchdog reset helps nobody. Live
+    // telemetry, verification and guided actions are all cleared below: those
+    // are moment-in-time signals, and a frozen attitude or RC reading shown as
+    // if current would be genuinely misleading.
+    this.markStaleLink()
+    this.vehicle = undefined
+    this.hardwareBoard = undefined
+    this.uartsFile = createIdleUartsFileState()
+    this.pwmOutputCount = undefined
     this.parameterSyncRetryCount = 0
     this.parameterSyncLastRetryDownloaded = 0
     this.parameterSyncGapFillActive = false

--- a/packages/ardupilot-core/src/types.ts
+++ b/packages/ardupilot-core/src/types.ts
@@ -542,10 +542,33 @@ export interface CanBusState {
   escTelemetry: DronecanEscTelemetry[]
 }
 
+/**
+ * What is left on screen after the link goes away. The parameter table is kept
+ * (a board that watchdog-resets would otherwise blank the whole app every few
+ * seconds, and the values are still the last truth we had), but it is NOT live
+ * — every consumer that can act on the vehicle stays gated on
+ * `connection.kind === 'connected'`, and the UI must say plainly that what is
+ * shown is a snapshot of a link that has dropped.
+ */
+export interface StaleLinkState {
+  /** When the link dropped. */
+  sinceMs: number
+  /** Identity of the vehicle the retained values came from. */
+  vehicle?: VehicleIdentity
+  /** Parameters actually received before the drop, and the FC-reported total. */
+  downloaded: number
+  total: number
+}
+
 export interface ConfiguratorSnapshot {
   connection: TransportStatus
   vehicle?: VehicleIdentity
   hardware: HardwareState
+  /**
+   * Present only while showing retained values from a dropped link. Absent
+   * whenever the data on screen is live (or there is nothing to show).
+   */
+  staleLink?: StaleLinkState
   parameterStats: {
     downloaded: number
     total: number

--- a/tests/e2e/views.spec.ts
+++ b/tests/e2e/views.spec.ts
@@ -340,6 +340,23 @@ test.describe('tab order', () => {
   })
 })
 
+test.describe('Disconnect behaviour', () => {
+  test('a deliberate disconnect clears the vehicle data instead of leaving a stale-link banner', async ({ page }) => {
+    // The retained table + "link lost" banner exist for a link that went away on
+    // its own (a watchdogging board). Closing the link on purpose must give a
+    // clean slate — showing "showing the last data received" after the operator
+    // clicked Disconnect would be both wrong and alarming.
+    await page.goto('/')
+    await connectViaHeader(page)
+    await openView(page, 'config')
+    await expect(page.locator('.scoped-editor-field').first()).toBeVisible()
+
+    await page.getByTestId('disconnect-button').click()
+    await expect(page.getByTestId('stale-link-banner')).toHaveCount(0)
+    await expect(page.locator('.scoped-editor-field')).toHaveCount(0)
+  })
+})
+
 test.describe('Ports view', () => {
   test('serial options show as chips in the matrix (Notes column removed)', async ({ page }) => {
     await page.goto('/')

--- a/tests/parameter-sync-watchdog-resume.test.mjs
+++ b/tests/parameter-sync-watchdog-resume.test.mjs
@@ -128,7 +128,15 @@ test('a partial table survives a watchdog link drop and the next connect resumes
 
     session.watchdogReset()
     await sleep(20)
-    assert.equal(runtime.getSnapshot().parameters.length, 0, 'a dropped link still shows nothing while disconnected')
+    // The values stay on screen after the drop — blanking the app on every
+    // watchdog reset helps nobody — but they are explicitly marked stale.
+    const dropped = runtime.getSnapshot()
+    assert.equal(dropped.parameters.length, 5, 'the last table is retained while disconnected')
+    assert.ok(dropped.staleLink, 'and flagged as stale so the UI can say so')
+    assert.equal(dropped.staleLink.downloaded, 5)
+    assert.equal(dropped.staleLink.total, TOTAL)
+    assert.equal(dropped.vehicle, undefined, 'but the vehicle is gone: nothing may act on it')
+    assert.equal(dropped.parameterStats.status, 'idle', 'and no sync is considered live')
 
     // Operator reconnects; the board is up long enough to answer by-index reads.
     await runtime.connect()


### PR DESCRIPTION
Follow-up to #96, straight from testing against the board that prompted it. The resume works, but two things were still wrong in practice:

- the whole app blanked out on every watchdog reset;
- at ~**120 of 1320** parameters per window, finishing the table would have taken a dozen manual reconnects.

## 1. Retain the parameter table when a link drops

`resetLiveState()` no longer clears parameters/indices/count — it marks them stale (`staleLink`: identity, timestamp, downloaded/total). The table was already being stashed for the resume, so this **collapses the two mechanisms into one**: what the resume uses and what the operator sees are now the same values, not a copy.

Still cleared on a drop: live telemetry, verification, guided actions, vehicle identity, hardware state. Those are moment-in-time signals — a frozen attitude or RC reading shown as if current would be misleading.

**Nothing can act on a retained table.** Every write path is gated on `connection.kind === 'connected'` (`parameterWriteBlockReason` checks it first), which a dropped link cannot satisfy. Plus:
- retained values from a *different* board are discarded the moment a heartbeat identifies it;
- a deliberate **Disconnect** discards them outright (`discardRetainedParameters()`) — "showing the last data received" is only honest about a link that went away on its own.

## 2. A banner you cannot skim past

Amber, pulsing dot, full width above the view: the vehicle, `N/M parameters received (incomplete)`, the wall-clock time it dropped, and a Reconnect button.

Copy lives in a pure builder (`view-models/stale-link-notice.ts`) with 5 unit tests: unknown vehicle, an already-complete table (no false promise of a resume), a missing FC count (no bogus `0/0`), singular/plural, and a bogus timestamp.

## 3. Auto-resume through the resets

A new effect reconnects on its own while an incomplete download is outstanding, so the count climbs across windows instead of needing a dozen clicks. Deliberately narrow — web-serial only, only when `staleLink` shows an incomplete table, bounded to 5 minutes, and it stands down for a deliberate disconnect, an in-flight reboot reconnect, or any busy action.

The post-reboot reconnect's port-probing logic (bootloader-first, and the two-CDC-interface problem where only one carries MAVLink) is **extracted to `serial-reconnect.ts` and shared** rather than growing a second, subtly different copy. Reboot path keeps `fresh: true`; watchdog path passes `fresh: false` so it resumes.

## ArduCopter byte-identical

Retention and the banner only exist after a link drops, and the auto-resume only runs with an incomplete download outstanding. A healthy board completes on the first pass and none of this executes.

## Validation ladder

Rungs 1–3.
- `node --test` 753 pass / 0 fail
- vitest 547 pass (+5 new)
- Playwright 218 pass (+1 new: a deliberate disconnect must clear, not leave a stale banner)
- typecheck clean
- Verified in the demo that the banner renders with the config values still on screen after a drop, and that Disconnect gives a clean slate

**Rung 5 is the point of this change** and is next: the watchdogging board should now climb past 120/1320 across automatic reconnects.