### PR TITLE
fix(motors): curve the Motor Setup reorder/direction spin arcs outward too

### DIFF
--- a/apps/web/src/sections/MotorReorderDialog.tsx
+++ b/apps/web/src/sections/MotorReorderDialog.tsx
@@ -18,7 +18,7 @@ import { hasBitmaskFlag, toggleBitmaskFlag } from '../selectors/bitmask'
 import { readRoundedParameter, selectParameterById } from '../selectors/parameter-read'
 import type { MotorPreviewNode } from '../view-models/motor-preview'
 import { resolveMotorReverseEligibility } from '../view-models/motor-reverse'
-import { motorSpinArcPath } from '../views/motor-spin-arc'
+import { motorOutwardAngleDeg, motorSpinArcPath } from '../views/motor-spin-arc'
 import type { MotorReorderRow } from '../hooks/use-motor-reorder'
 
 export interface MotorReorderDialogProps {
@@ -261,7 +261,7 @@ export function MotorReorderDialog({
                           {node.stack ? <circle cx={x} cy={y} r={19} className="motor-mixer-preview__stack" /> : null}
                           {node.spin ? (
                             <path
-                              d={motorSpinArcPath(x, y, (node.stack ? 29 : 24) + 6, node.spin)}
+                              d={motorSpinArcPath(x, y, (node.stack ? 29 : 24) + 6, node.spin, motorOutwardAngleDeg(node.x, node.y))}
                               className="motor-mixer-preview__spin"
                               markerEnd="url(#spinArrowReorder)"
                             />
@@ -491,7 +491,7 @@ export function MotorReorderDialog({
                           {node.stack ? <circle cx={x} cy={y} r={19} className="motor-mixer-preview__stack" /> : null}
                           {node.spin ? (
                             <path
-                              d={motorSpinArcPath(x, y, (node.stack ? 29 : 24) + 6, node.spin)}
+                              d={motorSpinArcPath(x, y, (node.stack ? 29 : 24) + 6, node.spin, motorOutwardAngleDeg(node.x, node.y))}
                               className="motor-mixer-preview__spin"
                               markerEnd="url(#spinArrowDirection)"
                             />


### PR DESCRIPTION
Follow-up to #99. That PR made the **Motor Test** diagram's spin arcs curve outward from the hub, but the **Motor Setup → Order/Direction** preview (`MotorReorderDialog`) draws its own SVG and still called `motorSpinArcPath` with the default (arc over the top) — so a rear motor's arrow curved *above* its ring there, the exact thing #99 fixed on the other tab (reported with a screenshot of the Order preview).

Passes `motorOutwardAngleDeg(node.x, node.y)` at both reorder arc sites (Order and Direction tabs), matching `MotorMixerDiagram`. Rear-motor arrows now sit below their ring, front-motor arrows above.

**ArduCopter byte-identical**: presentational only (arc geometry).

## Validation
- typecheck clean, vitest 559 pass
- Verified in the demo reorder preview: top motors (3,1) arc above, bottom motors (2,4) below