### PR TITLE
feat(parameters): a backup import no longer auto-stages everything

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -955,7 +955,10 @@ export function App() {
     handleExportParameterBackup,
     handleExportParameterBackupAsParm,
     handleExportParameterBackupAsParams,
-    handleImportParameterBackup
+    handleImportParameterBackup,
+    pendingParameterImport,
+    stagePendingParameterImport,
+    dismissPendingParameterImport
   } = useParameterBackupIo({
     snapshot,
     parameterImportExclusions,
@@ -8663,6 +8666,9 @@ export function App() {
           onExportParameterBackupAsParm={handleExportParameterBackupAsParm}
           onExportParameterBackupAsParams={handleExportParameterBackupAsParams}
           onImportParameterBackup={handleImportParameterBackup}
+          pendingParameterImport={pendingParameterImport}
+          onStagePendingParameterImport={stagePendingParameterImport}
+          onDismissPendingParameterImport={dismissPendingParameterImport}
           onRefreshParameters={() => handleGuidedAction('request-parameters')}
           refreshDisabled={busyAction !== undefined || !canRunGuidedAction(snapshot, 'request-parameters')}
           parameterEnumOverrides={parameterEnumOverrides}

--- a/apps/web/src/hooks/use-parameter-backup-io.ts
+++ b/apps/web/src/hooks/use-parameter-backup-io.ts
@@ -1,13 +1,15 @@
 // Parameter backup import/export I/O. Owns the three "Export Backup"
 // serializers (ArduConfigurator JSON / Mission Planner .parm /
 // QGroundControl .params) and the "Import Backup" file handler that parses a
-// backup, stages the differing values as drafts (honouring the opt-in import
+// backup, holds the differing values as a PENDING import for the operator to
+// stage (honouring the opt-in import
 // exclusions), and scrolls the diff into view.
 //
 // `handleOpenParameterBackup` (a one-line `.click()` on an App-owned <input>
 // ref) lives in App.tsx: the ref is a DOM concern this hook has no need to
 // know about, and none of the logic-bearing handlers touch it.
 
+import { useState } from 'react'
 import type { ChangeEvent, Dispatch, SetStateAction } from 'react'
 
 import {
@@ -44,11 +46,27 @@ export interface UseParameterBackupIoParams {
   setParameterFollowUp: Dispatch<SetStateAction<ParameterFollowUp | undefined>>
 }
 
+/** An import that has been READ but not staged. */
+export interface PendingParameterImport {
+  /** Draft values the import would stage, keyed by param id. */
+  draftValues: ParameterDraftValues
+  /** How many of those differ from the currently synced value. */
+  changedCount: number
+  /** Where it came from, for the prompt copy. */
+  fileName: string
+}
+
 export interface UseParameterBackupIoResult {
   handleExportParameterBackup: () => void
   handleExportParameterBackupAsParm: () => void
   handleExportParameterBackupAsParams: () => void
   handleImportParameterBackup: (event: ChangeEvent<HTMLInputElement>) => Promise<void>
+  /** Set once a file is read; cleared by staging or dismissing it. */
+  pendingParameterImport: PendingParameterImport | undefined
+  /** Stage every value from the pending import. */
+  stagePendingParameterImport: () => void
+  /** Throw the pending import away without staging anything. */
+  dismissPendingParameterImport: () => void
 }
 
 export function useParameterBackupIo({
@@ -60,6 +78,10 @@ export function useParameterBackupIo({
   setParameterNotice,
   setParameterFollowUp
 }: UseParameterBackupIoParams): UseParameterBackupIoResult {
+  // An import used to stage every differing value the instant the file was
+  // read, which turns "let me look at this backup" into a pending write of
+  // hundreds of parameters. Hold it here instead and let the operator decide.
+  const [pendingParameterImport, setPendingParameterImport] = useState<PendingParameterImport>()
   function buildBackupAppInfo(): { appVersion: string; appGitHash: string; appGitBranch: string } {
     return { appVersion: APP_VERSION, appGitHash: GIT_HASH, appGitBranch: GIT_BRANCH }
   }
@@ -123,7 +145,12 @@ export function useParameterBackupIo({
       const restore = deriveDraftValuesFromParameterBackup(snapshot.parameters, backup, {
         excludeCategories
       })
-      replaceDrafts(restore.draftValues)
+      // NOT staged yet — see pendingParameterImport.
+      setPendingParameterImport({
+        draftValues: restore.draftValues,
+        changedCount: restore.changedCount,
+        fileName: file.name
+      })
       setParameterFollowUp(undefined)
       const unknownNote =
         restore.unknownParameterIds.length > 0
@@ -167,7 +194,7 @@ export function useParameterBackupIo({
         tone: isMigration || restore.changedCount > 0 ? 'warning' : 'neutral',
         text:
           restore.changedCount > 0
-            ? `Loaded ${restore.changedCount} differing parameter value(s) from backup — review the staged diff below, then click Apply All to write to the controller.${unknownNote}${excludedNote}${migrationNote}${firmwareMismatchNote}`
+            ? `Read ${restore.changedCount} differing parameter value(s) from backup. Nothing is staged yet — stage all of them, or pick individual ones from the list.${unknownNote}${excludedNote}${migrationNote}${firmwareMismatchNote}`
             : `Backup matched the current synced values.${unknownNote}${excludedNote}${migrationNote}${firmwareMismatchNote}`
       })
       // Auto-scroll the staged diff into view so the operator sees the
@@ -198,6 +225,22 @@ export function useParameterBackupIo({
     handleExportParameterBackup,
     handleExportParameterBackupAsParm,
     handleExportParameterBackupAsParams,
-    handleImportParameterBackup
+    handleImportParameterBackup,
+    pendingParameterImport,
+    stagePendingParameterImport: () => {
+      if (!pendingParameterImport) {
+        return
+      }
+      replaceDrafts(pendingParameterImport.draftValues)
+      setPendingParameterImport(undefined)
+      setParameterNotice({
+        tone: 'warning',
+        text: `Staged ${pendingParameterImport.changedCount} value(s) from ${pendingParameterImport.fileName}. Review the diff, then Apply All to write them.`
+      })
+    },
+    dismissPendingParameterImport: () => {
+      setPendingParameterImport(undefined)
+      setParameterNotice(undefined)
+    }
   }
 }

--- a/apps/web/src/sections/ParametersSection.tsx
+++ b/apps/web/src/sections/ParametersSection.tsx
@@ -9,6 +9,7 @@ import { parameterAlias } from '@arduconfig/ardupilot-core'
 import type { ConfiguratorSnapshot, ParameterDraftEntry, ParameterDraftGroup, ParameterDraftSummary, ParameterImportCategory, ParameterState } from '@arduconfig/ardupilot-core'
 import type { NormalizedFirmwareMetadataBundle } from '@arduconfig/param-metadata'
 import { Panel, StatusBadge, buttonStyle } from '@arduconfig/ui-kit'
+import type { PendingParameterImport } from '../hooks/use-parameter-backup-io'
 
 import {
   formatParameterDelta,
@@ -87,6 +88,10 @@ export interface ParametersSectionProps {
   nonDefaultParamIds: ReadonlySet<string> | null
   /** "Show only changed" — restrict the table (and export) to non-default params. */
   showOnlyNonDefault: boolean
+  /** A backup that has been read but NOT staged. */
+  pendingParameterImport: PendingParameterImport | undefined
+  onStagePendingParameterImport: () => void
+  onDismissPendingParameterImport: () => void
   /** Params verified-written in the last few seconds — briefly flagged green. */
   recentlyWrittenParamIds: ReadonlySet<string>
   onToggleShowOnlyNonDefault: () => void
@@ -142,6 +147,9 @@ export function ParametersSection(props: ParametersSectionProps): ReactElement {
     onRequestReboot: handleRequestReboot,
     nonDefaultParamIds,
     showOnlyNonDefault,
+    pendingParameterImport,
+    onStagePendingParameterImport,
+    onDismissPendingParameterImport,
     recentlyWrittenParamIds,
     onToggleShowOnlyNonDefault: handleToggleShowOnlyNonDefault,
     fetchDefaultsBusy
@@ -516,6 +524,44 @@ export function ParametersSection(props: ParametersSectionProps): ReactElement {
 	              )}
 	            </div>
 	          ) : null}
+
+          {/* An import used to stage every differing value the moment the file
+            * was read, turning "let me look at this backup" into a pending write
+            * of hundreds of parameters. It is held unstaged now, and this is the
+            * prominent way to take it — the operator can also stage individual
+            * rows from the source fields instead. */}
+          {pendingParameterImport ? (
+            <div className="parameter-import-prompt" data-testid="parameter-import-prompt" role="status">
+              <div>
+                <strong>
+                  {pendingParameterImport.changedCount} value
+                  {pendingParameterImport.changedCount === 1 ? '' : 's'} read from{' '}
+                  {pendingParameterImport.fileName}
+                </strong>
+                <small>Nothing is staged yet. Staging only queues the writes — you still review and Apply All.</small>
+              </div>
+              <div className="parameter-import-prompt__actions">
+                <button
+                  type="button"
+                  data-testid="parameter-import-stage-all"
+                  style={buttonStyle('primary')}
+                  onClick={onStagePendingParameterImport}
+                  disabled={busyAction !== undefined || pendingParameterImport.changedCount === 0}
+                >
+                  Stage all ({pendingParameterImport.changedCount})
+                </button>
+                <button
+                  type="button"
+                  data-testid="parameter-import-dismiss"
+                  style={buttonStyle()}
+                  onClick={onDismissPendingParameterImport}
+                  disabled={busyAction !== undefined}
+                >
+                  Discard import
+                </button>
+              </div>
+            </div>
+          ) : null}
 
           {parameterDraftSummary.stagedCategories.length > 0 ? (
             <small className="parameter-review__hint">

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -15863,3 +15863,35 @@ button.mavlink-inspector__sent-row {
     grid-template-columns: minmax(0, 1fr);
   }
 }
+
+/* Pending-import prompt. Sits where the auto-staged diff used to appear, so the
+   "stage all" action is exactly where an operator's eye already goes after
+   choosing a file. */
+.parameter-import-prompt {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  align-items: center;
+  justify-content: space-between;
+  padding: 12px 14px;
+  margin-bottom: 12px;
+  border-radius: 8px;
+  border: 1px solid color-mix(in srgb, var(--warning) 55%, transparent);
+  background: color-mix(in srgb, var(--warning) 10%, transparent);
+}
+
+.parameter-import-prompt strong {
+  display: block;
+}
+
+.parameter-import-prompt small {
+  display: block;
+  margin-top: 2px;
+  color: var(--text-muted);
+}
+
+.parameter-import-prompt__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}

--- a/tests/e2e/views.spec.ts
+++ b/tests/e2e/views.spec.ts
@@ -372,6 +372,37 @@ test.describe('Parameters tab (expert-only)', () => {
     await expect(page.getByTestId('parameter-detail-select-GPS_TYPE')).toHaveValue('5')
   })
 
+  test('importing a backup stages nothing until Stage all is pressed', async ({ page }) => {
+    // An import used to stage every differing value the instant the file was
+    // read, turning "let me look at this backup" into a pending write of
+    // hundreds of parameters.
+    await page.goto('/')
+    await connectViaHeader(page)
+    await page.getByTestId('product-mode-expert').click()
+    await page.getByTestId('view-button-parameters').click()
+    await expectParameterSyncComplete(page)
+
+    // A Mission Planner .parm file — one differing value. Simpler to hand-write
+    // than the app's own JSON schema, and it exercises the same import path.
+    // The testid is the visible button; the file input is the hidden sibling.
+    await page.locator('input[aria-label="Import parameter backup file"]').setInputFiles({
+      name: 'e2e-backup.parm',
+      mimeType: 'text/plain',
+      buffer: Buffer.from('BATT_LOW_VOLT,13.5\n')
+    })
+
+    // Read, but NOT staged.
+    const prompt = page.getByTestId('parameter-import-prompt')
+    await expect(prompt).toBeVisible()
+    await expect(prompt).toContainText('e2e-backup.parm')
+    await expect(page.getByRole('button', { name: /^Apply All \(0\)/ })).toBeVisible()
+
+    // Stage all is the explicit, obvious action.
+    await page.getByTestId('parameter-import-stage-all').click()
+    await expect(page.getByRole('button', { name: /^Apply All \(1\)/ })).toBeVisible()
+    await expect(prompt).toHaveCount(0)
+  })
+
   test('dropping a category drops every staged row in it', async ({ page }) => {
     // The review list is grouped by category, so a category is the unit an
     // operator thinks in when abandoning part of a change set. Before this the


### PR DESCRIPTION
Importing a backup staged **every** differing value the instant the file was read. That turns "let me look at what's in this backup" into a pending write of potentially hundreds of parameters, with the only exit being **Discard All** — and on a cross-vehicle or cross-firmware import, many of those values are ones you wouldn't have chosen.

The import is now held as a **pending** import: read, counted, and checked for board/vehicle/firmware mismatch exactly as before, but not staged.

A prompt sits where the auto-staged diff used to appear — exactly where your eye already goes after choosing a file:

- **Stage all (n)** — stage every value, then review and Apply All as usual
- **Discard import** — throw it away without touching the draft set

Individual values can still be staged one at a time from the source fields, which is the point of not committing to the whole set up front. Staging is still only staging: nothing is written until Apply All.

## Validation

Rungs 1–2: **786 node** · **598 vitest** · new Playwright case (import a `.parm`, assert `Apply All (0)` with the prompt shown, press Stage all, assert `Apply All (1)` and the prompt gone).

**The full e2e suite was not re-run** for this change.