### PR TITLE
fix(params): keep a touched review row from vanishing mid-edit

### DIFF
--- a/apps/web/src/hooks/use-parameter-draft-derivations.ts
+++ b/apps/web/src/hooks/use-parameter-draft-derivations.ts
@@ -39,8 +39,14 @@ export function useParameterDraftDerivations(input: {
     () => parameterDraftEntries.filter((entry) => entry.status === 'invalid'),
     [parameterDraftEntries]
   )
+  // The review list keeps a row for every TOUCHED param — staged (will write)
+  // AND unchanged (edited back to the current value). Without 'unchanged' the
+  // row vanished the instant a typed value matched the original, yanking the
+  // input out from under the operator mid-edit (the "param disappears" bug that
+  // led to a wrong value being committed). Unchanged rows render muted and are
+  // never written; only Discard removes them.
   const stagedParameterGroups = useMemo(
-    () => groupParameterDraftEntries(parameterDraftEntries, ['staged']),
+    () => groupParameterDraftEntries(parameterDraftEntries, ['staged', 'unchanged']),
     [parameterDraftEntries]
   )
   const invalidParameterGroups = useMemo(

--- a/apps/web/src/sections/ParametersSection.tsx
+++ b/apps/web/src/sections/ParametersSection.tsx
@@ -571,7 +571,7 @@ export function ParametersSection(props: ParametersSectionProps): ReactElement {
                 <section key={group.category} className="parameter-diff-group">
                   <header>
                     <strong>{formatCategoryLabel(group.category)}</strong>
-                    <span>{group.entries.length} staged</span>
+                    <span>{group.entries.filter((entry) => entry.status === 'staged').length} staged</span>
                   </header>
 
                   {group.entries.map((draft) => {
@@ -590,8 +590,15 @@ export function ParametersSection(props: ParametersSectionProps): ReactElement {
                     const isBitmask = draft.definition?.bitmask === true
                     const inputId = `parameter-diff-edit-${draft.id}`
                     const currentRawValue = editedValues[draft.id] ?? String(draft.nextValue)
+                    // 'unchanged' = the operator edited this back to the live
+                    // value. Keep the row (so the input never vanishes mid-edit)
+                    // but render it muted — it won't write.
+                    const isUnchanged = draft.status === 'unchanged'
                     return (
-                    <div key={draft.id} className="parameter-diff-item parameter-diff-item--selectable">
+                    <div
+                      key={draft.id}
+                      className={`parameter-diff-item parameter-diff-item--selectable${isUnchanged ? ' parameter-diff-item--unchanged' : ''}`}
+                    >
                       <input
                         type="checkbox"
                         className="parameter-diff-item__select"
@@ -641,7 +648,9 @@ export function ParametersSection(props: ParametersSectionProps): ReactElement {
                           />
                         )}
                       </span>
-                      <span className="parameter-diff-delta">{formatParameterDelta(draft.delta, draft.definition?.unit)}</span>
+                      <span className="parameter-diff-delta">
+                        {isUnchanged ? 'matches current — won’t write' : formatParameterDelta(draft.delta, draft.definition?.unit)}
+                      </span>
                       {/* Per-row Discard so the operator can deselect a
                        *  single staged change from the Apply All set
                        *  without leaving the Show Changes view. Apply All

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -11046,6 +11046,16 @@ details.metadata-settings-section:not([open]) > summary::after {
   border-top: 1px solid rgba(39, 49, 59, 0.72);
 }
 
+/* Touched then edited back to the live value — kept in the review so the input
+   never vanishes mid-edit, but muted since it won't write. */
+.parameter-diff-item--unchanged {
+  opacity: 0.62;
+}
+.parameter-diff-item--unchanged .parameter-diff-delta {
+  color: var(--text-muted);
+  font-style: italic;
+}
+
 /* A preset change the operator dropped before applying. */
 .parameter-diff-item--dropped {
   opacity: 0.5;

--- a/tests/e2e/views.spec.ts
+++ b/tests/e2e/views.spec.ts
@@ -319,6 +319,30 @@ test.describe('Parameters tab (expert-only)', () => {
     await expect(page.getByTestId('parameter-diff-grid')).toBeInViewport()
   })
 
+  test('a staged review row edited back to the original stays put (no vanish mid-edit)', async ({ page }) => {
+    // Bug: editing a staged value in the Show Changes review to equal the live
+    // value dropped the row from under the operator's cursor — how a half-typed
+    // value (ANGLE_MAX = 3 instead of 3000) got committed. The touched row now
+    // stays as a muted "won't write" row until Discard.
+    await page.goto('/')
+    await connectViaHeader(page)
+    await page.getByTestId('product-mode-expert').click()
+    await page.getByTestId('view-button-parameters').click()
+    await page.getByTestId('parameter-search-input').fill('ANGLE_MAX')
+
+    const tableInput = page.locator('.parameter-table input[type=number]').first()
+    await tableInput.fill('3000') // stage 4500 -> 3000
+    const reviewInput = page.getByTestId('parameter-diff-edit-ANGLE_MAX')
+    await expect(reviewInput).toBeVisible()
+
+    // Edit the staged value back to the original — the row must NOT disappear.
+    await reviewInput.fill('4500')
+    await expect(page.getByTestId('parameter-diff-edit-ANGLE_MAX')).toBeVisible()
+    await expect(page.locator('.parameter-diff-item--unchanged')).toContainText('won’t write')
+    // It's not counted toward the writable staged set.
+    await expect(page.getByRole('button', { name: /Apply All \(0\)/ })).toBeVisible()
+  })
+
   test('Export is one picker where you choose the format', async ({ page }) => {
     // Was a primary "Export" button sitting next to a separate "Export Legacy…"
     // select, which read as two competing exports. Now a single picker: pick


### PR DESCRIPTION
**Reported bug:** in the Parameters **Show Changes** review, editing a staged value to equal the live value (or emptying the box) dropped the row out from under the operator's cursor — the input you were typing in disappeared. That's how a half-typed value got committed (ANGLE_MAX ended up **3 instead of 3000/30°**).

**Cause:** the review filtered to status `staged` only, so the instant a typed value matched the original the draft became `unchanged` and left the list.

**Fix:** the review now keeps every **touched** param — `staged` **and** `unchanged` — so editing back to the original leaves the row in place, rendered muted with *"matches current — won't write"* and its input intact. Only **Discard** removes it. The writable set (Apply All, the "N staged" count) still counts `staged` only, so an unchanged row never writes.

## ArduCopter byte-identical
Review/UI only — no write-path or param change. (The main parameter table already kept its inputs; this only affected the review.)

## Validation
Rungs 1 + 3. node 755, Playwright 225 (+1 regression: a review row edited back to the original stays put and reads "won't write"). Reproduced the original vanish first, confirmed the fix.

---
Note: this is the bug half of the Parameters feedback. The metadata / old-alias-name / enum-meaning / type-or-dropdown asks are the "bring back the detail view" feature (inline row expansion) — coming next.