### PR TITLE
fix(osd): show the OSD backend by default instead of collapsed

### DIFF
--- a/apps/web/src/views/Osd.tsx
+++ b/apps/web/src/views/Osd.tsx
@@ -487,14 +487,13 @@ export function OsdView(props: OsdViewProps) {
             </button>
           </div>
 
-          {/* Backend strip moved above Screen Options — the FC-side
-           *  backend selection (analog / DisplayPort / MSP) is conceptually
-           *  the parent of the per-screen options below, and BF puts the
-           *  backend selectors near the top too. Collapsed details<summary>
-           *  so it occupies one line when the operator isn't editing
-           *  backends — keeps the page from front-loading three big
-           *  selects on every visit. */}
-          <details className="bf-gui-box osd-backend-strip" data-testid="osd-backend-strip">
+          {/* Backend strip above Screen Options — the FC-side backend selection
+           *  (analog / DisplayPort / MSP) is conceptually the parent of the
+           *  per-screen options below, and BF puts the backend selectors near
+           *  the top too. Open by default (operator request): the backend is
+           *  the first thing to confirm on the OSD tab, so it shouldn't be
+           *  hidden behind a collapsed summary. */}
+          <details className="bf-gui-box osd-backend-strip" data-testid="osd-backend-strip" open>
             <summary className="bf-gui-box__titlebar">
               <strong>Backend</strong>
               <small>{previewToolbar.backendText} · {previewToolbar.switchingText} · {previewToolbar.cellsText}</small>

--- a/tests/e2e/views.spec.ts
+++ b/tests/e2e/views.spec.ts
@@ -2021,6 +2021,17 @@ test.describe('Presets erase settings', () => {
 })
 
 test.describe('OSD view preview', () => {
+  test('Backend strip is open by default so the OSD backend is visible', async ({ page }) => {
+    await page.goto('/')
+    await connectViaHeader(page)
+    await openView(page, 'osd')
+
+    const strip = page.getByTestId('osd-backend-strip')
+    await expect(strip).toHaveAttribute('open', '')
+    // The OSD_TYPE backend selector is visible without expanding anything.
+    await expect(strip.locator('.scoped-editor-field__param-id', { hasText: 'OSD_TYPE' })).toBeVisible()
+  })
+
   test('MSP cell count is compact and nudges an explicit value when Auto', async ({ page }) => {
     await page.goto('/')
     await connectViaHeader(page)


### PR DESCRIPTION
The Backend strip (OSD_TYPE / channel / switch method) was a collapsed `<details>`. The backend (analog MAX7456 vs MSP DisplayPort) is the first thing to confirm on the OSD tab — operator asked for it to be visible. Adds `open` so it renders expanded, matching the Messages and Screen Options strips.

ArduCopter byte-identical: presentational only. Validation: node 755, Playwright 224 (+1).