### PR TITLE
fix(setup): unblock guided setup at the Airframe step and name each step's real blocker

### DIFF
--- a/apps/desktop/src/bridge-websocket.ts
+++ b/apps/desktop/src/bridge-websocket.ts
@@ -81,7 +81,9 @@ async function createBridgeTransport(options: BridgeOptions) {
       // voltage sags, the RC link blips once, and an EKF notice fires. Tests
       // that construct the scenario without options still see the static
       // legacy behavior.
-      const scenario = createArduCopterMockScenario({ dynamicCadenceMs: 7000 })
+      // guidedMotionCadenceMs streams the scripted attitude + stick rehearsal
+      // the guided-setup exercises need to be completable over the bridge.
+      const scenario = createArduCopterMockScenario({ dynamicCadenceMs: 7000, guidedMotionCadenceMs: 250 })
       return new MockTransport('bridge-demo-transport', {
         initialFrames: scenario.initialFrames,
         respondToOutbound: scenario.respondToOutbound,

--- a/apps/web/src/runtime-factory.ts
+++ b/apps/web/src/runtime-factory.ts
@@ -150,7 +150,20 @@ export function createRuntime(
     // tests drive subsystem-disabled states (e.g. BATT_MONITOR=0 to
     // exercise the Failsafe view's #481 disabled-monitor collapse).
     const parameterOverrides = readDemoParamOverridesFromUrl()
-    const scenarioOptions = { dynamicCadenceMs: 7000, parameterOverrides }
+    // guidedMotionCadenceMs additionally streams a scripted attitude + stick
+    // rehearsal, without which the guided-setup exercises (orientation check,
+    // RC mapping, stick range, mode switch) can never complete against a fixed
+    // level attitude and fixed stick positions — guided setup could not get
+    // past the Airframe step in demo mode.
+    //
+    // Test-only hook: ?demoMotion=off pins the demo back to a fixed level
+    // attitude and centred sticks, for e2e that asserts invariants about a
+    // vehicle at rest (e.g. "centred sticks must not integrate yaw heading").
+    const scenarioOptions = {
+      dynamicCadenceMs: 7000,
+      guidedMotionCadenceMs: readDemoMotionEnabledFromUrl() ? 250 : undefined,
+      parameterOverrides
+    }
     const scenario = mode === 'demo-plane'
       ? createArduPlaneMockScenario(scenarioOptions)
       : mode === 'demo-rover'
@@ -211,6 +224,16 @@ export function createRuntime(
 // query param is absent or empty, so production users see no behaviour
 // change. Numbers must parse as finite; an unparseable value is skipped
 // (silently — this is a test affordance, not a UI feature).
+// The demo's scripted attitude/stick motion is ON by default — without it the
+// guided-setup exercises can never complete. `?demoMotion=off` pins the vehicle
+// back to rest for tests that need a motionless baseline.
+function readDemoMotionEnabledFromUrl(): boolean {
+  if (typeof window === 'undefined') {
+    return true
+  }
+  return new URLSearchParams(window.location.search).get('demoMotion')?.trim().toLowerCase() !== 'off'
+}
+
 function readDemoParamOverridesFromUrl(): Record<string, number | null> | undefined {
   if (typeof window === 'undefined') {
     return undefined

--- a/apps/web/src/sections/SetupWizardDetail.tsx
+++ b/apps/web/src/sections/SetupWizardDetail.tsx
@@ -20,12 +20,26 @@ export interface SetupWizardDetailProps {
 }
 
 export function SetupWizardDetail({ selectedSetupSection, snapshot }: SetupWizardDetailProps): ReactElement {
+  // The criteria list is what actually gates the step, but it lived inside a
+  // collapsed <details> and the header only showed "2/5 criteria" — never WHICH
+  // one was unmet. That is the mechanical reason a blocked step reads as
+  // "unclear what's wanted". Name the first unmet criterion up front, and leave
+  // the full list open whenever the step is not complete.
+  const nextUnmetCriterion = selectedSetupSection.criteria.find((criterion) => !criterion.met)
+  const stepComplete = selectedSetupSection.status === 'complete'
+
   return (
     <div className="setup-wizard__detail">
       <div>
         <h4>What to do</h4>
         <p>{selectedSetupSection.detail}</p>
       </div>
+
+      {nextUnmetCriterion ? (
+        <p className="setup-wizard__next-criterion" data-testid="setup-wizard-next-criterion">
+          <strong>Still needed:</strong> {nextUnmetCriterion.label}
+        </p>
+      ) : null}
 
       {selectedSetupSection.id === 'accelerometer' ? (
         <AccelerometerPoseGuide
@@ -36,7 +50,7 @@ export function SetupWizardDetail({ selectedSetupSection, snapshot }: SetupWizar
         />
       ) : null}
 
-      <details className="setup-flow__criteria" data-testid="setup-wizard-criteria">
+      <details className="setup-flow__criteria" data-testid="setup-wizard-criteria" open={!stepComplete}>
         <summary>
           <strong>Completion Criteria</strong>
           <span className="setup-flow__criteria-count">

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -2300,6 +2300,22 @@ textarea:focus {
   color: var(--warning);
 }
 
+/* The single unmet criterion that is actually holding the step, promoted out of
+ * the criteria disclosure so a blocked step says what it wants. */
+.setup-wizard__next-criterion {
+  margin: 0;
+  padding: 8px 12px;
+  border-left: 3px solid var(--warning);
+  border-radius: 4px;
+  background: color-mix(in srgb, var(--warning) 10%, transparent);
+  color: var(--text);
+}
+
+.setup-wizard__next-criterion strong {
+  color: var(--warning);
+  margin-right: 6px;
+}
+
 .setup-flow__actions {
   display: flex;
   flex-wrap: wrap;

--- a/apps/web/src/view-models/setup-confirmation-signatures.test.ts
+++ b/apps/web/src/view-models/setup-confirmation-signatures.test.ts
@@ -47,7 +47,10 @@ describe('buildSetupConfirmationSignatures', () => {
 
   it('produces a signature for every guided-setup section', () => {
     expect(Object.keys(sig()).sort()).toEqual(
-      ['accelerometer', 'airframe', 'compass', 'esc-range', 'failsafe', 'level', 'outputs', 'power', 'radio'].sort()
+      // 'modes' was missing here, which meant getSetupConfirmationRecord always
+      // found an undefined signature for the Modes step and silently discarded
+      // any confirmation stored against it.
+      ['accelerometer', 'airframe', 'compass', 'esc-range', 'failsafe', 'level', 'modes', 'outputs', 'power', 'radio'].sort()
     )
   })
 

--- a/apps/web/src/view-models/setup-confirmation-signatures.ts
+++ b/apps/web/src/view-models/setup-confirmation-signatures.ts
@@ -120,6 +120,15 @@ export function buildSetupConfirmationSignatures(inputs: SetupConfirmationSignat
           trim: readRoundedParameter(snapshot, `RC${observation.channelNumber}_TRIM`)
         }))
       }),
+      // The modes signature pins the reviewed mode CONFIGURATION (which channel
+      // selects modes and what each position is assigned to). A waiver stops
+      // counting exactly when the operator re-assigns a mode position, which is
+      // when it should. Without an entry here getSetupConfirmationRecord finds
+      // an undefined signature and silently discards every 'modes' record.
+      modes: JSON.stringify({
+        modeChannel: readRoundedParameter(snapshot, 'FLTMODE_CH'),
+        modes: [1, 2, 3, 4, 5, 6].map((slot) => readRoundedParameter(snapshot, `FLTMODE${slot}`))
+      }),
       // Failsafe/power signatures pin the reviewed CONFIGURATION only.
       // Live state (telemetry-verified flags, pre-arm issue text) churns
       // across every reboot — fresh pre-arm checks re-run, telemetry flags

--- a/apps/web/src/view-models/setup-flow-sections.test.ts
+++ b/apps/web/src/view-models/setup-flow-sections.test.ts
@@ -249,3 +249,143 @@ describe('radio section RCIN preflight', () => {
     expect(directionMet({ roll: 'correct', pitch: 'correct', throttle: 'correct', yaw: 'correct' })).toBe(true)
   })
 })
+
+// The physical exercises (orientation tilt, RC stick sweeps, mode-switch walk)
+// cannot always be performed: a bench FC, an airframe too large to tilt, a
+// replay/demo feed with a fixed attitude. Each of those steps gates the WHOLE
+// wizard — an unmet criterion leaves every later step sequenceState 'locked'
+// with its rail button disabled — so each carries an operator waiver recorded
+// as an 'already-done' confirmation, mirroring the calibration steps.
+describe('exercise waivers unblock the sequential flow', () => {
+  const waived = (sectionId: string) => ({
+    setupConfirmations: { [sectionId]: { signature: 'sig', confirmedAtMs: 1, outcome: 'already-done' as const } },
+    setupConfirmationSignatures: { [sectionId]: 'sig' }
+  })
+
+  const airframeStub = () =>
+    ({
+      frameClassValue: 1,
+      frameClassLabel: 'Quad',
+      frameTypeValue: 1,
+      frameTypeLabel: 'X',
+      expectedMotorCount: 4,
+      frameTypeIgnored: false
+    }) as unknown as SetupFlowSectionsInputs['airframe']
+
+  const AIRFRAME = [{ id: 'airframe', title: 'Airframe' }]
+  const buildAirframe = (over: Partial<SetupFlowSectionsInputs> = {}) =>
+    buildSetupFlowSections(
+      inputs(AIRFRAME, {
+        snapshot: snapshot(AIRFRAME, { liveVerification: { attitudeTelemetry: { verified: true } } }),
+        airframe: airframeStub(),
+        ...over
+      })
+    )[0]
+
+  it('airframe: a level-only attitude feed leaves the step incomplete without a waiver', () => {
+    const airframe = buildAirframe()
+    expect(airframe.status).not.toBe('complete')
+    expect(airframe.criteria.find((criterion) => /Orientation exercise/.test(criterion.label))?.met).toBe(false)
+  })
+
+  it('airframe: offers the orientation waiver while the exercise has not passed', () => {
+    const waiver = buildAirframe().actions.find(
+      (action) => 'label' in action && action.label === 'Orientation Verified Elsewhere — Continue'
+    )
+    expect(waiver?.confirmationOutcome).toBe('already-done')
+  })
+
+  it('airframe: the waiver completes the step so later steps can unlock', () => {
+    const airframe = buildAirframe(waived('airframe'))
+    expect(airframe.status).toBe('complete')
+    expect(airframe.confirmationOutcome).toBe('already-done')
+  })
+
+  it('airframe: the waiver also covers the live-attitude criterion it depends on', () => {
+    const airframe = buildSetupFlowSections(
+      inputs(AIRFRAME, {
+        snapshot: snapshot(AIRFRAME, { liveVerification: { attitudeTelemetry: { verified: false } } }),
+        airframe: airframeStub(),
+        ...waived('airframe')
+      })
+    )[0]
+    expect(airframe.status).toBe('complete')
+  })
+
+  it('airframe: withholds the confirm while FRAME_CLASS is present-but-unset (0)', () => {
+    // The completion criterion requires FRAME_CLASS != 0, so a confirm enabled
+    // at 0 ticked nothing and explained nothing.
+    const airframe = buildSetupFlowSections(
+      inputs(AIRFRAME, {
+        snapshot: snapshot(AIRFRAME, { liveVerification: { attitudeTelemetry: { verified: true } } }),
+        airframe: { ...airframeStub(), frameClassValue: 0 } as unknown as SetupFlowSectionsInputs['airframe']
+      })
+    )[0]
+    const confirm = airframe.actions.find((action) => 'label' in action && action.label === 'Confirm Airframe Review')
+    expect(confirm && 'disabled' in confirm ? confirm.disabled : undefined).toBe(true)
+    const waiver = airframe.actions.find(
+      (action) => 'label' in action && action.label === 'Orientation Verified Elsewhere — Continue'
+    )
+    expect(waiver && 'disabled' in waiver ? waiver.disabled : undefined).toBe(true)
+  })
+
+  const RADIO = [{ id: 'radio', title: 'Radio' }]
+  it('radio: the waiver satisfies mapping, range, endpoints and directions at once', () => {
+    const radio = buildSetupFlowSections(
+      inputs(RADIO, {
+        snapshot: snapshot(RADIO, { liveVerification: { rcInput: { verified: true, channelCount: 8 } } }),
+        ...waived('radio')
+      })
+    )[0]
+    expect(radio.status).toBe('complete')
+    expect(radio.criteria.every((criterion) => criterion.met)).toBe(true)
+  })
+
+  it('radio: offers the waiver only while the directions are unverified', () => {
+    const label = 'Radio Verified Elsewhere — Continue'
+    const unverified = buildSetupFlowSections(
+      inputs(RADIO, { snapshot: snapshot(RADIO, { liveVerification: { rcInput: { verified: true, channelCount: 8 } } }) })
+    )[0]
+    expect(unverified.actions.some((action) => 'label' in action && action.label === label)).toBe(true)
+
+    const verified = buildSetupFlowSections(
+      inputs(RADIO, {
+        rcDirectionResults: { roll: 'correct', pitch: 'correct', throttle: 'correct', yaw: 'correct' },
+        snapshot: snapshot(RADIO, { liveVerification: { rcInput: { verified: true, channelCount: 8 } } })
+      })
+    )[0]
+    expect(verified.actions.some((action) => 'label' in action && action.label === label)).toBe(false)
+  })
+
+  const MODES = [{ id: 'modes', title: 'Flight Modes' }]
+  it('modes: gains a waiver where it previously had no operator escape at all', () => {
+    const modes = buildSetupFlowSections(inputs(MODES))[0]
+    expect(modes.status).not.toBe('complete')
+    const waiver = modes.actions.find(
+      (action) => 'label' in action && action.label === 'Flight Modes Verified Elsewhere — Continue'
+    )
+    expect(waiver?.confirmationOutcome).toBe('already-done')
+
+    const escaped = buildSetupFlowSections(inputs(MODES, waived('modes')))[0]
+    expect(escaped.status).toBe('complete')
+  })
+})
+
+describe('locked-step blocking reason', () => {
+  it('keeps naming the blocking step even when a follow-up is pending', () => {
+    // A pending follow-up used to REPLACE the sequence reason outright, so a
+    // locked step reported e.g. "Reboot required" and never said which step
+    // was actually holding the flow.
+    const sections = buildSetupFlowSections(
+      inputs([{ id: 'link', title: 'Link' }, { id: 'mystery', title: 'Mystery' }], {
+        snapshot: snapshot([{ id: 'link', title: 'Link' }, { id: 'mystery', title: 'Mystery' }], {
+          connection: { kind: 'disconnected' }
+        }),
+        setupFlowFollowUp: { title: 'Reboot required', tone: 'warning', text: '', actions: [] }
+      })
+    )
+    const locked = sections.find((section) => section.id === 'mystery')
+    expect(locked?.blockingReason).toContain('Complete Link before moving on to Mystery.')
+    expect(locked?.blockingReason).toContain('Reboot required')
+  })
+})

--- a/apps/web/src/view-models/setup-flow-sections.ts
+++ b/apps/web/src/view-models/setup-flow-sections.ts
@@ -200,7 +200,21 @@ export function buildSetupFlowSections(inputs: SetupFlowSectionsInputs): SetupFl
             disabled: busyAction !== undefined || !canRunGuidedAction(snapshot, 'request-parameters')
           })
           break
-        case 'airframe':
+        case 'airframe': {
+          // An 'already-done' airframe sign-off is the orientation waiver: the
+          // operator is asserting the frame geometry AND the horizon behaviour
+          // were verified outside the configurator. A plain 'complete' sign-off
+          // still requires the exercise to pass.
+          const airframeOrientationWaived = airframeConfirmation?.outcome === 'already-done'
+          // FRAME_CLASS=0 is present-but-unset. The completion criterion below
+          // requires it non-zero, so letting the operator "confirm" at zero
+          // produced a button that ticked nothing and explained nothing.
+          const airframeFrameUnusable =
+            isCopterVehicle
+              ? airframe.frameClassValue === undefined ||
+                airframe.frameClassValue === 0 ||
+                (!airframe.frameTypeIgnored && airframe.frameTypeValue === undefined)
+              : (snapshot.vehicle?.vehicle ?? 'Unknown') === 'Unknown'
           criteria = [
             ...(isCopterVehicle
               ? [
@@ -229,12 +243,25 @@ export function buildSetupFlowSections(inputs: SetupFlowSectionsInputs): SetupFl
               met: boardOrientation !== undefined
             },
             {
+              // Waived alongside the exercise below: both depend on the same
+              // live ATTITUDE stream, so leaving this one hard would rebuild the
+              // wall the waiver exists to remove.
               label: 'Live attitude telemetry is present',
-              met: snapshot.liveVerification.attitudeTelemetry.verified
+              met: snapshot.liveVerification.attitudeTelemetry.verified || airframeOrientationWaived
             },
             {
-              label: 'Orientation exercise passed',
-              met: orientationExercise.status === 'passed'
+              // The orientation check needs the operator to physically tilt the
+              // aircraft past ±12°. That is not always possible (a bench FC, a
+              // large airframe, a static demo/replay feed with a level attitude
+              // stream), and this criterion gates the WHOLE wizard: without a
+              // waiver every later step stays sequenceState 'locked' with its
+              // rail button disabled and no way forward. So it accepts an
+              // explicit operator waiver, exactly like the calibration steps'
+              // "Already Calibrated — Continue".
+              label: airframeOrientationWaived
+                ? 'Orientation verified outside the configurator'
+                : 'Orientation exercise passed',
+              met: orientationExercise.status === 'passed' || airframeOrientationWaived
             },
             {
               label: 'Operator confirmed the detected frame geometry matches the build',
@@ -250,7 +277,9 @@ export function buildSetupFlowSections(inputs: SetupFlowSectionsInputs): SetupFl
           // the criteria list for what's wrong.
           detail = isCopterVehicle && airframe.frameClassValue === 0
             ? 'FRAME_CLASS is unset (0) — set a valid frame class in Motors → ESC & Protocol (Frame) or Config → Frame before continuing. The autopilot reports "Frame: UNSUPPORTED" and will refuse every calibration command in this state.'
-            : 'Confirm the detected frame geometry, verify the live horizon behavior against the board orientation, then explicitly sign off before moving on to output review or motor testing.'
+            : airframeOrientationWaived
+              ? 'Orientation was signed off as verified outside the configurator, so the tilt exercise is not required for this build. Run the orientation check any time you want to confirm the horizon behavior in-app.'
+              : 'Confirm the detected frame geometry, verify the live horizon behavior against the board orientation, then explicitly sign off before moving on to output review or motor testing. If the aircraft cannot be tilted here, sign the orientation off as verified elsewhere.'
           evidence = [
             ...(isCopterVehicle
               ? [
@@ -281,13 +310,29 @@ export function buildSetupFlowSections(inputs: SetupFlowSectionsInputs): SetupFl
           })
           actions.splice(1, 0, {
             kind: airframeConfirmation ? 'clear-confirmation' : 'confirm-step',
-            label: airframeConfirmation ? 'Clear Review Confirmation' : 'Confirm Airframe Review',
+            label: airframeConfirmation
+              ? airframeOrientationWaived
+                ? 'Clear Orientation Waiver'
+                : 'Clear Review Confirmation'
+              : 'Confirm Airframe Review',
             tone: 'secondary',
             sectionId: 'airframe',
-            disabled: isCopterVehicle
-              ? airframe.frameClassValue === undefined || (!airframe.frameTypeIgnored && airframe.frameTypeValue === undefined)
-              : (snapshot.vehicle?.vehicle ?? 'Unknown') === 'Unknown'
+            confirmationOutcome: 'complete',
+            disabled: airframeFrameUnusable
           })
+          // The escape hatch. Without it a vehicle that cannot be tilted past
+          // ±12° (bench FC, large airframe, static attitude feed) leaves this
+          // step permanently incomplete and every later step locked.
+          if (!airframeConfirmation && orientationExercise.status !== 'passed') {
+            actions.push({
+              kind: 'confirm-step',
+              label: 'Orientation Verified Elsewhere — Continue',
+              tone: 'secondary',
+              sectionId: 'airframe',
+              confirmationOutcome: 'already-done',
+              disabled: busyAction !== undefined || airframeFrameUnusable
+            })
+          }
           // FRAME_CLASS/FRAME_TYPE always exist on a connected Copter, so a
           // missing value here is never a real misconfiguration — it's a param
           // the sync never received (a dropped frame under a lossy link). Left
@@ -309,7 +354,9 @@ export function buildSetupFlowSections(inputs: SetupFlowSectionsInputs): SetupFl
               disabled: busyAction !== undefined || !canRunGuidedAction(snapshot, 'request-parameters')
             })
           }
+          confirmationOutcome = airframeConfirmation?.outcome
           break
+        }
         case 'outputs':
           criteria = isCopterVehicle
             ? [
@@ -725,26 +772,35 @@ export function buildSetupFlowSections(inputs: SetupFlowSectionsInputs): SetupFl
             : radioReversedAxes.length > 0
               ? `reversed: ${radioReversedAxes.join(', ')}`
               : 'not checked yet'
+          // Same waiver shape as the airframe orientation check and the
+          // calibration steps: an 'already-done' sign-off means the radio was
+          // mapped, ranged and direction-checked outside the configurator. It
+          // exists so a build the in-app exercises cannot drive (no live stick
+          // feed, a radio already set up in Mission Planner) does not leave this
+          // step permanently incomplete and every later step locked.
+          const radioWaived = radioConfirmation?.outcome === 'already-done'
           criteria = [
             {
               label: 'Live RC telemetry is present',
-              met: snapshot.liveVerification.rcInput.verified
+              met: snapshot.liveVerification.rcInput.verified || radioWaived
             },
             {
               label: 'RC mapping exercise captured roll, pitch, throttle, and yaw',
-              met: rcMappingSession.status === 'ready'
+              met: rcMappingSession.status === 'ready' || radioWaived
             },
             {
               label: 'Stick range exercise passed',
-              met: rcRangeExercise.status === 'passed'
+              met: rcRangeExercise.status === 'passed' || radioWaived
             },
             {
               label: 'RC endpoint capture completed',
-              met: rcCalibrationSession.status === 'ready'
+              met: rcCalibrationSession.status === 'ready' || radioWaived
             },
             {
-              label: 'RC channel directions verified — no axis reads backwards',
-              met: radioDirectionsVerified
+              label: radioWaived
+                ? 'RC channel directions verified outside the configurator'
+                : 'RC channel directions verified — no axis reads backwards',
+              met: radioDirectionsVerified || radioWaived
             },
             {
               label: 'Operator reviewed RC mapping and calibration values',
@@ -770,7 +826,9 @@ export function buildSetupFlowSections(inputs: SetupFlowSectionsInputs): SetupFl
                 ? rcRangeExercise.failureReason ?? 'Stick range exercise failed.'
                 : rcCalibrationSession.status === 'failed'
                   ? rcCalibrationSession.failureReason ?? 'RC endpoint capture failed.'
-                  : 'Use the guided one-axis-at-a-time receiver mapping first, then verify stick travel, capture endpoints, and sign off the full radio review.'
+                  : radioWaived
+                    ? 'The radio was signed off as mapped, ranged and direction-checked outside the configurator, so the in-app exercises are not required for this build. Run them any time you want to reconfirm the channel directions here.'
+                    : 'Use the guided one-axis-at-a-time receiver mapping first, then verify stick travel, capture endpoints, and sign off the full radio review. If this radio was already set up and direction-checked elsewhere, sign it off as verified elsewhere instead.'
           // Include directions + review: they're the two things most likely to
           // be the actual blocker, and the old 5-item .slice(0,4) always dropped
           // the Review pill and never surfaced directions at all.
@@ -796,9 +854,10 @@ export function buildSetupFlowSections(inputs: SetupFlowSectionsInputs): SetupFl
           })
           actions.splice(1, 0, {
             kind: radioConfirmation ? 'clear-confirmation' : 'confirm-step',
-            label: radioConfirmation ? 'Clear RC Review' : 'Confirm RC Review',
+            label: radioConfirmation ? (radioWaived ? 'Clear RC Waiver' : 'Clear RC Review') : 'Confirm RC Review',
             tone: 'secondary',
             sectionId: 'radio',
+            confirmationOutcome: 'complete',
             // Gate on directions too: without this the operator could "Confirm RC
             // Review" (ticking the confirmation) while the step stays incomplete
             // because the directions criterion is unmet, with the real blocker
@@ -842,6 +901,20 @@ export function buildSetupFlowSections(inputs: SetupFlowSectionsInputs): SetupFl
               })
             }
           }
+          // The escape hatch. Deliberately worded so the operator knows exactly
+          // what they are asserting — a reversed throttle or pitch axis is a
+          // flyaway hazard, so this must never read as a generic "skip".
+          if (!radioConfirmation && !radioDirectionsVerified) {
+            actions.push({
+              kind: 'confirm-step',
+              label: 'Radio Verified Elsewhere — Continue',
+              tone: 'secondary',
+              sectionId: 'radio',
+              confirmationOutcome: 'already-done',
+              disabled: busyAction !== undefined
+            })
+          }
+          confirmationOutcome = radioConfirmation?.outcome
           break
         }
         case 'failsafe':
@@ -899,19 +972,26 @@ export function buildSetupFlowSections(inputs: SetupFlowSectionsInputs): SetupFl
               !snapshot.liveVerification.batteryTelemetry.verified
           })
           break
-        case 'modes':
+        case 'modes': {
+          // Modes previously had NO operator escape of any kind: the switch
+          // exercise had to pass, full stop. On a build the exercise cannot
+          // drive that left the final steps of the wizard unreachable.
+          const modesConfirmation = getSetupConfirmationRecord('modes')
+          const modesWaived = modesConfirmation?.outcome === 'already-done'
           criteria = [
             {
               label: 'Mode channel is configured',
-              met: modeSwitchEstimate.channelNumber !== undefined
+              met: modeSwitchEstimate.channelNumber !== undefined || modesWaived
             },
             {
               label: 'At least two distinct flight-mode positions are assigned',
-              met: modeExerciseAssignments.length >= 2
+              met: modeExerciseAssignments.length >= 2 || modesWaived
             },
             {
-              label: 'Mode switch exercise passed',
-              met: modeSwitchExercise.status === 'passed'
+              label: modesWaived
+                ? 'Flight modes verified outside the configurator'
+                : 'Mode switch exercise passed',
+              met: modeSwitchExercise.status === 'passed' || modesWaived
             }
           ]
           summary =
@@ -936,7 +1016,30 @@ export function buildSetupFlowSections(inputs: SetupFlowSectionsInputs): SetupFl
             tone: 'primary',
             disabled: !canRunModeSwitchExercise || modeSwitchExercise.status === 'running'
           })
+          if (modesConfirmation) {
+            actions.push({
+              kind: 'clear-confirmation',
+              label: 'Clear Flight Mode Waiver',
+              tone: 'secondary',
+              sectionId: 'modes'
+            })
+          } else if (modeSwitchExercise.status !== 'passed') {
+            actions.push({
+              kind: 'confirm-step',
+              label: 'Flight Modes Verified Elsewhere — Continue',
+              tone: 'secondary',
+              sectionId: 'modes',
+              confirmationOutcome: 'already-done',
+              disabled: busyAction !== undefined
+            })
+          }
+          if (modesWaived) {
+            detail =
+              'Flight modes were signed off as verified outside the configurator, so the in-app switch exercise is not required for this build. Run it any time you want to reconfirm every switch position here.'
+          }
+          confirmationOutcome = modesConfirmation?.outcome
           break
+        }
         case 'power':
           criteria = [
             {
@@ -1029,12 +1132,16 @@ export function buildSetupFlowSections(inputs: SetupFlowSectionsInputs): SetupFl
         }
       }
 
+      // The sequence reason is the one the operator can act on ("go finish step
+      // N"). A pending follow-up used to REPLACE it outright, so a locked step
+      // reported e.g. "Reboot required" and never said which step was actually
+      // holding the flow — and it clobbered any section-specific blocking copy
+      // built above. Lead with the sequence reason and append the follow-up.
+      const sequenceReason = `Complete ${currentIncompleteSectionTitle} before moving on to ${section.title}.`
       return {
         ...section,
         sequenceState: 'locked',
-        blockingReason: setupFlowFollowUp
-          ? setupFlowFollowUp.title
-          : `Complete ${currentIncompleteSectionTitle} before moving on to ${section.title}.`
+        blockingReason: setupFlowFollowUp ? `${sequenceReason} ${setupFlowFollowUp.title}` : sequenceReason
       }
     })
 }

--- a/packages/protocol-mavlink/src/mock-scenario.ts
+++ b/packages/protocol-mavlink/src/mock-scenario.ts
@@ -51,6 +51,25 @@ export interface MockScenarioOptions {
    */
   dynamicCadenceMs?: number
   /**
+   * How often to emit the guided-setup motion stream (ATTITUDE + RC_CHANNELS),
+   * in milliseconds. Leave undefined (the default) and the mock emits attitude
+   * and stick positions only as static one-shots, exactly as before.
+   *
+   * The demo needs this because the guided-setup exercises are driven ENTIRELY
+   * by live motion: the orientation check waits for pitch <= -12 deg then roll
+   * >= +12 deg, RC mapping waits for one channel at a time to move off its
+   * baseline, and the stick-range exercise waits for each axis to reach both
+   * ends of travel. Against a fixed level attitude and fixed stick positions
+   * none of them can ever complete, which left guided setup unable to progress
+   * past the Airframe step in demo mode.
+   *
+   * This is deliberately separate from `dynamicCadenceMs`: that cadence is the
+   * slow scenario-event tick (~7 s in the demo), far too slow to drive an
+   * exercise, and the existing state-machine tests depend on its exact framing.
+   * Demo runtimes typically pass 250.
+   */
+  guidedMotionCadenceMs?: number
+  /**
    * Clock override for deterministic tests. Defaults to `Date.now`.
    */
   now?: () => number
@@ -1471,6 +1490,7 @@ function buildMockScenario(profile: MockVehicleProfile, options: MockScenarioOpt
   // the same scenario instance.
   const dynamicState = createDynamicState()
   const dynamicCadenceMs = options.dynamicCadenceMs
+  const guidedMotionCadenceMs = options.guidedMotionCadenceMs
   const now = options.now ?? (() => Date.now())
   // MAVLink v2 sequence is a single byte that the codec masks to 0..255.
   // Wrap explicitly so long-running demos don't drift to silly numbers.
@@ -1948,9 +1968,11 @@ function buildMockScenario(profile: MockVehicleProfile, options: MockScenarioOpt
       return responses
     },
     attachDynamicEmitter: (emit) => {
+      const stopMotion = attachGuidedMotionEmitter(emit)
+
       if (!dynamicCadenceMs || dynamicCadenceMs <= 0) {
         // State machine disabled — preserve the static behavior.
-        return () => {}
+        return stopMotion
       }
 
       // Pin the first tick's wall-clock baseline so battery sag math is
@@ -1981,9 +2003,187 @@ function buildMockScenario(profile: MockVehicleProfile, options: MockScenarioOpt
 
       return () => {
         clearInterval(timer)
+        stopMotion()
       }
     }
   }
+
+  /**
+   * The guided-setup motion stream. Opt-in via `guidedMotionCadenceMs`, so
+   * every existing caller (and every test that omits it) keeps the previous
+   * static attitude / stick behavior unchanged.
+   */
+  function attachGuidedMotionEmitter(emit: (frame: Uint8Array) => void): () => void {
+    if (!guidedMotionCadenceMs || guidedMotionCadenceMs <= 0) {
+      return () => {}
+    }
+
+    let motionTick = 0
+    const motionTimer = setInterval(() => {
+      motionTick += 1
+      const timeBootMs = Math.max(0, now() - (dynamicState.startedAtMs || now()))
+      const { rollDeg, pitchDeg } = mockAttitudeForTick(motionTick)
+      emit(
+        codec.encode(
+          envelope(
+            nextDynamicSequence(),
+            attitudeMessage(timeBootMs, (rollDeg * Math.PI) / 180, (pitchDeg * Math.PI) / 180)
+          )
+        )
+      )
+
+      // Hold the sticks silent through the scripted RC link blip, otherwise
+      // this stream would immediately paper over the zero-channel frame the
+      // state machine emits and the link loss would never register.
+      if (dynamicState.rcLinkStage === 'dropping') {
+        return
+      }
+
+      emit(
+        codec.encode(
+          envelope(nextDynamicSequence(), {
+            type: 'RC_CHANNELS',
+            timeBootMs,
+            channelCount: 8,
+            channels: mockRcChannelsForTick(motionTick),
+            rssi: 100
+          })
+        )
+      )
+    }, guidedMotionCadenceMs)
+
+    if (typeof (motionTimer as { unref?: () => void }).unref === 'function') {
+      ;(motionTimer as { unref?: () => void }).unref?.()
+    }
+
+    return () => {
+      clearInterval(motionTimer)
+    }
+  }
+}
+
+// --- Guided-setup motion choreography ------------------------------------
+//
+// A deterministic, endlessly repeating rehearsal of the physical actions the
+// guided-setup exercises wait for. Frame counts below are in motion ticks, so
+// at the demo's 250 ms cadence the attitude loop runs ~13 s and the stick loop
+// ~15 s — long enough to read on screen, short enough that an operator who
+// starts an exercise sees it complete without waiting.
+//
+// Both loops are pure functions of the tick index: no wall clock, no RNG, so a
+// replayed or re-run session produces the identical stream.
+
+/** Degrees of tilt held during the pitch/roll legs. The orientation exercise
+ *  needs |angle| > 12; 22 clears it with margin for the ramp in/out. */
+const MOCK_MOTION_TILT_DEG = 22
+
+interface MockAttitudeLeg {
+  ticks: number
+  rollDeg: number
+  pitchDeg: number
+}
+
+// Ordered to match ORIENTATION_EXERCISE_ORDER in the web app (level ->
+// pitch-forward -> roll-right), so an exercise started at any point in the loop
+// completes within at most two cycles. Nose-forward is NEGATIVE pitch, matching
+// ArduPilot's ATTITUDE convention.
+const MOCK_ATTITUDE_LEGS: MockAttitudeLeg[] = [
+  { ticks: 12, rollDeg: 0, pitchDeg: 0 },
+  { ticks: 12, rollDeg: 0, pitchDeg: -MOCK_MOTION_TILT_DEG },
+  { ticks: 8, rollDeg: 0, pitchDeg: 0 },
+  { ticks: 12, rollDeg: MOCK_MOTION_TILT_DEG, pitchDeg: 0 },
+  { ticks: 8, rollDeg: 0, pitchDeg: 0 }
+]
+
+const MOCK_ATTITUDE_LOOP_TICKS = MOCK_ATTITUDE_LEGS.reduce((total, leg) => total + leg.ticks, 0)
+
+/** Ease between legs so the demo horizon glides instead of snapping. */
+function easeInOut(progress: number): number {
+  return progress < 0.5 ? 2 * progress * progress : 1 - 2 * (1 - progress) * (1 - progress)
+}
+
+export function mockAttitudeForTick(tick: number): { rollDeg: number; pitchDeg: number } {
+  const loopTick = ((tick % MOCK_ATTITUDE_LOOP_TICKS) + MOCK_ATTITUDE_LOOP_TICKS) % MOCK_ATTITUDE_LOOP_TICKS
+  let offset = 0
+  for (let index = 0; index < MOCK_ATTITUDE_LEGS.length; index += 1) {
+    const leg = MOCK_ATTITUDE_LEGS[index]
+    if (loopTick < offset + leg.ticks) {
+      const previous = MOCK_ATTITUDE_LEGS[(index - 1 + MOCK_ATTITUDE_LEGS.length) % MOCK_ATTITUDE_LEGS.length]
+      // Ramp over the first third of the leg, then hold — the exercise samples
+      // the held portion, so the target angle is stable while it checks.
+      const legProgress = (loopTick - offset) / leg.ticks
+      const blend = easeInOut(Math.min(1, legProgress / 0.34))
+      return {
+        rollDeg: previous.rollDeg + (leg.rollDeg - previous.rollDeg) * blend,
+        pitchDeg: previous.pitchDeg + (leg.pitchDeg - previous.pitchDeg) * blend
+      }
+    }
+    offset += leg.ticks
+  }
+  return { rollDeg: 0, pitchDeg: 0 }
+}
+
+interface MockStickLeg {
+  ticks: number
+  /** 1-based RC channel this leg moves; every other channel sits at rest. */
+  channelNumber?: number
+  pwm?: number
+}
+
+// One axis at a time, in RCMAP order (roll=1, pitch=2, throttle=3, yaw=4), with
+// a rest gap between axes. The gap matters: RC mapping locks onto the channel
+// that moves ALONE, so overlapping legs would make it ambiguous.
+//
+// Each axis sweeps to the wrong end FIRST and finishes on its named positive
+// direction (roll right, pitch up, throttle up, yaw right), because the
+// direction latch keeps the last decisive sample. Pitch "up" is stick-back =
+// LOW pwm, which the demo deliberately reads as reversed while RC2_REVERSED=0 —
+// that is the teaching moment the Receiver tab's direction card exists for, and
+// it flips to correct as soon as the operator writes RC2_REVERSED=1.
+const MOCK_STICK_REST_PWM: Record<number, number> = { 1: 1500, 2: 1500, 3: 1100, 4: 1500 }
+const MOCK_STICK_LEGS: MockStickLeg[] = [
+  { ticks: 4 },
+  { ticks: 5, channelNumber: 1, pwm: 1200 },
+  { ticks: 6, channelNumber: 1, pwm: 1800 },
+  { ticks: 4 },
+  { ticks: 5, channelNumber: 2, pwm: 1800 },
+  { ticks: 6, channelNumber: 2, pwm: 1200 },
+  { ticks: 4 },
+  { ticks: 6, channelNumber: 3, pwm: 1900 },
+  { ticks: 4 },
+  { ticks: 5, channelNumber: 4, pwm: 1200 },
+  { ticks: 6, channelNumber: 4, pwm: 1800 },
+  { ticks: 4 }
+]
+
+const MOCK_STICK_LOOP_TICKS = MOCK_STICK_LEGS.reduce((total, leg) => total + leg.ticks, 0)
+
+export function mockRcChannelsForTick(tick: number): number[] {
+  const loopTick = ((tick % MOCK_STICK_LOOP_TICKS) + MOCK_STICK_LOOP_TICKS) % MOCK_STICK_LOOP_TICKS
+  const channels = [
+    MOCK_STICK_REST_PWM[1],
+    MOCK_STICK_REST_PWM[2],
+    MOCK_STICK_REST_PWM[3],
+    MOCK_STICK_REST_PWM[4],
+    // CH5/CH6 are the endpoint exercise's optional switch channels. They toggle
+    // on a slow independent divisor so the capture can see both ends.
+    tick % 40 < 20 ? 1000 : 2000,
+    tick % 60 < 30 ? 1000 : 2000,
+    1500,
+    1500
+  ]
+
+  let offset = 0
+  for (const leg of MOCK_STICK_LEGS) {
+    if (loopTick < offset + leg.ticks) {
+      if (leg.channelNumber !== undefined && leg.pwm !== undefined) {
+        channels[leg.channelNumber - 1] = leg.pwm
+      }
+      return channels
+    }
+    offset += leg.ticks
+  }
+  return channels
 }
 
 interface DynamicMockState {

--- a/tests/e2e/views.spec.ts
+++ b/tests/e2e/views.spec.ts
@@ -1918,7 +1918,11 @@ test.describe('Receiver channel-direction check', () => {
 
 test.describe('Receiver stick-driven craft', () => {
   test('centred sticks hold heading and sit level (no yaw spin)', async ({ page }) => {
-    await page.goto('/')
+    // demoMotion=off pins the demo to a level attitude and centred sticks. The
+    // demo otherwise streams a scripted stick rehearsal (so the guided-setup
+    // exercises can complete), which would deflect yaw and defeat the point of
+    // this test — it guards that a CENTRED stick does not integrate heading.
+    await page.goto('/?demoMotion=off')
     await connectViaHeader(page)
     await openView(page, 'receiver')
     const att = page.getByTestId('receiver-stick-attitude')
@@ -2734,15 +2738,21 @@ test.describe('ArduPlane demo', () => {
     await expect(page.getByTestId('session-vehicle-name')).toHaveText('ArduCopter', { timeout: VEHICLE_CONNECT_TIMEOUT })
     await expect(page.getByTestId('setup-wizard')).toBeVisible()
 
-    // The completion-criteria checklist is collapsed into a disclosure with an
-    // at-a-glance "N/N done" summary, so the checklist items are hidden until
-    // expanded — this is the anti-scrolling condense pass.
+    // The completion-criteria checklist is a disclosure with an at-a-glance
+    // "N/N done" summary, but on an INCOMPLETE step it starts open: leaving the
+    // one unmet criterion collapsed behind a "2/5 criteria" badge was why a
+    // blocked step read as "unclear what's wanted". The operator can still fold
+    // it away.
     const criteria = page.getByTestId('setup-wizard-criteria')
     await expect(criteria).toContainText('done')
     const firstCriterion = criteria.locator('li').first()
-    await expect(firstCriterion).toBeHidden()
-    await criteria.locator('summary').click()
     await expect(firstCriterion).toBeVisible()
+    await criteria.locator('summary').click()
+    await expect(firstCriterion).toBeHidden()
+
+    // The single blocking criterion is also promoted out of the disclosure, so
+    // the step says what it still wants without any expanding at all.
+    await expect(page.getByTestId('setup-wizard-next-criterion')).toContainText('Still needed:')
 
     // The advanced-settings parameter editor is behind its own disclosure on the
     // airframe step instead of always stacked open below the checklist.
@@ -2753,6 +2763,38 @@ test.describe('ArduPlane demo', () => {
     // the live session is preserved.
     await page.getByRole('button', { name: /Vehicle Link/ }).click()
     await expect(page.getByTestId('setup-wizard-complete-banner')).toContainText('complete')
+  })
+
+  test('the orientation waiver unblocks the Airframe step and unlocks the rest of the flow', async ({ page }) => {
+    // Airframe (step 2) required the physical orientation exercise to pass, and
+    // every later step is locked behind it, so a vehicle that cannot be tilted
+    // hard-stopped the whole wizard with no way forward.
+    // Deliberately NOT using ?guidedSetupStep= here: that dev shortcut also
+    // un-disables locked steps, which is precisely the gate under test. The
+    // wizard auto-selects Airframe anyway once Vehicle Link completes.
+    await page.goto('/?demoMotion=off')
+    await page.getByTestId('transport-mode-select').selectOption('demo')
+    await page.getByTestId('connect-button').click()
+    await expect(page.getByTestId('session-vehicle-name')).toHaveText('ArduCopter', { timeout: VEHICLE_CONNECT_TIMEOUT })
+    await openView(page, 'guided-setup')
+    await expect(page.getByTestId('setup-wizard')).toBeVisible()
+
+    // Locked: the Outputs step cannot be selected while Airframe is incomplete.
+    const outputsStep = page.getByRole('button', { name: /Step 3/ })
+    await expect(outputsStep).toBeDisabled()
+
+    // Airframe unlocks as soon as the initial parameter sync finishes.
+    const airframeStep = page.getByRole('button', { name: /Step 2/ })
+    await expect(airframeStep).toBeEnabled({ timeout: VEHICLE_CONNECT_TIMEOUT })
+    await airframeStep.click()
+
+    // The waiver IS the step's operator sign-off, so one click satisfies both
+    // the orientation criterion and the frame-geometry confirmation.
+    await page.getByRole('button', { name: 'Orientation Verified Elsewhere — Continue' }).click()
+    await expect(page.getByRole('button', { name: 'Clear Orientation Waiver' })).toBeVisible()
+
+    await expect(page.getByTestId('setup-wizard-complete-banner')).toContainText('complete')
+    await expect(outputsStep).toBeEnabled()
   })
 
   test('Plane Outputs Direction & Test shows an honest note, not the quad motor bench', async ({ page }) => {

--- a/tests/mock-guided-motion.test.mjs
+++ b/tests/mock-guided-motion.test.mjs
@@ -1,0 +1,101 @@
+// The guided-setup exercises are driven entirely by live motion. Against the
+// mock's previous fixed level attitude and fixed stick positions none of them
+// could ever complete, so guided setup could not progress past the Airframe
+// step in demo mode. These tests pin the scripted motion to the thresholds the
+// exercises actually check — if either side drifts, the demo silently goes back
+// to being unfinishable, which is exactly the failure this replaces.
+
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import {
+  createArduCopterMockScenario,
+  mockAttitudeForTick,
+  mockRcChannelsForTick
+} from '@arduconfig/protocol-mavlink'
+
+// Mirrors orientationStepSatisfied in apps/web/src/setup-exercise-helpers.ts.
+const LEVEL = (roll, pitch) => Math.abs(roll) <= 8 && Math.abs(pitch) <= 8
+const PITCH_FORWARD = (_roll, pitch) => pitch <= -12
+const ROLL_RIGHT = (roll) => roll >= 12
+
+test('the attitude loop hits level, pitch-forward and roll-right in exercise order', () => {
+  // Walk two full loops so a run starting mid-cycle still completes.
+  const samples = Array.from({ length: 120 }, (_, tick) => mockAttitudeForTick(tick))
+
+  let stage = 0
+  const order = [LEVEL, PITCH_FORWARD, ROLL_RIGHT]
+  for (const { rollDeg, pitchDeg } of samples) {
+    if (stage < order.length && order[stage](rollDeg, pitchDeg)) {
+      stage += 1
+    }
+  }
+
+  assert.equal(stage, order.length, 'The orientation exercise must be able to run to completion on the mock stream.')
+})
+
+test('the attitude loop is deterministic and periodic', () => {
+  for (let tick = 0; tick < 40; tick += 1) {
+    assert.deepEqual(mockAttitudeForTick(tick), mockAttitudeForTick(tick + 52))
+  }
+})
+
+test('the attitude loop returns to level, so it never parks the horizon tilted', () => {
+  const levelSamples = Array.from({ length: 52 }, (_, tick) => mockAttitudeForTick(tick)).filter(({ rollDeg, pitchDeg }) =>
+    LEVEL(rollDeg, pitchDeg)
+  )
+  assert.ok(levelSamples.length > 0, 'Expected the loop to spend time level.')
+})
+
+test('the stick loop moves exactly one axis at a time off its rest position', () => {
+  // RC mapping locks onto the channel that moves ALONE — overlapping axes would
+  // make the capture ambiguous and the exercise would never resolve a channel.
+  const rest = [1500, 1500, 1100, 1500]
+  for (let tick = 0; tick < 60; tick += 1) {
+    const channels = mockRcChannelsForTick(tick)
+    const movedAxes = rest.filter((restPwm, index) => Math.abs(channels[index] - restPwm) > 50)
+    assert.ok(movedAxes.length <= 1, `Tick ${tick} moved ${movedAxes.length} control axes at once.`)
+  }
+})
+
+test('every control axis reaches both ends of travel across one stick loop', () => {
+  const seen = [0, 1, 2, 3].map(() => ({ low: false, high: false }))
+  for (let tick = 0; tick < 60; tick += 1) {
+    const channels = mockRcChannelsForTick(tick)
+    for (const index of [0, 1, 2, 3]) {
+      if (channels[index] <= 1250) seen[index].low = true
+      if (channels[index] >= 1750) seen[index].high = true
+    }
+  }
+
+  // Throttle rests low, so its "low" end is its rest position; the other three
+  // must be driven to both ends for the stick-range exercise to pass.
+  assert.ok(seen[0].low && seen[0].high, 'Roll must sweep both ends.')
+  assert.ok(seen[1].low && seen[1].high, 'Pitch must sweep both ends.')
+  assert.ok(seen[2].low && seen[2].high, 'Throttle must sweep both ends.')
+  assert.ok(seen[3].low && seen[3].high, 'Yaw must sweep both ends.')
+})
+
+test('the motion stream stays off unless guidedMotionCadenceMs is passed', async () => {
+  // Every existing caller and test omits the option, so the mock must stay
+  // byte-for-byte equivalent to the previous static scenario for them.
+  const scenario = createArduCopterMockScenario({ dynamicCadenceMs: 0 })
+  const frames = []
+  const stop = scenario.attachDynamicEmitter((frame) => frames.push(frame))
+  await new Promise((resolve) => setTimeout(resolve, 120))
+  stop()
+  assert.equal(frames.length, 0, 'No motion frames may be emitted without the opt-in.')
+})
+
+test('the motion stream emits once guidedMotionCadenceMs is passed', async () => {
+  const scenario = createArduCopterMockScenario({ guidedMotionCadenceMs: 10 })
+  const frames = []
+  const stop = scenario.attachDynamicEmitter((frame) => frames.push(frame))
+  await new Promise((resolve) => setTimeout(resolve, 120))
+  stop()
+  assert.ok(frames.length > 0, 'Expected ATTITUDE/RC_CHANNELS frames on the motion stream.')
+
+  const countAfterStop = frames.length
+  await new Promise((resolve) => setTimeout(resolve, 60))
+  assert.equal(frames.length, countAfterStop, 'The returned detach must stop the motion stream.')
+})


### PR DESCRIPTION
## The problem

Guided setup could not get past **step 2**.

Airframe required the orientation exercise to pass — a physical tilt past ±12° read from live attitude. A section completes only when *every* criterion is met, and every later section locks behind the first incomplete one, so the whole wizard stopped dead:

- step rail buttons for steps 3–10 `disabled` (`SetupWizardHeader.tsx:79`)
- "Next" `disabled` until the step completes (`SetupWizardAside.tsx:122`)
- `moveSetupWizard` a silent no-op (`App.tsx:5972`)

Unlike Accelerometer / Level / Compass, Airframe had **no escape hatch**. "Reset" and "Mark Failed" leave the criterion exactly as unmet as `running` does.

## Reproduced on real hardware

Not a demo-only artifact. Replaying a live ArduCopter's snapshot + ATTITUDE trace (1125/1125 params synced, attitude verified) through the shipping view-model and exercise state machine:

```
Step 2 Airframe: in-progress / current (4/6)  still needed: Orientation exercise passed
Step 3 Outputs:  in-progress / LOCKED
Step 4-10:       all LOCKED
```

The exercise correctly banks the `level` step from real data, then waits forever for a tilt a bench-mounted board never provides. The demo just made it unconditional: the mock emitted a fixed level attitude and fixed stick positions, so the orientation, RC-mapping, stick-range and mode-switch exercises could never complete there at all.

## What changed

- **Waivers on the three exercise-gated steps** (Airframe, Radio, Modes), recorded as an `already-done` confirmation — the same shape the calibration steps already use. The Airframe waiver also covers the live-attitude criterion, which depends on the same stream.
  - Modes had **no operator escape at all**, and **no confirmation signature** — so `confirmSetupSection` early-returned and any record stored against it was silently discarded. Its own test asserted "a signature for every section" while omitting `modes`.
- **`FRAME_CLASS=0` no longer enables "Confirm Airframe Review".** The criterion requires non-zero, so the button ticked nothing and explained nothing.
- **The blocker is visible.** The single unmet criterion is promoted out of the collapsed disclosure as "Still needed: …", and the list defaults open on an incomplete step. Hiding it behind a "2/5 criteria" badge is the mechanical reason a blocked step read as *unclear what's wanted*.
- **Locked steps name the blocking step again.** A pending follow-up used to replace that copy outright, reporting e.g. "Reboot required" without ever saying which step held the flow.
- **Opt-in `guidedMotionCadenceMs`** streams a deterministic attitude + stick rehearsal so the demo can finish the exercises. Opt-in specifically so every existing caller and test keeps the previous static behavior byte-for-byte; `?demoMotion=off` pins the demo back to rest.

## ArduCopter invariant

Deliberate and scoped to **guided-setup UX**. No parameter writes, commands, or calibration behavior change — `confirmSetupSection` touches no MAVLink, it's local state persisted to setup-progress storage. The orientation exercise's thresholds and state machine are untouched.

## Safety note — please review

The **Radio waiver lets an operator past the RC channel-direction check**, which is flyaway-relevant. It's worded as an explicit assertion ("Radio Verified Elsewhere") rather than a generic skip, and is tallied as an exception with a warning badge — the same trade-off the calibration steps already make. Flagging it explicitly because it widens a safety gate.

The Airframe waiver similarly allows waiving "live attitude telemetry is present". That's required — leaving it hard would rebuild the wall the waiver removes — but it is a skippable health signal.

## Validation ladder

- **Rung 1** mock runtime — 768 node tests ✅ (7 new, pinning the mock choreography to the exact thresholds the exercises check, so the demo can't silently become unfinishable again)
- **Rung 2/3** — 592 vitest ✅ (8 new for the waivers and locked-step copy) · 227 Playwright e2e ✅ (new test walks the demo from a locked step 3 through the waiver to an unlocked flow)
- **Live FC** — snapshot + attitude-trace replay through the real view-model, confirming the block, the waiver, and that the `FRAME_CLASS` gate is a no-op on a configured board

Two e2e failures surfaced during the work and both were real, not noise: a test asserting centred sticks don't integrate yaw heading (fixed by adding the `?demoMotion=off` seam rather than weakening the invariant), and one asserting the criteria list starts collapsed (inverted, since that's the behavior this changes).

**Outstanding:** rung 5 confirmation that a *real tilt* drives the exercise to `passed` — the board stayed level across two capture windows. Low risk: that code path is unmodified, and the replay exercised it successfully for the `level` step.
