### PR TITLE
feat(config): make the board-orientation picture 3D so every option is visible

### DIFF
--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -8552,7 +8552,9 @@ details.metadata-settings-section:not([open]) > summary::after {
   font-size: 11px;
 }
 
-/* Top-down board-mounting picture under the Board orientation dropdown. */
+/* 3D board-mounting picture under the Board orientation dropdown. A thin slab
+   posed by roll/pitch/yaw inside a tilted scene, so every orientation — flat,
+   upside down, on its edge — is visible. */
 .board-orientation-diagram {
   display: flex;
   flex-direction: column;
@@ -8562,14 +8564,17 @@ details.metadata-settings-section:not([open]) > summary::after {
 }
 .board-orientation-diagram__stage {
   position: relative;
-  width: 150px;
-  height: 150px;
+  width: 160px;
+  height: 160px;
   display: flex;
   align-items: center;
   justify-content: center;
   border: 1px dashed rgba(var(--edge-rgb), 0.18);
   border-radius: var(--radius-md);
   background: rgba(var(--fill-rgb), 0.4);
+}
+.board-orientation-diagram__stage--3d {
+  perspective: 480px;
 }
 .board-orientation-diagram__front {
   position: absolute;
@@ -8580,31 +8585,69 @@ details.metadata-settings-section:not([open]) > summary::after {
   font-size: 9px;
   letter-spacing: 0.16em;
   color: var(--text-dim, var(--text-muted));
+  z-index: 1;
 }
-.board-orientation-diagram__svg {
-  width: 108px;
-  height: 108px;
-  transition: transform 0.25s ease;
+/* Oblique (isometric-ish) camera: tilted back AND yawed a little, so no board
+   face is ever edge-on — an on-its-side (Roll/Pitch 90) mount stays visible. */
+.board-orientation-diagram__scene {
+  transform-style: preserve-3d;
+  transform: rotateX(56deg) rotateY(-26deg);
 }
-.board-orientation-diagram__board {
-  fill: rgba(var(--fill-rgb), 0.9);
-  stroke: rgba(var(--edge-rgb), 0.4);
-  stroke-width: 2;
+.board-orientation-diagram__board3d {
+  position: relative;
+  width: 80px;
+  height: 104px;
+  transform-style: preserve-3d;
+  transition: transform 0.3s ease;
 }
+.board-orientation-diagram__face {
+  position: absolute;
+  inset: 0;
+  border-radius: 8px;
+  backface-visibility: hidden;
+  border: 1.5px solid rgba(var(--edge-rgb), 0.5);
+}
+.board-orientation-diagram__face--top {
+  background: linear-gradient(160deg, rgba(var(--fill-rgb), 0.98), rgba(var(--fill-rgb), 0.86));
+  transform: translateZ(3px);
+}
+.board-orientation-diagram__face--bottom {
+  /* A warm underside so an upside-down mount is unmistakable. */
+  background: color-mix(in srgb, var(--warning) 40%, rgba(var(--fill-rgb), 0.9));
+  transform: rotateY(180deg) translateZ(3px);
+}
+/* Forward arrow on the top face (points to the board's nose / +X). */
 .board-orientation-diagram__arrow {
-  fill: var(--accent, var(--primary-500));
-}
-.board-orientation-diagram__arrow-stem {
-  stroke: var(--accent, var(--primary-500));
-  stroke-width: 2.5;
-}
-.board-orientation-diagram__usb {
-  fill: rgba(var(--edge-rgb), 0.5);
+  position: absolute;
+  top: 8px;
+  left: 50%;
+  width: 0;
+  height: 0;
+  transform: translateX(-50%);
+  border-left: 9px solid transparent;
+  border-right: 9px solid transparent;
+  border-bottom: 16px solid var(--accent, var(--primary-500));
 }
 .board-orientation-diagram__imu {
-  fill: rgba(var(--edge-rgb), 0.28);
-  stroke: rgba(var(--edge-rgb), 0.45);
-  stroke-width: 1;
+  position: absolute;
+  top: 40px;
+  left: 50%;
+  width: 26px;
+  height: 26px;
+  transform: translateX(-50%);
+  border-radius: 3px;
+  background: rgba(var(--edge-rgb), 0.28);
+  border: 1px solid rgba(var(--edge-rgb), 0.45);
+}
+.board-orientation-diagram__usb {
+  position: absolute;
+  bottom: 4px;
+  left: 50%;
+  width: 22px;
+  height: 8px;
+  transform: translateX(-50%);
+  border-radius: 2px;
+  background: rgba(var(--edge-rgb), 0.55);
 }
 .board-orientation-diagram__note {
   max-width: 22ch;
@@ -8623,19 +8666,12 @@ details.metadata-settings-section:not([open]) > summary::after {
   line-height: 1.4;
 }
 .board-orientation-diagram__caption {
-  display: flex;
-  align-items: center;
-  gap: 8px;
   font-size: 12px;
 }
-.board-orientation-diagram__badge {
-  padding: 1px 7px;
-  border-radius: 999px;
-  background: var(--warning-weak);
-  color: var(--warning);
-  font-size: 10px;
-  letter-spacing: 0.04em;
-  text-transform: uppercase;
+@media (prefers-reduced-motion: reduce) {
+  .board-orientation-diagram__board3d {
+    transition: none;
+  }
 }
 
 .can-bus-header {

--- a/apps/web/src/view-models/board-orientation-visual.test.ts
+++ b/apps/web/src/view-models/board-orientation-visual.test.ts
@@ -3,51 +3,43 @@ import { describe, expect, it } from 'vitest'
 import { deriveBoardOrientationVisual } from './board-orientation-visual'
 
 describe('deriveBoardOrientationVisual', () => {
-  it('None (0) is a flat, un-rotated board', () => {
-    expect(deriveBoardOrientationVisual(0, 'None')).toEqual({ kind: 'flat', yawDeg: 0, inverted: false, label: 'None' })
-  })
-
-  it('pure yaw rotates the board flat', () => {
-    expect(deriveBoardOrientationVisual(2, 'Yaw 90')).toMatchObject({ kind: 'flat', yawDeg: 90, inverted: false })
-    expect(deriveBoardOrientationVisual(6, 'Yaw 270')).toMatchObject({ kind: 'flat', yawDeg: 270, inverted: false })
-    expect(deriveBoardOrientationVisual(1, 'Yaw 45')).toMatchObject({ kind: 'flat', yawDeg: 45 })
-  })
-
-  it('Roll 180 mirrors left-right (nose stays forward); Pitch 180 mirrors top-bottom', () => {
-    // The distinction matters: a Roll-180 board still points forward, a
-    // Pitch-180 board points backward — the mirror axis is what encodes that.
-    expect(deriveBoardOrientationVisual(8, 'Roll 180')).toMatchObject({
-      kind: 'inverted',
-      yawDeg: 0,
-      inverted: true,
-      mirror: 'x'
-    })
-    expect(deriveBoardOrientationVisual(12, 'Pitch 180')).toMatchObject({ kind: 'inverted', inverted: true, mirror: 'y' })
-  })
-
-  it('yaw + 180 flip keeps the yaw and marks it inverted', () => {
-    expect(deriveBoardOrientationVisual(10, 'Yaw 90 Roll 180')).toMatchObject({
-      kind: 'inverted',
-      yawDeg: 90,
-      inverted: true,
-      mirror: 'x'
+  it('None (0) is an un-rotated board', () => {
+    expect(deriveBoardOrientationVisual(0, 'None')).toEqual({
+      kind: 'depictable',
+      roll: 0,
+      pitch: 0,
+      yaw: 0,
+      label: 'None'
     })
   })
 
-  it('a 90/270 roll or pitch is edge-mounted — no flat picture', () => {
-    expect(deriveBoardOrientationVisual(16, 'Roll 90')).toMatchObject({ kind: 'edge', inverted: false })
-    expect(deriveBoardOrientationVisual(24, 'Pitch 90')).toMatchObject({ kind: 'edge' })
-    expect(deriveBoardOrientationVisual(28, 'Pitch 90 Roll 90')).toMatchObject({ kind: 'edge' })
-    expect(deriveBoardOrientationVisual(16, 'Roll 90')?.note).toMatch(/side or at an angle/i)
+  it('parses pure yaw', () => {
+    expect(deriveBoardOrientationVisual(2, 'Yaw 90')).toMatchObject({ kind: 'depictable', yaw: 90, roll: 0, pitch: 0 })
+    expect(deriveBoardOrientationVisual(6, 'Yaw 270')).toMatchObject({ yaw: 270 })
   })
 
-  it('odd combined angles (Yaw 293 Pitch 68 Roll 180) are edge-mounted', () => {
-    expect(deriveBoardOrientationVisual(38, 'Yaw 293 Pitch 68 Roll 180')).toMatchObject({ kind: 'edge' })
+  it('parses a 180 flip', () => {
+    expect(deriveBoardOrientationVisual(8, 'Roll 180')).toMatchObject({ roll: 180, pitch: 0, yaw: 0 })
+    expect(deriveBoardOrientationVisual(12, 'Pitch 180')).toMatchObject({ pitch: 180, roll: 0, yaw: 0 })
   })
 
-  it('45/315 roll are edge-mounted (tilted), not flat', () => {
-    expect(deriveBoardOrientationVisual(42, 'Roll 45')).toMatchObject({ kind: 'edge' })
-    expect(deriveBoardOrientationVisual(43, 'Roll 315')).toMatchObject({ kind: 'edge' })
+  it('parses combined yaw + roll', () => {
+    expect(deriveBoardOrientationVisual(10, 'Yaw 90 Roll 180')).toMatchObject({ yaw: 90, roll: 180, pitch: 0 })
+  })
+
+  it('parses edge/tilted mounts (now depictable in 3D)', () => {
+    expect(deriveBoardOrientationVisual(16, 'Roll 90')).toMatchObject({ kind: 'depictable', roll: 90 })
+    expect(deriveBoardOrientationVisual(24, 'Pitch 90')).toMatchObject({ kind: 'depictable', pitch: 90 })
+    expect(deriveBoardOrientationVisual(28, 'Pitch 90 Roll 90')).toMatchObject({ pitch: 90, roll: 90 })
+    expect(deriveBoardOrientationVisual(42, 'Roll 45')).toMatchObject({ roll: 45 })
+  })
+
+  it('parses the odd combined angle (Yaw 293 Pitch 68 Roll 180)', () => {
+    expect(deriveBoardOrientationVisual(38, 'Yaw 293 Pitch 68 Roll 180')).toMatchObject({
+      yaw: 293,
+      pitch: 68,
+      roll: 180
+    })
   })
 
   it('custom orientations (>=100) are not depictable', () => {

--- a/apps/web/src/view-models/board-orientation-visual.ts
+++ b/apps/web/src/view-models/board-orientation-visual.ts
@@ -1,33 +1,21 @@
-// Turn an AHRS_ORIENTATION value into what a top-down board picture should show.
-//
-// The enum labels encode Yaw/Roll/Pitch rotations (e.g. "Yaw 90 Roll 180").
-// A flat top-down diagram can faithfully show:
-//   - pure Yaw (the board rotated in its mounting plane), and
-//   - a 180° flip (Roll 180 / Pitch 180 = mounted upside down),
-// but NOT a 90°/270°/45° roll or pitch (the board is on its edge or tilted),
-// where a flat rotation would mislead. Those get a "non-flat mounting" note
-// instead of a wrong picture.
+// Turn an AHRS_ORIENTATION value into a 3D board pose. The enum labels encode a
+// composition of Yaw/Roll/Pitch rotations (e.g. "Yaw 90 Roll 180"); a 3D board
+// can show every one — flat yaw, upside-down flips, and the edge/tilted mounts a
+// flat 2D picture couldn't. Only the Custom orientations (>=100, set by explicit
+// angles) aren't depictable.
 
-export type BoardOrientationKind = 'flat' | 'inverted' | 'edge' | 'custom'
+export type BoardOrientationKind = 'depictable' | 'custom'
 
 export interface BoardOrientationVisual {
   kind: BoardOrientationKind
-  /** Yaw to rotate the top-down board by, degrees clockwise. 0 for non-flat. */
-  yawDeg: number
-  /** True when the board is mounted upside down (a 180° roll or pitch). */
-  inverted: boolean
-  /**
-   * Which axis a 180° flip mirrors, applied after the yaw rotation:
-   *   - Roll 180 flips about the forward axis: nose stays forward, board sees
-   *     its underside → mirror LEFT-RIGHT ('x').
-   *   - Pitch 180 flips about the right axis: nose points backward → mirror
-   *     TOP-BOTTOM ('y').
-   * Undefined when not inverted.
-   */
-  mirror?: 'x' | 'y'
+  /** Rotation to pose the board by, degrees. Applied intrinsically roll→pitch→yaw
+   *  (ArduPilot's order) by the 3D view. All 0 for "None". */
+  roll: number
+  pitch: number
+  yaw: number
   /** The human label (e.g. "Yaw 90 Roll 180"). */
   label: string
-  /** Set for 'edge'/'custom' — why no flat picture is drawn. */
+  /** Set for 'custom' — why no board is posed. */
   note?: string
 }
 
@@ -53,41 +41,13 @@ export function deriveBoardOrientationVisual(
 
   // Custom orientations (100-102) are a quaternion/angle set we can't depict.
   if (value >= 100) {
-    return { kind: 'custom', yawDeg: 0, inverted: false, label, note: 'Custom orientation — set by explicit angles.' }
+    return { kind: 'custom', roll: 0, pitch: 0, yaw: 0, label, note: 'Custom orientation — set by explicit angles.' }
   }
 
   if (value === 0 || /^none$/i.test(label)) {
-    return { kind: 'flat', yawDeg: 0, inverted: false, label }
+    return { kind: 'depictable', roll: 0, pitch: 0, yaw: 0, label }
   }
 
   const { yaw, roll, pitch } = parseAngles(label)
-
-  // A flat picture is only honest when roll and pitch are each either 0 or a
-  // full 180° flip. Any 45/90/270/315 (or the odd 68/293/315) roll/pitch means
-  // the board sits on its edge or at an angle — depict a note, not a rotation.
-  const flipRoll = roll === 180
-  const flipPitch = pitch === 180
-  const rollIsFlatOrFlip = roll === 0 || roll === 180
-  const pitchIsFlatOrFlip = pitch === 0 || pitch === 180
-
-  if (!rollIsFlatOrFlip || !pitchIsFlatOrFlip) {
-    return {
-      kind: 'edge',
-      yawDeg: 0,
-      inverted: false,
-      label,
-      note: 'Board is mounted on its side or at an angle — see the label for the exact rotation.'
-    }
-  }
-
-  const inverted = flipRoll || flipPitch
-  return {
-    kind: inverted ? 'inverted' : 'flat',
-    yawDeg: yaw % 360,
-    inverted,
-    // Roll 180 mirrors left-right (nose stays forward); Pitch 180 mirrors
-    // top-bottom (nose points backward).
-    ...(flipRoll ? { mirror: 'x' as const } : flipPitch ? { mirror: 'y' as const } : {}),
-    label
-  }
+  return { kind: 'depictable', roll, pitch, yaw, label }
 }

--- a/apps/web/src/views/BoardOrientationDiagram.tsx
+++ b/apps/web/src/views/BoardOrientationDiagram.tsx
@@ -1,9 +1,13 @@
-// Top-down picture of the flight controller as it is mounted, from the
-// AHRS_ORIENTATION value. A board rectangle with a forward arrow, a USB
-// connector notch and an IMU chip, rotated by the orientation's yaw and flipped
-// when the board is mounted upside down — so the operator sees the mounting, not
-// just an enum value. Edge/tilted and custom orientations show a note instead of
-// a misleading flat rotation. Dumb presentational component.
+// 3D picture of the flight controller as it is mounted, from AHRS_ORIENTATION.
+// A thin board slab (distinct top vs bottom faces, a forward arrow, a USB notch)
+// posed by the orientation's roll/pitch/yaw, inside a tilted scene so depth
+// reads — so every option is visible, including the edge/tilted and upside-down
+// mounts a flat 2D picture couldn't show. Custom orientations show a note.
+//
+// Axis mapping (body -> CSS): yaw about the board's normal = rotateZ; roll about
+// the forward axis = rotateY; pitch about the right axis = rotateX. Composed
+// intrinsically roll -> pitch -> yaw (ArduPilot's order) — in CSS that's written
+// outermost-first, i.e. rotateZ(yaw) rotateX(pitch) rotateY(roll).
 
 import type { BoardOrientationVisual } from '../view-models/board-orientation-visual'
 
@@ -13,52 +17,49 @@ export interface BoardOrientationDiagramProps {
 }
 
 export function BoardOrientationDiagram({ visual, testId }: BoardOrientationDiagramProps) {
-  const depictable = visual.kind === 'flat' || visual.kind === 'inverted'
-
-  return (
-    <div className="board-orientation-diagram" data-testid={testId}>
-      <div className="board-orientation-diagram__stage">
-        {/* Fixed airframe reference: "FRONT" marker at the top, so the board's
-            rotation reads against the vehicle's forward direction. */}
-        <span className="board-orientation-diagram__front" aria-hidden="true">
-          FRONT
-        </span>
-        {depictable ? (
-          <svg
-            viewBox="0 0 120 120"
-            role="img"
-            aria-label={`Board mounted: ${visual.label}`}
-            className="board-orientation-diagram__svg"
-            style={{
-              // Yaw rotates the board; a 180° flip mirrors it about the axis the
-              // roll/pitch inversion acts on (x = left-right for Roll 180, y =
-              // top-bottom for Pitch 180) so the forward arrow points correctly.
-              transform: `rotate(${visual.yawDeg}deg)${
-                visual.mirror === 'x' ? ' scaleX(-1)' : visual.mirror === 'y' ? ' scaleY(-1)' : ''
-              }`
-            }}
-          >
-            {/* Board body */}
-            <rect x="30" y="24" width="60" height="72" rx="7" className="board-orientation-diagram__board" />
-            {/* Forward arrow (points to the board's own +X / nose) */}
-            <polygon points="60,10 52,28 68,28" className="board-orientation-diagram__arrow" />
-            <line x1="60" y1="26" x2="60" y2="60" className="board-orientation-diagram__arrow-stem" />
-            {/* USB / connector notch at the rear edge */}
-            <rect x="50" y="96" width="20" height="7" rx="2" className="board-orientation-diagram__usb" />
-            {/* IMU chip, offset so a flip is visible */}
-            <rect x="44" y="40" width="20" height="20" rx="3" className="board-orientation-diagram__imu" />
-          </svg>
-        ) : (
+  if (visual.kind === 'custom') {
+    return (
+      <div className="board-orientation-diagram" data-testid={testId}>
+        <div className="board-orientation-diagram__stage">
           <div className="board-orientation-diagram__note" data-testid="board-orientation-note">
             <strong>{visual.label}</strong>
             <p>{visual.note}</p>
           </div>
-        )}
+        </div>
+        <div className="board-orientation-diagram__caption">{visual.label}</div>
       </div>
-      <div className="board-orientation-diagram__caption">
-        <span>{visual.label}</span>
-        {visual.inverted ? <span className="board-orientation-diagram__badge">Upside down</span> : null}
+    )
+  }
+
+  const boardTransform = `rotateZ(${visual.yaw}deg) rotateX(${visual.pitch}deg) rotateY(${visual.roll}deg)`
+
+  return (
+    <div className="board-orientation-diagram" data-testid={testId}>
+      <div className="board-orientation-diagram__stage board-orientation-diagram__stage--3d">
+        <span className="board-orientation-diagram__front" aria-hidden="true">
+          FRONT
+        </span>
+        {/* Tilted scene so the board's thickness / which face is up reads. */}
+        <div className="board-orientation-diagram__scene">
+          <div
+            className="board-orientation-diagram__board3d"
+            data-testid="board-orientation-3d"
+            style={{ transform: boardTransform }}
+            role="img"
+            aria-label={`Board mounted: ${visual.label}`}
+          >
+            {/* Top face — the component side, with the forward arrow. */}
+            <div className="board-orientation-diagram__face board-orientation-diagram__face--top">
+              <div className="board-orientation-diagram__arrow" aria-hidden="true" />
+              <div className="board-orientation-diagram__imu" aria-hidden="true" />
+              <div className="board-orientation-diagram__usb" aria-hidden="true" />
+            </div>
+            {/* Bottom face — a distinct colour so an upside-down mount is obvious. */}
+            <div className="board-orientation-diagram__face board-orientation-diagram__face--bottom" aria-hidden="true" />
+          </div>
+        </div>
       </div>
+      <div className="board-orientation-diagram__caption">{visual.label}</div>
     </div>
   )
 }

--- a/tests/e2e/views.spec.ts
+++ b/tests/e2e/views.spec.ts
@@ -1420,17 +1420,24 @@ test.describe('Config view', () => {
     const diagram = page.getByTestId('board-orientation-diagram')
     await expect(diagram).toBeVisible() // demo AHRS_ORIENTATION=0 (None)
     await expect(diagram).toContainText('None')
+    const board = page.getByTestId('board-orientation-3d')
+    await expect(board).toBeVisible()
 
     const select = section.locator('select').first()
-    // Roll 180 -> "Upside down" badge; the SVG stays (a depictable flip).
+    // Roll 180 (upside down) — 3D board posed, caption updates.
     await select.selectOption('8')
-    await expect(diagram).toContainText('Upside down')
-    await expect(diagram.locator('svg')).toBeVisible()
+    await expect(diagram).toContainText('Roll 180')
+    await expect(board).toHaveAttribute('style', /rotateY\(180deg\)/)
 
-    // Roll 90 -> edge mount: a note, no flat SVG (never a misleading rotation).
+    // Roll 90 (on its edge) — now depictable in 3D (2D couldn't show it).
     await select.selectOption('16')
+    await expect(diagram).toContainText('Roll 90')
+    await expect(board).toHaveAttribute('style', /rotateY\(90deg\)/)
+
+    // A Custom orientation can't be posed — shows a note instead of a board.
+    await select.selectOption('101')
     await expect(page.getByTestId('board-orientation-note')).toBeVisible()
-    await expect(diagram.locator('svg')).toHaveCount(0)
+    await expect(page.getByTestId('board-orientation-3d')).toHaveCount(0)
   })
 
   test('Config tab exposes an Apply / Revert toolbar wired to the Config draft scope', async ({ page }) => {


### PR DESCRIPTION
Follow-up to #104. That flat top-down picture could only honestly show yaw and 180° flips; edge/tilted mounts (Roll/Pitch 90/270, 45/315, odd combos) fell back to a text note. This replaces it with a **CSS-3D board** posed by the orientation's roll/pitch/yaw — a thin slab with distinct top/bottom faces, a forward arrow, IMU and USB — inside a tilted oblique scene, so **all ~40 orientations are visible**:
- flat yaw rotates the board (the arrow swings to the new nose direction),
- a 180° flip shows the **warm underside** (unmistakably upside down),
- an on-its-side mount **stands the board on edge**.

## How
Axis mapping (body→CSS): yaw = `rotateZ`, roll = `rotateY`, pitch = `rotateX`, composed `rotateZ(yaw) rotateX(pitch) rotateY(roll)` — ArduPilot's intrinsic roll→pitch→yaw order. Camera is `rotateX(56) rotateY(-26)` so no board face is ever edge-on (a Roll 90 board would otherwise vanish). Only **Custom** (≥100, explicit angles) isn't depictable — keeps the note.

No external 3D library (pure CSS transforms), CSP-safe, honours `prefers-reduced-motion`. `deriveBoardOrientationVisual` now returns the raw roll/pitch/yaw (8 unit tests).

## ArduCopter byte-identical
Presentational only.

## Validation
Rungs 1 + 3. node 755, vitest 583, Playwright 223. Verified in the demo across None / Yaw 90 / Roll 180 (underside up) / Roll 90 (on edge) / Pitch 90.