### PR TITLE
fix(motors): spin arrow as a compact dome above/below the motor, not a ring-hugging band

### DIFF
--- a/apps/web/src/sections/MotorReorderDialog.tsx
+++ b/apps/web/src/sections/MotorReorderDialog.tsx
@@ -226,8 +226,8 @@ export function MotorReorderDialog({
                 <div className="motor-mixer-preview motor-mixer-preview--dialog">
                   <svg viewBox="0 0 260 260" role="img" aria-label="Schematic reordered motor map preview">
                     <defs>
-                      <marker id="spinArrowReorder" markerWidth="6" markerHeight="6" refX="3" refY="3" orient="auto">
-                        <path d="M 0 0 L 6 3 L 0 6 z" className="motor-mixer-preview__spin-head" />
+                      <marker id="spinArrowReorder" markerWidth="8" markerHeight="8" refX="4" refY="4" orient="auto">
+                        <path d="M 0 0 L 8 4 L 0 8 z" className="motor-mixer-preview__spin-head" />
                       </marker>
                     </defs>
                     <rect x="0" y="0" width="260" height="260" rx="18" className="motor-mixer-preview__backdrop" />
@@ -261,7 +261,7 @@ export function MotorReorderDialog({
                           {node.stack ? <circle cx={x} cy={y} r={19} className="motor-mixer-preview__stack" /> : null}
                           {node.spin ? (
                             <path
-                              d={motorSpinArcPath(x, y, (node.stack ? 29 : 24) + 6, node.spin, motorOutwardAngleDeg(node.x, node.y))}
+                              d={motorSpinArcPath(x, y, (node.stack ? 29 : 24) + 13, node.spin, motorOutwardAngleDeg(node.x, node.y))}
                               className="motor-mixer-preview__spin"
                               markerEnd="url(#spinArrowReorder)"
                             />
@@ -458,8 +458,8 @@ export function MotorReorderDialog({
                 <div className="motor-mixer-preview motor-mixer-preview--dialog">
                   <svg viewBox="0 0 260 260" role="img" aria-label="Clickable motor map — click a motor to spin it">
                     <defs>
-                      <marker id="spinArrowDirection" markerWidth="6" markerHeight="6" refX="3" refY="3" orient="auto">
-                        <path d="M 0 0 L 6 3 L 0 6 z" className="motor-mixer-preview__spin-head" />
+                      <marker id="spinArrowDirection" markerWidth="8" markerHeight="8" refX="4" refY="4" orient="auto">
+                        <path d="M 0 0 L 8 4 L 0 8 z" className="motor-mixer-preview__spin-head" />
                       </marker>
                     </defs>
                     <rect x="0" y="0" width="260" height="260" rx="18" className="motor-mixer-preview__backdrop" />
@@ -491,7 +491,7 @@ export function MotorReorderDialog({
                           {node.stack ? <circle cx={x} cy={y} r={19} className="motor-mixer-preview__stack" /> : null}
                           {node.spin ? (
                             <path
-                              d={motorSpinArcPath(x, y, (node.stack ? 29 : 24) + 6, node.spin, motorOutwardAngleDeg(node.x, node.y))}
+                              d={motorSpinArcPath(x, y, (node.stack ? 29 : 24) + 13, node.spin, motorOutwardAngleDeg(node.x, node.y))}
                               className="motor-mixer-preview__spin"
                               markerEnd="url(#spinArrowDirection)"
                             />

--- a/apps/web/src/views/MotorMixerDiagram.tsx
+++ b/apps/web/src/views/MotorMixerDiagram.tsx
@@ -24,8 +24,8 @@ export function MotorMixerDiagram({ nodes, geometryMode, outputLabelByMotor, cla
     <div className={`motor-mixer-preview${className ? ` ${className}` : ''}`} data-testid={testId}>
       <svg viewBox="0 0 260 260" role="img" aria-label="Schematic motor map">
         <defs>
-          <marker id="spinArrowTest" markerWidth="6" markerHeight="6" refX="3" refY="3" orient="auto">
-            <path d="M 0 0 L 6 3 L 0 6 z" className="motor-mixer-preview__spin-head" />
+          <marker id="spinArrowTest" markerWidth="8" markerHeight="8" refX="4" refY="4" orient="auto">
+            <path d="M 0 0 L 8 4 L 0 8 z" className="motor-mixer-preview__spin-head" />
           </marker>
         </defs>
         <rect x="0" y="0" width="260" height="260" rx="18" className="motor-mixer-preview__backdrop" />
@@ -42,7 +42,7 @@ export function MotorMixerDiagram({ nodes, geometryMode, outputLabelByMotor, cla
               {node.stack ? <circle cx={x} cy={y} r={19} className="motor-mixer-preview__stack" /> : null}
               {node.spin ? (
                 <path
-                  d={motorSpinArcPath(x, y, (node.stack ? 29 : 24) + 6, node.spin, motorOutwardAngleDeg(node.x, node.y))}
+                  d={motorSpinArcPath(x, y, (node.stack ? 29 : 24) + 13, node.spin, motorOutwardAngleDeg(node.x, node.y))}
                   className="motor-mixer-preview__spin"
                   markerEnd="url(#spinArrowTest)"
                 />

--- a/apps/web/src/views/motor-spin-arc.test.ts
+++ b/apps/web/src/views/motor-spin-arc.test.ts
@@ -29,13 +29,16 @@ describe('motorOutwardAngleDeg', () => {
 })
 
 describe('motorSpinArcPath', () => {
-  it('is unchanged (arc over the top) when no outward angle is given', () => {
-    // Historical default: endpoints at 215° / -35° around a 100,100 ring, r=30.
+  it('defaults to a 160° dome over the top when no outward angle is given', () => {
+    // Endpoints at 90±80 = 170° / 10° (math) around a 100,100 ring, r=30.
     const cw = parseArc(motorSpinArcPath(100, 100, 30, 'cw'))
-    // start at 215° math → x = 100 + 30cos215 ≈ 75.4, y = 100 - 30sin215 ≈ 117.2
-    expect(cw.x0).toBeCloseTo(100 + 30 * Math.cos((215 * Math.PI) / 180), 0)
-    expect(cw.y0).toBeCloseTo(100 - 30 * Math.sin((215 * Math.PI) / 180), 0)
+    // cw start at 170° math → x = 100 + 30cos170 ≈ 70.5, y = 100 - 30sin170 ≈ 94.8
+    expect(cw.x0).toBeCloseTo(100 + 30 * Math.cos((170 * Math.PI) / 180), 0)
+    expect(cw.y0).toBeCloseTo(100 - 30 * Math.sin((170 * Math.PI) / 180), 0)
     expect(cw.sweep).toBe(1)
+    // Both endpoints sit above the ring centre (the dome caps the top).
+    expect(cw.y0).toBeLessThan(100)
+    expect(cw.y1).toBeLessThan(100)
   })
 
   it('flips the sweep flag between cw and ccw', () => {
@@ -43,27 +46,21 @@ describe('motorSpinArcPath', () => {
     expect(parseArc(motorSpinArcPath(0, 0, 10, 'ccw')).sweep).toBe(0)
   })
 
-  it('centres the gap on the hub side: a rear motor arcs below its ring', () => {
-    // Rear motor: outward points down (-90°). The arc spans ±125° around -90°,
-    // i.e. from 35° to -215°, so its midpoint (-90°, straight down in screen =
-    // BELOW the ring centre) has the largest y. Sample both endpoints and the
-    // midpoint; the arc's lowest point on screen must be below the ring centre.
+  it('a rear motor domes BELOW its ring (outward = down)', () => {
+    // Outward -90°: endpoints at -90±80 = -10° / -170°, belly straight down.
+    // Both endpoints sit below the ring centre; the belly is further below.
     const cy = 100
     const r = 30
     const arc = parseArc(motorSpinArcPath(100, cy, r, 'cw', -90))
-    const mid = cy + r // straight-down point of the ring
-    // Both endpoints sit near the top gap (small y), the swept belly is at the
-    // bottom — assert the endpoints straddle the vertical and the belly is below.
-    expect(Math.max(arc.y0, arc.y1)).toBeLessThan(mid) // endpoints above the belly
-    expect(arc.y0).toBeLessThan(cy + r) // sanity: within ring vertical extent
+    expect(arc.y0).toBeGreaterThan(cy) // endpoint below centre
+    expect(arc.y1).toBeGreaterThan(cy)
   })
 
-  it('a front motor arcs above its ring (mirror of the rear case)', () => {
+  it('a front motor domes ABOVE its ring (mirror of the rear case)', () => {
     const cy = 100
     const r = 30
     const arc = parseArc(motorSpinArcPath(100, cy, r, 'cw', 90))
-    // Endpoints near the bottom gap → larger y than the ring centre.
-    expect(Math.min(arc.y0, arc.y1)).toBeGreaterThan(cy - r) // belly is above (small y)
-    expect(Math.max(arc.y0, arc.y1)).toBeGreaterThan(cy) // gap endpoints below centre
+    expect(arc.y0).toBeLessThan(cy) // endpoint above centre
+    expect(arc.y1).toBeLessThan(cy)
   })
 })

--- a/apps/web/src/views/motor-spin-arc.ts
+++ b/apps/web/src/views/motor-spin-arc.ts
@@ -8,9 +8,11 @@
 // — matching how operators draw prop directions on a frame. Callers that don't
 // know a motor's position keep the historical default (centred over the top).
 
-// Half-span of the arc, degrees. 125° each side → a 250° sweep, leaving a ~110°
-// gap on the hub-facing side where the arm meets the ring.
-const ARC_HALF_SPAN_DEG = 125
+// Half-span of the arc, degrees. 80° each side → a 160° sweep: a compact curved
+// arrow that sits as a dome ABOVE a front motor / BELOW a rear one (rather than a
+// band wrapping the whole ring), matching how spin direction is sketched on a
+// frame. The wide hub-facing gap keeps the glyph clearly outside the ring.
+const ARC_HALF_SPAN_DEG = 80
 
 /**
  * @param outwardAngleDeg math angle (y-up, 0°=+x/right, 90°=up) pointing from


### PR DESCRIPTION
Follow-up to #99/#100. The spin arcs swept ~250° and hugged the ring, reading as a band wrapped around each motor. The intended look (per the reference sketch) is a **small curved arrow floating above a front motor / below a rear one** — the way you'd sketch spin direction on a frame.

Three tweaks in the shared arc geometry + SVG marker defs:
- `ARC_HALF_SPAN_DEG` 125 → 80 (a 160° dome instead of a 250° band)
- stand the arc off the ring (radius +6 → +13) so it floats clearly outside
- bigger arrowhead marker (6 → 8) so direction reads at a glance

Applies everywhere spin arcs are drawn (Motor Test diagram + Motor Setup Order/Direction previews). **Direction is unchanged** — still driven by the per-frame `FRAME_MOTOR_LAYOUTS` table.

**ArduCopter byte-identical**: presentational only.

## Validation
- typecheck clean, vitest 559 pass (arc geometry test updated for the 160° dome)
- Playwright motor-test spec pass
- Verified in the demo: quad-X shows a dome above M1/M3, below M2/M4 — matches the sketch