### PR TITLE
fix(metadata): resolve upstream metadata through legacy parameter renames

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -41,6 +41,7 @@ import {
   type ParameterWriteRequest,
   type RcAxisId,
   type RcMappingCandidate,
+  LEGACY_PARAM_ALIASES,
 } from '@arduconfig/ardupilot-core'
 import {
   arducopterMetadata,
@@ -561,7 +562,11 @@ export function App() {
     if (upstreamParameters && upstreamParameters.vehicle === activeVehicle) {
       return {
         ...base,
-        parameters: mergeUpstreamParameters(base.parameters, upstreamParameters.params)
+        // LEGACY_PARAM_ALIASES lets upstream metadata published under a
+        // modern name (CAM1_SERVO_ON) also resolve for a controller streaming
+        // the legacy one (CAM_SERVO_ON), which otherwise rendered with no
+        // metadata at all.
+        parameters: mergeUpstreamParameters(base.parameters, upstreamParameters.params, LEGACY_PARAM_ALIASES)
       }
     }
     return base

--- a/packages/ardupilot-core/src/parameter-aliases.ts
+++ b/packages/ardupilot-core/src/parameter-aliases.ts
@@ -26,7 +26,19 @@ export const LEGACY_PARAM_ALIASES: Record<string, string> = {
   // MODE_CH -> FLTMODE_CH flight-mode channel rename.
   SYSID_THISMAV: 'MAV_SYSID',
   SYSID_MYGCS: 'MAV_GCS_SYSID',
-  MODE_CH: 'FLTMODE_CH'
+  MODE_CH: 'FLTMODE_CH',
+  // ArduPilot 4.5+ per-instance camera rename. Verified against AP_Camera.cpp's
+  // own conversion table (k_param_camera_key indices 2 and 3): these two are
+  // pure renames of the same INT16 PWM value.
+  //
+  // NOT included: CAM_DURATION -> CAM1_DURATION. That conversion also changes
+  // units — AP_Camera.cpp converts "CAM_DURATION (in deci-seconds) to
+  // CAM1_DURATION (in seconds)" with a *0.1 factor — so aliasing it would show
+  // a seconds range/unit against a deci-second value. Same reason
+  // TRIM_ARSPD_CM and Q_A_ACCEL_* are excluded above. CAM_DURATION is curated
+  // directly instead, with its real deci-second metadata.
+  CAM_SERVO_ON: 'CAM1_SERVO_ON',
+  CAM_SERVO_OFF: 'CAM1_SERVO_OFF'
 }
 
 // modern -> legacy (the reverse map).

--- a/packages/param-metadata/src/arducopter.ts
+++ b/packages/param-metadata/src/arducopter.ts
@@ -1540,6 +1540,22 @@ export const arducopterMetadata: FirmwareMetadataBundle = {
       rebootRequired: true,
       options: enumOptions(ARDUCOPTER_CAM_TRIGG_TYPE_LABELS)
     },
+    // Curated rather than aliased to CAM1_DURATION on purpose: AP_Camera.cpp
+    // converts "CAM_DURATION (in deci-seconds) to CAM1_DURATION (in seconds)"
+    // with a *0.1 factor, so borrowing the modern parameter's metadata would
+    // put a seconds unit and a 0-5 range against a deci-second value. The
+    // legacy bounds below are the modern 0-5 s range expressed in deci-seconds.
+    CAM_DURATION: {
+      id: 'CAM_DURATION',
+      label: 'Camera Shutter Duration',
+      description:
+        'How long the camera shutter is held open, in DECI-seconds (0.1 s units) — a value of 10 is one second. Legacy camera parameter; firmware 4.5+ replaces it with CAM1_DURATION, which is expressed in whole seconds.',
+      category: 'peripherals',
+      unit: 'ds',
+      minimum: 0,
+      maximum: 50,
+      step: 1
+    },
     CAM_AUTO_ONLY: {
       id: 'CAM_AUTO_ONLY',
       label: 'Distance Trigger in AUTO Only',

--- a/packages/param-metadata/src/upstream.ts
+++ b/packages/param-metadata/src/upstream.ts
@@ -38,7 +38,16 @@ function isNonEmptyString(value: string | undefined): value is string {
  */
 export function mergeUpstreamParameters(
   handAuthored: Record<string, ParameterDefinition>,
-  upstream: UpstreamParameterMap
+  upstream: UpstreamParameterMap,
+  /**
+   * legacy -> modern parameter renames, so upstream metadata published under
+   * the modern name also resolves for a controller streaming the legacy one.
+   * Passed IN rather than imported: the alias table lives in ardupilot-core,
+   * which depends on this package, so importing it here would invert the
+   * layering. Defaults to none, leaving the merge unchanged for callers that
+   * do not care.
+   */
+  legacyAliases: Record<string, string> = {}
 ): Record<string, ParameterDefinition> {
   const merged: Record<string, ParameterDefinition> = { ...handAuthored }
 
@@ -73,6 +82,25 @@ export function mergeUpstreamParameters(
       bitmask: up.bitmask,
       rebootRequired: up.rebootRequired
     }
+  }
+
+  // Mirror upstream metadata onto the LEGACY name of any renamed parameter.
+  //
+  // Upstream ships only the modern name (CAM1_SERVO_ON), but a controller on
+  // older firmware streams the legacy one (CAM_SERVO_ON) — so the row rendered
+  // with no metadata at all even though the description existed under the other
+  // name. The alias table already promises "byId lookups resolve either way";
+  // this is what makes that true for metadata as well as values.
+  //
+  // Only renames the alias table vouches for are mirrored. Renames that also
+  // changed units are deliberately absent from it (CAM_DURATION's deci-seconds
+  // to seconds, TRIM_ARSPD_CM's cm/s to m/s), because borrowing the modern
+  // metadata there would put the wrong unit and range on a legacy value.
+  for (const [legacyId, modernId] of Object.entries(legacyAliases)) {
+    if (merged[legacyId] || !merged[modernId]) {
+      continue
+    }
+    merged[legacyId] = { ...merged[modernId], id: legacyId }
   }
 
   return merged

--- a/tests/parameter-aliases.test.mjs
+++ b/tests/parameter-aliases.test.mjs
@@ -1,7 +1,7 @@
 import assert from 'node:assert/strict'
 import test from 'node:test'
 
-import { parameterAlias } from '../packages/ardupilot-core/dist/index.js'
+import { LEGACY_PARAM_ALIASES, parameterAlias } from '../packages/ardupilot-core/dist/index.js'
 
 test('parameterAlias resolves a legacy id to its modern name', () => {
   // GPS_TYPE (legacy) -> GPS1_TYPE (modern). The alias is NOT the legacy one.
@@ -18,4 +18,30 @@ test('parameterAlias resolves a modern id back to its legacy (old) name', () => 
 test('parameterAlias returns undefined for a param with no rename', () => {
   assert.equal(parameterAlias('ATC_RAT_RLL_P'), undefined)
   assert.equal(parameterAlias('NOT_A_PARAM'), undefined)
+})
+
+// A rename that ALSO changes units must never be aliased: the alias makes the
+// two names interchangeable for metadata, so a unit change would put the wrong
+// unit and range on the value the controller actually reports.
+test('renames that changed units are deliberately excluded from the alias table', () => {
+  for (const excluded of [
+    // AP_Camera.cpp: "convert CAM_DURATION (in deci-seconds) to CAM1_DURATION
+    // (in seconds)" — a *0.1 factor.
+    'CAM_DURATION',
+    // cm/s -> m/s.
+    'TRIM_ARSPD_CM'
+  ]) {
+    assert.equal(
+      LEGACY_PARAM_ALIASES[excluded],
+      undefined,
+      `${excluded} changed units across the rename and must not be aliased`
+    )
+  }
+})
+
+test('the camera servo renames ARE aliased (pure renames, same PWM value)', () => {
+  // Verified against AP_Camera.cpp's own conversion table, k_param_camera_key
+  // indices 2 and 3: same INT16, no scaling.
+  assert.equal(LEGACY_PARAM_ALIASES.CAM_SERVO_ON, 'CAM1_SERVO_ON')
+  assert.equal(LEGACY_PARAM_ALIASES.CAM_SERVO_OFF, 'CAM1_SERVO_OFF')
 })

--- a/tests/upstream-merge.test.mjs
+++ b/tests/upstream-merge.test.mjs
@@ -75,3 +75,64 @@ test('real upstream import enriches the curated ArduCopter catalog', () => {
   assert.ok(advanced, 'advanced category should be created for upstream-only params')
   assert.equal(advanced.viewId, 'parameters')
 })
+
+// Upstream publishes metadata under the MODERN name only. A controller on older
+// firmware streams the LEGACY one, so the row rendered with no metadata at all
+// even though the description existed under the other name — found by loading
+// the app against the demo vehicle and counting rows showing the
+// "Metadata to be expanded from upstream ArduPilot bundles" placeholder.
+test('upstream metadata resolves through a legacy parameter rename', () => {
+  const merged = mergeUpstreamParameters(
+    {},
+    {
+      CAM1_SERVO_ON: {
+        label: 'Camera servo ON PWM value',
+        description: 'PWM value in microseconds to move servo to when shutter is activated',
+        unit: 'PWM',
+        minimum: 1000,
+        maximum: 2000
+      }
+    },
+    { CAM_SERVO_ON: 'CAM1_SERVO_ON' }
+  )
+
+  assert.ok(merged.CAM_SERVO_ON, 'the legacy name must resolve to the modern metadata')
+  assert.equal(merged.CAM_SERVO_ON.label, 'Camera servo ON PWM value')
+  assert.equal(merged.CAM_SERVO_ON.unit, 'PWM')
+  // The id stays the LEGACY one: it is what the controller reports and what the
+  // UI must show, even though the description came from the modern entry.
+  assert.equal(merged.CAM_SERVO_ON.id, 'CAM_SERVO_ON')
+  // The modern entry is untouched.
+  assert.equal(merged.CAM1_SERVO_ON.id, 'CAM1_SERVO_ON')
+})
+
+test('a curated legacy definition always wins over the alias mirror', () => {
+  // The mirror fills a GAP; it must never overwrite curation. CAM_DURATION is
+  // the case that matters — it is curated deliberately because its rename also
+  // changed units, so borrowing the modern metadata would be wrong.
+  const merged = mergeUpstreamParameters(
+    {
+      CAM_DURATION: {
+        id: 'CAM_DURATION',
+        label: 'Camera Shutter Duration',
+        description: 'deci-seconds',
+        category: 'peripherals',
+        unit: 'ds',
+        minimum: 0,
+        maximum: 50
+      }
+    },
+    { CAM1_DURATION: { label: 'Camera shutter duration held open', unit: 's', minimum: 0, maximum: 5 } },
+    { CAM_DURATION: 'CAM1_DURATION' }
+  )
+
+  assert.equal(merged.CAM_DURATION.unit, 'ds', 'the curated deci-second unit must survive')
+  assert.equal(merged.CAM_DURATION.maximum, 50)
+})
+
+test('no alias map leaves the merge exactly as it was', () => {
+  const upstream = { CAM1_SERVO_ON: { label: 'Camera servo ON PWM value' } }
+  const withoutAliases = mergeUpstreamParameters({}, upstream)
+  assert.equal(withoutAliases.CAM_SERVO_ON, undefined)
+  assert.ok(withoutAliases.CAM1_SERVO_ON)
+})


### PR DESCRIPTION
I tested this in a browser against the demo vehicle instead of reasoning about it, and the diagnosis changed twice.

## The backbone already existed

Per-vehicle upstream metadata is already lazy-loaded as its own chunk on connect and merged with curated definitions winning field-by-field. Of the **1173** parameters the demo controller reports, **1170 rendered full metadata**. Building a backbone would have duplicated working infrastructure.

## The actual gap: 3 parameters

`CAM_DURATION`, `CAM_SERVO_ON`, `CAM_SERVO_OFF` — renamed to `CAM1_*` in firmware 4.5+. Upstream publishes only the **modern** name; the controller streams the **legacy** one. The lookup missed and the row fell back to *"Metadata to be expanded from upstream ArduPilot bundles"*.

`mergeUpstreamParameters` now mirrors upstream metadata onto the legacy name of any rename the alias table vouches for, keeping the legacy id (what the controller reports and the UI must show). The alias map is **passed in** rather than imported — it lives in `ardupilot-core`, which depends on `param-metadata`, so importing it there would invert the layering.

## The trap

**`CAM_DURATION` must not be aliased.** From `AP_Camera.cpp`:

> `// convert CAM_DURATION (in deci-seconds) to CAM1_DURATION (in seconds)`

with a `*0.1` factor. Borrowing the modern metadata would put a **seconds** unit and 0–5 range against a **deci-second** value — the same reason `TRIM_ARSPD_CM` and `Q_A_ACCEL_*` are already excluded from that table. So it's curated directly with its real deci-second unit and 0–50 range.

Only `CAM_SERVO_ON`/`OFF` are aliased, verified against `AP_Camera.cpp`'s own conversion table (`k_param_camera_key` indices 2 and 3 — same INT16 PWM value, no scaling).

## Verified

In the browser after the fix: **0 of 1173** rows show the placeholder, down from 3.

## Validation

Rungs 1–3: **793 node** (5 new — the alias mirror, curation beating the mirror, an absent alias map leaving the merge untouched, and unit-changing renames staying out of the table) · **604 vitest** · **231 e2e**.

ArduCopter behaviour unchanged — metadata display only, no write path, curation always wins.