### PR TITLE
feat(config): group the Config tab into category tabs with folded advanced fields

### DIFF
--- a/apps/web/src/hooks/use-config-sections.ts
+++ b/apps/web/src/hooks/use-config-sections.ts
@@ -9,7 +9,60 @@ import { useCallback, useMemo } from 'react'
 
 import { firmwareVersionAtLeast, type ConfiguratorSnapshot } from '@arduconfig/ardupilot-core'
 
-import type { ConfigSection } from '../views/Config'
+import type { ConfigCategoryId, ConfigSection } from '../views/Config'
+
+// Which top-tab group each section belongs to. Sections not listed fall back to
+// 'system' (the catch-all), so a new section is never orphaned off the tabs.
+const CATEGORY_BY_SECTION: Record<string, ConfigCategoryId> = {
+  frame: 'airframe',
+  'board-orientation': 'airframe',
+  'esc-dshot': 'airframe',
+  compass: 'sensors',
+  'active-imu': 'sensors',
+  'system-rates': 'sensors',
+  'fast-loop-rate': 'sensors',
+  gps: 'gps',
+  'receiver-signal': 'rc-arming',
+  arming: 'rc-arming',
+  'pilot-rates': 'rc-arming',
+  identity: 'system',
+  logging: 'system',
+  beeper: 'system',
+  'camera-trigger': 'system'
+}
+
+// Rarely-touched fields folded into each card's "Advanced" disclosure, so a card
+// leads with the knobs an operator actually reaches for. Everything not listed
+// stays in the always-visible common set.
+const ADVANCED_FIELDS: Record<string, readonly string[]> = {
+  'board-orientation': ['AHRS_TRIM_X', 'AHRS_TRIM_Y', 'AHRS_TRIM_Z'],
+  compass: ['COMPASS_USE2', 'COMPASS_USE3', 'COMPASS_AUTO_ROT', 'COMPASS_DISBLMSK'],
+  'esc-dshot': ['SERVO_DSHOT_RATE', 'SERVO_BLH_POLES', 'SERVO_BLH_BDMASK', 'SERVO_BLH_RVMASK'],
+  'system-rates': ['INS_GYRO_RATE', 'INS_FAST_SAMPLE'],
+  'fast-loop-rate': ['FSTRATE_DIV'],
+  'pilot-rates': ['ACRO_RP_RATE', 'ACRO_Y_RATE', 'ACRO_RP_EXPO', 'ACRO_Y_EXPO'],
+  'active-imu': ['INS_USE2', 'INS_USE3'],
+  gps: ['GPS_GNSS_MODE', 'GPS_AUTO_SWITCH', 'GPS_PRIMARY'],
+  'receiver-signal': ['RC_OPTIONS', 'RC_PROTOCOLS'],
+  arming: ['ARMING_RUDDER'],
+  identity: ['SYSID_MYGCS', 'BRD_BOOT_DELAY'],
+  logging: ['LOG_BITMASK', 'LOG_DISARMED', 'LOG_REPLAY'],
+  beeper: ['NTF_BUZZ_TYPES'],
+  'camera-trigger': ['CAM_DURATION', 'CAM_AUTO_ONLY', 'CAM_SERVO_ON', 'CAM_SERVO_OFF']
+}
+
+// Tag a built section with its category + which of its fields are advanced.
+// Centralised here so the section definitions below stay declarative.
+function categorize(section: ConfigSection): ConfigSection {
+  const advanced = ADVANCED_FIELDS[section.id]
+  return {
+    ...section,
+    category: CATEGORY_BY_SECTION[section.id] ?? 'system',
+    fields: advanced
+      ? section.fields.map((field) => (advanced.includes(field.paramId) ? { ...field, advanced: true } : field))
+      : section.fields
+  }
+}
 
 export function useConfigSections(snapshot: ConfiguratorSnapshot) {
   const activeVehicle = snapshot.vehicle?.vehicle
@@ -51,7 +104,7 @@ export function useConfigSections(snapshot: ConfiguratorSnapshot) {
   const armingDescription = armingIsSkip
     ? 'Pre-arm checks to skip + which inputs may arm. ARMING_SKIPCHK = 0 runs every check (recommended); set bits skip individual checks (ArduPilot 4.7+).'
     : 'Pre-arm checks bitmask + which inputs are allowed to arm. ARMING_CHECK "All checks" runs every check; clear it to disable individual checks.'
-  const configSections: readonly ConfigSection[] = useMemo(() => [
+  const configSections: readonly ConfigSection[] = useMemo(() => ([
     ...(hasFrame
       ? [
           {
@@ -266,7 +319,7 @@ export function useConfigSections(snapshot: ConfiguratorSnapshot) {
     // Statistics (STAT_*) moved to the Setup view's side panel — lifetime
     // counters read better next to the live instruments than buried in the
     // Config grab-bag.
-  ], [
+  ] as readonly ConfigSection[]).map(categorize), [
     activeVehicle,
     hasFastRate,
     hasPilotRates,

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -12891,13 +12891,75 @@ details.metadata-settings-section:not([open]) > summary::after {
 }
 
 .config-grid {
-  /* Masonry packing via CSS multicolumn: short sections (frame, identity,
-     fast-loop) tuck under tall ones (arming/RC bitmasks, ESC) instead of
-     leaving a row's worth of dead space beside them. The Apply/Revert toolbar
-     below stays reachable via the sticky rule on .config-toolbar. */
-  columns: 300px;
+  /* Masonry packing via CSS multicolumn: short sections tuck under tall ones
+     instead of leaving dead space. With the category tabs, a group holds only a
+     few cards, so cap the width so 2-3 cards read as a calm flow rather than
+     spreading thin across a wide screen. */
+  columns: 360px 3;
   column-gap: var(--space-3, 12px);
   padding-right: 6px;
+  max-width: 1180px;
+}
+
+/* Category tab strip — reuses .tab-strip; a little breathing room + the
+   unsaved-changes dot on a group you're not looking at. */
+.config-category-nav {
+  margin-bottom: var(--space-3, 12px);
+}
+.config-category-nav__dot {
+  display: inline-block;
+  width: 7px;
+  height: 7px;
+  margin-left: 6px;
+  border-radius: 50%;
+  background: var(--warning);
+  vertical-align: middle;
+}
+
+/* Per-card Advanced disclosure — rarely-touched fields folded so each card
+   leads with the essentials. */
+.config-section__advanced {
+  margin-top: 4px;
+  border-top: 1px solid rgba(var(--edge-rgb), 0.08);
+  padding-top: 6px;
+}
+.config-section__advanced > summary {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  cursor: pointer;
+  list-style: none;
+  font-size: 11px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+  padding: 2px 0;
+}
+.config-section__advanced > summary::-webkit-details-marker {
+  display: none;
+}
+.config-section__advanced > summary::before {
+  content: '▸';
+  font-size: 9px;
+  transition: transform 0.15s ease;
+}
+.config-section__advanced[open] > summary::before {
+  transform: rotate(90deg);
+}
+.config-section__advanced-count {
+  min-width: 15px;
+  height: 15px;
+  padding: 0 4px;
+  border-radius: 999px;
+  background: rgba(var(--edge-rgb), 0.12);
+  color: var(--text-muted);
+  font-size: 10px;
+  line-height: 15px;
+  text-align: center;
+  letter-spacing: 0;
+}
+.config-section__editors--advanced {
+  margin-top: 6px;
 }
 
 .config-section {

--- a/apps/web/src/views/Config.tsx
+++ b/apps/web/src/views/Config.tsx
@@ -1,4 +1,4 @@
-import type { ReactNode } from 'react'
+import { useMemo, useState, type ReactNode } from 'react'
 
 import type { ParameterState } from '@arduconfig/ardupilot-core'
 import { Panel, StatusBadge, buttonStyle } from '@arduconfig/ui-kit'
@@ -27,13 +27,36 @@ export interface ConfigSectionField {
   /** Decimal places for read-only float values. Editable fields go
    *  through the shared float formatter from param-metadata. */
   digits?: number
+  /** Rarely-touched field folded into a per-card "Advanced" disclosure,
+   *  so each card leads with the knobs an operator actually reaches for. */
+  advanced?: boolean
 }
+
+/** Config category ids — the top tab groups. */
+export type ConfigCategoryId = 'airframe' | 'sensors' | 'gps' | 'rc-arming' | 'system'
+
+export interface ConfigCategory {
+  id: ConfigCategoryId
+  label: string
+}
+
+// Tab order across the top of the Config surface. One calm group at a time
+// instead of 14 stacked cards.
+export const CONFIG_CATEGORIES: readonly ConfigCategory[] = [
+  { id: 'airframe', label: 'Airframe' },
+  { id: 'sensors', label: 'Sensors' },
+  { id: 'gps', label: 'GPS' },
+  { id: 'rc-arming', label: 'RC & Arming' },
+  { id: 'system', label: 'System' }
+]
 
 export interface ConfigSection {
   id: string
   title: string
   description: string
   fields: readonly ConfigSectionField[]
+  /** Which top-tab group this section belongs to. */
+  category?: ConfigCategoryId
   /** True = read-only data list (used for STAT_* counters). */
   readOnly?: boolean
   /** True = the section is a placeholder; render a "planned" badge
@@ -74,6 +97,12 @@ function formatReadOnlyValue(
   return field.unit ? `${text} ${field.unit}` : text
 }
 
+// A field carries an unsaved edit when its draft status is staged or invalid.
+function fieldHasUnsaved(draftStatusById: ScopedFieldDraftMap, paramId: string): boolean {
+  const status = draftStatusById.get(paramId)?.status
+  return status === 'staged' || status === 'invalid'
+}
+
 export function ConfigView(props: ConfigViewProps) {
   const {
     sections,
@@ -90,14 +119,139 @@ export function ConfigView(props: ConfigViewProps) {
     onApply,
     onRevert
   } = props
+
+  // Categories that actually have sections for this vehicle/build — an empty
+  // group never gets a tab.
+  const presentCategories = useMemo(
+    () => CONFIG_CATEGORIES.filter((category) => sections.some((section) => section.category === category.id)),
+    [sections]
+  )
+
+  const [activeCategory, setActiveCategory] = useState<ConfigCategoryId>(presentCategories[0]?.id ?? 'airframe')
+  // Keep the active tab valid if the section set changes under us.
+  const effectiveCategory = presentCategories.some((category) => category.id === activeCategory)
+    ? activeCategory
+    : presentCategories[0]?.id ?? 'airframe'
+
+  // Which categories hold an unsaved edit, for the tab dot — so a staged change
+  // on a tab you're not looking at is never invisible.
+  const unsavedByCategory = useMemo(() => {
+    const set = new Set<ConfigCategoryId>()
+    for (const section of sections) {
+      if (!section.category || section.readOnly) continue
+      if (section.fields.some((field) => fieldHasUnsaved(draftStatusById, field.paramId))) {
+        set.add(section.category)
+      }
+    }
+    return set
+  }, [sections, draftStatusById])
+
+  const visibleSections = useMemo(
+    () => sections.filter((section) => (section.category ?? 'system') === effectiveCategory),
+    [sections, effectiveCategory]
+  )
+
+  // One editable field row (or the "(not reported)" placeholder). Shared by the
+  // common set and the folded Advanced set.
+  function renderField(field: ConfigSectionField): ReactNode {
+    const parameter = parametersById.get(field.paramId)
+    if (!parameter) {
+      return (
+        <div
+          key={field.paramId}
+          className="config-section__missing-row"
+          data-testid={`config-field-missing-${field.paramId}`}
+        >
+          <span>{field.label}</span>
+          <small>{field.paramId}</small>
+          <span className="config-section__missing-value">— (not reported)</span>
+        </div>
+      )
+    }
+    const hasOptions = (parameter.definition?.options ?? []).length > 0
+    const editor =
+      parameter.definition?.bitmask && hasOptions ? (
+        <ScopedBitmaskField
+          parameter={parameter}
+          liveValue={parameter.value}
+          editedValues={editedValues}
+          onChange={onEditChange}
+          draftStatusById={draftStatusById}
+        />
+      ) : hasOptions ? (
+        <ScopedSelectField
+          parameter={parameter}
+          liveValue={parameter.value}
+          editedValues={editedValues}
+          onChange={onEditChange}
+          draftStatusById={draftStatusById}
+          layout="chips"
+        />
+      ) : (
+        <ScopedField
+          parameter={parameter}
+          liveValue={parameter.value}
+          editedValues={editedValues}
+          onChange={onEditChange}
+          draftStatusById={draftStatusById}
+          stepFallback={field.unit === 'rad' ? 0.001 : 1}
+        />
+      )
+    const description = parameter.definition?.description
+    return (
+      <div key={field.paramId} className="config-section__field-row">
+        {editor}
+        {description ? (
+          <span className="config-section__info-wrap">
+            <button
+              type="button"
+              className="config-section__info"
+              data-testid={`config-field-info-${field.paramId}`}
+              aria-label={`About ${parameter.definition?.label ?? field.label}`}
+            >
+              i
+            </button>
+            <span className="config-section__info-tip" role="tooltip">
+              {description}
+            </span>
+          </span>
+        ) : null}
+      </div>
+    )
+  }
+
   return (
     <div id="setup-panel-config">
       <Panel
         title="Config"
-        subtitle="Board orientation, arming, system identity, beeper, statistics."
+        subtitle="Airframe, sensors, GPS, RC & arming, and system settings — grouped so you only see one area at a time."
       >
+        {presentCategories.length > 1 ? (
+          <div className="tab-strip config-category-nav" data-testid="config-category-nav" role="tablist">
+            {presentCategories.map((category) => {
+              const isActive = category.id === effectiveCategory
+              return (
+                <button
+                  key={category.id}
+                  type="button"
+                  role="tab"
+                  aria-selected={isActive}
+                  className={`tab-strip__tab${isActive ? ' is-active' : ''}`}
+                  data-testid={`config-category-${category.id}`}
+                  onClick={() => setActiveCategory(category.id)}
+                >
+                  <span className="tab-strip__tab-title">{category.label}</span>
+                  {unsavedByCategory.has(category.id) ? (
+                    <span className="config-category-nav__dot" title="Unsaved changes in this group" aria-label="unsaved changes" />
+                  ) : null}
+                </button>
+              )
+            })}
+          </div>
+        ) : null}
+
         <div className="config-grid" data-testid="config-section-grid">
-          {sections.map((section) => (
+          {visibleSections.map((section) => (
             <article
               key={section.id}
               className={`config-section${section.planned ? ' config-section--planned' : ''}${section.readOnly ? ' config-section--readonly' : ''}`}
@@ -132,76 +286,39 @@ export function ConfigView(props: ConfigViewProps) {
                   })}
                 </dl>
               ) : (
-                <div className="config-section__editors">
-                  {section.fields.map((field) => {
-                    const parameter = parametersById.get(field.paramId)
-                    if (!parameter) {
-                      return (
-                        <div
-                          key={field.paramId}
-                          className="config-section__missing-row"
-                          data-testid={`config-field-missing-${field.paramId}`}
+                (() => {
+                  const commonFields = section.fields.filter((field) => !field.advanced)
+                  const advancedFields = section.fields.filter((field) => field.advanced)
+                  // If a card is ALL advanced (shouldn't happen, but guard),
+                  // show them as common rather than an empty card behind a fold.
+                  const [leadFields, foldedFields] =
+                    commonFields.length > 0 ? [commonFields, advancedFields] : [advancedFields, []]
+                  const foldedUnsaved = foldedFields.some((field) => fieldHasUnsaved(draftStatusById, field.paramId))
+                  return (
+                    <div className="config-section__editors">
+                      {leadFields.map((field) => renderField(field))}
+                      {foldedFields.length > 0 ? (
+                        <details
+                          className="config-section__advanced"
+                          data-testid={`config-advanced-${section.id}`}
+                          // Auto-open when a folded field has an unsaved edit (so
+                          // it's never hidden); otherwise `undefined` leaves the
+                          // disclosure user-toggleable rather than force-closed.
+                          open={foldedUnsaved || undefined}
                         >
-                          <span>{field.label}</span>
-                          <small>{field.paramId}</small>
-                          <span className="config-section__missing-value">— (not reported)</span>
-                        </div>
-                      )
-                    }
-                    const hasOptions = (parameter.definition?.options ?? []).length > 0
-                    const editor =
-                      parameter.definition?.bitmask && hasOptions ? (
-                        <ScopedBitmaskField
-                          parameter={parameter}
-                          liveValue={parameter.value}
-                          editedValues={editedValues}
-                          onChange={onEditChange}
-                          draftStatusById={draftStatusById}
-                        />
-                      ) : hasOptions ? (
-                        <ScopedSelectField
-                          parameter={parameter}
-                          liveValue={parameter.value}
-                          editedValues={editedValues}
-                          onChange={onEditChange}
-                          draftStatusById={draftStatusById}
-                          layout="chips"
-                        />
-                      ) : (
-                        <ScopedField
-                          parameter={parameter}
-                          liveValue={parameter.value}
-                          editedValues={editedValues}
-                          onChange={onEditChange}
-                          draftStatusById={draftStatusById}
-                          stepFallback={field.unit === 'rad' ? 0.001 : 1}
-                        />
-                      )
-                    // Per-param "i" — hover/focus reveals the ArduPilot
-                    // description right next to the field it documents.
-                    const description = parameter.definition?.description
-                    return (
-                      <div key={field.paramId} className="config-section__field-row">
-                        {editor}
-                        {description ? (
-                          <span className="config-section__info-wrap">
-                            <button
-                              type="button"
-                              className="config-section__info"
-                              data-testid={`config-field-info-${field.paramId}`}
-                              aria-label={`About ${parameter.definition?.label ?? field.label}`}
-                            >
-                              i
-                            </button>
-                            <span className="config-section__info-tip" role="tooltip">
-                              {description}
-                            </span>
-                          </span>
-                        ) : null}
-                      </div>
-                    )
-                  })}
-                </div>
+                          <summary>
+                            Advanced
+                            <span className="config-section__advanced-count">{foldedFields.length}</span>
+                            {foldedUnsaved ? <span className="config-category-nav__dot" aria-label="unsaved changes" /> : null}
+                          </summary>
+                          <div className="config-section__editors config-section__editors--advanced">
+                            {foldedFields.map((field) => renderField(field))}
+                          </div>
+                        </details>
+                      ) : null}
+                    </div>
+                  )
+                })()
               )}
               {!section.planned && section.footer ? (
                 <div className="config-section__footer">{section.footer}</div>

--- a/tests/e2e/app.spec.ts
+++ b/tests/e2e/app.spec.ts
@@ -659,6 +659,8 @@ test.describe('browser configurator regression flows', () => {
   test('Config arming checks render as a bitmask chip grid', async ({ page }) => {
     await connectToVehicle(page, 'demo')
     await openView(page, 'config')
+    // Arming lives under the "RC & Arming" category tab now.
+    await page.getByTestId('config-category-rc-arming').click()
 
     // ARMING_CHECK is flagged bitmask, so the Config arming section shows
     // per-bit chips. Demo seeds ARMING_CHECK=1 (bit 0 = "All checks").

--- a/tests/e2e/views.spec.ts
+++ b/tests/e2e/views.spec.ts
@@ -177,6 +177,33 @@ async function openView(page: Page, viewId: string): Promise<void> {
   await page.getByTestId(`view-button-${viewId}`).click()
 }
 
+// The Config tab groups its sections into top-tab categories; click the tab that
+// holds a given section before asserting on it.
+const CONFIG_SECTION_CATEGORY: Record<string, string> = {
+  frame: 'airframe',
+  'board-orientation': 'airframe',
+  'esc-dshot': 'airframe',
+  compass: 'sensors',
+  'active-imu': 'sensors',
+  'system-rates': 'sensors',
+  'fast-loop-rate': 'sensors',
+  gps: 'gps',
+  'receiver-signal': 'rc-arming',
+  arming: 'rc-arming',
+  'pilot-rates': 'rc-arming',
+  identity: 'system',
+  logging: 'system',
+  beeper: 'system',
+  'camera-trigger': 'system'
+}
+
+async function openConfigSection(page: Page, sectionId: string): Promise<void> {
+  const category = CONFIG_SECTION_CATEGORY[sectionId]
+  if (category) {
+    await page.getByTestId(`config-category-${category}`).click()
+  }
+}
+
 test.describe('a11y', () => {
   const transitionMs = (value: string): number =>
     Math.max(
@@ -730,6 +757,8 @@ test.describe('Config — vehicle-aware mode channel', () => {
     await expect(page.getByTestId('session-vehicle-name')).toHaveText('ArduRover', { timeout: VEHICLE_CONNECT_TIMEOUT })
     await expectParameterSyncComplete(page)
     await openView(page, 'config')
+    await openConfigSection(page, 'receiver-signal')
+    await expect(page.getByTestId('config-section-receiver-signal')).toBeVisible()
     await expect(page.getByTestId('config-field-missing-FLTMODE_CH')).toHaveCount(0)
     await expect(page.getByTestId('config-field-missing-MODE_CH')).toHaveCount(0)
 
@@ -740,6 +769,7 @@ test.describe('Config — vehicle-aware mode channel', () => {
     await expect(page.getByTestId('session-vehicle-name')).toHaveText('ArduSub', { timeout: VEHICLE_CONNECT_TIMEOUT })
     await expectParameterSyncComplete(page)
     await openView(page, 'config')
+    await openConfigSection(page, 'receiver-signal')
     await expect(page.getByTestId('config-field-missing-FLTMODE_CH')).toHaveCount(0)
   })
 })
@@ -1369,24 +1399,26 @@ test.describe('Config view', () => {
     await page.getByTestId('view-button-config').click()
 
     await expect(page.getByTestId('config-section-grid')).toBeVisible()
-    for (const id of [
-      'board-orientation',
-      'arming',
-      'identity',
-      'beeper',
-      'camera-trigger',
-      'gps',
-      'logging'
-    ]) {
-      await expect(page.getByTestId(`config-section-${id}`)).toBeVisible()
+    // Sections live under top-tab categories now — the category strip shows the
+    // five groups, and each holds its sections.
+    await expect(page.getByTestId('config-category-nav')).toBeVisible()
+    for (const [sectionId, category] of [
+      ['board-orientation', 'airframe'],
+      ['gps', 'gps'],
+      ['arming', 'rc-arming'],
+      ['pilot-rates', 'rc-arming'],
+      ['identity', 'system'],
+      ['beeper', 'system'],
+      ['camera-trigger', 'system'],
+      ['logging', 'system']
+    ] as const) {
+      await page.getByTestId(`config-category-${category}`).click()
+      await expect(page.getByTestId(`config-section-${sectionId}`)).toBeVisible()
     }
     // Statistics moved to the Setup side panel — no longer a Config section.
     await expect(page.getByTestId('config-section-statistics')).toHaveCount(0)
-    // Pilot-rate knobs are mirrored into Config (demo Copter streams the full set).
-    await expect(page.getByTestId('config-section-pilot-rates')).toBeVisible()
     // Fast-rate thread is build-gated: the demo Copter mock does not stream
-    // FSTRATE_*, so the Fast loop rate section must be hidden rather than
-    // rendering empty "(not reported)" rows.
+    // FSTRATE_*, so the Fast loop rate section must never render.
     await expect(page.getByTestId('config-section-fast-loop-rate')).toHaveCount(0)
   })
 
@@ -1395,10 +1427,13 @@ test.describe('Config view', () => {
     await page.getByTestId('transport-mode-select').selectOption('demo')
     await page.getByTestId('connect-button').click()
     await page.getByTestId('view-button-config').click()
+    await openConfigSection(page, 'compass')
 
     const compass = page.getByTestId('config-section-compass')
     await expect(compass).toBeVisible()
-    // The curated compass knobs render with their param-name hints.
+    // The curated compass knobs render with their param-name hints. AUTO_ROT and
+    // DISBLMSK are in the card's Advanced fold — open it first.
+    await compass.getByTestId('config-advanced-compass').click()
     for (const id of ['COMPASS_EXTERNAL', 'COMPASS_ORIENT', 'COMPASS_AUTO_ROT', 'COMPASS_DISBLMSK']) {
       await expect(compass.locator('.scoped-editor-field__param-id', { hasText: id }).first()).toBeVisible()
     }
@@ -1415,6 +1450,7 @@ test.describe('Config view', () => {
     await page.getByTestId('transport-mode-select').selectOption('demo')
     await page.getByTestId('connect-button').click()
     await page.getByTestId('view-button-config').click()
+    await openConfigSection(page, 'board-orientation')
 
     const section = page.getByTestId('config-section-board-orientation')
     const diagram = page.getByTestId('board-orientation-diagram')
@@ -1540,9 +1576,9 @@ test.describe('Config view', () => {
     await page.getByTestId('view-button-config').click()
     const esc = page.getByTestId('config-section-esc-dshot')
     await esc.scrollIntoViewIfNeeded()
-    // Wait for SERVO_BLH_BDMASK to be synced (its presence is how the app knows
-    // the firmware supports BDShot) before changing the protocol — otherwise the
-    // auto-enable correctly treats it as unsupported.
+    // BLH_BDMASK is folded under Advanced; open it so the synced bits are in the
+    // DOM (their presence is how the app knows the firmware supports BDShot).
+    await esc.getByTestId('config-advanced-esc-dshot').click()
     const bits = page.getByTestId('scoped-bitmask-SERVO_BLH_BDMASK').locator('.scoped-bitmask-bit')
     await expect(bits.first()).toBeVisible()
     // MOT_PWM_TYPE is the first field (a select); switch it to a different DShot
@@ -1581,10 +1617,11 @@ test.describe('Config view', () => {
     await openView(page, 'config')
     const grid = page.getByTestId('config-section-grid')
     await expect(grid).toBeVisible()
-    // Sections pack via CSS multicolumn (columns: 300px) so short cards tuck
-    // under tall ones instead of leaving a row of dead space.
+    // Sections pack via CSS multicolumn so short cards tuck under tall ones
+    // instead of leaving a row of dead space (capped at 3 columns now that a
+    // category holds only a few cards).
     const columnWidth = await grid.evaluate((el) => getComputedStyle(el).columnWidth)
-    expect(columnWidth).toBe('300px')
+    expect(columnWidth).toBe('360px')
   })
 
   test('Receiver & signal section mirrors RSSI / mode-channel / RC options into Config', async ({ page }) => {
@@ -1592,9 +1629,11 @@ test.describe('Config view', () => {
     await page.getByTestId('transport-mode-select').selectOption('demo')
     await page.getByTestId('connect-button').click()
     await page.getByTestId('view-button-config').click()
+    await openConfigSection(page, 'receiver-signal')
     const section = page.getByTestId('config-section-receiver-signal')
-    await section.scrollIntoViewIfNeeded()
     await expect(section).toBeVisible()
+    // RC_OPTIONS is a set-once bitmask, folded under Advanced — open it.
+    await section.getByTestId('config-advanced-receiver-signal').click()
     // RC_OPTIONS renders as a chip grid here too (shared bitmask field).
     await expect(page.getByTestId('scoped-bitmask-RC_OPTIONS')).toBeVisible()
   })
@@ -1608,7 +1647,9 @@ test.describe('Config view', () => {
     const esc = page.getByTestId('config-section-esc-dshot')
     await esc.scrollIntoViewIfNeeded()
     await expect(esc).toBeVisible()
-    // Reverse + bidirectional-DShot masks render as per-output chip grids.
+    // Reverse + bidirectional-DShot masks are set-once, folded under Advanced.
+    await esc.getByTestId('config-advanced-esc-dshot').click()
+    // …then render as per-output chip grids.
     await expect(page.getByTestId('scoped-bitmask-SERVO_BLH_RVMASK')).toBeVisible()
     await expect(page.getByTestId('scoped-bitmask-SERVO_BLH_BDMASK')).toBeVisible()
     // Reverse is off by default (demo SERVO_BLH_RVMASK=0).
@@ -1650,23 +1691,30 @@ test.describe('Config view', () => {
     await page.getByTestId('connect-button').click()
     await page.getByTestId('view-button-config').click()
 
+    // system-rates + active-imu live under the Sensors tab.
+    await openConfigSection(page, 'system-rates')
     await expect(page.getByTestId('config-section-system-rates')).toBeVisible()
     await expect(page.getByTestId('config-section-active-imu')).toBeVisible()
-    // Max lean angle resolves to the param the FC actually streams (ANGLE_MAX on
-    // <=4.6, ATC_ANGLE_MAX on 4.7+) — the demo streams ANGLE_MAX, so the field
-    // reports a value rather than "(not reported)".
-    const pilotRates = page.getByTestId('config-section-pilot-rates')
-    await expect(pilotRates.getByText('Max lean angle')).toBeVisible()
-    await expect(pilotRates).not.toContainText('not reported')
     // Main loop rate renders as a dropdown (enum), defaulting to 400 Hz.
     const rates = page.getByTestId('config-section-system-rates')
     await expect(rates.getByText('Main loop rate')).toBeVisible()
-    // GPS behavior section now carries the multi-GPS knobs.
+
+    // Max lean angle (pilot-rates, RC & Arming tab). Resolves to the param the
+    // FC actually streams (ANGLE_MAX <=4.6, ATC_ANGLE_MAX 4.7+) — demo streams
+    // ANGLE_MAX, so it reports a value rather than "(not reported)".
+    await openConfigSection(page, 'pilot-rates')
+    const pilotRates = page.getByTestId('config-section-pilot-rates')
+    await expect(pilotRates.getByText('Max lean angle')).toBeVisible()
+    await expect(pilotRates).not.toContainText('not reported')
+
+    // GPS behavior — the multi-GPS knobs (Auto switch / Primary select) are
+    // set-once, folded under Advanced.
+    await openConfigSection(page, 'gps')
     const gps = page.getByTestId('config-section-gps')
+    await gps.getByTestId('config-advanced-gps').click()
     await expect(gps.getByText('Auto switch')).toBeVisible()
     // GPS_TYPE renders as "Primary GPS Type" and GPS_PRIMARY as "Primary GPS
-    // Select" (metadata labels), so match the specific GPS_PRIMARY knob rather
-    // than the ambiguous "Primary GPS" substring shared by both.
+    // Select"; match the specific GPS_PRIMARY knob.
     await expect(gps.getByText('Primary GPS Select')).toBeVisible()
   })
 
@@ -1684,8 +1732,10 @@ test.describe('Config view', () => {
     await page.getByTestId('transport-mode-select').selectOption('demo')
     await page.getByTestId('connect-button').click()
     await page.getByTestId('view-button-config').click()
-
+    // system-rates is under Sensors; Fast sampling is folded under Advanced.
+    await openConfigSection(page, 'system-rates')
     const rates = page.getByTestId('config-section-system-rates')
+    await rates.getByTestId('config-advanced-system-rates').click()
     const field = rates.locator('.scoped-editor-field', { hasText: 'Fast sampling' })
     await expect(field.locator('.scoped-editor-field__param-id')).toHaveText('INS_FAST_SAMPLE')
 
@@ -4072,8 +4122,9 @@ test.describe('Scoped write-progress bar', () => {
     await expectParameterSyncComplete(page)
 
     await page.getByTestId('view-button-config').click()
+    await openConfigSection(page, 'system-rates')
     const rates = page.getByTestId('config-section-system-rates')
-    await rates.scrollIntoViewIfNeeded()
+    await rates.getByTestId('config-advanced-system-rates').click()
     // Stage a config edit (INS_FAST_SAMPLE) so config:apply has something to write.
     await rates.locator('.scoped-editor-field', { hasText: 'Fast sampling' }).locator('input[type=number]').fill('3')
 


### PR DESCRIPTION
The Config tab was a wall — **14 sections, ~50 fields, three columns, all at once**, nothing prioritised. Reorganised into **five top-tab categories** (Airframe · Sensors · GPS · RC & Arming · System) showing one calm group at a time, and each card now **leads with its essentials** while rarely-touched fields fold under a per-card **"Advanced (n)"** disclosure.

Before: one long scroll of every section. After: Airframe = 3 cards, System = 4 cards, each ~1 screen with room to breathe.

## How
- **Categories:** a section→category map + `ADVANCED_FIELDS` map in `use-config-sections` (centralised so the section definitions stay declarative); each built section is tagged via `categorize()`. `ConfigView` renders the shared `.tab-strip`, shows only the active category's sections, and keeps a valid active tab if the section set changes.
- **Advanced fold:** advanced-flagged fields render in a `<details>` per card; auto-opens (uncontrolled — `open || undefined` so it stays user-toggleable) when a folded field has an unsaved edit, with a count + unsaved-dot in the summary.
- **Cross-tab safety:** Apply/Revert stays **global** (staged edits in any tab apply together — scope unchanged), and a tab with unsaved changes shows a **dot** so a staged edit on a hidden tab is never invisible.

## ArduCopter byte-identical
Pure presentation / information architecture — same sections, fields, params, and apply scope; only grouping + disclosure changed.

## Validation
Rungs 1 + 3. node 755, vitest 583, Playwright 223. Config e2e updated to open the owning tab / advanced fold before asserting (new section→category helper). Verified in the demo across all five tabs + an expanded Advanced fold.