### PR TITLE
feat(ports): auto-configure the peripheral when a UART's protocol needs it

### DIFF
--- a/apps/web/src/param-review.ts
+++ b/apps/web/src/param-review.ts
@@ -12,6 +12,7 @@ import {
 } from './param-groups'
 import { AUTOTUNE_COPTER_PARAM_IDS, AUTOTUNE_PLANE_REVIEW_PARAM_IDS } from './autotune-params'
 import { OSD_PARAM_IDS } from './osd-params'
+import { PORT_PAIRING_PARAM_IDS } from './view-models/port-protocol-pairings'
 import { PLANE_SOARING_ADSB_PARAM_IDS } from './plane-soaring-adsb-params'
 import { TUNING_PARAM_IDS, TUNING_PLANE_PARAM_IDS, TUNING_ROVER_PARAM_IDS, TUNING_SUB_PARAM_IDS } from './tuning-params'
 
@@ -44,7 +45,12 @@ export function isPortsReviewParamId(paramId: string): boolean {
   return (
     /^SERIAL\d+_(PROTOCOL|BAUD|OPTIONS)$/.test(paramId) ||
     /^BRD_SER\d+_RTSCTS$/.test(paramId) ||
-    GPS_PARAM_IDS.includes(paramId as (typeof GPS_PARAM_IDS)[number])
+    GPS_PARAM_IDS.includes(paramId as (typeof GPS_PARAM_IDS)[number]) ||
+    // Peripheral-enable params a protocol pairing stages (DisplayPort->OSD_TYPE,
+    // Tramp/SmartAudio->VTX_ENABLE/VTX_TYPES) live in the ports scope too, so a
+    // staged pairing commits together with the SERIALn_PROTOCOL change. They
+    // stay editable from the OSD/VTX tabs as well (both scopes include them).
+    PORT_PAIRING_PARAM_IDS.includes(paramId as (typeof PORT_PAIRING_PARAM_IDS)[number])
   )
 }
 

--- a/apps/web/src/sections/PortsSection.tsx
+++ b/apps/web/src/sections/PortsSection.tsx
@@ -32,6 +32,7 @@ import { describeBitmaskSelections, hasBitmaskFlag, toggleBitmaskFlag } from '..
 import type { SerialPortViewModel } from '../serial-port-helpers'
 import { toneForScopedDraftReview } from '../tone-helpers'
 import type { AdditionalSettingsGroup, CanNodePeripheralViewModel, GpsPeripheralViewModel } from '../view-models/peripherals'
+import { pairedDraftsForSerialProtocol, pairingNoteForSerialProtocol } from '../view-models/port-protocol-pairings'
 import { ScopedField, ScopedSelectField } from '../views/ScopedField'
 
 export interface PortsSectionProps {
@@ -182,6 +183,21 @@ export function PortsSection(props: PortsSectionProps): ReactElement {
   // verbatim move; aliasing avoids touching the JSX.
   const handleApplyScopedParameterDrafts = onApplyScopedDrafts
   const handleDiscardScopedParameterDrafts = onDiscardScopedDrafts
+
+  // Set a port's protocol AND stage any paired peripheral-enable drafts, so
+  // picking DisplayPort also turns on the OSD backend and picking a VTX-control
+  // protocol enables the VTX — staged (visible, revertible), applied with the
+  // port change. See view-models/port-protocol-pairings.
+  const handleSelectSerialProtocol = (protocolParamId: string, rawValue: string) => {
+    setDraft(protocolParamId, rawValue)
+    const protocolValue = Number(rawValue)
+    if (Number.isNaN(protocolValue)) {
+      return
+    }
+    for (const paired of pairedDraftsForSerialProtocol(protocolValue, snapshot)) {
+      setDraft(paired.paramId, String(paired.value))
+    }
+  }
 
   return (
 
@@ -366,7 +382,7 @@ export function PortsSection(props: PortsSectionProps): ReactElement {
                                           <select
                                             value={editedValues[protocolParameter.id] ?? String(port.protocolValue ?? '')}
                                             onChange={(event) =>
-                                              setDraft(protocolParameter.id, event.target.value)
+                                              handleSelectSerialProtocol(protocolParameter.id, event.target.value)
                                             }
                                             disabled={!port.editable}
                                           >
@@ -377,6 +393,16 @@ export function PortsSection(props: PortsSectionProps): ReactElement {
                                             ))}
                                           </select>
                                           <small>{protocolParameter ? formatArducopterSerialProtocol(Number(editedValues[protocolParameter.id] ?? port.protocolValue)) : port.protocolLabel}</small>
+                                          {(() => {
+                                            const note = pairingNoteForSerialProtocol(
+                                              Number(editedValues[protocolParameter.id] ?? port.protocolValue)
+                                            )
+                                            return note ? (
+                                              <small className="ports-matrix-row__pairing-note" data-testid={`port-pairing-note-${port.portNumber}`}>
+                                                {note}
+                                              </small>
+                                            ) : null
+                                          })()}
                                         </label>
                                       ) : (
                                         <div className="ports-matrix-row__readout">{port.protocolLabel}</div>

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -7442,6 +7442,16 @@ textarea:focus {
 /* The raw ArduPilot parameter name shown under every friendly label (e.g.
  * "Vertical speed" / VSPEED) — muted and monospace so it reads as metadata,
  * not as a second label competing with the one above it. */
+/* Note under a port's Function select when the chosen protocol auto-stages a
+   paired peripheral param (DisplayPort->OSD_TYPE, Tramp/SmartAudio->VTX_*). */
+.ports-matrix-row__pairing-note {
+  display: block;
+  margin-top: 3px;
+  color: var(--accent, var(--text-muted));
+  font-size: 11px;
+  line-height: 1.35;
+}
+
 .scoped-editor-field__param-id {
   display: block;
   margin-top: 1px;

--- a/apps/web/src/view-models/port-protocol-pairings.test.ts
+++ b/apps/web/src/view-models/port-protocol-pairings.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest'
+
+import { pairedDraftsForSerialProtocol, pairingNoteForSerialProtocol } from './port-protocol-pairings'
+
+// Minimal snapshot stub: only .parameters is read.
+function snap(params: Record<string, number>) {
+  return {
+    parameters: Object.entries(params).map(([id, value]) => ({ id, value }))
+  } as unknown as Parameters<typeof pairedDraftsForSerialProtocol>[1]
+}
+
+describe('pairedDraftsForSerialProtocol', () => {
+  it('DisplayPort (42) stages OSD_TYPE = 5 (MSP DisplayPort)', () => {
+    expect(pairedDraftsForSerialProtocol(42, snap({ OSD_TYPE: 1 }))).toEqual([{ paramId: 'OSD_TYPE', value: 5 }])
+  })
+
+  it('does not re-stage OSD_TYPE when it is already MSP DisplayPort', () => {
+    expect(pairedDraftsForSerialProtocol(42, snap({ OSD_TYPE: 5 }))).toEqual([])
+  })
+
+  it('Tramp (44) enables the VTX and ORs in the Tramp bit (bit 2 = value 4)', () => {
+    const drafts = pairedDraftsForSerialProtocol(44, snap({ VTX_ENABLE: 0, VTX_TYPES: 0 }))
+    expect(drafts).toEqual([
+      { paramId: 'VTX_ENABLE', value: 1 },
+      { paramId: 'VTX_TYPES', value: 4 }
+    ])
+  })
+
+  it('SmartAudio (37) ORs in the SmartAudio bit (bit 1 = value 2) without clearing others', () => {
+    // VTX_TYPES already has Tramp (4); SmartAudio adds 2 -> 6.
+    const drafts = pairedDraftsForSerialProtocol(37, snap({ VTX_ENABLE: 1, VTX_TYPES: 4 }))
+    // VTX_ENABLE already 1 -> skipped; only the bitmask changes.
+    expect(drafts).toEqual([{ paramId: 'VTX_TYPES', value: 6 }])
+  })
+
+  it('stages nothing when the transport bit is already set and VTX enabled', () => {
+    expect(pairedDraftsForSerialProtocol(44, snap({ VTX_ENABLE: 1, VTX_TYPES: 4 }))).toEqual([])
+  })
+
+  it('never stages a param the firmware does not report', () => {
+    // No OSD_TYPE in params -> DisplayPort stages nothing.
+    expect(pairedDraftsForSerialProtocol(42, snap({ SERIAL1_PROTOCOL: 42 }))).toEqual([])
+    // No VTX params -> Tramp stages nothing.
+    expect(pairedDraftsForSerialProtocol(44, snap({ SERIAL1_PROTOCOL: 44 }))).toEqual([])
+  })
+
+  it('returns nothing for a protocol without a pairing', () => {
+    expect(pairedDraftsForSerialProtocol(5, snap({ OSD_TYPE: 1, VTX_ENABLE: 0 }))).toEqual([])
+  })
+
+  it('describes each pairing (and nothing for unpaired protocols)', () => {
+    expect(pairingNoteForSerialProtocol(42)).toMatch(/OSD backend/i)
+    expect(pairingNoteForSerialProtocol(44)).toMatch(/Tramp/i)
+    expect(pairingNoteForSerialProtocol(37)).toMatch(/SmartAudio/i)
+    expect(pairingNoteForSerialProtocol(5)).toBeNull()
+  })
+})

--- a/apps/web/src/view-models/port-protocol-pairings.ts
+++ b/apps/web/src/view-models/port-protocol-pairings.ts
@@ -1,0 +1,106 @@
+// When a serial port's Function (SERIALn_PROTOCOL) is set to a peripheral that
+// needs a second parameter flipped to actually work, this computes the paired
+// parameter drafts to stage alongside it — so picking "DisplayPort" also turns
+// the OSD backend on, and picking a VTX-control protocol enables the VTX and
+// allows that transport. The drafts are staged (visible, revertible, applied
+// together), never written silently.
+//
+// Pairings (values verified against ArduPilot source):
+//   SERIALn_PROTOCOL 42 (MSP DisplayPort) -> OSD_TYPE = 5 (OSD_MSP_DISPLAYPORT)
+//   SERIALn_PROTOCOL 44 (IRC Tramp)       -> VTX_ENABLE = 1, VTX_TYPES |= bit 2 (Tramp)
+//   SERIALn_PROTOCOL 37 (SmartAudio)      -> VTX_ENABLE = 1, VTX_TYPES |= bit 1 (SmartAudio)
+
+import type { ConfiguratorSnapshot } from '@arduconfig/ardupilot-core'
+
+export interface PairedDraft {
+  paramId: string
+  value: number
+}
+
+// SERIALn_PROTOCOL enum values that carry a pairing.
+export const SERIAL_PROTOCOL_DISPLAYPORT = 42
+export const SERIAL_PROTOCOL_SMARTAUDIO = 37
+export const SERIAL_PROTOCOL_TRAMP = 44
+
+const OSD_TYPE_MSP_DISPLAYPORT = 5
+// VTX_TYPES bit indices (AP_VideoTX): 0 CRSF, 1 SmartAudio, 2 Tramp, 3 MSP.
+const VTX_TYPES_BIT_SMARTAUDIO = 1
+const VTX_TYPES_BIT_TRAMP = 2
+
+// Every parameter these pairings can touch — used to pull them into the Ports
+// apply scope so a staged pairing commits together with the port change.
+export const PORT_PAIRING_PARAM_IDS = ['OSD_TYPE', 'VTX_ENABLE', 'VTX_TYPES'] as const
+
+function currentValue(snapshot: ConfiguratorSnapshot, paramId: string): number | undefined {
+  const p = snapshot.parameters.find((param) => param.id === paramId)
+  return p?.value
+}
+
+function has(snapshot: ConfiguratorSnapshot, paramId: string): boolean {
+  return snapshot.parameters.some((param) => param.id === paramId)
+}
+
+/**
+ * Paired drafts to stage when a port's protocol becomes `protocolValue`.
+ * Returns only params that (a) the firmware actually reports (so we never stage
+ * a write the FC can't honour) and (b) would genuinely change (already-correct
+ * values are skipped, so re-selecting DisplayPort doesn't re-stage OSD_TYPE=5).
+ */
+export function pairedDraftsForSerialProtocol(
+  protocolValue: number,
+  snapshot: ConfiguratorSnapshot
+): PairedDraft[] {
+  const drafts: PairedDraft[] = []
+
+  const stageIfChanged = (paramId: string, value: number) => {
+    if (!has(snapshot, paramId)) {
+      return
+    }
+    if (currentValue(snapshot, paramId) === value) {
+      return
+    }
+    drafts.push({ paramId, value })
+  }
+
+  const enableVtxTransport = (bitIndex: number) => {
+    stageIfChanged('VTX_ENABLE', 1)
+    if (!has(snapshot, 'VTX_TYPES')) {
+      return
+    }
+    const current = currentValue(snapshot, 'VTX_TYPES') ?? 0
+    const next = current | (1 << bitIndex)
+    if (next !== current) {
+      drafts.push({ paramId: 'VTX_TYPES', value: next })
+    }
+  }
+
+  switch (protocolValue) {
+    case SERIAL_PROTOCOL_DISPLAYPORT:
+      stageIfChanged('OSD_TYPE', OSD_TYPE_MSP_DISPLAYPORT)
+      break
+    case SERIAL_PROTOCOL_TRAMP:
+      enableVtxTransport(VTX_TYPES_BIT_TRAMP)
+      break
+    case SERIAL_PROTOCOL_SMARTAUDIO:
+      enableVtxTransport(VTX_TYPES_BIT_SMARTAUDIO)
+      break
+    default:
+      break
+  }
+
+  return drafts
+}
+
+/** Short operator-facing note describing what a pairing will stage, or null. */
+export function pairingNoteForSerialProtocol(protocolValue: number): string | null {
+  switch (protocolValue) {
+    case SERIAL_PROTOCOL_DISPLAYPORT:
+      return 'Also sets the OSD backend to MSP DisplayPort (OSD_TYPE).'
+    case SERIAL_PROTOCOL_TRAMP:
+      return 'Also enables the VTX and allows Tramp control (VTX_ENABLE, VTX_TYPES).'
+    case SERIAL_PROTOCOL_SMARTAUDIO:
+      return 'Also enables the VTX and allows SmartAudio control (VTX_ENABLE, VTX_TYPES).'
+    default:
+      return null
+  }
+}

--- a/tests/e2e/views.spec.ts
+++ b/tests/e2e/views.spec.ts
@@ -412,6 +412,21 @@ test.describe('Ports view', () => {
     await expect(hints.filter({ hasText: /_RTSCTS$/ }).first()).toBeVisible()
     await expect(hints.filter({ hasText: /^SERIAL\d+_OPTIONS$/ }).first()).toBeVisible()
   })
+
+  test('a DisplayPort / VTX-control protocol shows what it also auto-configures', async ({ page }) => {
+    // Picking DisplayPort or a VTX-control protocol on a UART also needs a second
+    // param flipped (OSD backend / VTX enable) to work. The pairing stages those
+    // as visible drafts; each such port surfaces a note saying so. The demo seeds
+    // a DisplayPort port (SERIAL6=42) and a SmartAudio port (SERIAL5=37).
+    await page.goto('/')
+    await connectViaHeader(page)
+    await openView(page, 'ports')
+    const notes = page.locator('.ports-matrix-row__pairing-note')
+    await expect(notes.filter({ hasText: /OSD backend to MSP DisplayPort/i })).toBeVisible()
+    await expect(notes.filter({ hasText: /SmartAudio control/i })).toBeVisible()
+    // A plain protocol (GPS on SERIAL3) carries no pairing note.
+    await expect(notes.filter({ hasText: /GPS/i })).toHaveCount(0)
+  })
 })
 
 test.describe('Networking view (Expert + networking-capable FC)', () => {


### PR DESCRIPTION
Picking a serial protocol that needs a second parameter flipped to work now stages that paired param alongside it — so you don't set **DisplayPort** on a UART and then wonder why nothing shows on the OSD, or set **SmartAudio/Tramp** and find the VTX never comes up.

## Pairings (values verified against ArduPilot source)
| Protocol | Also stages |
|---|---|
| `42` MSP DisplayPort | `OSD_TYPE = 5` (OSD_MSP_DISPLAYPORT) |
| `44` IRC Tramp | `VTX_ENABLE = 1`, `VTX_TYPES` \|= Tramp bit (2) |
| `37` SmartAudio | `VTX_ENABLE = 1`, `VTX_TYPES` \|= SmartAudio bit (1) |

## Staged, never silent
Picking the protocol stages the paired param(s) as **visible, revertible drafts**, applied **together** with the `SERIALn_PROTOCOL` change (per your choice). The Function cell shows a note saying what else it will set. It only stages:
- a param the firmware **actually reports** (never a write the FC can't honour), and
- when the value would **genuinely change** — already-correct values are skipped, and `VTX_TYPES` is OR'd so it never clears another transport's bit.

## Where it lives
Pure logic in `view-models/port-protocol-pairings.ts` (8 unit tests: each pairing, bit-OR preservation, skip-when-equal, skip-when-absent, note text). `PORT_PAIRING_PARAM_IDS` (`OSD_TYPE`/`VTX_ENABLE`/`VTX_TYPES`) added to `isPortsReviewParamId` so a staged pairing commits with the port change — they stay editable from the OSD/VTX tabs too.

## ArduCopter byte-identical
No auto-write — only a staged draft the operator Applies. A protocol with no pairing behaves exactly as before.

## Validation
Rungs 1 + 3. node 755, vitest 567 (+8), Playwright 220 (+1). Verified in the demo: DisplayPort port shows the OSD note, SmartAudio port the VTX note, a GPS port shows none.