### PR TITLE
feat(params/wiki): auto-fetch defaults, colour row state, and enrich the parameter search

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -920,6 +920,36 @@ export function App() {
   // hook) so the export can honour the same set.
   const [nonDefaultParamIds, setNonDefaultParamIds] = useState<ReadonlySet<string> | null>(null)
   const [showOnlyNonDefault, setShowOnlyNonDefault] = useState(false)
+  // Params written successfully in the last few seconds. Purely a visual
+  // confirmation: a staged row reads yellow, and on a verified write it turns
+  // green briefly before settling back. Without this there was no visible
+  // difference between "I typed a value" and "the controller took it" — the
+  // draft just disappeared.
+  const [recentlyWrittenParamIds, setRecentlyWrittenParamIds] = useState<ReadonlySet<string>>(
+    () => new Set<string>()
+  )
+  const recentlyWrittenTimerRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined)
+  const markParametersWritten = useCallback((paramIds: string[]) => {
+    if (paramIds.length === 0) {
+      return
+    }
+    setRecentlyWrittenParamIds(new Set(paramIds))
+    if (recentlyWrittenTimerRef.current) {
+      clearTimeout(recentlyWrittenTimerRef.current)
+    }
+    recentlyWrittenTimerRef.current = setTimeout(() => {
+      recentlyWrittenTimerRef.current = undefined
+      setRecentlyWrittenParamIds(new Set<string>())
+    }, 4000)
+  }, [])
+  useEffect(
+    () => () => {
+      if (recentlyWrittenTimerRef.current) {
+        clearTimeout(recentlyWrittenTimerRef.current)
+      }
+    },
+    []
+  )
   const [fetchDefaultsBusy, setFetchDefaultsBusy] = useState(false)
   const {
     handleExportParameterBackup,
@@ -3174,6 +3204,7 @@ export function App() {
         (progress) => setScopedWriteProgress({ completed: progress.completed, total: progress.total, scopeLabel })
       )
       appliedParamIds.push(...result.applied.map((entry) => entry.paramId))
+      markParametersWritten(result.applied.map((entry) => entry.paramId))
       setParameterNotice({
         tone: result.unconfirmed.length > 0 ? 'warning' : 'success',
         text:
@@ -3302,6 +3333,7 @@ export function App() {
         (progress) => setApplyAllProgress({ completed: progress.completed, total: progress.total })
       )
       appliedParamIds.push(...result.applied.map((entry) => entry.paramId))
+      markParametersWritten(result.applied.map((entry) => entry.paramId))
       setParameterNotice({
         tone: result.unconfirmed.length > 0 ? 'warning' : 'success',
         text:
@@ -8638,7 +8670,24 @@ export function App() {
           onRequestReboot={() => void handleGuidedAction('reboot-autopilot')}
           nonDefaultParamIds={nonDefaultParamIds}
           showOnlyNonDefault={showOnlyNonDefault}
-          onToggleShowOnlyNonDefault={() => setShowOnlyNonDefault((previous) => !previous)}
+          // Ticking "show only changed" fetches the firmware defaults it needs,
+          // rather than requiring the operator to press a separate button first.
+          // Fetching defaults was never the goal — it only ever existed to make
+          // this filter possible, so making it a prerequisite step pushed the
+          // app's bookkeeping onto the operator. Already-fetched defaults are
+          // reused; only turning the filter ON triggers a fetch.
+          recentlyWrittenParamIds={recentlyWrittenParamIds}
+          onToggleShowOnlyNonDefault={() => {
+            const enabling = !showOnlyNonDefault
+            if (enabling && !nonDefaultParamIds && !fetchDefaultsBusy) {
+              // handleFetchParamDefaults flips the filter on itself once the
+              // defaults land, so a failed fetch leaves the filter off rather
+              // than on-but-showing-everything.
+              void handleFetchParamDefaults()
+              return
+            }
+            setShowOnlyNonDefault(enabling)
+          }}
           onFetchParamDefaults={handleFetchParamDefaults}
           fetchDefaultsBusy={fetchDefaultsBusy}
         />

--- a/apps/web/src/sections/ParametersSection.tsx
+++ b/apps/web/src/sections/ParametersSection.tsx
@@ -87,6 +87,8 @@ export interface ParametersSectionProps {
   nonDefaultParamIds: ReadonlySet<string> | null
   /** "Show only changed" — restrict the table (and export) to non-default params. */
   showOnlyNonDefault: boolean
+  /** Params verified-written in the last few seconds — briefly flagged green. */
+  recentlyWrittenParamIds: ReadonlySet<string>
   onToggleShowOnlyNonDefault: () => void
   /** Fetch the packed defaults from the FC to populate nonDefaultParamIds. */
   onFetchParamDefaults: () => void | Promise<void>
@@ -140,8 +142,8 @@ export function ParametersSection(props: ParametersSectionProps): ReactElement {
     onRequestReboot: handleRequestReboot,
     nonDefaultParamIds,
     showOnlyNonDefault,
+    recentlyWrittenParamIds,
     onToggleShowOnlyNonDefault: handleToggleShowOnlyNonDefault,
-    onFetchParamDefaults: handleFetchParamDefaults,
     fetchDefaultsBusy
   } = props
 
@@ -299,22 +301,18 @@ export function ParametersSection(props: ParametersSectionProps): ReactElement {
           >
             Refresh
           </button>
-          <button
-            type="button"
-            data-testid="parameter-fetch-defaults-button"
-            style={buttonStyle()}
-            onClick={() => void handleFetchParamDefaults()}
-            disabled={fetchDefaultsBusy || refreshDisabled}
-            title="Fetch firmware defaults from the FC (ArduPilot 4.5+) so 'Show only changed' can filter to non-default params."
-          >
-            {fetchDefaultsBusy ? 'Fetching…' : nonDefaultParamIds ? 'Refresh defaults' : 'Fetch defaults'}
-          </button>
+          {/* The separate Fetch/Refresh-defaults button is gone. Fetching
+            * defaults was never a goal in itself — it existed only so this
+            * filter could work, so asking for it as a prerequisite step made the
+            * operator do the app's bookkeeping. Ticking the box now fetches on
+            * demand (see handleToggleShowOnlyNonDefault) and the label reports
+            * progress inline. */}
           <label
             className="parameter-show-changed"
             title={
               nonDefaultParamIds
                 ? 'Show only params that differ from their firmware default.'
-                : 'Fetch defaults first to enable this filter.'
+                : 'Show only params that differ from their firmware default. Fetches the defaults from the FC on first use (needs ArduPilot 4.5+).'
             }
           >
             <input
@@ -322,9 +320,13 @@ export function ParametersSection(props: ParametersSectionProps): ReactElement {
               data-testid="parameter-show-changed-toggle"
               checked={showOnlyNonDefault}
               onChange={handleToggleShowOnlyNonDefault}
-              disabled={!nonDefaultParamIds}
+              disabled={fetchDefaultsBusy || refreshDisabled}
             />
-            <span>Show only changed{nonDefaultParamIds ? ` (${nonDefaultParamIds.size})` : ''}</span>
+            <span>
+              {fetchDefaultsBusy
+                ? 'Fetching defaults…'
+                : `Show only changed${nonDefaultParamIds ? ` (${nonDefaultParamIds.size})` : ''}`}
+            </span>
           </label>
         </div>
 
@@ -777,12 +779,19 @@ export function ParametersSection(props: ParametersSectionProps): ReactElement {
             // parameter table shows real descriptions/units/categories for the
             // whole tree, not just curated params.
             const definition = metadataCatalog.parameters[parameter.id] ?? parameter.definition
+            // Row state reads as colour rather than as a button tint: yellow
+            // staged (typed, not written), green just-written (the controller
+            // confirmed it), red invalid. A staged row used to be a barely
+            // perceptible gradient, so "have my edits gone in?" was not
+            // answerable at a glance.
             const rowClassName =
               draft?.status === 'staged'
                 ? 'parameter-row parameter-row--staged'
                 : draft?.status === 'invalid'
                   ? 'parameter-row parameter-row--invalid'
-                  : 'parameter-row'
+                  : recentlyWrittenParamIds.has(parameter.id)
+                    ? 'parameter-row parameter-row--written'
+                    : 'parameter-row'
 
             const isExpanded = selectedParameterId === parameter.id
             return (

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -11455,12 +11455,27 @@ details.metadata-settings-section:not([open]) > summary::after {
   display: block;
 }
 
+/* Row state as colour. Previously a staged row was a near-imperceptible fill
+   gradient, so "did my edit go in?" could not be answered at a glance. The left
+   bar carries the signal at any zoom / colour profile; the wash keeps the text
+   readable rather than shouting. Red is reserved for invalid (and, later, for a
+   dropped row). */
 .parameter-row--staged {
-  background: linear-gradient(180deg, rgba(var(--fill-rgb), 0.98), rgba(var(--fill-rgb), 1));
+  background: color-mix(in srgb, var(--warning) 12%, transparent);
+  box-shadow: inset 3px 0 0 var(--warning);
+}
+
+.parameter-row--written {
+  background: color-mix(in srgb, var(--success, #4ade80) 12%, transparent);
+  box-shadow: inset 3px 0 0 var(--success, #4ade80);
+  /* Fades out on its own — a permanent green would claim the row is still
+     special long after the write. */
+  transition: background 600ms ease-out, box-shadow 600ms ease-out;
 }
 
 .parameter-row--invalid {
-  background: rgba(53, 23, 23, 0.42);
+  background: color-mix(in srgb, var(--danger) 14%, transparent);
+  box-shadow: inset 3px 0 0 var(--danger);
 }
 
 .parameter-row--selected {

--- a/wiki/_static/custom.css
+++ b/wiki/_static/custom.css
@@ -44,3 +44,28 @@
   font-size: 0.85em;
   color: var(--color-foreground-secondary, #666);
 }
+
+/* Search stays put while results scroll — it is on every parameter page, so it
+   should behave like a persistent tool rather than page content. */
+.param-search--sticky {
+  position: sticky;
+  top: 0;
+  z-index: 5;
+  padding: 8px 0;
+  background: var(--color-background-primary, #fff);
+}
+
+.param-search__desc {
+  display: block;
+  margin-top: 2px;
+  font-size: 0.85em;
+  line-height: 1.45;
+  color: var(--color-foreground-primary, #222);
+}
+
+/* Empty until a query is typed, so it must not reserve vertical space above
+   the page's real content. */
+.param-search__status:empty {
+  display: none;
+  margin: 0;
+}

--- a/wiki/_static/parameter-search.js
+++ b/wiki/_static/parameter-search.js
@@ -44,6 +44,9 @@
     if (name.indexOf(needle) === 0) return 1
     if (name.indexOf(needle) !== -1) return 2
     if (display.indexOf(needle) !== -1) return 3
+    // Descriptions are in the index now, so a prose search finds things a name
+    // search cannot — ranked last so a named parameter always wins.
+    if ((entry.x || '').toLowerCase().indexOf(needle) !== -1) return 4
     return -1
   }
 
@@ -88,8 +91,24 @@
       li.appendChild(link)
       var meta = document.createElement('span')
       meta.className = 'param-search__meta'
-      meta.textContent = entry.d + (entry.u ? ' · ' + entry.u : '') + (entry.r ? ' · reboot required' : '')
+      var facts = [entry.d]
+      if (entry.u) facts.push(entry.u)
+      if (entry.rg) facts.push('range ' + entry.rg)
+      if (entry.lv) facts.push(entry.lv)
+      if (entry.r) facts.push('reboot required')
+      if (entry.opt) facts.push('has value list')
+      meta.textContent = facts.join(' · ')
       li.appendChild(meta)
+
+      // The full upstream description, inline. Answering "what does this do" in
+      // the results list is the point of searching; making the operator open a
+      // page to read one sentence defeats it.
+      if (entry.x) {
+        var desc = document.createElement('span')
+        desc.className = 'param-search__desc'
+        desc.textContent = entry.x
+        li.appendChild(desc)
+      }
       fragment.appendChild(li)
     }
     results.appendChild(fragment)

--- a/wiki/tools/generate_parameter_reference.py
+++ b/wiki/tools/generate_parameter_reference.py
@@ -43,6 +43,26 @@ SOURCES = [
 ]
 
 
+SEARCH_MARKUP = [
+    ".. raw:: html",
+    "",
+    '   <div class="param-search param-search--sticky">',
+    '     <input',
+    '       id="param-search-input"',
+    '       type="search"',
+    '       placeholder="Search all ArduCopter 4.7 parameters…"',
+    '       autocomplete="off"',
+    '       autocapitalize="off"',
+    '       spellcheck="false"',
+    '       aria-label="Search parameters"',
+    "     />",
+    '     <p id="param-search-status" class="param-search__status"></p>',
+    '     <ol id="param-search-results" class="param-search__results"></ol>',
+    "   </div>",
+    "",
+]
+
+
 def rst_escape(text: str) -> str:
     """Neutralise the inline markup characters that appear in upstream prose.
 
@@ -110,11 +130,13 @@ def render_values(values) -> list[str]:
         except ValueError:
             return (1, 0.0)
 
-    lines = ["   .. list-table::", "      :header-rows: 1", "      :widths: 20 80", "",
-             "      * - Value", "        - Meaning"]
+    # NOT indented: a leading indent made docutils treat the whole table as a
+    # blockquote, so every Values/Bitmask table rendered inset and grey.
+    lines = [".. list-table::", "   :header-rows: 1", "   :widths: 20 80", "",
+             "   * - Value", "     - Meaning"]
     for key, label in sorted(pairs, key=sort_key):
-        lines.append(f"      * - ``{rst_escape(clean(key))}``")
-        lines.append(f"        - {rst_escape(clean(label))}")
+        lines.append(f"   * - ``{rst_escape(clean(key))}``")
+        lines.append(f"     - {rst_escape(clean(label))}")
     lines.append("")
     return lines
 
@@ -180,12 +202,21 @@ def render_parameter(name: str, meta: dict) -> tuple[list[str], dict]:
         lines.append("")
         lines.extend(render_values(values))
 
+    # Enough metadata to answer the question in the results list itself. Raw
+    # this is ~900 KB, but it gzips to ~114 KB and Cloudflare compresses on the
+    # wire, so the cost of not needing a page load is small.
     index_entry = {
         "n": name,
         "d": display,
         "u": clean(units) if units else "",
         "r": bool(meta.get("RebootRequired")),
+        "x": clean(meta.get("Description", "")),
+        "lv": clean(user) if user else "",
     }
+    if isinstance(rng, dict) and ("low" in rng or "high" in rng):
+        index_entry["rg"] = f"{clean(rng.get('low', '?'))} to {clean(rng.get('high', '?'))}"
+    if meta.get("Values") or meta.get("Bitmask"):
+        index_entry["opt"] = True
     return lines, index_entry
 
 
@@ -235,9 +266,11 @@ def generate(source: str, vehicle: str, firmware: str) -> None:
             title,
             "=" * len(title),
             "",
-            f"{len(params)} parameters in the ``{group}`` family "
-            f"({vehicle} {firmware}).",
+            f"{len(params)} parameters in the ``{group}`` family. "
+            f"**{vehicle} {firmware} only** — other vehicles share many of these "
+            "names but not always the same ranges or meanings.",
             "",
+            *SEARCH_MARKUP,
         ]
         # NO ".. contents::" here. Furo builds its own "On this page" sidebar
         # from the headings and rejects the directive by rendering a red ERROR
@@ -294,9 +327,10 @@ def generate(source: str, vehicle: str, firmware: str) -> None:
             "=" * len(title),
             "",
             f"{len(entries)} parameter families beginning with {letter} "
-            f"({letter_total} parameters). "
-            ":doc:`Back to the parameter search <index>`.",
+            f"({letter_total} parameters). **{vehicle} {firmware} only.** "
+            ":doc:`Back to the parameter reference <index>`.",
             "",
+            *SEARCH_MARKUP,
         ]
         lines.append(
             " · ".join(
@@ -318,22 +352,13 @@ def generate(source: str, vehicle: str, firmware: str) -> None:
         f"Every {vehicle} {firmware} parameter — **{total}** of them, across "
         f"{len(group_rows)} families. Start typing to find one.",
         "",
-        ".. raw:: html",
+        ".. warning::",
         "",
-        '   <div class="param-search">',
-        '     <input',
-        '       id="param-search-input"',
-        '       type="search"',
-        '       placeholder="e.g. BATT_ or arming or gyro rate"',
-        '       autocomplete="off"',
-        '       autocapitalize="off"',
-        '       spellcheck="false"',
-        '       aria-label="Search parameters"',
-        '     />',
-        '     <p id="param-search-status" class="param-search__status">Loading parameter index…</p>',
-        '     <ol id="param-search-results" class="param-search__results"></ol>',
-        "   </div>",
+        f"   These are **{vehicle} {firmware}** parameters only. Plane, Rover and Sub",
+        "   share many of the same names, but not always the same ranges, defaults or",
+        "   value meanings — do not read this page for another vehicle.",
         "",
+        *SEARCH_MARKUP,
         "Browse by family",
         "----------------",
         "",


### PR DESCRIPTION
## Parameters tab

**Ticking "Show only changed" now fetches the defaults it needs.** The separate Fetch/Refresh-defaults button is gone — fetching defaults was never a goal in itself, it existed *only* so that filter could work, so requiring it as a prerequisite step pushed the app's own bookkeeping onto the operator. Progress shows in the checkbox label. A failed fetch leaves the filter **off** rather than on-but-unfiltered.

**Row state reads as colour** instead of a button tint:

| state | colour |
|---|---|
| staged (typed, not written) | yellow |
| just written (controller confirmed) | green, fades after 4 s |
| invalid | red |

Red stays reserved so a dropped row can use it later, per your note.

**"Just written" didn't exist as a state.** On a successful write the draft simply vanished — visually identical to never having staged it. Added a short-lived recently-written set covering both write paths. It fades out on its own; a permanent green would claim the row is still special long after the fact.

## Wiki parameter reference

- **Search on every parameter page**, sticky — not just the section index.
- **Vehicle scope stated on every page**: these are ArduCopter 4.7 parameters, and other vehicles share names without always sharing ranges or meanings.
- **Results carry metadata inline** — full description, units, range, user level, reboot-required, whether a value list exists — so the list answers "what does this do" without opening a page. Descriptions are searchable too, ranked below name matches so a named parameter always wins. Index goes to ~1.2 MB raw but **~129 KB gzipped**, which is what actually ships.
- **Fixed Values/Bitmask tables rendering as grey inset blockquotes** — the emitted table was indented, which docutils reads as a blockquote.

## On MOT_OPTIONS

It's present upstream and renders correctly on the wiki (bitmask table and all). It shows no metadata **in the app** because it's absent from the hand-curated bundle. That's the metadata-backbone gap, not a wiki bug, and it is **not fixed here** — it's the case that motivates wiring ParameterRepository into the app.

## Validation

Rungs 1–3: **786 node** · **598 vitest** · **229 Playwright e2e**. Sphinx builds 0 errors / 0 warnings.