### PR TITLE
fix(config): flatten the orientation camera so "None" reads as a flat board

### DIFF
--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -8587,11 +8587,12 @@ details.metadata-settings-section:not([open]) > summary::after {
   color: var(--text-dim, var(--text-muted));
   z-index: 1;
 }
-/* Oblique (isometric-ish) camera: tilted back AND yawed a little, so no board
-   face is ever edge-on — an on-its-side (Roll/Pitch 90) mount stays visible. */
+/* Gentle top-down-ish camera: a flat ("None") board reads as lying flat, with
+   just enough tilt + a small yaw that an on-its-side (Roll/Pitch 90) mount is
+   never perfectly edge-on and still shows. */
 .board-orientation-diagram__scene {
   transform-style: preserve-3d;
-  transform: rotateX(56deg) rotateY(-26deg);
+  transform: rotateX(32deg) rotateY(-14deg);
 }
 .board-orientation-diagram__board3d {
   position: relative;


### PR DESCRIPTION
Operator feedback on #106: the 3D orientation camera (`rotateX 56 / rotateY 26`) skewed a flat board into a parallelogram, so **None looked tilted, not flat**.

Gentles the camera to `rotateX(32) rotateY(-14)`: a flat / pure-yaw board now reads as lying flat, while the small remaining tilt + yaw keeps an on-its-side (Roll/Pitch 90) mount from being perfectly edge-on so it still shows.

ArduCopter byte-identical: one CSS transform. Verified in the demo: None lies flat, Roll 180 shows the underside, Roll 90 stands on edge.