### PR TITLE
fix(wiki): drop the .. contents:: directive Furo renders as an error block

### DIFF
--- a/tests/wiki-parameter-reference.test.mjs
+++ b/tests/wiki-parameter-reference.test.mjs
@@ -74,6 +74,20 @@ test('every indexed parameter is reachable: its page exists and declares its anc
   assert.deepEqual(broken.slice(0, 5), [], `${broken.length} unreachable parameter(s)`)
 })
 
+test('generated pages carry no directive that a theme renders as an error block', () => {
+  // Furo builds its own "On this page" sidebar and REJECTS a `.. contents::`
+  // directive by rendering a red ERROR block into the page body. sphinx-build
+  // reports that as neither an error nor a warning, so a clean build log said
+  // nothing while all 387 pages shipped the banner. Asserting on the source is
+  // the cheap guard; the expensive one (scanning built HTML for
+  // docutils system-message nodes) needs a full Sphinx build.
+  generate()
+  const offenders = readdirSync(PARAMS_DIR)
+    .filter((name) => name.startsWith('group-') && name.endsWith('.rst'))
+    .filter((name) => readFileSync(path.join(PARAMS_DIR, name), 'utf8').includes('.. contents::'))
+  assert.deepEqual(offenders.slice(0, 3), [], `${offenders.length} page(s) still use .. contents::`)
+})
+
 test('page titles escape the trailing underscore every ArduPilot family name has', () => {
   // An unescaped trailing underscore is RST hyperlink-reference syntax: it
   // produced ~290 "Unknown target name" build errors and a mangled heading.

--- a/wiki/tools/generate_parameter_reference.py
+++ b/wiki/tools/generate_parameter_reference.py
@@ -222,11 +222,12 @@ def generate(source: str, vehicle: str, firmware: str) -> None:
             f"{len(params)} parameters in the ``{group}`` family "
             f"({vehicle} {firmware}).",
             "",
-            ".. contents::",
-            "   :local:",
-            "   :depth: 1",
-            "",
         ]
+        # NO ".. contents::" here. Furo builds its own "On this page" sidebar
+        # from the headings and rejects the directive by rendering a red ERROR
+        # block INTO the page — which sphinx-build reports as neither an error
+        # nor a warning, so a clean build log said nothing while all 387 pages
+        # carried the banner.
         for name in sorted(params):
             meta = params[name]
             if not isinstance(meta, dict):


### PR DESCRIPTION
Every generated parameter page shipped with a red ERROR banner above its content:

> ERROR: Adding a table of contents in Furo-based documentation is unnecessary, and does not work well with existing styling.

## Why it got through

Furo builds its own "On this page" sidebar from the headings and rejects the directive by rendering a docutils `system-message` **into the page body**. `sphinx-build` reports that as **neither an error nor a warning** — the build log was clean (0 errors, 0 warnings) while all 387 pages carried the banner.

I validated the build output rather than the rendered HTML, so this went straight to production. Caught from a screenshot of the live page.

## Fix

Remove the directive. Nothing is lost — Furo's sidebar already lists every parameter on the page (verified in the rebuilt HTML).

Added a test asserting no generated page uses `.. contents::`. The stronger check — scanning built HTML for `system-message` nodes — needs a full Sphinx build, so the cheap source-level guard runs in the normal suite instead.

## Validation

Rung 1 — **785 node tests** (1 new). Sphinx rebuild clean; a scan of the built HTML finds **zero** `system-message` nodes site-wide, with Furo's on-this-page nav still listing every parameter.