### PR TITLE
feat(snapshots): bulk-select restore rows, sharing the Parameters selection logic

### DIFF
--- a/apps/web/src/hooks/use-calibration-notices.ts
+++ b/apps/web/src/hooks/use-calibration-notices.ts
@@ -9,13 +9,16 @@
 // App body used to declare them inline.
 
 import { useState, type Dispatch, type SetStateAction } from 'react'
+import type { ParameterNotice } from './use-parameter-feedback'
 
-import type { StatusTone } from '../status-tone'
 
-export interface CalibrationNotice {
-  tone: StatusTone
-  text: string
-}
+/**
+ * A calibration banner is the same shape as every other status banner in the
+ * app — tone + text — so it is an alias rather than a second declaration. Kept
+ * as a named alias (not a bare re-export) so calibration call sites still read
+ * as calibration, while a change to the banner shape lands in one place.
+ */
+export type CalibrationNotice = ParameterNotice
 
 export interface UseCalibrationNoticesResult {
   /** Voltage value the operator types from a multimeter for BATT_VOLT_MULT rescale. */

--- a/apps/web/src/hooks/use-draft-selection.ts
+++ b/apps/web/src/hooks/use-draft-selection.ts
@@ -1,0 +1,87 @@
+// Bulk-selection state for a parameter-diff review list.
+//
+// The Parameters tab has had shift-click range selection and a "Drop selected"
+// bulk action for a while; the Snapshots restore preview never did, so
+// abandoning part of a restore meant one row at a time. The rules are identical
+// on both surfaces — the same anchor semantics, the same need to forget ids that
+// have left the list — so they live here rather than being written twice.
+//
+// The pure rules stay in view-models/draft-selection.ts (unit-tested off React);
+// this owns the React state, the anchor ref, and the pruning effect.
+
+import { useCallback, useEffect, useRef, useState } from 'react'
+
+import { applyDraftSelectionClick, pruneDraftSelection } from '../view-models/draft-selection'
+
+export interface UseDraftSelectionResult {
+  selectedIds: ReadonlySet<string>
+  /** Click a row's checkbox. Shift extends from the last clicked row. */
+  handleSelectionClick: (id: string, shiftKey: boolean) => void
+  /** Select every currently-listed row, or clear the selection. */
+  setAllSelected: (selected: boolean) => void
+  /** Forget specific ids — used when rows are dropped by another control, so a
+   *  following "Drop selected (n)" count cannot include rows already gone. */
+  forgetIds: (ids: readonly string[]) => void
+  /** Clear everything, including the shift-click anchor. */
+  clearSelection: () => void
+  /** True when every listed row is selected (drives the select-all checkbox). */
+  allSelected: boolean
+}
+
+/**
+ * @param orderedIds every row currently in the list, in display order. Shift-click
+ * ranges are computed against this order, and any selected id NOT in it is
+ * pruned — rows leave the list via apply/drop/discard, and a stale id would make
+ * the "Drop selected (n)" count lie.
+ */
+export function useDraftSelection(orderedIds: readonly string[]): UseDraftSelectionResult {
+  const [selectedIds, setSelectedIds] = useState<ReadonlySet<string>>(() => new Set())
+  const anchorRef = useRef<string | null>(null)
+
+  useEffect(() => {
+    setSelectedIds((current) => pruneDraftSelection(current, orderedIds))
+  }, [orderedIds])
+
+  const handleSelectionClick = useCallback(
+    (id: string, shiftKey: boolean) => {
+      setSelectedIds((current) =>
+        applyDraftSelectionClick(current, orderedIds, id, { shiftKey, anchorId: anchorRef.current })
+      )
+      anchorRef.current = id
+    },
+    [orderedIds]
+  )
+
+  const setAllSelected = useCallback(
+    (selected: boolean) => {
+      setSelectedIds(selected ? new Set(orderedIds) : new Set())
+      anchorRef.current = null
+    },
+    [orderedIds]
+  )
+
+  const forgetIds = useCallback((ids: readonly string[]) => {
+    setSelectedIds((current) => {
+      if (current.size === 0) {
+        return current
+      }
+      const next = new Set(current)
+      ids.forEach((id) => next.delete(id))
+      return next.size === current.size ? current : next
+    })
+  }, [])
+
+  const clearSelection = useCallback(() => {
+    setSelectedIds(new Set())
+    anchorRef.current = null
+  }, [])
+
+  return {
+    selectedIds,
+    handleSelectionClick,
+    setAllSelected,
+    forgetIds,
+    clearSelection,
+    allSelected: orderedIds.length > 0 && selectedIds.size === orderedIds.length
+  }
+}

--- a/apps/web/src/sections/ParametersSection.tsx
+++ b/apps/web/src/sections/ParametersSection.tsx
@@ -10,6 +10,7 @@ import type { ConfiguratorSnapshot, ParameterDraftEntry, ParameterDraftGroup, Pa
 import type { NormalizedFirmwareMetadataBundle } from '@arduconfig/param-metadata'
 import { Panel, StatusBadge, buttonStyle } from '@arduconfig/ui-kit'
 import type { PendingParameterImport } from '../hooks/use-parameter-backup-io'
+import { useDraftSelection } from '../hooks/use-draft-selection'
 import {
   isOverridableInvalidEntry,
   overridableInvalidParamIds,
@@ -26,7 +27,6 @@ import {
 import { ScopedBitmaskPopover } from '../views/ScopedField'
 import { ParameterDetail } from '../views/ParameterDetail'
 import { parameterApplyBlockedReason } from '../apply-gate'
-import { applyDraftSelectionClick, pruneDraftSelection } from '../view-models/draft-selection'
 import { parameterSearchPredicate } from '../view-models/filtered-parameters'
 import { toneForParameterDraftStatus } from '../tone-helpers'
 import type { ParameterFollowUp, ParameterNotice } from '../hooks/use-parameter-feedback'
@@ -167,8 +167,7 @@ export function ParametersSection(props: ParametersSectionProps): ReactElement {
   // state, so it lives here. Shift-click range semantics are in
   // view-models/draft-selection.ts (unit-tested); the anchor is the last
   // row whose checkbox was clicked.
-  const [selectedDraftIds, setSelectedDraftIds] = useState<ReadonlySet<string>>(new Set())
-  const selectionAnchorRef = useRef<string | null>(null)
+
   // After a write, bring the reboot-required follow-up (and its inline Request
   // Reboot button) into view, so a reboot-required change can be completed
   // without scrolling back up the param list to find the prompt.
@@ -245,20 +244,16 @@ export function ParametersSection(props: ParametersSectionProps): ReactElement {
     () => visibleStagedGroups.flatMap((group) => group.entries.map((entry) => entry.id)),
     [visibleStagedGroups]
   )
-  useEffect(() => {
-    // Rows leave the staged list via apply/drop/discard-all — selection
-    // must not keep ghost ids (the "Drop selected (N)" count would lie).
-    setSelectedDraftIds((current) => pruneDraftSelection(current, stagedOrderedIds))
-  }, [stagedOrderedIds])
-  const handleDraftSelectionClick = (draftId: string, shiftKey: boolean): void => {
-    setSelectedDraftIds((current) =>
-      applyDraftSelectionClick(current, stagedOrderedIds, draftId, {
-        shiftKey,
-        anchorId: selectionAnchorRef.current
-      })
-    )
-    selectionAnchorRef.current = draftId
-  }
+  // Shift-click ranges, select-all, pruning of ids that have left the list —
+  // shared with the Snapshots restore preview via useDraftSelection.
+  const {
+    selectedIds: selectedDraftIds,
+    handleSelectionClick: handleDraftSelectionClick,
+    setAllSelected: setAllDraftsSelected,
+    forgetIds: forgetSelectedDraftIds,
+    clearSelection: clearDraftSelection,
+    allSelected: allDraftsSelected
+  } = useDraftSelection(stagedOrderedIds)
   // Drop every staged row in one category. Also clears those ids from the
   // checkbox selection, so a subsequent "Drop selected" count doesn't include
   // rows that are already gone.
@@ -269,20 +264,12 @@ export function ParametersSection(props: ParametersSectionProps): ReactElement {
 
   const handleDropDraftGroup = (draftIds: string[]): void => {
     draftIds.forEach((draftId) => handleDiscardParameterDraft(draftId))
-    setSelectedDraftIds((current) => {
-      if (current.size === 0) {
-        return current
-      }
-      const next = new Set(current)
-      draftIds.forEach((draftId) => next.delete(draftId))
-      return next.size === current.size ? current : next
-    })
+    forgetSelectedDraftIds(draftIds)
   }
 
   const handleDropSelectedDrafts = (): void => {
     selectedDraftIds.forEach((draftId) => handleDiscardParameterDraft(draftId))
-    setSelectedDraftIds(new Set())
-    selectionAnchorRef.current = null
+    clearDraftSelection()
   }
 
   // Draft-status lookup for the bitmask checkbox editor (ScopedBitmaskField
@@ -587,10 +574,8 @@ export function ParametersSection(props: ParametersSectionProps): ReactElement {
                 <input
                   type="checkbox"
                   data-testid="parameter-diff-select-all"
-                  checked={selectedDraftIds.size === stagedOrderedIds.length && stagedOrderedIds.length > 0}
-                  onChange={(event) =>
-                    setSelectedDraftIds(event.target.checked ? new Set(stagedOrderedIds) : new Set())
-                  }
+                  checked={allDraftsSelected}
+                  onChange={(event) => setAllDraftsSelected(event.target.checked)}
                   disabled={busyAction !== undefined}
                 />
                 <span>Select all</span>

--- a/apps/web/src/sections/SnapshotsSection.tsx
+++ b/apps/web/src/sections/SnapshotsSection.tsx
@@ -8,6 +8,7 @@
 // No behaviour change — every JSX attribute and inline closure is verbatim
 // from the original block.
 
+import { useMemo } from 'react'
 import type { ChangeEvent, ReactElement, RefObject } from 'react'
 import type {
   ConfiguratorSnapshot,
@@ -42,6 +43,7 @@ import {
   overridableInvalidParamIds,
   paramIdsForGroup
 } from '../view-models/parameter-diff-actions'
+import { useDraftSelection } from '../hooks/use-draft-selection'
 import { ParameterDiffGroupActions } from '../views/ParameterDiffGroupActions'
 import { ParameterDiffIdentity, ParameterDiffInvalidRow } from '../views/ParameterDiffRow'
 
@@ -327,6 +329,22 @@ export function SnapshotsSection(props: SnapshotsSectionProps): ReactElement {
   // an override; a param missing from the sync or a non-numeric draft cannot.
   // Drives both the per-row affordance and the "Override all (n)" count, so the
   // count never promises more than it can deliver.
+  // Bulk selection over the restore diff — shift-click ranges and a one-press
+  // "Drop selected", the same controls the Parameters review has had. Without
+  // it, abandoning part of a restore meant dropping rows one at a time.
+  const snapshotRestoreOrderedIds = useMemo(
+    () => selectedSnapshotDiffGroups.flatMap((group) => group.entries.map((entry) => entry.id)),
+    [selectedSnapshotDiffGroups]
+  )
+  const {
+    selectedIds: selectedRestoreIds,
+    handleSelectionClick: handleRestoreSelectionClick,
+    setAllSelected: setAllRestoreSelected,
+    forgetIds: forgetRestoreIds,
+    clearSelection: clearRestoreSelection,
+    allSelected: allRestoreSelected
+  } = useDraftSelection(snapshotRestoreOrderedIds)
+
   const selectedSnapshotOverridableInvalidIds = overridableInvalidParamIds(
     selectedSnapshotInvalidEntries,
     parameterEnumOverrides
@@ -840,6 +858,35 @@ export function SnapshotsSection(props: SnapshotsSectionProps): ReactElement {
                 </label>
 
                 {selectedSnapshotChangedEntries.length > 0 ? (
+                  <div className="parameter-diff-bulk" data-testid="snapshot-diff-bulk">
+                    <label className="parameter-diff-bulk__all">
+                      <input
+                        type="checkbox"
+                        data-testid="snapshot-diff-select-all"
+                        checked={allRestoreSelected}
+                        onChange={(event) => setAllRestoreSelected(event.target.checked)}
+                        disabled={busyAction !== undefined}
+                      />
+                      <span>Select all</span>
+                    </label>
+                    <button
+                      type="button"
+                      data-testid="snapshot-diff-drop-selected"
+                      style={buttonStyle()}
+                      onClick={() => {
+                        const ids = [...selectedRestoreIds]
+                        ids.forEach((paramId) => handleDropSnapshotRestoreEntry(paramId))
+                        clearRestoreSelection()
+                      }}
+                      disabled={busyAction !== undefined || selectedRestoreIds.size === 0}
+                      title="Drop every selected row from this restore. Shift-click checkboxes to select a range."
+                    >
+                      Drop selected ({selectedRestoreIds.size})
+                    </button>
+                  </div>
+                ) : null}
+
+                {selectedSnapshotChangedEntries.length > 0 ? (
                   <div className="parameter-diff-grid">
                     {selectedSnapshotDiffGroups.map((group) => (
                       <section key={group.category} className="parameter-diff-group">
@@ -865,7 +912,11 @@ export function SnapshotsSection(props: SnapshotsSectionProps): ReactElement {
                               {
                                 label: 'Drop group',
                                 testId: `snapshot-diff-drop-group-${group.category}`,
-                                onClick: () => handleDropSnapshotGroup(paramIdsForGroup(group)),
+                                onClick: () => {
+                                  const ids = paramIdsForGroup(group)
+                                  handleDropSnapshotGroup(ids)
+                                  forgetRestoreIds(ids)
+                                },
                                 disabled: busyAction !== undefined,
                                 title: `Drop all ${group.entries.length} ${formatCategoryLabel(group.category)} change(s) from this restore.`
                               }
@@ -874,7 +925,18 @@ export function SnapshotsSection(props: SnapshotsSectionProps): ReactElement {
                         </header>
 
                         {group.entries.map((draft) => (
-                          <div key={draft.id} className="parameter-diff-item">
+                          <div key={draft.id} className="parameter-diff-item parameter-diff-item--selectable">
+                            <input
+                              type="checkbox"
+                              className="parameter-diff-item__select"
+                              data-testid={`snapshot-diff-select-${draft.id}`}
+                              checked={selectedRestoreIds.has(draft.id)}
+                              aria-label={`Select ${draft.id} for bulk drop`}
+                              title="Select for bulk drop. Shift-click selects a range."
+                              disabled={busyAction !== undefined}
+                              onClick={(event) => handleRestoreSelectionClick(draft.id, event.shiftKey)}
+                              onChange={() => {}}
+                            />
                             <ParameterDiffIdentity draft={draft} />
                             <span className="parameter-diff-values">
                               {formatParameterValue(draft.currentValue, draft.definition?.unit)} to{' '}

--- a/tests/e2e/views.spec.ts
+++ b/tests/e2e/views.spec.ts
@@ -4184,6 +4184,20 @@ test.describe('Snapshot restore', () => {
     await expect(page.getByTestId('snapshot-diff-drop-BATT_LOW_VOLT')).toBeVisible()
     await expect(page.getByTestId('snapshot-restore-dropped-note')).toHaveCount(0)
 
+    // Bulk selection, shared with the Parameters review: the restore preview
+    // had no way to abandon several rows at once, so a partial restore meant
+    // dropping them one at a time.
+    await expect(page.getByTestId('snapshot-diff-drop-selected')).toBeDisabled()
+    await page.getByTestId('snapshot-diff-select-BATT_LOW_VOLT').click()
+    await expect(page.getByTestId('snapshot-diff-drop-selected')).toContainText('Drop selected (1)')
+    await page.getByTestId('snapshot-diff-drop-selected').click()
+    await expect(page.getByTestId('snapshot-diff-drop-BATT_LOW_VOLT')).toHaveCount(0)
+    await page.getByTestId('snapshot-restore-undo-drops').click()
+    await expect(page.getByTestId('snapshot-diff-drop-BATT_LOW_VOLT')).toBeVisible()
+    // The selection must not survive the drop — otherwise the count would
+    // include a row that is no longer there.
+    await expect(page.getByTestId('snapshot-diff-drop-selected')).toContainText('Drop selected (0)')
+
     // Group-level Stage/Drop: the preview is grouped by category, and acting
     // on a whole group is the natural unit for a partial restore. Staging is
     // gated on the same overwrite ack as the per-row Stage.


### PR DESCRIPTION
Final slice of the Snapshots ↔ Parameters sharing scope.

## Item 3 — bulk selection

The Parameters review has had shift-click range select and a one-press **Drop selected** for a while. The Snapshots restore preview had neither, so abandoning part of a restore meant dropping rows one at a time.

The rules are identical on both surfaces, so they move into a `useDraftSelection` hook — the pure shift-click/pruning rules stay in `view-models/draft-selection.ts`, already unit-tested off React — and **Snapshots gains the feature** by using it.

Parameters is migrated onto the same hook rather than keeping its copy: its inline state, anchor ref and pruning effect are gone, behaviour unchanged.

Selection is pruned whenever a row leaves the list, and group-drop forgets the ids it dropped, so a following `Drop selected (n)` can never count a row that's no longer there. The e2e asserts exactly that — after dropping the selection the count reads **0**, not 1.

## Item 6 — notice types

Scoped as "unify two parallel notice shapes", but the library notices **already** share `ParameterNotice`. The only duplicate left was `CalibrationNotice` declaring the same `{ tone, text }` a second time. It's now a named alias, so the shape lives in one place while calibration call sites still read as calibration.

Smaller than scoped, and honestly cosmetic — it's here because it was on the list, not because it was worth much.

## Still not shared

The provisioning-profile preview keeps plain rows. It has no per-row *or* bulk actions, so selection would be UI with nothing behind it.

## Validation

Rungs 1–3: **793 node** · **604 vitest** · **231 Playwright e2e** (full suite; the snapshot-restore spec now covers select → bulk drop → undo, and that the selection doesn't survive the drop).