### PR TITLE
docs(wiki): bring the wiki current with the Config/Params/Motor/CAN/OSD changes

### DIFF
--- a/wiki/can-dronecan.rst
+++ b/wiki/can-dronecan.rst
@@ -127,6 +127,17 @@ parameter read/write/save plumbing, but is aimed at routine DroneCAN node setup
 rather than the full expert toolkit (firmware update and ESC telemetry live in
 the Inspector). It is available without Expert mode.
 
+.. tip::
+
+   **"Enable the CAN bus?"** A common trap is to set a peripheral's driver to
+   DroneCAN (for example ``GPS_TYPE`` = 9/22/23, or ``BATT_MONITOR`` = 8) and
+   then find nothing on the bus because the CAN interface was never turned on.
+   When the CAN tab detects that situation — a DroneCAN peripheral selected but
+   CAN bus 1 not enabled for DroneCAN — it shows a one-click **Enable CAN bus &
+   reboot** prompt that writes ``CAN_P1_DRIVER = 1`` and ``CAN_D1_PROTOCOL = 1``
+   (both reboot-required) after an automatic backup. Nodes appear after the
+   reboot.
+
 See also :doc:`parameters` for editing flight-controller parameters and
 :doc:`logs-inspectors` for the live MAVLink stream.
 

--- a/wiki/config.rst
+++ b/wiki/config.rst
@@ -1,0 +1,61 @@
+Config
+======
+
+The **Config** tab is the baseline-settings surface — the "everything else"
+knobs that don't warrant their own tab but that you still reach for on a fresh
+build: airframe geometry, board orientation, compass, GPS behavior, RC and
+arming settings, and system identity/logging. It edits the same parameters the
+:doc:`parameters` tab exposes, but grouped into a product-shaped layout with the
+staged-draft workflow used across the app (edit → review → apply).
+
+Category tabs
+-------------
+
+The settings are grouped into five **category tabs** across the top, so you only
+see one area at a time instead of a wall of cards:
+
+- **Airframe** — frame class/type, board orientation, and the ESC/DShot protocol.
+- **Sensors** — compass, active IMUs, and the system (loop/gyro) rates.
+- **GPS** — GPS driver, auto-config, update rate, and multi-GPS behavior.
+- **RC & Arming** — RSSI/mode-channel and RC settings, arming checks and
+  arm/disarm behavior, and the pilot stick rates.
+- **System** — MAVLink identity, logging, the beeper/LED, and camera trigger.
+
+Each card leads with the settings you actually reach for; rarely-touched fields
+(trims, expo, boot delay, log bitmask, and the like) fold under a per-card
+**Advanced (n)** disclosure — click it to reveal them. A field with an unsaved
+edit keeps its Advanced section open, and any category tab holding an unsaved
+change is marked with a dot.
+
+Board orientation preview
+-------------------------
+
+The **Board orientation** card (under *Airframe*) shows a small **3D picture of
+the flight controller** as it is mounted, driven by the selected
+``AHRS_ORIENTATION``. It reacts to the dropdown before you apply: a flat/yaw
+orientation rotates the board, a 180° flip shows the board upside down, and an
+on-its-side (Roll/Pitch 90) mount stands it on edge — so you can confirm the
+mounting matches reality rather than reading an enum value. Custom orientations
+(set by explicit angles) show a note instead of a posed board.
+
+Compass
+-------
+
+The **Compass** card (under *Sensors*) collects the compass settings ArduPilot
+otherwise leaves in the raw parameter tree: which compasses to use for yaw
+(``COMPASS_USE`` / ``USE2`` / ``USE3``), auto declination, how the primary
+external compass is mounted (``COMPASS_EXTERNAL``) and its orientation
+(``COMPASS_ORIENT``, the same rotation set as the board orientation), the
+auto-orientation check run during calibration (``COMPASS_AUTO_ROT``), and —
+under Advanced — a mask of driver types to block (``COMPASS_DISBLMSK``).
+ArduPilot auto-detects compasses; an internal one follows the board orientation,
+while an external one uses its own orientation set here.
+
+Applying changes
+----------------
+
+Edits stage as local drafts and don't touch the aircraft until you apply. The
+**Apply Config** / **Revert** toolbar at the bottom is global to the tab — it
+commits (or discards) every staged change across all five category tabs in one
+press, so you can range across categories and apply once. Reboot-sensitive
+changes prompt you to reboot afterward, the same as elsewhere in the app.

--- a/wiki/first-time-setup/osd-vtx.rst
+++ b/wiki/first-time-setup/osd-vtx.rst
@@ -35,10 +35,13 @@ The tab works like Betaflight's OSD editor:
 Backend and screen options
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The **Backend** strip selects how the OSD is rendered:
+The **Backend** strip — shown expanded by default, since the backend is the
+first thing to confirm — selects how the OSD is rendered:
 
 - ``OSD_TYPE`` — the OSD backend: *Disabled*, *MAX7456* (analog), *SITL*, *MSP*,
-  *TXONLY*, or *MSP DisplayPort*. (Changing it requires a reboot.)
+  *TXONLY*, or *MSP DisplayPort*. (Changing it requires a reboot.) Choosing
+  **MSP DisplayPort** as a serial-port function on the :doc:`ports-serial` tab
+  sets this for you.
 - ``OSD_CHAN`` and ``OSD_SW_METHOD`` — the RC channel and method used to switch
   between screens.
 
@@ -59,8 +62,10 @@ VTX configuration
 -----------------
 
 The **VTX** tab controls a video transmitter over a SmartAudio or Tramp control
-link (assign the control UART on the :doc:`ports-serial` tab first). The
-parameters the app exposes are:
+link. Assign the control UART on the :doc:`ports-serial` tab first — choosing
+**IRC Tramp** or **SmartAudio** there stages ``VTX_ENABLE`` and the matching
+``VTX_TYPES`` transport bit for you, so the transmitter is already enabled when
+you reach this tab. The parameters the app exposes are:
 
 - ``VTX_ENABLE`` — turns VTX control on or off.
 - ``VTX_FREQ`` — the transmit frequency in MHz.

--- a/wiki/first-time-setup/outputs-motors.rst
+++ b/wiki/first-time-setup/outputs-motors.rst
@@ -52,17 +52,24 @@ Direction tab (both gated behind the props-off acknowledgement):
 
 .. note::
 
-   ArduPilot expects motors numbered and spinning in a specific pattern for your
-   frame class and type. The schematic only draws spin arrows for frames whose
-   direction table is known, so cross-check against the ArduPilot motor-order
-   diagram for your exact frame.
+   The schematic draws the **real layout for your frame**. It reads
+   ``FRAME_CLASS`` / ``FRAME_TYPE`` and renders that frame's actual motor
+   positions and per-motor spin directions from ArduPilot's motor matrix — so an
+   H-frame reads as an H, a hexa shows six arms, a Y6 shows its coaxial stacks,
+   and so on, rather than always drawing a quad-X. Each motor's spin arrow
+   curves above (front) or below (rear) its ring in the correct CW/CCW
+   direction. Still confirm each motor physically spins the way its arrow shows
+   before flying.
 
 Motor test (props off)
 ----------------------
 
-The **Test** sub-tab spins motors at a set throttle for a set time. Pick a single
-output, all motors in sequence, or all at once; set **Throttle %** (1–100) and
-**Duration** (up to 5 s, 30 s in Expert mode). It sends
+The **Test** sub-tab spins motors at a set throttle for a set time, with the
+frame diagram (the real per-frame layout and spin arrows described above)
+alongside the sliders so you can see which numbered motor maps to which output
+and expected direction. Pick a single output, all motors in sequence, or all at
+once; set **Throttle %** (1–100) and **Duration** (up to 5 s, 30 s in Expert
+mode). It sends
 ``MAV_CMD_DO_MOTOR_TEST`` and is gated by eligibility checks — the vehicle must be
 connected, disarmed, parameter-synced, with no other guided action running — plus
 the physical-safety acknowledgements. There's no "test finished" message from the

--- a/wiki/first-time-setup/ports-serial.rst
+++ b/wiki/first-time-setup/ports-serial.rst
@@ -31,6 +31,23 @@ label, with five columns:
    MAVLink2 = 2, GPS = 5, ESC Telemetry = 16, **RC Input = 23**, MSP = 32. A
    value of ``-1`` (None) disables the port.
 
+Paired peripheral settings
+--------------------------
+
+A serial protocol alone isn't always enough to bring a peripheral up — the
+peripheral itself has to be enabled too. When you pick one of these, Ports also
+**stages the paired parameter** so it works without a second trip, shown as a
+note under the Function dropdown:
+
+- **MSP DisplayPort** also stages ``OSD_TYPE = 5`` (the MSP DisplayPort OSD
+  backend).
+- **IRC Tramp** or **SmartAudio** also stages ``VTX_ENABLE = 1`` and sets the
+  matching transport bit in ``VTX_TYPES``.
+
+These are staged as visible, revertible drafts applied **together** with the
+``SERIALn_PROTOCOL`` change — nothing is written until you apply — and are
+skipped if the value is already correct.
+
 Assigning RC input
 ------------------
 

--- a/wiki/getting-connected.rst
+++ b/wiki/getting-connected.rst
@@ -49,3 +49,11 @@ After connecting
 Once connected, the header shows the vehicle type, firmware version, and a live
 link indicator, and the parameter table syncs. From here, head to
 :doc:`guided-setup` for a fresh vehicle, or jump straight to any tab.
+
+If the link drops mid-sync — for example a board that watchdog-resets partway
+through the parameter download — the configurator keeps the parameters it
+already read behind a **"link lost"** banner (they are marked as no longer
+live, and nothing can be written while disconnected). On reconnect the download
+**resumes from where it stopped** rather than restarting from zero, and it keeps
+retrying while the board is coming back, so a resetting board still ends up with
+a complete parameter table. A dropped link is not data loss.

--- a/wiki/index.rst
+++ b/wiki/index.rst
@@ -37,6 +37,7 @@ each tab. If you are new, start with :doc:`introduction` and
    :maxdepth: 2
    :caption: Configuration & Tools
 
+   config
    tuning
    parameters
    lua

--- a/wiki/parameters.rst
+++ b/wiki/parameters.rst
@@ -4,9 +4,10 @@ Parameters (Expert)
 The **Parameters** tab is the raw parameter editor — the full ArduPilot
 parameter tree with search, inline editing, staged drafts, verified writes, and
 import/export. It is an **Expert** surface: the product-shaped tabs (Setup,
-Ports, Receiver, Outputs, Power, Tuning) cover routine workflow changes more
-safely, so reach for this tab when you need a parameter those surfaces do not
-expose, or when you are migrating a configuration between aircraft.
+:doc:`Config <config>`, Ports, Receiver, Outputs, Power, Tuning) cover routine
+workflow changes more safely, so reach for this tab when you need a parameter
+those surfaces do not expose, or when you are migrating a configuration between
+aircraft.
 
 Browsing, search, and categories
 ---------------------------------
@@ -20,10 +21,28 @@ the running firmware. A **search** box — pinned to the top of the editor so it
 scroll the table — filters by name with wildcards (for example ``ARMING_*`` or
 ``*VOLT*``), and a **category** dropdown narrows to a single group such as
 rangefinder, gimbal, or serial. A **Refresh** button pulls the tree fresh from
-the controller, bypassing the auto-refresh. Each row shows the parameter's
-name, description, unit, and current value alongside an inline editor: a number
-field, or — for bitmask parameters — a grid of per-bit checkboxes with a
-raw-value box so you can paste a mask straight from another configuration.
+the controller, bypassing the auto-refresh. Each row is compact — name, current
+value, and the draft editor — so more of the tree stays on screen.
+
+Expanding a row for detail
+--------------------------
+
+Click a row to **expand it in place**. The expanded panel brings back the full
+metadata for that parameter:
+
+- the friendly **label**, full **description**, **unit**, and documented
+  **range**;
+- the parameter's **old / renamed name**, when ArduPilot has renamed it (for
+  example ``GPS_TYPE`` is *also known as* ``GPS1_TYPE``, and ``MAV_SYSID`` shows
+  its *old name* ``SYSID_THISMAV``) — so you know what to search the ArduPilot
+  wiki or an older configuration for;
+- for an **enum**, what the current value **means** (for example ``9 —
+  DroneCAN``); and
+- a richer editor: type a raw **Value** directly, **or** pick a named option
+  from the enum **dropdown** — both edit the same draft. Bitmask parameters edit
+  as a grid of per-bit checkboxes, each labelled with its bit meaning.
+
+Click the row again to collapse it.
 
 Editing and staged drafts
 -------------------------
@@ -31,8 +50,11 @@ Editing and staged drafts
 Editing a value does not write it immediately — it stages a local **draft**.
 Drafts are reviewed as a grouped diff (current → new, with the delta) before
 anything reaches the aircraft, and each draft is classified as **staged** or
-**invalid** (out of range, or outside the known enum values). Apply a single row
-with its **Apply** button, or write the whole set with **Apply All**.
+**invalid** (out of range, or outside the known enum values). A row you have
+touched but edited back to the live value stays in the review as a muted
+"matches current — won't write" entry until you **Drop** it, so the row never
+disappears out from under you mid-edit. Apply a single row with its **Apply**
+button, or write the whole set with **Apply All**.
 
 Writes use the verified ``PARAM_SET`` → ``PARAM_VALUE`` path: each value is sent
 and then confirmed against the controller's read-back within a tolerance. A

--- a/wiki/reference.rst
+++ b/wiki/reference.rst
@@ -40,6 +40,15 @@ Some parameters only apply after a reboot. When a change needs one, the app
 surfaces a reboot prompt — reboot the flight controller (or power-cycle it) and
 re-check the value. See :doc:`parameters`.
 
+**The link dropped and I saw a "link lost" banner.**
+This is not data loss. If the connection drops — including a board that
+watchdog-resets partway through the parameter sync — the app keeps the
+parameters it already read behind a **link lost** banner (marked as no longer
+live; writes are blocked while disconnected). On reconnect the parameter
+download **resumes from where it stopped** instead of restarting, so even a
+board that keeps resetting eventually reaches a complete table. See
+:doc:`getting-connected`.
+
 Supported hardware
 ------------------
 


### PR DESCRIPTION
Audited the wiki against what's shipped and updated the stale/missing pages.

- **`config.rst` (NEW)** — the **Config tab had no wiki page at all**. Documents the five category tabs (Airframe/Sensors/GPS/RC & Arming/System), the per-card **Advanced** disclosures, the **3D board-orientation preview**, and the **Compass** section. Added to the index toctree.
- **`parameters.rst`** — rows now **expand inline** into a detail panel: label/description/unit/range, the **old/renamed name**, the enum value **meaning**, and the **type-or-dropdown** editor. Notes that a review row edited back to the live value now stays put ("won't write") rather than vanishing. Adds Config to the product-tab list.
- **`getting-connected.rst` + `reference.rst`** — the **link-lost banner** and param-download **resume** across a watchdog/link drop (a dropped link is not data loss).
- **`ports-serial.rst`** — **paired peripheral settings**: DisplayPort stages `OSD_TYPE`, Tramp/SmartAudio stage `VTX_ENABLE` + the `VTX_TYPES` bit.
- **`osd-vtx.rst`** — Backend strip open by default; cross-refs the Ports pairing.
- **`outputs-motors.rst`** — the Motor Test/Setup schematic draws the **real per-frame geometry** with per-motor spin arrows, not a hardcoded quad-X.
- **`can-dronecan.rst`** — the **"enable the CAN bus"** prompt.

Verified with a local `sphinx-build`: build succeeded, no warnings, all `:doc:` cross-references resolve. The deploy rebuilds the wiki from source into the bundle, so only the `.rst` source is committed.