### PR TITLE
fix(snapshots): override blocked values in place, pair the row actions, and add group stage/drop

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1955,8 +1955,8 @@ export function App() {
     invalid: selectedSnapshotInvalidEntries,
     signature: selectedSnapshotDiffSignature
   } = useMemo(
-    () => selectEntityDiff(snapshot.parameters, filteredSnapshotRestoreDraftValues),
-    [snapshot.parameters, filteredSnapshotRestoreDraftValues]
+    () => selectEntityDiff(snapshot.parameters, filteredSnapshotRestoreDraftValues, parameterEnumOverrides),
+    [snapshot.parameters, filteredSnapshotRestoreDraftValues, parameterEnumOverrides]
   )
   const {
     handleCaptureLiveSnapshot,
@@ -7907,6 +7907,7 @@ export function App() {
             snapshotImportCalibration,
             snapshotRestoreExcludedCalibrationCount,
             snapshotRestoreDroppedParamIds,
+            parameterEnumOverrides,
             stagedProvisioningOverlayParameters,
             selectedProvisioningProfile,
             selectedProvisioningProfileRestore,
@@ -7928,6 +7929,45 @@ export function App() {
               setSnapshotNotice({
                 tone: 'warning',
                 text: `Staged ${entry.id} as a draft. Write all from the draft bar to apply it.`
+              })
+            },
+            // Group-level Stage/Drop over one category of the restore diff.
+            handleApplySnapshotGroup: (entries) => {
+              const stageable = entries.filter((entry) => entry.nextValue !== undefined)
+              if (stageable.length === 0) {
+                return
+              }
+              mergeDrafts(
+                Object.fromEntries(stageable.map((entry) => [entry.id, String(entry.nextValue)]))
+              )
+              setSnapshotNotice({
+                tone: 'warning',
+                text: `Staged ${stageable.length} change(s) as drafts. Write all from the draft bar to apply them.`
+              })
+            },
+            handleDropSnapshotGroup: (paramIds) => {
+              paramIds.forEach((paramId) => handleDropSnapshotRestoreEntry(paramId))
+              setSnapshotNotice({
+                tone: 'neutral',
+                text: `Dropped ${paramIds.length} change(s) from this restore.`
+              })
+            },
+            handleToggleParameterEnumOverride,
+            // Bulk "Override and write anyway" for the rescuable invalid rows,
+            // so a cross-board restore blocked by a handful of metadata-range
+            // rejections doesn't require a per-row detour through Parameters.
+            handleOverrideAllSnapshotInvalid: (paramIds) => {
+              if (paramIds.length === 0) {
+                return
+              }
+              setParameterEnumOverrides((current) => {
+                const next = new Set(current)
+                paramIds.forEach((paramId) => next.add(paramId))
+                return next
+              })
+              setSnapshotNotice({
+                tone: 'warning',
+                text: `Overrode ${paramIds.length} blocked value(s). They no longer block the write — review them before writing.`
               })
             },
             handleCaptureLiveSnapshot,

--- a/apps/web/src/sections/SnapshotsSection.tsx
+++ b/apps/web/src/sections/SnapshotsSection.tsx
@@ -85,6 +85,9 @@ export interface SnapshotsSectionDerived {
   /** Param ids individually dropped from this restore via the per-row Drop
    *  button — used to grey out/hide already-dropped rows. */
   snapshotRestoreDroppedParamIds: ReadonlySet<string>
+  /** Params currently carrying an operator "Override and write anyway", so
+   *  the invalid rows can show the override as active and offer to undo it. */
+  parameterEnumOverrides: ReadonlySet<string>
   stagedProvisioningOverlayParameters: readonly ParameterBackupEntry[]
   selectedProvisioningProfile: SavedProvisioningProfile | undefined
   selectedProvisioningProfileRestore: ParameterBackupImportResult | undefined
@@ -106,6 +109,20 @@ export interface SnapshotsSectionHandlers {
    *  individual parameters like the Parameters tab). Same overwrite ack
    *  gates it as the full restore. */
   handleApplySnapshotEntry: (entry: ParameterDraftEntry) => void | Promise<void>
+  /** Stage every row of one category at once. The restore preview is
+   *  already grouped by category, so this is the group-level counterpart to
+   *  the per-row Stage — staging 30 Tuning rows one click at a time was the
+   *  actual cost of a partial restore. */
+  handleApplySnapshotGroup: (entries: ParameterDraftEntry[]) => void
+  /** Drop every row of one category at once. */
+  handleDropSnapshotGroup: (paramIds: string[]) => void
+  /** Toggle "Override and write anyway" for one param, WITHOUT leaving
+   *  Snapshots. A metadata-derived rejection (min/max/enum) used to be
+   *  fixable only by staging the invalid set, navigating to Parameters,
+   *  re-filtering, and overriding each row there. */
+  handleToggleParameterEnumOverride: (paramId: string) => void
+  /** Override every invalid row that CAN be overridden, in one action. */
+  handleOverrideAllSnapshotInvalid: (paramIds: string[]) => void
   handleCaptureLiveSnapshot: () => void | Promise<void>
   /** Refreshes the SELECTED snapshot's backup with current live values
    *  in place (same id) instead of creating a new saved entry. */
@@ -241,6 +258,7 @@ export function SnapshotsSection(props: SnapshotsSectionProps): ReactElement {
     snapshotImportCalibration,
     snapshotRestoreExcludedCalibrationCount,
     snapshotRestoreDroppedParamIds,
+    parameterEnumOverrides,
     stagedProvisioningOverlayParameters,
     selectedProvisioningProfile,
     selectedProvisioningProfileRestore,
@@ -268,6 +286,10 @@ export function SnapshotsSection(props: SnapshotsSectionProps): ReactElement {
     handleApplySelectedProvisioningProfile,
     handleApplySelectedSnapshotRestore,
     handleApplySnapshotEntry,
+    handleApplySnapshotGroup,
+    handleDropSnapshotGroup,
+    handleToggleParameterEnumOverride,
+    handleOverrideAllSnapshotInvalid,
     handleCaptureLiveSnapshot,
     handleOverwriteSelectedSnapshot,
     handleDropSnapshotRestoreEntry,
@@ -293,6 +315,14 @@ export function SnapshotsSection(props: SnapshotsSectionProps): ReactElement {
     handleToggleSelectedProvisioningProfileProtection,
     handleToggleSelectedSnapshotProtection
   } = handlers
+
+  // Only the metadata-derived rejections (min / max / enum) can be rescued by
+  // an override; a param missing from the sync or a non-numeric draft cannot.
+  // Drives both the per-row affordance and the "Override all (n)" count, so the
+  // count never promises more than it can deliver.
+  const selectedSnapshotOverridableInvalidIds = selectedSnapshotInvalidEntries
+    .filter((entry) => entry.overridable === true && !parameterEnumOverrides.has(entry.id))
+    .map((entry) => entry.id)
 
   return (
 
@@ -808,6 +838,36 @@ export function SnapshotsSection(props: SnapshotsSectionProps): ReactElement {
                         <header>
                           <strong>{formatCategoryLabel(group.category)}</strong>
                           <span>{group.entries.length} changed</span>
+                          {/* Group-level Stage/Drop. The preview is already
+                           *  grouped by category, so a whole group is the
+                           *  natural unit for a partial restore — clicking 30
+                           *  Tuning rows one at a time was the real cost. */}
+                          <div className="parameter-diff-actions parameter-diff-actions--group">
+                            <button
+                              type="button"
+                              style={buttonStyle()}
+                              data-testid={`snapshot-diff-stage-group-${group.category}`}
+                              onClick={() => handleApplySnapshotGroup(group.entries)}
+                              disabled={busyAction !== undefined || !snapshotRestoreAcknowledged}
+                              title={
+                                snapshotRestoreAcknowledged
+                                  ? `Stage all ${group.entries.length} ${formatCategoryLabel(group.category)} change(s) as drafts.`
+                                  : 'Acknowledge the overwrite warning below first.'
+                              }
+                            >
+                              Stage group
+                            </button>
+                            <button
+                              type="button"
+                              style={buttonStyle()}
+                              data-testid={`snapshot-diff-drop-group-${group.category}`}
+                              onClick={() => handleDropSnapshotGroup(group.entries.map((entry) => entry.id))}
+                              disabled={busyAction !== undefined}
+                              title={`Drop all ${group.entries.length} ${formatCategoryLabel(group.category)} change(s) from this restore.`}
+                            >
+                              Drop group
+                            </button>
+                          </div>
                         </header>
 
                         {group.entries.map((draft) => (
@@ -828,39 +888,46 @@ export function SnapshotsSection(props: SnapshotsSectionProps): ReactElement {
                               ) : null}
                             </span>
                             <span className="parameter-diff-delta">{formatParameterDelta(draft.delta, draft.definition?.unit)}</span>
-                            {/* Per-row Apply — like the Parameters tab, this
-                             *  STAGES the single change as a draft (it does not
-                             *  write). The write happens from the global draft
-                             *  bar's "Write all". Gated on the same ack as the
-                             *  bulk stage so a deliberate overwrite set is
-                             *  confirmed before it enters the write queue. */}
-                            <button
-                              type="button"
-                              style={buttonStyle()}
-                              data-testid={`snapshot-diff-apply-${draft.id}`}
-                              onClick={() => void handleApplySnapshotEntry(draft)}
-                              disabled={busyAction !== undefined || !snapshotRestoreAcknowledged}
-                              title={
-                                snapshotRestoreAcknowledged
-                                  ? `Stage ${draft.id} from this snapshot as a draft — write it from the draft bar.`
-                                  : 'Acknowledge the overwrite warning below first.'
-                              }
-                            >
-                              Apply
-                            </button>
-                            {/* Per-row Drop — same contract as Parameters:
-                             *  excludes this param from the restore diff
-                             *  without leaving this view. */}
-                            <button
-                              type="button"
-                              style={buttonStyle()}
-                              data-testid={`snapshot-diff-drop-${draft.id}`}
-                              onClick={() => handleDropSnapshotRestoreEntry(draft.id)}
-                              disabled={busyAction !== undefined}
-                              title={`Drop the staged change to ${draft.id} (excludes it from this restore; keeps the live FC value as-is).`}
-                            >
-                              Drop
-                            </button>
+                            {/* Stage + Drop share ONE grid cell. As separate
+                             *  cells they overflowed the 4-column row and Drop
+                             *  wrapped to the next line at full column width. */}
+                            <div className="parameter-diff-actions">
+                              {/* Per-row Stage — like the Parameters tab, this
+                               *  STAGES the single change as a draft (it does
+                               *  not write). The write happens from the global
+                               *  draft bar's "Write all". Gated on the same ack
+                               *  as the bulk stage so a deliberate overwrite set
+                               *  is confirmed before it enters the write queue.
+                               *  (Labelled "Apply" until the field report — it
+                               *  never applied anything, it staged.) */}
+                              <button
+                                type="button"
+                                style={buttonStyle()}
+                                data-testid={`snapshot-diff-apply-${draft.id}`}
+                                onClick={() => void handleApplySnapshotEntry(draft)}
+                                disabled={busyAction !== undefined || !snapshotRestoreAcknowledged}
+                                title={
+                                  snapshotRestoreAcknowledged
+                                    ? `Stage ${draft.id} from this snapshot as a draft — write it from the draft bar.`
+                                    : 'Acknowledge the overwrite warning below first.'
+                                }
+                              >
+                                Stage
+                              </button>
+                              {/* Per-row Drop — same contract as Parameters:
+                               *  excludes this param from the restore diff
+                               *  without leaving this view. */}
+                              <button
+                                type="button"
+                                style={buttonStyle()}
+                                data-testid={`snapshot-diff-drop-${draft.id}`}
+                                onClick={() => handleDropSnapshotRestoreEntry(draft.id)}
+                                disabled={busyAction !== undefined}
+                                title={`Drop the staged change to ${draft.id} (excludes it from this restore; keeps the live FC value as-is).`}
+                              >
+                                Drop
+                              </button>
+                            </div>
                           </div>
                         ))}
                       </section>
@@ -889,6 +956,26 @@ export function SnapshotsSection(props: SnapshotsSectionProps): ReactElement {
                       <header>
                         <strong>Invalid restore values</strong>
                         <span>{selectedSnapshotInvalidEntries.length} invalid</span>
+                        {/* Bulk override for every row an override can
+                         *  actually rescue. These are metadata-derived
+                         *  rejections (min / max / enum) where the curated
+                         *  range can lag the firmware — common on a
+                         *  cross-board restore, which is exactly when a
+                         *  handful of rows block "Write all". */}
+                        {selectedSnapshotOverridableInvalidIds.length > 0 ? (
+                          <div className="parameter-diff-actions parameter-diff-actions--group">
+                            <button
+                              type="button"
+                              style={buttonStyle()}
+                              data-testid="snapshot-diff-override-all"
+                              onClick={() => handleOverrideAllSnapshotInvalid(selectedSnapshotOverridableInvalidIds)}
+                              disabled={busyAction !== undefined}
+                              title={`Override and write anyway for all ${selectedSnapshotOverridableInvalidIds.length} rescuable value(s), so they stop blocking the write.`}
+                            >
+                              Override all ({selectedSnapshotOverridableInvalidIds.length})
+                            </button>
+                          </div>
+                        ) : null}
                       </header>
 
                       {selectedSnapshotInvalidEntries.map((draft) => (
@@ -899,6 +986,30 @@ export function SnapshotsSection(props: SnapshotsSectionProps): ReactElement {
                           </span>
                           <span className="parameter-diff-values">{draft.rawValue || 'Empty draft'}</span>
                           <span className="parameter-diff-delta">{draft.reason ?? 'Invalid value'}</span>
+                          <div className="parameter-diff-actions">
+                            {/* Override without leaving Snapshots. Previously
+                             *  the only route was: tick "also stage these" →
+                             *  Show changes → Parameters tab → re-find each row
+                             *  → override it there. Offered only when an
+                             *  override can actually rescue the row (min / max
+                             *  / enum); a missing param or a non-numeric draft
+                             *  is not rescuable by any override. */}
+                            {draft.overridable ? (
+                              <button
+                                type="button"
+                                style={buttonStyle(parameterEnumOverrides.has(draft.id) ? 'secondary' : undefined)}
+                                data-testid={`snapshot-diff-override-${draft.id}`}
+                                onClick={() => handleToggleParameterEnumOverride(draft.id)}
+                                disabled={busyAction !== undefined}
+                                title={
+                                  parameterEnumOverrides.has(draft.id)
+                                    ? `Remove the override for ${draft.id} and flag it invalid again.`
+                                    : `Override and write anyway for ${draft.id} — the documented range/enum may lag this firmware.`
+                                }
+                              >
+                                {parameterEnumOverrides.has(draft.id) ? 'Overridden' : 'Override'}
+                              </button>
+                            ) : null}
                           {/* Every invalid row offers Drop — same contract
                               as Parameters — so the operator can dismiss a
                               bad restore value without first fixing it. */}
@@ -912,6 +1023,7 @@ export function SnapshotsSection(props: SnapshotsSectionProps): ReactElement {
                           >
                             Drop
                           </button>
+                          </div>
                         </div>
                       ))}
                     </section>

--- a/apps/web/src/selectors/entity-diff.ts
+++ b/apps/web/src/selectors/entity-diff.ts
@@ -56,9 +56,14 @@ export interface EntityDiff {
  */
 export function selectEntityDiff(
   snapshotParameters: ParameterState[],
-  draftValues: Record<string, string> | undefined
+  draftValues: Record<string, string> | undefined,
+  /** Params the operator rescued with "Override and write anyway". Without
+   *  this the snapshot restore preview kept showing an overridden value as
+   *  invalid, because the override only reached the global draft set — so
+   *  the operator had no way to see their own override take effect here. */
+  enumOverrides?: ReadonlySet<string>
 ): EntityDiff {
-  const entries = deriveParameterDraftEntries(snapshotParameters, draftValues ?? {})
+  const entries = deriveParameterDraftEntries(snapshotParameters, draftValues ?? {}, enumOverrides)
   return {
     entries,
     groups: groupParameterDraftEntries(entries, ['staged']),

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -11062,6 +11062,30 @@ details.metadata-settings-section:not([open]) > summary::after {
   border-top: 1px solid rgba(39, 49, 59, 0.72);
 }
 
+/* Row actions share the single trailing grid cell. Before this they were
+ * separate grid children, so a second (or third) button overflowed the
+ * 4-column track and wrapped onto the next row stretched to the full width of
+ * column 1 — the "Drop is huge and below Stage" report. Equal-basis buttons
+ * keep Stage/Drop/Override the same size next to each other. */
+.parameter-diff-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  align-items: center;
+  justify-content: flex-end;
+}
+
+.parameter-diff-actions > button {
+  flex: 0 0 auto;
+  min-width: 92px;
+}
+
+/* On a group header the actions sit after the count, pushed to the trailing
+ * edge without stretching the header's own layout. */
+.parameter-diff-actions--group {
+  margin-left: auto;
+}
+
 /* Touched then edited back to the live value — kept in the review so the input
    never vanishes mid-edit, but muted since it won't write. */
 .parameter-diff-item--unchanged {

--- a/packages/ardupilot-core/src/parameter-drafts.ts
+++ b/packages/ardupilot-core/src/parameter-drafts.ts
@@ -17,11 +17,18 @@ export interface ParameterDraftEntry {
   status: ParameterDraftStatus
   reason?: string
   /** True when this draft was rescued from `invalid` by an operator
-   *  "Override and write anyway" choice — currently only used for the
-   *  enum-mismatch reason, since metadata can lag the firmware and a
-   *  legitimate value can be flagged as outside-enum even when the FC
-   *  would accept it. Min/max violations are NOT overridable here. */
+   *  "Override and write anyway" choice. Applies to the three
+   *  metadata-derived rejections — below-minimum, above-maximum, and
+   *  enum-mismatch — because the curated metadata can lag the firmware and
+   *  flag a value the FC would accept. */
   override?: boolean
+  /** Only meaningful on `invalid` entries: can an operator "Override and
+   *  write anyway" rescue this one? True for the metadata-derived
+   *  rejections (min / max / enum). False for rejections no override can
+   *  fix — a param absent from the synced snapshot, or a non-numeric /
+   *  non-finite draft value. Lets the UI offer the override affordance only
+   *  where it would actually do something. */
+  overridable?: boolean
 }
 
 export interface ParameterDraftSummary {
@@ -120,7 +127,8 @@ function deriveParameterDraftEntry(
       category,
       rawValue,
       status: 'invalid',
-      reason: 'Parameter is not present in the synced snapshot.'
+      reason: 'Parameter is not present in the synced snapshot.',
+      overridable: false
     }
   }
 
@@ -133,7 +141,8 @@ function deriveParameterDraftEntry(
       rawValue,
       currentValue: parameter.value,
       status: 'invalid',
-      reason: 'Enter a numeric value before staging this parameter.'
+      reason: 'Enter a numeric value before staging this parameter.',
+      overridable: false
     }
   }
 
@@ -147,7 +156,8 @@ function deriveParameterDraftEntry(
       rawValue,
       currentValue: parameter.value,
       status: 'invalid',
-      reason: 'Only finite numeric values can be written to the controller.'
+      reason: 'Only finite numeric values can be written to the controller.',
+      overridable: false
     }
   }
 
@@ -168,7 +178,8 @@ function deriveParameterDraftEntry(
         currentValue: parameter.value,
         nextValue: parsedValue,
         status: 'invalid',
-        reason: `Value is below the documented minimum of ${parameter.definition.minimum}.`
+        reason: `Value is below the documented minimum of ${parameter.definition.minimum}.`,
+        overridable: true
       }
     }
   }
@@ -184,7 +195,8 @@ function deriveParameterDraftEntry(
         currentValue: parameter.value,
         nextValue: parsedValue,
         status: 'invalid',
-        reason: `Value is above the documented maximum of ${parameter.definition.maximum}.`
+        reason: `Value is above the documented maximum of ${parameter.definition.maximum}.`,
+        overridable: true
       }
     }
   }
@@ -218,7 +230,8 @@ function deriveParameterDraftEntry(
           currentValue: parameter.value,
           nextValue: parsedValue,
           status: 'invalid',
-          reason: 'Value is outside the known enum values for this parameter.'
+          reason: 'Value is outside the known enum values for this parameter.',
+          overridable: true
         }
       }
     }

--- a/tests/e2e/views.spec.ts
+++ b/tests/e2e/views.spec.ts
@@ -4062,6 +4062,24 @@ test.describe('Snapshot restore', () => {
     await expect(page.getByTestId('snapshot-diff-drop-BATT_LOW_VOLT')).toBeVisible()
     await expect(page.getByTestId('snapshot-restore-dropped-note')).toHaveCount(0)
 
+    // Group-level Stage/Drop: the preview is grouped by category, and acting
+    // on a whole group is the natural unit for a partial restore. Staging is
+    // gated on the same overwrite ack as the per-row Stage.
+    const groupDrop = page.getByTestId('snapshot-diff-drop-group-failsafe')
+    const groupStage = page.getByTestId('snapshot-diff-stage-group-failsafe')
+    await expect(groupDrop).toBeVisible()
+    await expect(groupStage).toBeDisabled()
+    await page.getByTestId('snapshot-restore-ack').check()
+    await expect(groupStage).toBeEnabled()
+
+    // Dropping the group clears every row in it, not just one.
+    await groupDrop.click()
+    await expect(page.getByTestId('snapshot-diff-drop-BATT_LOW_VOLT')).toHaveCount(0)
+    await expect(page.getByTestId('snapshot-restore-dropped-note')).toContainText('dropped')
+    await page.getByTestId('snapshot-restore-undo-drops').click()
+    await expect(page.getByTestId('snapshot-diff-drop-BATT_LOW_VOLT')).toBeVisible()
+    await page.getByTestId('snapshot-restore-ack').uncheck()
+
     // Overwrite Selected refreshes the SAME saved entry in place rather
     // than creating a new one.
     await page.getByTestId('overwrite-selected-snapshot-button').click()

--- a/tests/parameter-drafts-derivation.test.mjs
+++ b/tests/parameter-drafts-derivation.test.mjs
@@ -215,3 +215,51 @@ test('group filters by status and sorts categories then ids', () => {
   )
   assert.equal(invalidGroups[0].entries[0].status, 'invalid')
 })
+
+// `overridable` tells the UI which invalid rows an "Override and write anyway"
+// can actually rescue. It drives the Snapshots restore preview's per-row
+// Override button and its "Override all (n)" count, so a wrong value here
+// either hides a usable escape or promises one that does nothing.
+test('metadata-derived rejections are flagged overridable (min / max / enum)', () => {
+  const below = entryFor([param('P', 5, def({ minimum: 10 }))], { P: '2' }, 'P')
+  assert.equal(below.status, 'invalid')
+  assert.equal(below.overridable, true)
+
+  const above = entryFor([param('P', 5, def({ maximum: 10 }))], { P: '99' }, 'P')
+  assert.equal(above.status, 'invalid')
+  assert.equal(above.overridable, true)
+
+  const enumMismatch = entryFor(
+    [param('P', 1, def({ options: [{ value: 0, label: 'A' }, { value: 1, label: 'B' }] }))],
+    { P: '7' },
+    'P'
+  )
+  assert.equal(enumMismatch.status, 'invalid')
+  assert.equal(enumMismatch.overridable, true)
+})
+
+test('rejections no override can fix are flagged NOT overridable', () => {
+  const missing = entryFor([], { GHOST_PARAM: '1' }, 'GHOST_PARAM')
+  assert.equal(missing.overridable, false)
+
+  const empty = entryFor([param('P', 1, def())], { P: '   ' }, 'P')
+  assert.equal(empty.status, 'invalid')
+  assert.equal(empty.overridable, false)
+
+  const nonNumeric = entryFor([param('P', 1, def())], { P: 'abc' }, 'P')
+  assert.equal(nonNumeric.status, 'invalid')
+  assert.equal(nonNumeric.overridable, false)
+})
+
+test('an override actually rescues each metadata-derived rejection', () => {
+  const overrides = new Set(['P'])
+  const staged = (parameters, draftValues) =>
+    deriveParameterDraftEntries(parameters, draftValues, overrides).find((e) => e.id === 'P')
+
+  assert.equal(staged([param('P', 5, def({ minimum: 10 }))], { P: '2' }).status, 'staged')
+  assert.equal(staged([param('P', 5, def({ maximum: 10 }))], { P: '99' }).status, 'staged')
+  assert.equal(
+    staged([param('P', 1, def({ options: [{ value: 0, label: 'A' }] }))], { P: '7' }).status,
+    'staged'
+  )
+})


### PR DESCRIPTION
Four field reports against the snapshot restore preview.

## 1. Invalid values blocked "Write all" with no way out of this view

The only route was: tick "also stage these" → **Show changes** → Parameters tab → re-find each row → override it there, one param at a time.

Invalid rows now carry an inline **Override** (toggling to "Overridden"), plus **Override all (n)** on the section header for the common cross-board case.

Two things had to change for that to work at all:

- `selectEntityDiff` never received the override set, so an override made in Parameters **did not clear the row here**. It now takes `enumOverrides` and threads it into `deriveParameterDraftEntries`.
- Not every invalid row can be rescued. `ParameterDraftEntry` gains an **`overridable`** flag: `true` for the metadata-derived rejections (below-minimum / above-maximum / enum-mismatch, where curated metadata can lag firmware), `false` for the ones no override fixes (param absent from the sync, non-numeric, non-finite). The affordance and the `(n)` count appear **only** where an override actually does something.

## 2. Drop rendered full-width below its row

`.parameter-diff-item` is a 4-column grid and Stage/Drop were separate grid children, so the extra child overflowed the track and wrapped onto the next row stretched to column 1's width. They now share one trailing cell (`.parameter-diff-actions`), which also gives the new Override button somewhere to sit.

## 3. Per-row "Apply" is now "Stage"

It never applied anything — it staged a draft for the global draft bar, which is likely why it read as a separate write path. Label only; behavior and `data-testid` unchanged.

## 4. Category headers gain Stage group / Drop group

The preview is already grouped by category, and a group is the natural unit for a partial restore — staging 30 Tuning rows one click at a time was the real cost. Group staging is gated on the same overwrite acknowledgement as per-row staging.

**This is the interim grouping**, reusing the existing metadata categories. Operator-defined groups can slot in later behind the same controls.

## Incidental

Corrects a stale doc comment on `ParameterDraftEntry.override` claiming *"Min/max violations are NOT overridable here"*. The code has overridden min/max since the SERIAL7_BAUD report — the comment directly contradicted the behavior this change builds on.

## Safety / invariant

No write-path change: staging, verification, readback and rollback are untouched. An override still only relaxes **this app's** metadata validation — the firmware remains free to reject the value. ArduCopter parameter semantics unchanged.

## Validation ladder

Rungs 1–3:
- **771 node tests** (6 new, pinning `overridable` and that an override rescues each metadata-derived rejection)
- **592 vitest**
- **227 Playwright e2e** — snapshot restore spec extended to cover group stage/drop and its ack gating