### PR TITLE
feat(parameters): drop a whole category of staged changes at once

### DIFF
--- a/apps/web/src/sections/ParametersSection.tsx
+++ b/apps/web/src/sections/ParametersSection.tsx
@@ -244,6 +244,21 @@ export function ParametersSection(props: ParametersSectionProps): ReactElement {
     )
     selectionAnchorRef.current = draftId
   }
+  // Drop every staged row in one category. Also clears those ids from the
+  // checkbox selection, so a subsequent "Drop selected" count doesn't include
+  // rows that are already gone.
+  const handleDropDraftGroup = (draftIds: string[]): void => {
+    draftIds.forEach((draftId) => handleDiscardParameterDraft(draftId))
+    setSelectedDraftIds((current) => {
+      if (current.size === 0) {
+        return current
+      }
+      const next = new Set(current)
+      draftIds.forEach((draftId) => next.delete(draftId))
+      return next.size === current.size ? current : next
+    })
+  }
+
   const handleDropSelectedDrafts = (): void => {
     selectedDraftIds.forEach((draftId) => handleDiscardParameterDraft(draftId))
     setSelectedDraftIds(new Set())
@@ -573,6 +588,23 @@ export function ParametersSection(props: ParametersSectionProps): ReactElement {
                   <header>
                     <strong>{formatCategoryLabel(group.category)}</strong>
                     <span>{group.entries.filter((entry) => entry.status === 'staged').length} staged</span>
+                    {/* Drop a whole category at once. The review is already
+                      * grouped by category, so that is the unit an operator
+                      * thinks in when abandoning part of a change set — the
+                      * alternatives were one row at a time, or checkbox-select
+                      * the group by hand before "Drop selected". */}
+                    <div className="parameter-diff-actions parameter-diff-actions--group">
+                      <button
+                        type="button"
+                        style={buttonStyle()}
+                        data-testid={`parameter-diff-drop-group-${group.category}`}
+                        onClick={() => handleDropDraftGroup(group.entries.map((entry) => entry.id))}
+                        disabled={busyAction !== undefined || group.entries.length === 0}
+                        title={`Drop all ${group.entries.length} staged change(s) in ${formatCategoryLabel(group.category)}.`}
+                      >
+                        Drop group
+                      </button>
+                    </div>
                   </header>
 
                   {group.entries.map((draft) => {

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -11114,6 +11114,21 @@ details.metadata-settings-section:not([open]) > summary::after {
   font-size: 12px;
 }
 
+/* A group header carrying an action switches to centre alignment — a button
+   sitting on a text baseline reads as misaligned. The action's margin-left:auto
+   absorbs the free space, so the title and count stay together on the left. */
+.parameter-diff-group header:has(.parameter-diff-actions) {
+  align-items: center;
+}
+
+.parameter-diff-group header .parameter-diff-actions button {
+  text-transform: none;
+  letter-spacing: normal;
+  min-width: 0;
+  padding: 4px 10px;
+  font-size: 11px;
+}
+
 .parameter-diff-item {
   display: grid;
   grid-template-columns: minmax(140px, 1fr) minmax(180px, 1fr) minmax(140px, 0.8fr) auto;

--- a/tests/e2e/views.spec.ts
+++ b/tests/e2e/views.spec.ts
@@ -372,6 +372,34 @@ test.describe('Parameters tab (expert-only)', () => {
     await expect(page.getByTestId('parameter-detail-select-GPS_TYPE')).toHaveValue('5')
   })
 
+  test('dropping a category drops every staged row in it', async ({ page }) => {
+    // The review list is grouped by category, so a category is the unit an
+    // operator thinks in when abandoning part of a change set. Before this the
+    // options were one row at a time, or hand-selecting the group's checkboxes
+    // before "Drop selected".
+    await page.goto('/')
+    await connectViaHeader(page)
+    await page.getByTestId('product-mode-expert').click()
+    await page.getByTestId('view-button-parameters').click()
+
+    // Stage two failsafe params so the group has more than one row.
+    const search = page.getByTestId('parameter-search-input')
+    await search.fill('BATT_LOW_VOLT')
+    await page.locator('input[aria-label="BATT_LOW_VOLT value"]').first().fill('13.5')
+    await search.fill('BATT_CRT_VOLT')
+    await page.locator('input[aria-label="BATT_CRT_VOLT value"]').first().fill('12.9')
+    await search.fill('')
+
+    const dropGroup = page.getByTestId('parameter-diff-drop-group-failsafe')
+    await expect(dropGroup).toBeVisible()
+    await expect(page.getByRole('button', { name: /^Apply All \(2\)/ })).toBeVisible()
+
+    await dropGroup.click()
+    // Both rows gone in one click, and the group header with them.
+    await expect(page.getByRole('button', { name: /^Apply All \(0\)/ })).toBeVisible()
+    await expect(dropGroup).toHaveCount(0)
+  })
+
   test('clicking the row value editor also reveals the metadata detail', async ({ page }) => {
     // The editor cell swallows the row click so editing can never COLLAPSE an
     // expanded row (the control would vanish mid-edit). That also meant a click


### PR DESCRIPTION
The review list is already grouped by category, so a category is the unit an operator thinks in when abandoning part of a change set. Before this the options were one row at a time, or hand-ticking every checkbox in the group and then pressing **Drop selected**.

Each group header gains a **Drop group** button. It also clears those ids from the checkbox selection, so a following `Drop selected (n)` count can't include rows that are already gone.

Mirrors the group stage/drop added to the Snapshots restore preview in #115, so the two review surfaces behave the same way.

## Validation

Rungs 1–2: **786 node** · **598 vitest** · new Playwright case passing (stage two failsafe params, drop the group, both rows and the header go in one click).

**The full e2e suite was not re-run** for this change — only the targeted test.