### PR TITLE
fix(import): classify the thermal-cal and CALTEMP families as calibration

### DIFF
--- a/packages/ardupilot-core/src/parameter-backups.ts
+++ b/packages/ardupilot-core/src/parameter-backups.ts
@@ -10,23 +10,42 @@ const SNAPSHOT_COMPARE_TOLERANCE = 0.0001
  *
  * - `calibration` — sensor offsets/scales re-measured per airframe: compass
  *   offsets/diagonals/off-diagonals/motor-comp/scale, accel & gyro offsets and
- *   accel scale, and the AHRS board-level trims. Does NOT touch compass
- *   identity (COMPASS_DEV_ID, PRIO_ID, USE families) or orientation — those
- *   are configuration, not calibration.
+ *   accel scale, the accel/gyro calibration temperatures, the whole thermal
+ *   calibration (INS_TCALn_*) family, and the AHRS board-level trims. Does NOT
+ *   touch compass identity (COMPASS_DEV_ID, PRIO_ID, USE families) or
+ *   orientation — those are configuration, not calibration.
  * - `stream-rates` — the SRn_* MAVLink telemetry stream-rate group.
  * - `mission` — the MIS_* mission parameters.
  */
 export type ParameterImportCategory = 'calibration' | 'stream-rates' | 'mission'
 
+// Cross-checked against ArduPilot's own `Calibration` metadata flag (see
+// tests/parameter-import-exclusions.test.mjs, which asserts every upstream
+// Calibration-flagged id is matched here). That audit found this list was
+// catching only 63 of 192 such parameters: the entire thermal-calibration
+// family (INS_TCALn_*) and every IMU instance 4/5 leaked through, so an
+// "exclude calibrations" import was still carrying 129 per-unit values onto a
+// different airframe.
+//
+// The INS prefix has two shapes upstream — INS_ACC1_CALTEMP (instances 1-3) and
+// INS4_ACC_CALTEMP (instances 4-5) — hence the `INS\d*_` prefix throughout.
 const CALIBRATION_PATTERNS: readonly RegExp[] = [
   /^COMPASS_OFS\d?_[XYZ]$/, // COMPASS_OFS_X/Y/Z, COMPASS_OFS2_*, COMPASS_OFS3_*
   /^COMPASS_DIA\d?_[XYZ]$/,
   /^COMPASS_ODI\d?_[XYZ]$/,
   /^COMPASS_MOT\d?_[XYZ]$/,
+  /^COMPASS_MOTCT$/, // motor-compensation type is measured with the cal
   /^COMPASS_SCALE\d?$/,
-  /^INS_ACC\d?OFFS_[XYZ]$/, // first instance has no digit (INS_ACCOFFS_*)
-  /^INS_ACC\d?SCAL_[XYZ]$/,
-  /^INS_GYR\d?OFFS_[XYZ]$/,
+  /^INS\d*_ACC\d?OFFS_[XYZ]$/, // first instance has no digit (INS_ACCOFFS_*)
+  /^INS\d*_ACC\d?SCAL_[XYZ]$/,
+  /^INS\d*_GYR\d?OFFS_[XYZ]$/,
+  // Temperature the accel/gyro calibration was taken at.
+  /^INS\d*_(ACC|GYR)\d?_CALTEMP$/,
+  // Thermal calibration (TCAL): per-unit coefficients and the temperature range
+  // they were fitted over. Meaningless — and actively misleading — on any other
+  // physical IMU.
+  /^INS\d*_TCAL\d*_(ACC|GYR)\d_[XYZ]$/,
+  /^INS\d*_TCAL\d*_TM(IN|AX)$/,
   /^AHRS_TRIM_[XYZ]$/
 ]
 const STREAM_RATE_PATTERN = /^SR\d+_/

--- a/tests/parameter-import-exclusions.test.mjs
+++ b/tests/parameter-import-exclusions.test.mjs
@@ -175,3 +175,60 @@ test('createParameterBackup leaves opt-in categories out of the exported backup'
   assert.ok(ids(lean).includes('ATC_RAT_RLL_P'), 'tuning kept')
   assert.equal(lean.parameterCount, 2)
 })
+
+// Cross-check the calibration classifier against ArduPilot's OWN metadata.
+// Upstream marks per-unit calibration data with a `Calibration` flag in
+// apm.pdef.json, so that flag is the authority on what "exclude calibrations"
+// must strip — not our recollection of which families exist.
+//
+// This audit is how the gap was found: the hand-written pattern list matched
+// only 63 of 192 flagged parameters. The entire thermal-calibration family
+// (INS_TCALn_*) and every IMU instance 4/5 leaked through, so a cross-board
+// restore with "exclude calibrations" ticked still carried 129 per-unit values
+// onto a different airframe — silently, since nothing reports what a filter
+// failed to catch.
+test('the calibration classifier covers every parameter ArduPilot flags as calibration', async () => {
+  const { readFileSync, existsSync } = await import('node:fs')
+  const { fileURLToPath } = await import('node:url')
+  const path = await import('node:path')
+
+  const pinned = path.resolve(
+    path.dirname(fileURLToPath(import.meta.url)),
+    '..',
+    'wiki',
+    'data',
+    'apm.pdef.Copter-4.7.json'
+  )
+  // The wiki's pinned upstream metadata doubles as the reference set here.
+  assert.ok(existsSync(pinned), `missing pinned upstream metadata: ${pinned}`)
+
+  const payload = JSON.parse(readFileSync(pinned, 'utf8'))
+  const flagged = []
+  for (const params of Object.values(payload)) {
+    if (!params || typeof params !== 'object') continue
+    for (const [id, meta] of Object.entries(params)) {
+      if (meta && typeof meta === 'object' && meta.Calibration) flagged.push(id)
+    }
+  }
+  assert.ok(flagged.length > 150, `expected the full flagged set, saw ${flagged.length}`)
+
+  const missed = flagged.filter((id) => parameterImportExclusionCategory(id) !== 'calibration')
+  assert.deepEqual(
+    missed.sort().slice(0, 10),
+    [],
+    `${missed.length} calibration parameter(s) would survive an "exclude calibrations" import`
+  )
+})
+
+test('configuration parameters that merely live in a calibration family are NOT excluded', () => {
+  // The boundary matters in both directions: TCAL_ENABLE turns the thermal
+  // calibration on and is a per-build choice, so stripping it from an import
+  // would silently disable a feature the operator asked for.
+  for (const id of ['INS_TCAL1_ENABLE', 'INS_TCAL_OPTIONS', 'AHRS_ORIENTATION', 'COMPASS_DEV_ID', 'COMPASS_USE']) {
+    assert.notEqual(
+      parameterImportExclusionCategory(id),
+      'calibration',
+      `${id} is configuration, not calibration`
+    )
+  }
+})


### PR DESCRIPTION
You flagged `INS*CALTEMP` as calibration data. It is — and auditing the classifier against ArduPilot's own metadata showed the gap was far wider.

## The audit

Upstream marks per-unit calibration data with a `Calibration` flag in `apm.pdef.json`. Cross-checking our pattern list against it: **63 of 192** flagged parameters matched.

The **129** that leaked:

- accel/gyro calibration temperatures — `INS_ACCn_CALTEMP` / `INSn_ACC_CALTEMP` (what you spotted)
- the **entire thermal calibration family** — `INS_TCALn_ACCn_[XYZ]`, the GYR equivalents, and the `TMIN`/`TMAX` range they were fitted over
- every offset/scale on **IMU instances 4 and 5**
- `COMPASS_MOTCT`

So an import with **"exclude calibrations" ticked** was still carrying 129 per-unit values onto a different airframe — one IMU's thermal coefficients and calibration temperatures applied to different physical hardware. Silently, because nothing reports what a filter *failed* to catch.

The root cause of the second group: the INS prefix has two shapes upstream — `INS_ACC1_CALTEMP` for instances 1–3, `INS4_ACC_CALTEMP` for 4–5 — so patterns anchored on `INS_` missed half of them.

## Guard

A new test walks the pinned upstream metadata and asserts **every** `Calibration`-flagged id classifies as calibration, so this can't drift again. Plus one asserting the boundary in the other direction: `INS_TCAL1_ENABLE`, `INS_TCAL_OPTIONS`, `AHRS_ORIENTATION`, `COMPASS_DEV_ID`, `COMPASS_USE` are configuration and must **not** be stripped — silently disabling a feature the operator asked for is the opposite failure.

## Invariant

ArduCopter runtime behaviour unchanged. This only affects which values an **opt-in** import filter drops; nothing is excluded unless you tick it.

## Validation

Rungs 1–2: **788 node** (2 new) · **598 vitest** · typecheck clean. Full e2e not re-run — this path has no e2e surface.