### PR TITLE
feat(lua): restart scripting without rebooting the flight controller

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -8392,6 +8392,8 @@ export function App() {
         busyAction={luaScripts.busyAction}
         onEnableScripting={luaScripts.enableScripting}
         onReboot={luaScripts.reboot}
+        onRestartScripting={luaScripts.restartScripting}
+        onStopScripting={luaScripts.stopScripting}
         onRefresh={luaScripts.refresh}
         onInstall={luaScripts.install}
         onRemove={luaScripts.remove}

--- a/apps/web/src/hooks/use-lua-scripts.ts
+++ b/apps/web/src/hooks/use-lua-scripts.ts
@@ -18,6 +18,8 @@ export interface LuaScriptsCapableRuntime {
     options?: { verifyTimeoutMs?: number }
   ): Promise<{ paramId: string; confirmedValue: number }>
   reboot(): Promise<void>
+  restartScripting(): Promise<void>
+  stopScripting(): Promise<void>
 }
 
 export interface LuaScriptsNotice {
@@ -49,6 +51,8 @@ export interface LuaScriptsController {
   upload: (file: File) => void
   enableScripting: () => void
   reboot: () => void
+  restartScripting: () => void
+  stopScripting: () => void
 }
 
 /**
@@ -260,6 +264,52 @@ export function useLuaScripts(options: UseLuaScriptsOptions): LuaScriptsControll
     }
   }, [runtime])
 
+  // Restarting scripting is what ArduPilot actually asks for when a script
+  // changes — a full reboot drops the link, re-runs every startup check and
+  // re-syncs the parameter table to achieve the same thing.
+  const restartScripting = useCallback(async () => {
+    if (!runtime) return
+    setBusyAction('lua:restart-scripting')
+    setNotice(undefined)
+    try {
+      await runtime.restartScripting()
+      setNotice({
+        tone: 'success',
+        text: 'Scripting restarted. Scripts re-run from the start; the flight controller stayed up.'
+      })
+    } catch (error) {
+      setNotice({
+        tone: 'danger',
+        text:
+          error instanceof Error
+            ? `Restart scripting failed: ${error.message}`
+            : 'Restart scripting failed.'
+      })
+    } finally {
+      setBusyAction(undefined)
+    }
+  }, [runtime])
+
+  const stopScripting = useCallback(async () => {
+    if (!runtime) return
+    setBusyAction('lua:stop-scripting')
+    setNotice(undefined)
+    try {
+      await runtime.stopScripting()
+      setNotice({
+        tone: 'success',
+        text: 'Scripting stopped. It stays stopped until you restart scripting or reboot.'
+      })
+    } catch (error) {
+      setNotice({
+        tone: 'danger',
+        text: error instanceof Error ? `Stop scripting failed: ${error.message}` : 'Stop scripting failed.'
+      })
+    } finally {
+      setBusyAction(undefined)
+    }
+  }, [runtime])
+
   return {
     installed,
     installedLoading,
@@ -271,6 +321,8 @@ export function useLuaScripts(options: UseLuaScriptsOptions): LuaScriptsControll
     remove: (name) => void remove(name),
     upload: (file) => void upload(file),
     enableScripting: () => void enableScripting(),
-    reboot: () => void reboot()
+    reboot: () => void reboot(),
+    restartScripting: () => void restartScripting(),
+    stopScripting: () => void stopScripting()
   }
 }

--- a/apps/web/src/views/LuaScripts.tsx
+++ b/apps/web/src/views/LuaScripts.tsx
@@ -36,6 +36,10 @@ export interface LuaScriptsViewProps {
   busyAction?: string
   onEnableScripting: () => void
   onReboot: () => void
+  /** Restart Lua scripting without rebooting the flight controller. */
+  onRestartScripting: () => void
+  /** Stop Lua scripting until the next restart/reboot. */
+  onStopScripting: () => void
   onRefresh: () => void
   onInstall: (appletId: string) => void
   onRemove: (name: string) => void
@@ -57,10 +61,14 @@ function CapabilityBanner(props: {
   busyAction?: string
   onEnableScripting: () => void
   onReboot: () => void
+  onRestartScripting: () => void
+  onStopScripting: () => void
 }) {
-  const { capability, busyAction, onEnableScripting, onReboot } = props
+  const { capability, busyAction, onEnableScripting, onReboot, onRestartScripting, onStopScripting } = props
   const enabling = busyAction === 'lua:enable'
   const rebooting = busyAction === 'lua:reboot'
+  const restartingScripting = busyAction === 'lua:restart-scripting'
+  const stoppingScripting = busyAction === 'lua:stop-scripting'
 
   // A genuine warning: this build has no Lua VM at all.
   if (capability.capability === 'unsupported') {
@@ -114,12 +122,37 @@ function CapabilityBanner(props: {
       <p className="lua-status-line lua-status-line--success">
         <StatusBadge tone="success">Scripting on</StatusBadge>
         <span className="lua-status-text">
-          Lua is enabled{capability.heapSizePresent ? ` · heap ${kib(capability.heapSizeBytes)} KiB` : ''}. A reboot
-          applies newly-installed scripts.
+          Lua is enabled{capability.heapSizePresent ? ` · heap ${kib(capability.heapSizeBytes)} KiB` : ''}. Restart
+          scripting to apply newly-installed scripts — a full reboot is not needed.
         </span>
+        {/* Restart scripting is the action ArduPilot actually asks for when a
+         *  script changes ("restart scripting" STATUSTEXT). It is listed first
+         *  and styled as the primary because a reboot to achieve the same thing
+         *  drops the link, re-runs every startup check and re-syncs the whole
+         *  parameter table. */}
         <button
           type="button"
           className="lua-status-spacer"
+          style={buttonStyle('primary')}
+          onClick={onRestartScripting}
+          disabled={Boolean(busyAction)}
+          data-testid="lua-restart-scripting"
+          title="Stop and restart onboard Lua scripting (MAV_CMD_SCRIPTING). The flight controller stays up."
+        >
+          {restartingScripting ? 'Restarting scripting…' : 'Restart scripting'}
+        </button>
+        <button
+          type="button"
+          style={buttonStyle()}
+          onClick={onStopScripting}
+          disabled={Boolean(busyAction)}
+          data-testid="lua-stop-scripting"
+          title="Stop onboard Lua scripting until the next restart or reboot."
+        >
+          {stoppingScripting ? 'Stopping…' : 'Stop scripting'}
+        </button>
+        <button
+          type="button"
           style={buttonStyle()}
           onClick={onReboot}
           disabled={Boolean(busyAction)}
@@ -228,6 +261,8 @@ export function LuaScriptsView(props: LuaScriptsViewProps) {
     busyAction,
     onEnableScripting,
     onReboot,
+    onRestartScripting,
+    onStopScripting,
     onRefresh,
     onInstall,
     onRemove,
@@ -255,6 +290,8 @@ export function LuaScriptsView(props: LuaScriptsViewProps) {
               busyAction={busyAction}
               onEnableScripting={onEnableScripting}
               onReboot={onReboot}
+              onRestartScripting={onRestartScripting}
+              onStopScripting={onStopScripting}
             />
 
             {notice ? (

--- a/packages/ardupilot-core/src/runtime.ts
+++ b/packages/ardupilot-core/src/runtime.ts
@@ -193,6 +193,11 @@ export interface ArduPilotConfiguratorRuntimeOptions {
 // A real flight controller can take well over 5s to emit its first HEARTBEAT
 // (peripheral/compass/GPS init), so 20s covers a realistic cold boot. Tests
 // pass their own short timeoutMs.
+// SCRIPTING_CMD values (ardupilotmega.xml). Only the two AP_Scripting actually
+// accepts — REPL_START (0) / REPL_STOP (1) return MAV_RESULT_DENIED.
+const SCRIPTING_CMD_STOP = 2
+const SCRIPTING_CMD_STOP_AND_RESTART = 3
+
 const DEFAULT_HEARTBEAT_TIMEOUT_MS = 20000
 const DEFAULT_PARAMETER_SYNC_TIMEOUT_MS = 20000
 const PARAMETER_SYNC_STALL_RETRY_MS = 1500
@@ -1452,6 +1457,37 @@ export class ArduPilotConfiguratorRuntime {
     // table from this session may survive to be resumed against it.
     this.discardStaleLink()
     await this.sendCommand(MAV_CMD.PREFLIGHT_REBOOT_SHUTDOWN, [3, 0, 0, 0, 0, 0, 0], {
+      waitForAck: true,
+      ackTimeoutMs: 3000
+    })
+  }
+
+  /**
+   * Restart onboard Lua scripting WITHOUT rebooting the autopilot
+   * (MAV_CMD_SCRIPTING, param1 = SCRIPTING_CMD_STOP_AND_RESTART).
+   *
+   * ArduPilot asks for this whenever a script changes on disk — it emits a
+   * "restart scripting" STATUSTEXT — and until now the only way to act on it
+   * from here was a full flight-controller reboot, which drops the link,
+   * re-runs every startup check and re-syncs the whole parameter table.
+   *
+   * Values verified against AP_Scripting.cpp's handle_command_int_packet:
+   * STOP = 2, STOP_AND_RESTART = 3. REPL_START/REPL_STOP (0/1) are deliberately
+   * not exposed — that handler returns MAV_RESULT_DENIED for both.
+   */
+  async restartScripting(): Promise<void> {
+    await this.sendCommand(MAV_CMD.SCRIPTING, [SCRIPTING_CMD_STOP_AND_RESTART, 0, 0, 0, 0, 0, 0], {
+      waitForAck: true,
+      ackTimeoutMs: 3000
+    })
+  }
+
+  /**
+   * Stop onboard Lua scripting until the next restart or reboot
+   * (MAV_CMD_SCRIPTING, param1 = SCRIPTING_CMD_STOP).
+   */
+  async stopScripting(): Promise<void> {
+    await this.sendCommand(MAV_CMD.SCRIPTING, [SCRIPTING_CMD_STOP, 0, 0, 0, 0, 0, 0], {
       waitForAck: true,
       ackTimeoutMs: 3000
     })

--- a/packages/protocol-mavlink/src/constants.ts
+++ b/packages/protocol-mavlink/src/constants.ts
@@ -251,6 +251,8 @@ export const MAV_CMD = {
   PREFLIGHT_CALIBRATION: 241,
   PREFLIGHT_STORAGE: 245,
   PREFLIGHT_REBOOT_SHUTDOWN: 246,
+  /** ArduPilot-specific: control onboard Lua scripting (ardupilotmega.xml). */
+  SCRIPTING: 42701,
   // Put the RC receiver into bind/pair mode. ArduPilot routes this to the
   // active RC protocol's bind: CRSF/ExpressLRS sends the CRSF bind command
   // frame to the RX, Spektrum pulses the satellite bind. Params are ignored

--- a/packages/protocol-mavlink/src/mock-scenario.ts
+++ b/packages/protocol-mavlink/src/mock-scenario.ts
@@ -1848,6 +1848,39 @@ function buildMockScenario(profile: MockVehicleProfile, options: MockScenarioOpt
                 })
               )
             )
+          } else if (outbound.message.command === MAV_CMD.SCRIPTING) {
+            // The demo advertises SCR_ params, so it must also answer the
+            // scripting control command — otherwise "Restart scripting" only
+            // ever demonstrates its timeout path. param1 2 = STOP,
+            // 3 = STOP_AND_RESTART (AP_Scripting.cpp).
+            const scriptingCommand = Math.round(outbound.message.params[0] ?? 0)
+            responses.push(
+              codec.encode(
+                envelope(106, {
+                  type: 'COMMAND_ACK',
+                  command: MAV_CMD.SCRIPTING,
+                  // AP_Scripting accepts STOP and STOP_AND_RESTART and DENIES
+                  // the REPL commands; mirror that rather than blanket-accepting.
+                  result:
+                    scriptingCommand === 2 || scriptingCommand === 3
+                      ? MAV_RESULT.ACCEPTED
+                      : MAV_RESULT.DENIED,
+                  progress: 0,
+                  resultParam2: 0,
+                  targetSystem: outbound.header.systemId,
+                  targetComponent: outbound.header.componentId
+                })
+              ),
+              codec.encode(
+                envelope(107, {
+                  type: 'STATUSTEXT',
+                  severity: MAV_SEVERITY.INFO,
+                  text: scriptingCommand === 3 ? 'Scripting restarted' : 'Scripting stopped',
+                  statusId: 0,
+                  chunkSequence: 0
+                })
+              )
+            )
           } else if (outbound.message.command === MAV_CMD.PREFLIGHT_REBOOT_SHUTDOWN) {
             responses.push(
               codec.encode(

--- a/tests/e2e/views.spec.ts
+++ b/tests/e2e/views.spec.ts
@@ -693,6 +693,19 @@ test.describe('Lua Scripts view (Expert + scripting-capable FC)', () => {
     await expect(page.getByTestId('lua-card-smartaudio')).toBeVisible()
     await expect(page.getByTestId('lua-card-leds-on-switch')).toBeVisible()
 
+    // Restart/stop scripting sit beside Reboot. Restarting is what ArduPilot
+    // actually asks for when a script changes, and it keeps the link up — a
+    // reboot to achieve the same thing re-runs every startup check and re-syncs
+    // the parameter table.
+    await expect(page.getByTestId('lua-restart-scripting')).toBeVisible()
+    await expect(page.getByTestId('lua-stop-scripting')).toBeVisible()
+    await expect(page.getByTestId('lua-reboot')).toBeVisible()
+
+    await page.getByTestId('lua-restart-scripting').click()
+    await expect(page.getByTestId('lua-notice')).toContainText('Scripting restarted')
+    // The link must survive it — that is the whole point over a reboot.
+    await expect(page.getByTestId('session-vehicle-name')).toHaveText('ArduCopter')
+
     // Install a curated applet → uploads over MAVFTP, then the file appears in
     // the installed list and the card flips to "Reinstall".
     await page.getByTestId('lua-install-leds-on-switch').click()

--- a/tests/lua-scripting-restart.test.mjs
+++ b/tests/lua-scripting-restart.test.mjs
@@ -1,0 +1,124 @@
+// Restarting onboard Lua scripting without rebooting the flight controller.
+//
+// ArduPilot asks for exactly this whenever a script changes on disk (it emits a
+// "restart scripting" STATUSTEXT), but the only control the app offered was a
+// full reboot — which drops the link, re-runs every startup check and re-syncs
+// the whole parameter table to achieve the same thing.
+//
+// The command id and the enum values are the whole risk here: a wrong param1
+// silently does nothing (AP_Scripting returns DENIED or UNSUPPORTED rather than
+// failing loudly), so they are asserted against the values read out of
+// AP_Scripting.cpp and ardupilotmega.xml.
+
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { ArduPilotConfiguratorRuntime } from '../packages/ardupilot-core/dist/index.js'
+import { arducopterMetadata } from '../packages/param-metadata/dist/index.js'
+import { MAV_RESULT } from '../packages/protocol-mavlink/dist/index.js'
+
+/** MAV_CMD_SCRIPTING, ardupilotmega.xml. */
+const MAV_CMD_SCRIPTING = 42701
+
+function createScriptingSession(sent) {
+  const statusListeners = []
+  const messageListeners = []
+
+  const emit = (message) =>
+    messageListeners.forEach((listener) =>
+      listener({ header: { systemId: 1, componentId: 1, sequence: 0 }, message, timestampMs: Date.now() })
+    )
+
+  return {
+    getTransportStatus: () => ({ kind: 'connected' }),
+    onStatus(listener) {
+      statusListeners.push(listener)
+      return () => {}
+    },
+    onMessage(listener) {
+      messageListeners.push(listener)
+      return () => {}
+    },
+    async connect() {
+      statusListeners.forEach((listener) => listener({ kind: 'connected' }))
+      emit({
+        type: 'HEARTBEAT',
+        autopilot: 3,
+        vehicleType: 2,
+        baseMode: 0,
+        customMode: 0,
+        systemStatus: 4,
+        mavlinkVersion: 3
+      })
+    },
+    async disconnect() {
+      statusListeners.forEach((listener) => listener({ kind: 'disconnected', reason: 'test' }))
+    },
+    destroy() {},
+    async send(message) {
+      sent.push(message)
+      if (message.command === MAV_CMD_SCRIPTING) {
+        emit({
+          type: 'COMMAND_ACK',
+          command: MAV_CMD_SCRIPTING,
+          result: MAV_RESULT.ACCEPTED,
+          progress: 0,
+          resultParam2: 0,
+          targetSystem: 1,
+          targetComponent: 1
+        })
+      }
+    }
+  }
+}
+
+async function withRuntime(run) {
+  const sent = []
+  const runtime = new ArduPilotConfiguratorRuntime(createScriptingSession(sent), arducopterMetadata)
+  try {
+    await runtime.connect()
+    await run(runtime, sent)
+  } finally {
+    await runtime.disconnect().catch(() => {})
+    runtime.destroy()
+  }
+}
+
+test('restartScripting sends MAV_CMD_SCRIPTING with STOP_AND_RESTART (3)', async () => {
+  await withRuntime(async (runtime, sent) => {
+    await runtime.restartScripting()
+    const command = sent.find((message) => message.command === MAV_CMD_SCRIPTING)
+    assert.ok(command, 'a MAV_CMD_SCRIPTING (42701) command was sent')
+    // AP_Scripting.cpp: SCRIPTING_CMD_STOP_AND_RESTART sets _restart = true.
+    assert.equal(command.params[0], 3, 'param1 must be SCRIPTING_CMD_STOP_AND_RESTART')
+  })
+})
+
+test('stopScripting sends MAV_CMD_SCRIPTING with STOP (2)', async () => {
+  await withRuntime(async (runtime, sent) => {
+    await runtime.stopScripting()
+    const command = sent.find((message) => message.command === MAV_CMD_SCRIPTING)
+    assert.ok(command, 'a MAV_CMD_SCRIPTING (42701) command was sent')
+    // SCRIPTING_CMD_STOP sets _stop = true WITHOUT _restart.
+    assert.equal(command.params[0], 2, 'param1 must be SCRIPTING_CMD_STOP')
+  })
+})
+
+test('neither command reboots the flight controller', async () => {
+  // The entire point: a reboot drops the link and re-syncs the parameter table.
+  await withRuntime(async (runtime, sent) => {
+    await runtime.restartScripting()
+    await runtime.stopScripting()
+    const reboots = sent.filter((message) => message.command === 246) // PREFLIGHT_REBOOT_SHUTDOWN
+    assert.deepEqual(reboots, [], 'no PREFLIGHT_REBOOT_SHUTDOWN may be sent')
+  })
+})
+
+test('the REPL commands are not exposed — AP_Scripting refuses them', async () => {
+  // REPL_START (0) and REPL_STOP (1) both return MAV_RESULT_DENIED in
+  // AP_Scripting.cpp's handler, so offering them would be a button that always
+  // fails. The runtime exposes only the two the firmware accepts.
+  assert.equal(typeof ArduPilotConfiguratorRuntime.prototype.restartScripting, 'function')
+  assert.equal(typeof ArduPilotConfiguratorRuntime.prototype.stopScripting, 'function')
+  assert.equal(ArduPilotConfiguratorRuntime.prototype.startScriptingRepl, undefined)
+})


### PR DESCRIPTION
ArduPilot asks for a scripting restart whenever a script changes on disk (it emits a *"restart scripting"* STATUSTEXT), but the only control this app offered was a **full reboot** — which drops the link, re-runs every startup check, and re-syncs the whole parameter table to achieve what one command does.

## Added — `MAV_CMD_SCRIPTING` (42701)

| Action | param1 |
|---|---|
| **Restart scripting** | `3` — `SCRIPTING_CMD_STOP_AND_RESTART` |
| **Stop scripting** | `2` — `SCRIPTING_CMD_STOP` |

Both values read out of `AP_Scripting.cpp`'s `handle_command_int_packet` rather than recalled. That same handler returns `MAV_RESULT_DENIED` for `REPL_START` (0) and `REPL_STOP` (1), so those are **deliberately not exposed** — they'd be buttons that always fail.

Restart leads the capability banner as the primary action, since it's what the firmware actually asks for. Stop sits next to it (you mentioned you never use it) and Reboot stays as the last resort. The banner copy no longer claims a reboot is needed to apply new scripts.

## The demo mock now answers it too

It already advertises `SCR_` params, so without an ack the new button could only ever demonstrate its own **timeout path** — which is exactly what the first e2e run showed:

> `Restart scripting failed: Timed out waiting for COMMAND(42701) acknowledgment after 3000ms`

The mock mirrors the firmware's acceptance rule (ACCEPTED for 2/3, DENIED otherwise) rather than blanket-accepting, so a wrong param1 fails in the demo the same way it would on a real vehicle.

## Validation

Rungs 1–3: **797 node** (4 new — the command id and both enum values, that neither command sends a reboot, and that the REPL commands stay unexposed) · **604 vitest** · **231 e2e** — the Lua spec now restarts scripting and asserts **the link survives it**, which is the whole point over a reboot.

**Not yet exercised against a real flight controller.** ArduCopter behaviour is unchanged unless the operator presses one of these — no parameter writes, no change to any existing command.