### PR TITLE
refactor(params/snapshots): share the diff row shells between both review surfaces

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -251,6 +251,7 @@ import type {
 } from './app-types'
 import { AP_PERIPH_PARAM_METADATA } from './view-models/ap-periph-param-metadata'
 import { parseParamPck } from './view-models/param-pck'
+import { stageableDraftValues } from './view-models/parameter-diff-actions'
 import { createMotorPreviewNodes } from './view-models/motor-preview'
 import { deriveCanEnablement } from './view-models/can-enablement'
 import { deriveBoardOrientationVisual } from './view-models/board-orientation-visual'
@@ -8004,16 +8005,19 @@ export function App() {
             },
             // Group-level Stage/Drop over one category of the restore diff.
             handleApplySnapshotGroup: (entries) => {
-              const stageable = entries.filter((entry) => entry.nextValue !== undefined)
-              if (stageable.length === 0) {
+              // stageableDraftValues is shared with the Parameters review: it
+              // skips rows with no resolved value rather than staging an empty
+              // string, which would turn an unreadable row into an invalid
+              // draft that then blocks the whole write.
+              const values = stageableDraftValues(entries)
+              const count = Object.keys(values).length
+              if (count === 0) {
                 return
               }
-              mergeDrafts(
-                Object.fromEntries(stageable.map((entry) => [entry.id, String(entry.nextValue)]))
-              )
+              mergeDrafts(values)
               setSnapshotNotice({
                 tone: 'warning',
-                text: `Staged ${stageable.length} change(s) as drafts. Write all from the draft bar to apply them.`
+                text: `Staged ${count} change(s) as drafts. Write all from the draft bar to apply them.`
               })
             },
             handleDropSnapshotGroup: (paramIds) => {

--- a/apps/web/src/sections/ParametersSection.tsx
+++ b/apps/web/src/sections/ParametersSection.tsx
@@ -16,6 +16,7 @@ import {
   paramIdsForGroup
 } from '../view-models/parameter-diff-actions'
 import { ParameterDiffGroupActions } from '../views/ParameterDiffGroupActions'
+import { ParameterDiffIdentity, ParameterDiffInvalidRow } from '../views/ParameterDiffRow'
 
 import {
   formatParameterDelta,
@@ -699,10 +700,7 @@ export function ParametersSection(props: ParametersSectionProps): ReactElement {
                         onClick={(event) => handleDraftSelectionClick(draft.id, event.shiftKey)}
                         onChange={() => {}}
                       />
-                      <span>
-                        <strong>{draft.id}</strong>
-                        <small>{draft.label}</small>
-                      </span>
+                      <ParameterDiffIdentity draft={draft} />
                       <span className="parameter-diff-values">
                         <em>Current:</em> {formatParameterDraftValue(draft.definition, draft.currentValue)}
                         {' → '}
@@ -813,43 +811,40 @@ export function ParametersSection(props: ParametersSectionProps): ReactElement {
                     // rewording a message in parameter-drafts.ts would have
                     // silently removed the Override button here while the
                     // Snapshots preview (which reads the flag) kept it.
-                    const isOverridableValidation = isOverridableInvalidEntry(draft)
                     return (
-                      <div key={draft.id} className="parameter-diff-item">
-                        <span>
-                          <strong>{draft.id}</strong>
-                          <small>{draft.label}</small>
-                        </span>
-                        <span className="parameter-diff-values">{draft.rawValue || 'Empty draft'}</span>
-                        <span className="parameter-diff-delta">{draft.reason ?? 'Invalid value'}</span>
-                        <div className="parameter-diff-item__actions">
-                          {isOverridableValidation ? (
+                      <ParameterDiffInvalidRow
+                        key={draft.id}
+                        draft={draft}
+                        actions={
+                          <>
+                            {isOverridableInvalidEntry(draft) ? (
+                              <button
+                                type="button"
+                                data-testid={`parameter-diff-override-${draft.id}`}
+                                style={buttonStyle()}
+                                onClick={() => handleToggleParameterEnumOverride(draft.id)}
+                                disabled={busyAction !== undefined}
+                                title="Treat this value as valid and let it write through — useful when the firmware accepts a value the metadata's documented range or enum doesn't yet include."
+                              >
+                                Override and write anyway
+                              </button>
+                            ) : null}
+                            {/* Every invalid row offers Drop — same contract
+                                as staged rows — so the operator can dismiss a
+                                bad draft without first having to fix it. */}
                             <button
                               type="button"
-                              data-testid={`parameter-diff-override-${draft.id}`}
+                              data-testid={`parameter-diff-discard-${draft.id}`}
                               style={buttonStyle()}
-                              onClick={() => handleToggleParameterEnumOverride(draft.id)}
+                              onClick={() => handleDiscardParameterDraft(draft.id)}
                               disabled={busyAction !== undefined}
-                              title="Treat this value as valid and let it write through — useful when the firmware accepts a value the metadata's documented range or enum doesn't yet include."
+                              title={`Drop the invalid draft to ${draft.id} (clears the local edit; keeps the live FC value as-is).`}
                             >
-                              Override and write anyway
+                              Drop
                             </button>
-                          ) : null}
-                          {/* Every invalid row offers Drop — same contract
-                              as staged rows — so the operator can dismiss a
-                              bad draft without first having to fix it. */}
-                          <button
-                            type="button"
-                            data-testid={`parameter-diff-discard-${draft.id}`}
-                            style={buttonStyle()}
-                            onClick={() => handleDiscardParameterDraft(draft.id)}
-                            disabled={busyAction !== undefined}
-                            title={`Drop the invalid draft to ${draft.id} (clears the local edit; keeps the live FC value as-is).`}
-                          >
-                            Drop
-                          </button>
-                        </div>
-                      </div>
+                          </>
+                        }
+                      />
                     )
                   })}
                 </section>

--- a/apps/web/src/sections/SnapshotsSection.tsx
+++ b/apps/web/src/sections/SnapshotsSection.tsx
@@ -37,8 +37,13 @@ import { describeBitmaskDraftValue, formatParameterDelta, formatParameterValue }
 import type { SavedParameterSnapshot } from '../snapshot-library'
 import type { SavedProvisioningProfile } from '../provisioning-library'
 import { SnapshotsView } from '../views/Snapshots'
-import { overridableInvalidParamIds, paramIdsForGroup } from '../view-models/parameter-diff-actions'
+import {
+  isOverridableInvalidEntry,
+  overridableInvalidParamIds,
+  paramIdsForGroup
+} from '../view-models/parameter-diff-actions'
 import { ParameterDiffGroupActions } from '../views/ParameterDiffGroupActions'
+import { ParameterDiffIdentity, ParameterDiffInvalidRow } from '../views/ParameterDiffRow'
 
 /**
  * The full STM32 UID is a 24-hex (96-bit) string — too wide for a
@@ -870,10 +875,7 @@ export function SnapshotsSection(props: SnapshotsSectionProps): ReactElement {
 
                         {group.entries.map((draft) => (
                           <div key={draft.id} className="parameter-diff-item">
-                            <span>
-                              <strong>{draft.id}</strong>
-                              <small>{draft.label}</small>
-                            </span>
+                            <ParameterDiffIdentity draft={draft} />
                             <span className="parameter-diff-values">
                               {formatParameterValue(draft.currentValue, draft.definition?.unit)} to{' '}
                               {formatParameterValue(draft.nextValue, draft.definition?.unit)}
@@ -976,52 +978,50 @@ export function SnapshotsSection(props: SnapshotsSectionProps): ReactElement {
                       </header>
 
                       {selectedSnapshotInvalidEntries.map((draft) => (
-                        <div key={draft.id} className="parameter-diff-item">
-                          <span>
-                            <strong>{draft.id}</strong>
-                            <small>{draft.label}</small>
-                          </span>
-                          <span className="parameter-diff-values">{draft.rawValue || 'Empty draft'}</span>
-                          <span className="parameter-diff-delta">{draft.reason ?? 'Invalid value'}</span>
-                          <div className="parameter-diff-actions">
-                            {/* Override without leaving Snapshots. Previously
-                             *  the only route was: tick "also stage these" →
-                             *  Show changes → Parameters tab → re-find each row
-                             *  → override it there. Offered only when an
-                             *  override can actually rescue the row (min / max
-                             *  / enum); a missing param or a non-numeric draft
-                             *  is not rescuable by any override. */}
-                            {draft.overridable ? (
+                        <ParameterDiffInvalidRow
+                          key={draft.id}
+                          draft={draft}
+                          actions={
+                            <>
+                              {/* Override without leaving Snapshots. Previously
+                               *  the only route was: tick "also stage these" →
+                               *  Show changes → Parameters tab → re-find each
+                               *  row → override it there. Offered only when an
+                               *  override can actually rescue the row (min /
+                               *  max / enum); a missing param or a non-numeric
+                               *  draft is not rescuable by any override. */}
+                              {isOverridableInvalidEntry(draft) ? (
+                                <button
+                                  type="button"
+                                  style={buttonStyle(parameterEnumOverrides.has(draft.id) ? 'secondary' : undefined)}
+                                  data-testid={`snapshot-diff-override-${draft.id}`}
+                                  onClick={() => handleToggleParameterEnumOverride(draft.id)}
+                                  disabled={busyAction !== undefined}
+                                  title={
+                                    parameterEnumOverrides.has(draft.id)
+                                      ? `Remove the override for ${draft.id} and flag it invalid again.`
+                                      : `Override and write anyway for ${draft.id} — the documented range/enum may lag this firmware.`
+                                  }
+                                >
+                                  {parameterEnumOverrides.has(draft.id) ? 'Overridden' : 'Override'}
+                                </button>
+                              ) : null}
+                              {/* Every invalid row offers Drop — same contract
+                                  as Parameters — so the operator can dismiss a
+                                  bad restore value without first fixing it. */}
                               <button
                                 type="button"
-                                style={buttonStyle(parameterEnumOverrides.has(draft.id) ? 'secondary' : undefined)}
-                                data-testid={`snapshot-diff-override-${draft.id}`}
-                                onClick={() => handleToggleParameterEnumOverride(draft.id)}
+                                style={buttonStyle()}
+                                data-testid={`snapshot-diff-drop-${draft.id}`}
+                                onClick={() => handleDropSnapshotRestoreEntry(draft.id)}
                                 disabled={busyAction !== undefined}
-                                title={
-                                  parameterEnumOverrides.has(draft.id)
-                                    ? `Remove the override for ${draft.id} and flag it invalid again.`
-                                    : `Override and write anyway for ${draft.id} — the documented range/enum may lag this firmware.`
-                                }
+                                title={`Drop the invalid restore value for ${draft.id} (excludes it from this restore).`}
                               >
-                                {parameterEnumOverrides.has(draft.id) ? 'Overridden' : 'Override'}
+                                Drop
                               </button>
-                            ) : null}
-                          {/* Every invalid row offers Drop — same contract
-                              as Parameters — so the operator can dismiss a
-                              bad restore value without first fixing it. */}
-                          <button
-                            type="button"
-                            style={buttonStyle()}
-                            data-testid={`snapshot-diff-drop-${draft.id}`}
-                            onClick={() => handleDropSnapshotRestoreEntry(draft.id)}
-                            disabled={busyAction !== undefined}
-                            title={`Drop the invalid restore value for ${draft.id} (excludes it from this restore).`}
-                          >
-                            Drop
-                          </button>
-                          </div>
-                        </div>
+                            </>
+                          }
+                        />
                       ))}
                     </section>
                   </div>
@@ -1564,10 +1564,7 @@ export function SnapshotsSection(props: SnapshotsSectionProps): ReactElement {
 
                         {group.entries.map((draft) => (
                           <div key={draft.id} className="parameter-diff-item">
-                            <span>
-                              <strong>{draft.id}</strong>
-                              <small>{draft.label}</small>
-                            </span>
+                            <ParameterDiffIdentity draft={draft} />
                             <span className="parameter-diff-values">
                               {formatParameterValue(draft.currentValue, draft.definition?.unit)} to{' '}
                               {formatParameterValue(draft.nextValue, draft.definition?.unit)}
@@ -1607,15 +1604,11 @@ export function SnapshotsSection(props: SnapshotsSectionProps): ReactElement {
                         <span>{selectedProvisioningProfileInvalidEntries.length} blocked</span>
                       </header>
 
+                      {/* No per-row action here on purpose: a blocked
+                          provisioning value is fixed by editing the profile,
+                          not by overriding or dropping it from this preview. */}
                       {selectedProvisioningProfileInvalidEntries.map((draft) => (
-                        <div key={draft.id} className="parameter-diff-item">
-                          <span>
-                            <strong>{draft.id}</strong>
-                            <small>{draft.label}</small>
-                          </span>
-                          <span className="parameter-diff-values">{draft.rawValue || 'Empty draft'}</span>
-                          <span className="parameter-diff-delta">{draft.reason ?? 'Invalid value'}</span>
-                        </div>
+                        <ParameterDiffInvalidRow key={draft.id} draft={draft} />
                       ))}
                     </section>
                   </div>

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -11149,6 +11149,11 @@ details.metadata-settings-section:not([open]) > summary::after {
   gap: 8px;
   align-items: center;
   justify-content: flex-end;
+  /* .parameter-diff-item is a grid, so the actions cell also has to place
+     itself at the trailing edge — this came from .parameter-diff-item__actions,
+     the second copy of this rule that the invalid rows used before both
+     surfaces moved onto the shared row component. */
+  justify-self: end;
 }
 
 .parameter-diff-actions > button {
@@ -11229,13 +11234,6 @@ details.metadata-settings-section:not([open]) > summary::after {
    (always available so the operator can dismiss a bad draft
    without first fixing or overriding it). User feedback: 'i cant
    drop the invalid param at all as work around.' */
-.parameter-diff-item__actions {
-  display: flex;
-  gap: 8px;
-  align-items: center;
-  justify-self: end;
-}
-
 /* Inline editor in the staged-diff list — user feedback: 'when i load
    params and see changes can i also edit here please?' Lets the
    operator nudge a value (FLTMODE_CH 8 → 6) without leaving the

--- a/apps/web/src/views/ParameterDiffRow.tsx
+++ b/apps/web/src/views/ParameterDiffRow.tsx
@@ -1,0 +1,65 @@
+// Shared row pieces for the two parameter-diff review surfaces (the Parameters
+// tab's grids and the Snapshots restore preview).
+//
+// Scope note — deliberately NOT a single shared "diff row" component. The two
+// CHANGED rows differ in substance, not decoration: the Parameters row carries a
+// bulk-select checkbox and an inline editor so a staged value can be nudged in
+// place, while the Snapshots row shows a read-only current→next pair with
+// stage/drop. Collapsing those into one component means a prop per difference,
+// which is harder to follow than the two straightforward blocks it replaces.
+//
+// What IS shared is extracted here: the identity cell every row renders
+// identically, and the INVALID row, which really was near-duplicate markup on
+// both sides — and is where the last divergence bug lived (one surface
+// string-matched the validator's prose to decide whether Override applied while
+// the other read the flag).
+
+import type { ReactNode } from 'react'
+
+import type { ParameterDraftEntry } from '@arduconfig/ardupilot-core'
+
+export interface ParameterDiffIdentityProps {
+  draft: ParameterDraftEntry
+}
+
+/** The `id` + human label cell, first column of every diff row on both surfaces. */
+export function ParameterDiffIdentity({ draft }: ParameterDiffIdentityProps) {
+  return (
+    <span>
+      <strong>{draft.id}</strong>
+      <small>{draft.label}</small>
+    </span>
+  )
+}
+
+export interface ParameterDiffInvalidRowProps {
+  draft: ParameterDraftEntry
+  /** Row actions (Override / Drop). Supplied by the surface, since the handlers
+   *  and their gating differ; the row shape does not.
+   *
+   *  Optional: the provisioning-profile preview lists blocked values with no
+   *  per-row action at all. The wrapper is omitted entirely in that case rather
+   *  than rendered empty, so the row does not occupy a fourth grid column it
+   *  has no content for. */
+  actions?: ReactNode
+  /** Extra testid on the row itself, when a surface needs to target it. */
+  testId?: string
+}
+
+/**
+ * One invalid draft: what it is, the value that failed, and why.
+ *
+ * `rawValue` rather than a formatted number on purpose — an invalid draft may
+ * not BE a number ("Enter a numeric value…"), so formatting it would either
+ * throw away what the operator typed or render NaN.
+ */
+export function ParameterDiffInvalidRow({ draft, actions, testId }: ParameterDiffInvalidRowProps) {
+  return (
+    <div className="parameter-diff-item" data-testid={testId}>
+      <ParameterDiffIdentity draft={draft} />
+      <span className="parameter-diff-values">{draft.rawValue || 'Empty draft'}</span>
+      <span className="parameter-diff-delta">{draft.reason ?? 'Invalid value'}</span>
+      {actions ? <div className="parameter-diff-actions">{actions}</div> : null}
+    </div>
+  )
+}


### PR DESCRIPTION
Second slice of the Snapshots ↔ Parameters sharing, scoped to what is genuinely the same on both sides.

## Extracted — `views/ParameterDiffRow.tsx`

**`ParameterDiffIdentity`** — the id + label cell every diff row renders. Hand-written 3×.

**`ParameterDiffInvalidRow`** — the whole invalid row. Hand-written **three** times, not two: my scoping counted the Parameters and Snapshots-restore copies and **missed a third** in the provisioning-profile preview. That one lists blocked values with no per-row action, so the actions wrapper is optional and omitted rather than rendered empty — an empty wrapper would occupy a fourth grid column with nothing in it.

## Also

- Consolidated `.parameter-diff-item__actions` into `.parameter-diff-actions` — two rules differing only by `justify-self`, one per surface.
- App.tsx's snapshot group-stage handler now uses the shared `stageableDraftValues`, so both surfaces skip rows with no resolved value the same way instead of one of them staging an empty string.

## Deliberately NOT shared: the changed rows

They differ in **substance**, not decoration. The Parameters row carries a bulk-select checkbox and an inline editor so a staged value can be nudged in place; the Snapshots row is a read-only current→next pair with stage/drop. Collapsing those needs a prop per difference, which reads worse than the two straightforward blocks it would replace. Sharing the cells they *do* have in common gets the value without the god-component.

## Result

Both surfaces hand-roll **zero** invalid-row shells and **zero** identity cells. Net −10 lines despite added explanatory comments.

No behaviour change: same testids, same handlers, same gating on every button.

## Validation

Rungs 1–3: **788 node** · **604 vitest** · **231 Playwright e2e** (full suite — this touches the rendering of every review row on both surfaces).