### PR TITLE
fix(runtime): bulk-stream a resumed parameter sync when the carried-over gap is large

### DIFF
--- a/packages/ardupilot-core/src/runtime.ts
+++ b/packages/ardupilot-core/src/runtime.ts
@@ -927,12 +927,27 @@ export class ArduPilotConfiguratorRuntime {
       })
       this.emit()
 
-      if (resumedFrom) {
-        // Refetch only what the dropped link never delivered. A full re-stream
-        // here would re-send everything we already hold and — on a board that
-        // resets every few seconds — never get further than the last attempt.
+      // Refetch only what the dropped link never delivered — a full re-stream
+      // re-sends everything we already hold and, on a board that resets every
+      // few seconds, never gets further than the last attempt.
+      //
+      // But by-index refetch is paced: MAX_PARAMETER_GAP_FILL_PER_PASS reads
+      // per pass, and the next pass waits out the stall timer
+      // (PARAMETER_SYNC_STALL_RETRY_MS, 1.5s+). That is the right shape for the
+      // handful of frames a lossy link drops, and the wrong shape for a gap of
+      // hundreds: a full table then costs several passes of pure waiting, so a
+      // reconnect after a reboot took far longer than a first connect and the
+      // operator's fastest move was to disconnect (which discards the carry-over
+      // via discardRetainedParameters) and reconnect for a clean bulk stream.
+      //
+      // So: target the gap when it fits in ONE pass, otherwise bulk-stream. The
+      // retained values stay on screen either way, and if the bulk stream stalls
+      // the existing retry path gap-fills automatically — which is what keeps a
+      // constantly-resetting board converging.
+      const resumeMissingIndices = resumedFrom ? this.missingParameterIndices() : []
+      if (resumedFrom && resumeMissingIndices.length <= MAX_PARAMETER_GAP_FILL_PER_PASS) {
         this.parameterSyncGapFillActive = true
-        await this.requestMissingParameters(this.missingParameterIndices())
+        await this.requestMissingParameters(resumeMissingIndices)
         this.scheduleParameterSyncRetry()
       } else {
         await this.requestParameterTable(vehicle.systemId, vehicle.componentId)

--- a/tests/parameter-sync-watchdog-resume.test.mjs
+++ b/tests/parameter-sync-watchdog-resume.test.mjs
@@ -250,3 +250,84 @@ test('a board whose parameter count changed discards the carried-over values', a
     runtime.destroy()
   }
 })
+
+// By-index refetch is PACED: MAX_PARAMETER_GAP_FILL_PER_PASS (256) reads per
+// pass, and the next pass waits out the stall timer (1.5s+). That is right for
+// the handful of frames a lossy link drops and wrong for a gap of hundreds —
+// a full table then costs several passes of pure waiting, which is why a
+// reconnect after a reboot was slower than a first connect and the operator's
+// fastest move was to disconnect (discarding the carry-over) and reconnect.
+// So the resume targets the gap only when it fits in ONE pass.
+test('a resume with a gap larger than one gap-fill pass bulk-streams instead of trickling by index', async () => {
+  const sent = []
+  const BIG_TOTAL = 600
+  // 100 delivered, 500 missing — far more than one 256-read pass.
+  const session = createResettingSession(sent, { windowSize: 100 })
+  session.setTotal(BIG_TOTAL)
+  const runtime = new ArduPilotConfiguratorRuntime(session, arducopterMetadata, {
+    parameterSyncStallRetryMs: 10_000
+  })
+  try {
+    await runtime.connect()
+    await runtime.requestParameterList({ timeoutMs: 500 })
+    assert.equal(runtime.getSnapshot().parameters.length, 100, 'first window delivered 100 of 600')
+
+    session.watchdogReset()
+    await sleep(20)
+    assert.equal(runtime.getSnapshot().staleLink.downloaded, 100, 'the partial table is carried over')
+
+    // Board is healthy again and the whole table streams on the reconnect.
+    session.setWindow(BIG_TOTAL)
+    const sentBefore = sent.length
+    await runtime.connect()
+    await runtime.requestParameterList({ timeoutMs: 500 })
+    await runtime.waitForParameterSync({ timeoutMs: 2000 })
+
+    const afterReconnect = sent.slice(sentBefore)
+    const reads = afterReconnect.filter((m) => m.type === 'PARAM_REQUEST_READ')
+    const lists = afterReconnect.filter((m) => m.type === 'PARAM_REQUEST_LIST')
+    assert.equal(lists.length, 1, 'the big gap took the bulk re-stream path')
+    assert.equal(reads.length, 0, 'and did NOT trickle 500 reads out at 256 per paced pass')
+    assert.equal(runtime.getSnapshot().parameterStats.downloaded, BIG_TOTAL, 'the table completed')
+  } finally {
+    runtime.destroy()
+  }
+})
+
+// The small-gap case must keep targeting indices: re-streaming 600 params to
+// recover 3 is the waste the gap-fill was built to avoid, and a constantly
+// resetting board depends on it to ever reach the tail of the table.
+test('a resume with a small gap still refetches by index', async () => {
+  const sent = []
+  const SMALL_TOTAL = 300
+  const session = createResettingSession(sent, { windowSize: 297 })
+  session.setTotal(SMALL_TOTAL)
+  const runtime = new ArduPilotConfiguratorRuntime(session, arducopterMetadata, {
+    parameterSyncStallRetryMs: 10_000
+  })
+  try {
+    await runtime.connect()
+    await runtime.requestParameterList({ timeoutMs: 500 })
+    session.watchdogReset()
+    await sleep(20)
+
+    const sentBefore = sent.length
+    await runtime.connect()
+    await runtime.requestParameterList({ timeoutMs: 500 })
+    await runtime.waitForParameterSync({ timeoutMs: 2000 })
+
+    const afterReconnect = sent.slice(sentBefore)
+    assert.equal(
+      afterReconnect.filter((m) => m.type === 'PARAM_REQUEST_LIST').length,
+      0,
+      'a 3-param gap must not re-stream the whole table'
+    )
+    assert.deepEqual(
+      afterReconnect.filter((m) => m.type === 'PARAM_REQUEST_READ').map((m) => m.paramIndex).sort((a, b) => a - b),
+      [297, 298, 299],
+      'only the missing indices were requested'
+    )
+  } finally {
+    runtime.destroy()
+  }
+})


### PR DESCRIPTION
**Field report:** after a reboot/reconnect cycle the parameter table loads far more slowly than on a first connect — and disconnecting then reconnecting restores full speed.

## Cause

`canResumeStaleLink()` takes the **by-index resume path** on any reconnect where the previous download was incomplete, the board matches, and it's within `PARAMETER_CARRY_OVER_TTL_MS` (10 min).

That path is deliberately paced: `requestMissingParameters()` emits at most `MAX_PARAMETER_GAP_FILL_PER_PASS` (**256**) `PARAM_REQUEST_READ` frames, then waits out the stall timer (`PARAMETER_SYNC_STALL_RETRY_MS`, **1.5 s**, backing off to 8 s) before the next pass.

That's the right shape for the handful of frames a lossy link drops. For a gap of *hundreds* it costs several passes of pure waiting, where a single `PARAM_REQUEST_LIST` would have the FC stream the whole table back-to-back.

The operator's workaround confirms the path: an explicit disconnect calls `discardRetainedParameters()`, so the next connect has no stale link to resume and takes the fast bulk path.

## Fix

On the **connect-time resume**, target the gap only when it fits in ONE gap-fill pass; otherwise bulk-stream. Retained values stay on screen either way, so the "link lost, showing last data" continuity is unchanged.

## What this deliberately does NOT change

The **stall-retry path still prefers by-index refetch**. That's what a constantly-resetting board depends on — a full re-stream always restarts at index 0 and dies before reaching the tail, which was the original 4.8-dev field repro. And if the new bulk re-stream stalls, the existing retry logic gap-fills automatically, so that board's recovery is reached either way. Its regression test is unchanged and still passing.

## Invariant

No write-path or parameter-semantics change — this only alters which request frames a resumed sync emits. ArduCopter behaviour is unaffected beyond the faster resume.

## Validation ladder

Rungs 1–3:
- **773 node tests** — 2 new: a >256 gap re-streams and emits *zero* by-index reads; a 3-param gap still targets exactly indices 297/298/299
- **592 vitest**
- **227 Playwright e2e**

Reasoned from the code paths and proven against the mock; **not measured on hardware**. The threshold (one pass = 256) is tied to the existing constant rather than a tuned number.