### PR TITLE
refactor(params/snapshots): share the diff-review actions, fixing a divergence bug

### DIFF
--- a/apps/web/src/sections/ParametersSection.tsx
+++ b/apps/web/src/sections/ParametersSection.tsx
@@ -10,6 +10,12 @@ import type { ConfiguratorSnapshot, ParameterDraftEntry, ParameterDraftGroup, Pa
 import type { NormalizedFirmwareMetadataBundle } from '@arduconfig/param-metadata'
 import { Panel, StatusBadge, buttonStyle } from '@arduconfig/ui-kit'
 import type { PendingParameterImport } from '../hooks/use-parameter-backup-io'
+import {
+  isOverridableInvalidEntry,
+  overridableInvalidParamIds,
+  paramIdsForGroup
+} from '../view-models/parameter-diff-actions'
+import { ParameterDiffGroupActions } from '../views/ParameterDiffGroupActions'
 
 import {
   formatParameterDelta,
@@ -255,6 +261,11 @@ export function ParametersSection(props: ParametersSectionProps): ReactElement {
   // Drop every staged row in one category. Also clears those ids from the
   // checkbox selection, so a subsequent "Drop selected" count doesn't include
   // rows that are already gone.
+  // Invalid rows in a group that an override can still rescue, excluding ones
+  // already overridden — shared with the Snapshots restore preview.
+  const overridableGroupIds = (group: ParameterDraftGroup): string[] =>
+    overridableInvalidParamIds(group.entries, parameterEnumOverrides)
+
   const handleDropDraftGroup = (draftIds: string[]): void => {
     draftIds.forEach((draftId) => handleDiscardParameterDraft(draftId))
     setSelectedDraftIds((current) => {
@@ -636,21 +647,20 @@ export function ParametersSection(props: ParametersSectionProps): ReactElement {
                     <span>{group.entries.filter((entry) => entry.status === 'staged').length} staged</span>
                     {/* Drop a whole category at once. The review is already
                       * grouped by category, so that is the unit an operator
-                      * thinks in when abandoning part of a change set — the
-                      * alternatives were one row at a time, or checkbox-select
-                      * the group by hand before "Drop selected". */}
-                    <div className="parameter-diff-actions parameter-diff-actions--group">
-                      <button
-                        type="button"
-                        style={buttonStyle()}
-                        data-testid={`parameter-diff-drop-group-${group.category}`}
-                        onClick={() => handleDropDraftGroup(group.entries.map((entry) => entry.id))}
-                        disabled={busyAction !== undefined || group.entries.length === 0}
-                        title={`Drop all ${group.entries.length} staged change(s) in ${formatCategoryLabel(group.category)}.`}
-                      >
-                        Drop group
-                      </button>
-                    </div>
+                      * thinks in when abandoning part of a change set. Shares the
+                      * group-action component with the Snapshots restore preview
+                      * so both review surfaces behave identically. */}
+                    <ParameterDiffGroupActions
+                      actions={[
+                        {
+                          label: 'Drop group',
+                          testId: `parameter-diff-drop-group-${group.category}`,
+                          onClick: () => handleDropDraftGroup(paramIdsForGroup(group)),
+                          disabled: busyAction !== undefined || group.entries.length === 0,
+                          title: `Drop all ${group.entries.length} staged change(s) in ${formatCategoryLabel(group.category)}.`
+                        }
+                      ]}
+                    />
                   </header>
 
                   {group.entries.map((draft) => {
@@ -760,6 +770,36 @@ export function ParametersSection(props: ParametersSectionProps): ReactElement {
                   <header>
                     <strong>{formatCategoryLabel(group.category)}</strong>
                     <span>{group.entries.length} invalid</span>
+                    {/* Bulk override, matching the Snapshots restore preview — a
+                      * cross-board import blocked by a handful of metadata-range
+                      * rejections should not need a click per row. Counts only
+                      * rows an override can actually rescue, so the number never
+                      * over-promises. */}
+                    <ParameterDiffGroupActions
+                      actions={[
+                        ...(overridableGroupIds(group).length > 0
+                          ? [
+                              {
+                                label: `Override all (${overridableGroupIds(group).length})`,
+                                testId: `parameter-diff-override-group-${group.category}`,
+                                onClick: () =>
+                                  overridableGroupIds(group).forEach((paramId) =>
+                                    handleToggleParameterEnumOverride(paramId)
+                                  ),
+                                disabled: busyAction !== undefined,
+                                title: 'Override and write anyway for every rescuable value in this category.'
+                              }
+                            ]
+                          : []),
+                        {
+                          label: 'Drop group',
+                          testId: `parameter-diff-drop-invalid-group-${group.category}`,
+                          onClick: () => handleDropDraftGroup(paramIdsForGroup(group)),
+                          disabled: busyAction !== undefined || group.entries.length === 0,
+                          title: `Drop all ${group.entries.length} invalid draft(s) in ${formatCategoryLabel(group.category)}.`
+                        }
+                      ]}
+                    />
                   </header>
 
                   {group.entries.map((draft) => {
@@ -768,11 +808,12 @@ export function ParametersSection(props: ParametersSectionProps): ReactElement {
                     // Non-numeric input ("Value must be numeric.") stays
                     // hard-invalid — that's a syntax problem, not a metadata
                     // disagreement the user can vouch for.
-                    const reason = draft.reason ?? ''
-                    const isOverridableValidation =
-                      reason === 'Value is outside the known enum values for this parameter.' ||
-                      reason.startsWith('Value is below the documented minimum of') ||
-                      reason.startsWith('Value is above the documented maximum of')
+                    // Reads the core's `overridable` flag. This used to
+                    // string-match the reason text the validator writes, so
+                    // rewording a message in parameter-drafts.ts would have
+                    // silently removed the Override button here while the
+                    // Snapshots preview (which reads the flag) kept it.
+                    const isOverridableValidation = isOverridableInvalidEntry(draft)
                     return (
                       <div key={draft.id} className="parameter-diff-item">
                         <span>

--- a/apps/web/src/sections/SnapshotsSection.tsx
+++ b/apps/web/src/sections/SnapshotsSection.tsx
@@ -37,6 +37,8 @@ import { describeBitmaskDraftValue, formatParameterDelta, formatParameterValue }
 import type { SavedParameterSnapshot } from '../snapshot-library'
 import type { SavedProvisioningProfile } from '../provisioning-library'
 import { SnapshotsView } from '../views/Snapshots'
+import { overridableInvalidParamIds, paramIdsForGroup } from '../view-models/parameter-diff-actions'
+import { ParameterDiffGroupActions } from '../views/ParameterDiffGroupActions'
 
 /**
  * The full STM32 UID is a 24-hex (96-bit) string — too wide for a
@@ -320,9 +322,10 @@ export function SnapshotsSection(props: SnapshotsSectionProps): ReactElement {
   // an override; a param missing from the sync or a non-numeric draft cannot.
   // Drives both the per-row affordance and the "Override all (n)" count, so the
   // count never promises more than it can deliver.
-  const selectedSnapshotOverridableInvalidIds = selectedSnapshotInvalidEntries
-    .filter((entry) => entry.overridable === true && !parameterEnumOverrides.has(entry.id))
-    .map((entry) => entry.id)
+  const selectedSnapshotOverridableInvalidIds = overridableInvalidParamIds(
+    selectedSnapshotInvalidEntries,
+    parameterEnumOverrides
+  )
 
   return (
 
@@ -841,33 +844,28 @@ export function SnapshotsSection(props: SnapshotsSectionProps): ReactElement {
                           {/* Group-level Stage/Drop. The preview is already
                            *  grouped by category, so a whole group is the
                            *  natural unit for a partial restore — clicking 30
-                           *  Tuning rows one at a time was the real cost. */}
-                          <div className="parameter-diff-actions parameter-diff-actions--group">
-                            <button
-                              type="button"
-                              style={buttonStyle()}
-                              data-testid={`snapshot-diff-stage-group-${group.category}`}
-                              onClick={() => handleApplySnapshotGroup(group.entries)}
-                              disabled={busyAction !== undefined || !snapshotRestoreAcknowledged}
-                              title={
-                                snapshotRestoreAcknowledged
+                           *  Tuning rows one at a time was the real cost.
+                           *  Shares the component with the Parameters tab. */}
+                          <ParameterDiffGroupActions
+                            actions={[
+                              {
+                                label: 'Stage group',
+                                testId: `snapshot-diff-stage-group-${group.category}`,
+                                onClick: () => handleApplySnapshotGroup(group.entries),
+                                disabled: busyAction !== undefined || !snapshotRestoreAcknowledged,
+                                title: snapshotRestoreAcknowledged
                                   ? `Stage all ${group.entries.length} ${formatCategoryLabel(group.category)} change(s) as drafts.`
                                   : 'Acknowledge the overwrite warning below first.'
+                              },
+                              {
+                                label: 'Drop group',
+                                testId: `snapshot-diff-drop-group-${group.category}`,
+                                onClick: () => handleDropSnapshotGroup(paramIdsForGroup(group)),
+                                disabled: busyAction !== undefined,
+                                title: `Drop all ${group.entries.length} ${formatCategoryLabel(group.category)} change(s) from this restore.`
                               }
-                            >
-                              Stage group
-                            </button>
-                            <button
-                              type="button"
-                              style={buttonStyle()}
-                              data-testid={`snapshot-diff-drop-group-${group.category}`}
-                              onClick={() => handleDropSnapshotGroup(group.entries.map((entry) => entry.id))}
-                              disabled={busyAction !== undefined}
-                              title={`Drop all ${group.entries.length} ${formatCategoryLabel(group.category)} change(s) from this restore.`}
-                            >
-                              Drop group
-                            </button>
-                          </div>
+                            ]}
+                          />
                         </header>
 
                         {group.entries.map((draft) => (
@@ -963,18 +961,17 @@ export function SnapshotsSection(props: SnapshotsSectionProps): ReactElement {
                          *  cross-board restore, which is exactly when a
                          *  handful of rows block "Write all". */}
                         {selectedSnapshotOverridableInvalidIds.length > 0 ? (
-                          <div className="parameter-diff-actions parameter-diff-actions--group">
-                            <button
-                              type="button"
-                              style={buttonStyle()}
-                              data-testid="snapshot-diff-override-all"
-                              onClick={() => handleOverrideAllSnapshotInvalid(selectedSnapshotOverridableInvalidIds)}
-                              disabled={busyAction !== undefined}
-                              title={`Override and write anyway for all ${selectedSnapshotOverridableInvalidIds.length} rescuable value(s), so they stop blocking the write.`}
-                            >
-                              Override all ({selectedSnapshotOverridableInvalidIds.length})
-                            </button>
-                          </div>
+                          <ParameterDiffGroupActions
+                            actions={[
+                              {
+                                label: `Override all (${selectedSnapshotOverridableInvalidIds.length})`,
+                                testId: 'snapshot-diff-override-all',
+                                onClick: () => handleOverrideAllSnapshotInvalid(selectedSnapshotOverridableInvalidIds),
+                                disabled: busyAction !== undefined,
+                                title: `Override and write anyway for all ${selectedSnapshotOverridableInvalidIds.length} rescuable value(s), so they stop blocking the write.`
+                              }
+                            ]}
+                          />
                         ) : null}
                       </header>
 

--- a/apps/web/src/view-models/parameter-diff-actions.test.ts
+++ b/apps/web/src/view-models/parameter-diff-actions.test.ts
@@ -1,0 +1,77 @@
+import type { ParameterDraftEntry, ParameterDraftGroup } from '@arduconfig/ardupilot-core'
+import { describe, expect, it } from 'vitest'
+
+import {
+  isOverridableInvalidEntry,
+  overridableInvalidParamIds,
+  paramIdsForGroup,
+  stageableDraftValues
+} from './parameter-diff-actions'
+
+function entry(over: Partial<ParameterDraftEntry> & { id: string }): ParameterDraftEntry {
+  return {
+    label: over.id,
+    category: 'general',
+    rawValue: '1',
+    status: 'staged',
+    ...over
+  } as ParameterDraftEntry
+}
+
+describe('overridableInvalidParamIds', () => {
+  it('returns only invalid rows the core marks overridable', () => {
+    // The flag is the authority. The Parameters tab used to string-match the
+    // reason text instead, so rewording a validator message would silently
+    // remove its Override button.
+    const ids = overridableInvalidParamIds(
+      [
+        entry({ id: 'RANGE_LOW', status: 'invalid', overridable: true }),
+        entry({ id: 'NON_NUMERIC', status: 'invalid', overridable: false }),
+        entry({ id: 'MISSING', status: 'invalid' }),
+        entry({ id: 'FINE', status: 'staged', overridable: true })
+      ],
+      new Set()
+    )
+    expect(ids).toEqual(['RANGE_LOW'])
+  })
+
+  it('excludes rows already overridden, so a bulk count never over-promises', () => {
+    const entries = [
+      entry({ id: 'A', status: 'invalid', overridable: true }),
+      entry({ id: 'B', status: 'invalid', overridable: true })
+    ]
+    expect(overridableInvalidParamIds(entries, new Set(['A']))).toEqual(['B'])
+    expect(overridableInvalidParamIds(entries, new Set(['A', 'B']))).toEqual([])
+  })
+})
+
+describe('isOverridableInvalidEntry', () => {
+  it('is true only for an invalid row flagged overridable', () => {
+    expect(isOverridableInvalidEntry(entry({ id: 'X', status: 'invalid', overridable: true }))).toBe(true)
+    expect(isOverridableInvalidEntry(entry({ id: 'X', status: 'invalid', overridable: false }))).toBe(false)
+    // A staged row is not an override candidate even if the flag lingers.
+    expect(isOverridableInvalidEntry(entry({ id: 'X', status: 'staged', overridable: true }))).toBe(false)
+  })
+})
+
+describe('paramIdsForGroup', () => {
+  it('lists every id in the group', () => {
+    const group = { category: 'tuning', entries: [entry({ id: 'A' }), entry({ id: 'B' })] } as ParameterDraftGroup
+    expect(paramIdsForGroup(group)).toEqual(['A', 'B'])
+  })
+})
+
+describe('stageableDraftValues', () => {
+  it('keys resolved next values for mergeDrafts', () => {
+    expect(stageableDraftValues([entry({ id: 'A', nextValue: 4 }), entry({ id: 'B', nextValue: 0 })])).toEqual({
+      A: '4',
+      B: '0'
+    })
+  })
+
+  it('skips rows with no resolved value rather than staging an empty string', () => {
+    // Staging '' would turn an unreadable row into an invalid draft that then
+    // blocks the whole write.
+    expect(stageableDraftValues([entry({ id: 'A', nextValue: 2 }), entry({ id: 'NOPE' })])).toEqual({ A: '2' })
+  })
+})

--- a/apps/web/src/view-models/parameter-diff-actions.ts
+++ b/apps/web/src/view-models/parameter-diff-actions.ts
@@ -1,0 +1,56 @@
+// Shared logic for the two parameter-diff review surfaces: the Parameters tab's
+// staged/invalid grids and the Snapshots restore preview.
+//
+// Both render the same shape — groups of ParameterDraftEntry rows with per-row
+// and per-group actions — and both had grown their own copy of the same
+// decisions. That divergence was not free: the Parameters tab decided whether a
+// row could be overridden by STRING-MATCHING the reason text the core writes
+// ("Value is below the documented minimum of…"), so rewording a message in
+// parameter-drafts.ts would have silently removed its Override button, while
+// Snapshots used the `overridable` flag the core actually exposes.
+//
+// Pure functions over draft entries — no React, no app state.
+
+import type { ParameterDraftEntry, ParameterDraftGroup } from '@arduconfig/ardupilot-core'
+
+/**
+ * Invalid rows an operator's "Override and write anyway" can actually rescue,
+ * excluding any that are already overridden.
+ *
+ * `overridable` comes from the core's own validation (true for the
+ * metadata-derived rejections — below-minimum, above-maximum, enum-mismatch;
+ * false for a missing param or a non-numeric value, which no override fixes).
+ * Reading the flag instead of the message means the two surfaces cannot drift
+ * from each other or from the validator.
+ */
+export function overridableInvalidParamIds(
+  entries: readonly ParameterDraftEntry[],
+  alreadyOverridden: ReadonlySet<string>
+): string[] {
+  return entries
+    .filter((entry) => entry.status === 'invalid' && entry.overridable === true && !alreadyOverridden.has(entry.id))
+    .map((entry) => entry.id)
+}
+
+/** Whether a single row should offer the override affordance at all. */
+export function isOverridableInvalidEntry(entry: ParameterDraftEntry): boolean {
+  return entry.status === 'invalid' && entry.overridable === true
+}
+
+/** Every param id in a group — the unit both surfaces drop/stage by. */
+export function paramIdsForGroup(group: ParameterDraftGroup): string[] {
+  return group.entries.map((entry) => entry.id)
+}
+
+/**
+ * Draft values for the rows in a group that can actually be staged, keyed for
+ * mergeDrafts. Rows without a resolved next value (an unparseable or missing
+ * entry) are skipped rather than staged as empty strings.
+ */
+export function stageableDraftValues(entries: readonly ParameterDraftEntry[]): Record<string, string> {
+  return Object.fromEntries(
+    entries
+      .filter((entry) => entry.nextValue !== undefined)
+      .map((entry) => [entry.id, String(entry.nextValue)])
+  )
+}

--- a/apps/web/src/views/ParameterDiffGroupActions.tsx
+++ b/apps/web/src/views/ParameterDiffGroupActions.tsx
@@ -1,0 +1,53 @@
+// Per-group actions on a parameter-diff group header, shared by the Parameters
+// tab's review grids and the Snapshots restore preview.
+//
+// Both surfaces render the same group header — title, count, then stage/drop
+// buttons pinned to the trailing edge — and both had their own copy of that
+// markup, its testids, and its disabled logic. Sharing it keeps the two review
+// surfaces behaving identically, which matters because an operator moves between
+// them doing the same job.
+//
+// Dumb presentational component: it takes labels and callbacks and owns no state.
+
+import type { ReactElement } from 'react'
+
+import { buttonStyle } from '@arduconfig/ui-kit'
+
+export interface ParameterDiffGroupAction {
+  label: string
+  /** Appended to `parameter-diff-` for the data-testid. */
+  testId: string
+  onClick: () => void
+  disabled?: boolean
+  title?: string
+  tone?: 'primary' | 'secondary'
+}
+
+export interface ParameterDiffGroupActionsProps {
+  actions: readonly ParameterDiffGroupAction[]
+}
+
+export function ParameterDiffGroupActions({ actions }: ParameterDiffGroupActionsProps): ReactElement | null {
+  const visible = actions.filter((action) => action !== undefined)
+  if (visible.length === 0) {
+    return null
+  }
+
+  return (
+    <div className="parameter-diff-actions parameter-diff-actions--group">
+      {visible.map((action) => (
+        <button
+          key={action.testId}
+          type="button"
+          data-testid={action.testId}
+          style={buttonStyle(action.tone)}
+          onClick={action.onClick}
+          disabled={action.disabled}
+          title={action.title}
+        >
+          {action.label}
+        </button>
+      ))}
+    </div>
+  )
+}


### PR DESCRIPTION
You suggested cleanup and more sharing between Snapshots and Parameters. Doing it surfaced a latent bug.

## The bug the duplication was hiding

Both surfaces render the same thing — groups of `ParameterDraftEntry` rows with per-row and per-group actions — and each had grown its own copy of the decisions behind them.

The Parameters tab decided whether an invalid row could be overridden by **string-matching the reason text the validator writes**:

```js
reason === 'Value is outside the known enum values for this parameter.' ||
reason.startsWith('Value is below the documented minimum of') || …
```

Snapshots reads the `overridable` boolean the core exposes for exactly this purpose. So **rewording any message in `parameter-drafts.ts` would have silently removed the Override button from the Parameters tab** while leaving it on the Snapshots preview — no test, no type error, no warning.

## Extracted

**`view-models/parameter-diff-actions.ts`** — pure helpers, co-located tests:
- `overridableInvalidParamIds` — flag-based; excludes already-overridden rows so a bulk count never over-promises
- `isOverridableInvalidEntry`
- `paramIdsForGroup`
- `stageableDraftValues` — skips rows with no resolved value rather than staging an empty string, which would turn an unreadable row into a write-blocking invalid draft

**`views/ParameterDiffGroupActions.tsx`** — the group-header action buttons. Three hand-rolled copies of that markup, its testids and its disabled logic became one component; both sections now have **zero**.

## Falls out of the sharing

The Parameters tab gains the **Override all (n)** bulk action the Snapshots preview already had, on each invalid group, plus a group drop on invalid groups. A cross-board import blocked by a handful of metadata-range rejections no longer needs a click per row.

Line count goes up (+97/−59) because of that added feature and the comments — the duplication itself is consolidated.

## Validation

Rungs 1–3: **788 node** · **604 vitest** (6 new on the extracted helpers) · **231 Playwright e2e** (full suite, not just the affected specs — this touches both sections).

No behaviour change to the shared paths. ArduCopter unaffected — review UI only.