### PR TITLE
feat(can): offer to enable the CAN bus when a DroneCAN peripheral is selected but it's off

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -251,6 +251,7 @@ import type {
 import { AP_PERIPH_PARAM_METADATA } from './view-models/ap-periph-param-metadata'
 import { parseParamPck } from './view-models/param-pck'
 import { createMotorPreviewNodes } from './view-models/motor-preview'
+import { deriveCanEnablement } from './view-models/can-enablement'
 import { buildRecentNotices } from './view-models/recent-notices'
 import { deriveExternalChannelClaims, deriveRcLogicChannelClaims } from './view-models/channel-usage'
 import { orderDraftsByEnableGate } from './view-models/enable-gate-write-order'
@@ -970,6 +971,8 @@ export function App() {
   const boardCatalogEntry = useMemo(() => findBoardCatalogEntry(snapshot.hardware.board?.boardType), [snapshot.hardware.board?.boardType])
   const rcChannelDisplays = buildRcChannelDisplays(snapshot)
   const airframe = deriveAirframe(snapshot, snapshot.vehicle?.vehicle)
+  // "DroneCAN peripheral selected but CAN bus off" detector for the CAN tab.
+  const canEnablement = useMemo(() => deriveCanEnablement(snapshot), [snapshot])
   // Copter (and the pre-connect / Unknown default) keeps motor-matrix
   // framing; Plane/Rover/Sub are not a quad, so vehicle-specific surfaces
   // branch off this instead of showing Copter motor logic.
@@ -2710,6 +2713,44 @@ export function App() {
   // a different port — the fix for "can't get back to choose a port" and for
   // landing on the SLCAN interface. The MAVLink port is auto-detected at connect
   // once more than one is granted.
+  // Enable the CAN bus for DroneCAN (CAN_P1_DRIVER=1, CAN_D1_PROTOCOL=1) from
+  // the CAN tab's prompt when a DroneCAN peripheral is selected but the bus is
+  // off. Verified write + auto-backup + reboot follow-up (both params are
+  // @RebootRequired), mirroring the preset-apply path.
+  async function handleEnableCanBus(): Promise<void> {
+    if (!runtime) {
+      return
+    }
+    const writes = deriveCanEnablement(runtime.getSnapshot()).writes
+    if (writes.length === 0) {
+      return
+    }
+    const autoBackup = createSavedSnapshot(
+      createParameterBackup(runtime.getSnapshot()),
+      'Before enabling CAN bus',
+      'captured',
+      { note: 'Auto-saved before enabling the CAN bus for DroneCAN.', tags: ['auto-backup', 'can-enable'] }
+    )
+    setSavedSnapshots((current) => [autoBackup, ...current.filter((entry) => entry.id !== autoBackup.id)])
+    setBusyAction('can:enable')
+    try {
+      const result = await runtime.setParameters(writes, UI_PARAMETER_WRITE_OPTIONS)
+      setParameterFollowUp({
+        requiresReboot: true,
+        refreshRequired: true,
+        changedCount: result.applied.length,
+        text: `Enabled the CAN bus for DroneCAN (${result.applied.length} write(s)). Reboot the flight controller, then pull parameters — DroneCAN nodes appear after the reboot.`
+      })
+    } catch (error) {
+      setSessionNotice({
+        tone: 'danger',
+        text: `Failed to enable the CAN bus: ${error instanceof Error ? error.message : 'unknown error'}. Pre-write snapshot "${autoBackup.label}" was saved.`
+      })
+    } finally {
+      setBusyAction((current) => (current === 'can:enable' ? undefined : current))
+    }
+  }
+
   async function handleChooseSerialPort(): Promise<void> {
     const serial = getWebSerialNavigator()
     if (!serial) {
@@ -8267,6 +8308,9 @@ export function App() {
         onFetchAllParameters={(nodeId) => { runtime?.fetchAllCanBusParameters(nodeId) }}
         onApplyAndSave={(nodeId, writes) => { void runtime?.applyAndSaveCanBusParameters(nodeId, writes) }}
         paramMetadata={(name) => metadataCatalog.parameters[name] ?? AP_PERIPH_PARAM_METADATA[name]}
+        enablement={canEnablement.needsEnable ? { triggerLabels: canEnablement.triggerLabels } : undefined}
+        onEnableCanBus={runtime ? () => { void handleEnableCanBus() } : undefined}
+        enableBusy={busyAction === 'can:enable'}
       />
       ) : null}
 

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -8518,6 +8518,40 @@ details.metadata-settings-section:not([open]) > summary::after {
    mechanism Mission Planner uses) so MAVLink stays alive on the same
    channel. The layout mirrors Ports / RC Mixer to keep operators in
    familiar visual territory while the data underneath is different. */
+/* "DroneCAN peripheral selected but CAN bus off" prompt at the top of the CAN
+   tab — an actionable amber banner with the one-click enable. */
+.can-bus-enable-prompt {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  flex-wrap: wrap;
+  margin-bottom: 14px;
+  padding: 12px 14px;
+  border: 1px solid color-mix(in srgb, var(--warning) 55%, transparent);
+  border-radius: var(--radius-md);
+  background: var(--warning-weak);
+  box-shadow: inset 3px 0 0 var(--warning);
+}
+.can-bus-enable-prompt__body {
+  min-width: min(100%, 22ch);
+  flex: 1 1 320px;
+}
+.can-bus-enable-prompt__body strong {
+  display: block;
+  margin-bottom: 2px;
+}
+.can-bus-enable-prompt__body p {
+  margin: 0;
+  color: var(--text-muted);
+  font-size: 12.5px;
+  line-height: 1.45;
+}
+.can-bus-enable-prompt__body code {
+  font-family: var(--font-data);
+  font-size: 11px;
+}
+
 .can-bus-header {
   display: flex;
   flex-wrap: wrap;

--- a/apps/web/src/view-models/can-enablement.test.ts
+++ b/apps/web/src/view-models/can-enablement.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'vitest'
+
+import { deriveCanEnablement } from './can-enablement'
+
+function snap(params: Record<string, number>) {
+  return {
+    parameters: Object.entries(params).map(([id, value]) => ({ id, value }))
+  } as unknown as Parameters<typeof deriveCanEnablement>[0]
+}
+
+describe('deriveCanEnablement', () => {
+  it('prompts to enable both params when GPS is DroneCAN and the bus is off', () => {
+    const r = deriveCanEnablement(snap({ GPS_TYPE: 9, CAN_P1_DRIVER: 0, CAN_D1_PROTOCOL: 0 }))
+    expect(r.needsEnable).toBe(true)
+    expect(r.triggerLabels).toEqual(['GPS is set to DroneCAN'])
+    expect(r.writes).toEqual([
+      { paramId: 'CAN_P1_DRIVER', paramValue: 1 },
+      { paramId: 'CAN_D1_PROTOCOL', paramValue: 1 }
+    ])
+  })
+
+  it('only writes the missing param when the driver is already on', () => {
+    const r = deriveCanEnablement(snap({ GPS_TYPE: 9, CAN_P1_DRIVER: 1, CAN_D1_PROTOCOL: 0 }))
+    expect(r.needsEnable).toBe(true)
+    expect(r.writes).toEqual([{ paramId: 'CAN_D1_PROTOCOL', paramValue: 1 }])
+  })
+
+  it('does nothing once the bus is enabled for DroneCAN', () => {
+    const r = deriveCanEnablement(snap({ GPS_TYPE: 9, CAN_P1_DRIVER: 1, CAN_D1_PROTOCOL: 1 }))
+    expect(r.needsEnable).toBe(false)
+    expect(r.writes).toEqual([])
+  })
+
+  it('does nothing when no driver is on DroneCAN', () => {
+    const r = deriveCanEnablement(snap({ GPS_TYPE: 2, CAN_P1_DRIVER: 0, CAN_D1_PROTOCOL: 0 }))
+    expect(r.needsEnable).toBe(false)
+  })
+
+  it('does nothing on a board with no CAN params (nothing to enable)', () => {
+    const r = deriveCanEnablement(snap({ GPS_TYPE: 9 }))
+    expect(r.needsEnable).toBe(false)
+    expect(r.writes).toEqual([])
+  })
+
+  it('triggers on a DroneCAN battery monitor and the moving-baseline GPS variants', () => {
+    expect(deriveCanEnablement(snap({ BATT_MONITOR: 8, CAN_P1_DRIVER: 0 })).needsEnable).toBe(true)
+    expect(deriveCanEnablement(snap({ GPS_TYPE: 22, CAN_P1_DRIVER: 0 })).triggerLabels).toEqual(['GPS is set to DroneCAN'])
+    expect(deriveCanEnablement(snap({ GPS_TYPE2: 23, CAN_P1_DRIVER: 0 })).triggerLabels).toEqual(['GPS 2 is set to DroneCAN'])
+  })
+
+  it('lists every trigger when several peripherals are on DroneCAN', () => {
+    const r = deriveCanEnablement(snap({ GPS_TYPE: 9, BATT_MONITOR: 8, CAN_P1_DRIVER: 0, CAN_D1_PROTOCOL: 0 }))
+    expect(r.triggerLabels).toEqual(['GPS is set to DroneCAN', 'Battery monitor is set to DroneCAN'])
+  })
+
+  it('handles a missing CAN_D1_PROTOCOL param (writes only the driver)', () => {
+    const r = deriveCanEnablement(snap({ GPS_TYPE: 9, CAN_P1_DRIVER: 0 }))
+    expect(r.writes).toEqual([{ paramId: 'CAN_P1_DRIVER', paramValue: 1 }])
+  })
+})

--- a/apps/web/src/view-models/can-enablement.ts
+++ b/apps/web/src/view-models/can-enablement.ts
@@ -1,0 +1,75 @@
+// Detect the common "I set a peripheral to DroneCAN but the CAN bus is still
+// off" trap. When a driver param is set to a DroneCAN value but CAN bus 1 isn't
+// enabled for DroneCAN, this surfaces a one-click enable (CAN_P1_DRIVER=1 +
+// CAN_D1_PROTOCOL=1) — the two params a fresh board needs before any DroneCAN
+// GPS/compass/battery node will talk. Values verified against ArduPilot source:
+//   CAN_Pn_DRIVER  0:Disabled 1:First driver … (enabling it enables the bus)
+//   CAN_Dn_PROTOCOL 0:Disabled 1:DroneCAN 4:PiccoloCAN …
+// Both are @RebootRequired.
+
+import type { ConfiguratorSnapshot } from '@arduconfig/ardupilot-core'
+
+const CAN_D_PROTOCOL_DRONECAN = 1
+
+// Driver params whose "this peripheral is on DroneCAN" value(s) should trigger
+// the helper. Deliberately a small, high-confidence set (GPS is by far the most
+// common); extend as more DroneCAN peripheral flows are covered.
+const DRONECAN_DRIVER_TRIGGERS: ReadonlyArray<{ paramId: string; values: readonly number[]; label: string }> = [
+  { paramId: 'GPS_TYPE', values: [9, 22, 23], label: 'GPS is set to DroneCAN' },
+  { paramId: 'GPS_TYPE2', values: [9, 22, 23], label: 'GPS 2 is set to DroneCAN' },
+  { paramId: 'BATT_MONITOR', values: [8], label: 'Battery monitor is set to DroneCAN' },
+  { paramId: 'BATT2_MONITOR', values: [8], label: 'Battery monitor 2 is set to DroneCAN' }
+]
+
+export interface CanEnablementState {
+  /** True when a DroneCAN driver is selected but CAN bus 1 isn't enabled for it. */
+  needsEnable: boolean
+  /** Human-readable reasons (e.g. "GPS is set to DroneCAN"). */
+  triggerLabels: string[]
+  /** The exact writes to enable DroneCAN on bus 1 (only params not already correct). */
+  writes: Array<{ paramId: string; paramValue: number }>
+}
+
+const EMPTY: CanEnablementState = { needsEnable: false, triggerLabels: [], writes: [] }
+
+function value(snapshot: ConfiguratorSnapshot, paramId: string): number | undefined {
+  return snapshot.parameters.find((p) => p.id === paramId)?.value
+}
+
+export function deriveCanEnablement(snapshot: ConfiguratorSnapshot): CanEnablementState {
+  // No CAN params reported → the board has no CAN bus; nothing to enable.
+  const p1 = value(snapshot, 'CAN_P1_DRIVER')
+  if (p1 === undefined) {
+    return EMPTY
+  }
+
+  const triggerLabels = DRONECAN_DRIVER_TRIGGERS.filter((trigger) => {
+    const current = value(snapshot, trigger.paramId)
+    return current !== undefined && trigger.values.includes(Math.round(current))
+  }).map((trigger) => trigger.label)
+
+  if (triggerLabels.length === 0) {
+    return EMPTY
+  }
+
+  const d1 = value(snapshot, 'CAN_D1_PROTOCOL')
+  const busEnabled = p1 >= 1 && d1 === CAN_D_PROTOCOL_DRONECAN
+  if (busEnabled) {
+    return EMPTY
+  }
+
+  const writes: CanEnablementState['writes'] = []
+  if (!(p1 >= 1)) {
+    writes.push({ paramId: 'CAN_P1_DRIVER', paramValue: 1 })
+  }
+  // Only stage the protocol write when the param exists and isn't already DroneCAN.
+  if (value(snapshot, 'CAN_D1_PROTOCOL') !== undefined && d1 !== CAN_D_PROTOCOL_DRONECAN) {
+    writes.push({ paramId: 'CAN_D1_PROTOCOL', paramValue: CAN_D_PROTOCOL_DRONECAN })
+  }
+
+  if (writes.length === 0) {
+    return EMPTY
+  }
+
+  return { needsEnable: true, triggerLabels, writes }
+}

--- a/apps/web/src/views/CanBus.tsx
+++ b/apps/web/src/views/CanBus.tsx
@@ -49,6 +49,13 @@ export interface CanBusViewProps {
    *  param list all derive from `state`. */
   title?: string
   subtitle?: string
+  /** "A DroneCAN peripheral is selected but the CAN bus is off" prompt: the
+   *  reasons to show and the one-click enable handler. Absent when the bus is
+   *  already enabled or no DroneCAN driver is selected. */
+  enablement?: { triggerLabels: string[] }
+  onEnableCanBus?: () => void
+  /** Disables the enable button while a write is in flight. */
+  enableBusy?: boolean
 }
 
 export function CanBusView(props: CanBusViewProps) {
@@ -63,7 +70,10 @@ export function CanBusView(props: CanBusViewProps) {
     onApplyAndSave,
     paramMetadata,
     title = 'DroneCAN Bus',
-    subtitle = 'Discover DroneCAN devices on the CAN bus and read, edit, and save their parameters — without dropping your vehicle connection.'
+    subtitle = 'Discover DroneCAN devices on the CAN bus and read, edit, and save their parameters — without dropping your vehicle connection.',
+    enablement,
+    onEnableCanBus,
+    enableBusy = false
   } = props
 
   const rows = useMemo(() => buildCanBusNodeRows(state), [state])
@@ -136,6 +146,26 @@ export function CanBusView(props: CanBusViewProps) {
   return (
     <div id="setup-panel-can">
       <Panel title={title} subtitle={subtitle}>
+        {enablement && onEnableCanBus ? (
+          <div className="can-bus-enable-prompt" role="status" data-testid="can-enable-prompt">
+            <div className="can-bus-enable-prompt__body">
+              <strong>Enable the CAN bus for DroneCAN?</strong>
+              <p>
+                {enablement.triggerLabels.join(', ')}, but CAN bus 1 isn’t enabled — nodes won’t be found until it is.
+                This sets <code>CAN_P1_DRIVER=1</code> and <code>CAN_D1_PROTOCOL=1</code> (DroneCAN) and needs a reboot.
+              </p>
+            </div>
+            <button
+              type="button"
+              style={buttonStyle('primary')}
+              data-testid="can-enable-button"
+              onClick={onEnableCanBus}
+              disabled={enableBusy}
+            >
+              {enableBusy ? 'Enabling…' : 'Enable CAN bus & reboot'}
+            </button>
+          </div>
+        ) : null}
         <header className="can-bus-header">
           <div className="can-bus-header__status">
             <StatusBadge tone={headerTone}>

--- a/packages/protocol-mavlink/src/mock-scenario.ts
+++ b/packages/protocol-mavlink/src/mock-scenario.ts
@@ -240,6 +240,10 @@ const mockParameters: ParameterState = {
   NET_P4_TYPE: 0,
   GPS_TYPE: 9,
   GPS_TYPE2: 0,
+  // DroneCAN GPS selected (GPS_TYPE=9) but the CAN bus is still off — the state
+  // the CAN tab's "enable CAN bus" prompt is built for.
+  CAN_P1_DRIVER: 0,
+  CAN_D1_PROTOCOL: 0,
   GPS_AUTO_CONFIG: 1,
   GPS_AUTO_SWITCH: 0,
   GPS_PRIMARY: 0,

--- a/tests/e2e/views.spec.ts
+++ b/tests/e2e/views.spec.ts
@@ -429,6 +429,25 @@ test.describe('Ports view', () => {
   })
 })
 
+test.describe('CAN bus enable prompt', () => {
+  test('prompts to enable the bus when a DroneCAN peripheral is selected but CAN is off', async ({ page }) => {
+    // Demo: GPS_TYPE=9 (DroneCAN) with CAN_P1_DRIVER=0 / CAN_D1_PROTOCOL=0 — the
+    // "I picked DroneCAN but the bus is off" trap. The CAN tab surfaces a
+    // one-click enable (CAN_P1_DRIVER=1 + CAN_D1_PROTOCOL=1, reboot-required).
+    await page.goto('/')
+    await page.getByTestId('transport-mode-select').selectOption('demo')
+    await page.getByTestId('connect-button').click()
+    await page.getByTestId('product-mode-expert').check()
+    await page.getByTestId('view-button-can').click()
+
+    const prompt = page.getByTestId('can-enable-prompt')
+    await expect(prompt).toBeVisible()
+    await expect(prompt).toContainText('GPS is set to DroneCAN')
+    await expect(prompt).toContainText('CAN_P1_DRIVER')
+    await expect(page.getByTestId('can-enable-button')).toBeEnabled()
+  })
+})
+
 test.describe('Networking view (Expert + networking-capable FC)', () => {
   test('appears only in Expert mode when the FC reports NET_ params, then renders IP + endpoint settings', async ({ page }) => {
     await page.goto('/')

--- a/tests/transport.test.mjs
+++ b/tests/transport.test.mjs
@@ -714,8 +714,8 @@ test('MockTransport serializes chunked inbound frames so demo parameter sync com
     const stats = await runtime.waitForParameterSync({ timeoutMs: 120000 })
 
     assert.equal(stats.status, 'complete')
-    assert.equal(stats.downloaded, 1166)
-    assert.equal(stats.total, 1166)
+    assert.equal(stats.downloaded, 1168)
+    assert.equal(stats.total, 1168)
     assert.equal(runtime.getSnapshot().parameters.find((parameter) => parameter.id === 'FRAME_CLASS')?.value, 1)
     assert.equal(runtime.getSnapshot().parameters.find((parameter) => parameter.id === 'FRAME_TYPE')?.value, 1)
   } finally {
@@ -846,7 +846,7 @@ test('Bundled WebSocket bridge can drive runtime heartbeat and parameter sync fr
     assert.equal(runtime.getSnapshot().connection.kind, 'connected')
     assert.equal(runtime.getSnapshot().vehicle?.vehicle, 'ArduCopter')
     assert.equal(stats.status, 'complete')
-    assert.equal(stats.downloaded, 1166)
+    assert.equal(stats.downloaded, 1168)
     assert.equal(runtime.getSnapshot().parameters.find((parameter) => parameter.id === 'FRAME_CLASS')?.value, 1)
   } finally {
     await runtime.disconnect().catch(() => {})


### PR DESCRIPTION
The common DroneCAN trap: set `GPS_TYPE` (or a battery monitor) to DroneCAN, then find **nothing** on the CAN bus because `CAN_P1_DRIVER`/`CAN_D1_PROTOCOL` were never turned on. The CAN tab now detects this and offers a one-click enable.

## Detector
`view-models/can-enablement.ts` fires when a driver param is set to a DroneCAN value (`GPS_TYPE`/`GPS_TYPE2` ∈ {9,22,23}, `BATT_MONITOR`/`BATT2_MONITOR` = 8) **and** CAN bus 1 isn't enabled for DroneCAN (`CAN_P1_DRIVER≥1 && CAN_D1_PROTOCOL==1`). Only when the board actually reports CAN params (no CAN hardware → nothing to enable). Computes the exact writes, skipping any already-correct param. 8 unit tests.

## Action
A one-click **"Enable CAN bus & reboot"** prompt at the top of the CAN tab. `handleEnableCanBus` does a verified `setParameters(CAN_P1_DRIVER=1, CAN_D1_PROTOCOL=1)` with an **auto-backup**, then a reboot-required follow-up (both params are `@RebootRequired`) — mirroring the preset-apply path. Explicit button, **not** a silent write.

## Values verified against ArduPilot source (AP_CANManager)
- `CAN_Pn_DRIVER` — `0:Disabled 1:First driver …` ("enables use of CAN buses")
- `CAN_Dn_PROTOCOL` — `0:Disabled 1:DroneCAN 4:PiccoloCAN …`

Demo seeds the trap state (`GPS_TYPE=9` + `CAN_P1_DRIVER=0`/`CAN_D1_PROTOCOL=0`) so the prompt is exercisable; param count 1166→1168.

## ArduCopter byte-identical
Prompt is display-only; the write only happens on an explicit click — no default-path change.

## Validation
Rungs 1 + 3. node 755, vitest 575 (+8), Playwright 221 (+1). Verified in the demo: the prompt shows for a DroneCAN GPS with the bus off and names the exact params.