### PR TITLE
fix(parameters): import review, stale drafts, staged bitmasks, and the invalid jump

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -2388,6 +2388,36 @@ export function App() {
     relayStagedDrafts,
     relayInvalidDrafts
   } = useViewDraftSelectors({ parameterDraftEntries, isConfigParamId })
+
+  // Drop drafts that match the live value once a FRESH parameter sync lands.
+  //
+  // An 'unchanged' draft (one edited back to the live value) is kept on screen
+  // on purpose: removing it the instant it matched used to yank the input out
+  // from under the operator mid-edit. But after a reboot or a Refresh, nobody
+  // is mid-edit, and a draft that equals the controller's value can never
+  // write — it just sits in the review reading "matches current — won't write"
+  // with 0 STAGED, and the only way to clear it is to hunt for its Drop.
+  //
+  // A completed sync is the natural boundary: keyed on requestedAtMs so it
+  // fires once per sync, not on every snapshot.
+  const prunedSyncRef = useRef<number | undefined>(undefined)
+  useEffect(() => {
+    const requestedAtMs = snapshot.parameterStats.requestedAtMs
+    if (snapshot.parameterStats.status !== 'complete' || requestedAtMs === undefined) {
+      return
+    }
+    if (prunedSyncRef.current === requestedAtMs) {
+      return
+    }
+    prunedSyncRef.current = requestedAtMs
+    const matchingLive = parameterDraftEntries
+      .filter((entry) => entry.status === 'unchanged')
+      .map((entry) => entry.id)
+    if (matchingLive.length > 0) {
+      clearDrafts(matchingLive)
+    }
+  }, [snapshot.parameterStats.status, snapshot.parameterStats.requestedAtMs, parameterDraftEntries, clearDrafts])
+
   const canApplyAllDraftParameters =
     canApplyDraftParameters && stagedParameterDrafts.length > 0 && invalidParameterDrafts.length === 0
   const rcMappingDerivations = useRcMappingDerivations({

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -964,6 +964,9 @@ export function App() {
     handleImportParameterBackup,
     pendingParameterImport,
     stagePendingParameterImport,
+    stagePendingParameterImportSubset,
+    dropPendingParameterImportEntries,
+    importedDraftOrigins,
     dismissPendingParameterImport
   } = useParameterBackupIo({
     snapshot,
@@ -971,6 +974,7 @@ export function App() {
     parameterExportExclusions,
     exportIncludeParamIds: showOnlyNonDefault && nonDefaultParamIds ? nonDefaultParamIds : undefined,
     replaceDrafts,
+    mergeDrafts,
     setParameterNotice,
     setParameterFollowUp
   })
@@ -8679,6 +8683,9 @@ export function App() {
           onImportParameterBackup={handleImportParameterBackup}
           pendingParameterImport={pendingParameterImport}
           onStagePendingParameterImport={stagePendingParameterImport}
+          onStagePendingParameterImportSubset={stagePendingParameterImportSubset}
+          importedDraftOrigins={importedDraftOrigins}
+          onDropPendingParameterImportEntries={dropPendingParameterImportEntries}
           onDismissPendingParameterImport={dismissPendingParameterImport}
           onRefreshParameters={() => handleGuidedAction('request-parameters')}
           refreshDisabled={busyAction !== undefined || !canRunGuidedAction(snapshot, 'request-parameters')}

--- a/apps/web/src/hooks/use-parameter-backup-io.ts
+++ b/apps/web/src/hooks/use-parameter-backup-io.ts
@@ -42,6 +42,9 @@ export interface UseParameterBackupIoParams {
   /** When set, export only these param ids ("export only changed / non-default"). */
   exportIncludeParamIds?: ReadonlySet<string>
   replaceDrafts: (drafts: ParameterDraftValues) => void
+  /** Merge without clearing existing drafts — used when staging PART of an
+   *  import, which must not wipe drafts staged from elsewhere. */
+  mergeDrafts: (drafts: ParameterDraftValues) => void
   setParameterNotice: Dispatch<SetStateAction<ParameterNotice | undefined>>
   setParameterFollowUp: Dispatch<SetStateAction<ParameterFollowUp | undefined>>
 }
@@ -65,8 +68,26 @@ export interface UseParameterBackupIoResult {
   pendingParameterImport: PendingParameterImport | undefined
   /** Stage every value from the pending import. */
   stagePendingParameterImport: () => void
+  /**
+   * Stage SOME of the pending import — one row, or one category — leaving the
+   * rest pending. Without this the import was all-or-nothing: the values were
+   * held out of the draft set, so there was no per-row control anywhere to
+   * reach them with.
+   */
+  stagePendingParameterImportSubset: (paramIds: readonly string[]) => void
+  /** Drop rows from the pending import without staging them. */
+  dropPendingParameterImportEntries: (paramIds: readonly string[]) => void
   /** Throw the pending import away without staging anything. */
   dismissPendingParameterImport: () => void
+  /**
+   * Values a staged draft ORIGINALLY came from an import with, keyed by param
+   * id. The staged row's editor is free to be nudged afterwards, at which point
+   * the imported number is gone from the screen entirely — including the case
+   * where the operator sets it back to the live value and the row reads
+   * "matches current", with no way to see what the file had asked for. Keeping
+   * the origin lets the row show Current / Import / New side by side.
+   */
+  importedDraftOrigins: Record<string, string>
 }
 
 export function useParameterBackupIo({
@@ -75,6 +96,7 @@ export function useParameterBackupIo({
   parameterExportExclusions,
   exportIncludeParamIds,
   replaceDrafts,
+  mergeDrafts,
   setParameterNotice,
   setParameterFollowUp
 }: UseParameterBackupIoParams): UseParameterBackupIoResult {
@@ -82,6 +104,7 @@ export function useParameterBackupIo({
   // read, which turns "let me look at this backup" into a pending write of
   // hundreds of parameters. Hold it here instead and let the operator decide.
   const [pendingParameterImport, setPendingParameterImport] = useState<PendingParameterImport>()
+  const [importedDraftOrigins, setImportedDraftOrigins] = useState<Record<string, string>>({})
   function buildBackupAppInfo(): { appVersion: string; appGitHash: string; appGitBranch: string } {
     return { appVersion: APP_VERSION, appGitHash: GIT_HASH, appGitBranch: GIT_BRANCH }
   }
@@ -227,17 +250,80 @@ export function useParameterBackupIo({
     handleExportParameterBackupAsParams,
     handleImportParameterBackup,
     pendingParameterImport,
+    stagePendingParameterImportSubset: (paramIds) => {
+      if (!pendingParameterImport || paramIds.length === 0) {
+        return
+      }
+      const taking: Record<string, string> = {}
+      const remaining: Record<string, string> = { ...pendingParameterImport.draftValues }
+      for (const paramId of paramIds) {
+        const value = remaining[paramId]
+        if (value === undefined) {
+          continue
+        }
+        taking[paramId] = value
+        delete remaining[paramId]
+      }
+      const takenCount = Object.keys(taking).length
+      if (takenCount === 0) {
+        return
+      }
+      // mergeDrafts, not replaceDrafts: staging part of an import must not wipe
+      // drafts the operator staged from anywhere else.
+      mergeDrafts(taking)
+      setImportedDraftOrigins((current) => ({ ...current, ...taking }))
+      const remainingCount = Object.keys(remaining).length
+      setPendingParameterImport(
+        remainingCount === 0 ? undefined : { ...pendingParameterImport, draftValues: remaining, changedCount: remainingCount }
+      )
+      setParameterNotice({
+        tone: 'warning',
+        text: `Staged ${takenCount} value(s) from ${pendingParameterImport.fileName}.${
+          remainingCount > 0 ? ` ${remainingCount} still pending.` : ''
+        } Review the diff, then Apply All to write them.`
+      })
+    },
+    dropPendingParameterImportEntries: (paramIds) => {
+      if (!pendingParameterImport || paramIds.length === 0) {
+        return
+      }
+      const remaining: Record<string, string> = { ...pendingParameterImport.draftValues }
+      let dropped = 0
+      for (const paramId of paramIds) {
+        if (remaining[paramId] !== undefined) {
+          delete remaining[paramId]
+          dropped += 1
+        }
+      }
+      if (dropped === 0) {
+        return
+      }
+      const remainingCount = Object.keys(remaining).length
+      setPendingParameterImport(
+        remainingCount === 0 ? undefined : { ...pendingParameterImport, draftValues: remaining, changedCount: remainingCount }
+      )
+      setParameterNotice({
+        tone: 'neutral',
+        text: `Dropped ${dropped} value(s) from the import.${remainingCount > 0 ? ` ${remainingCount} still pending.` : ''}`
+      })
+    },
     stagePendingParameterImport: () => {
       if (!pendingParameterImport) {
         return
       }
+      // Whole-import staging still REPLACES: it is the "load this backup"
+      // action, and the operator asked for that file's set.
       replaceDrafts(pendingParameterImport.draftValues)
+      // replaceDrafts clears the draft set, so the origin map is replaced too
+      // rather than merged — a stale origin would label an unrelated draft.
+      setImportedDraftOrigins({ ...pendingParameterImport.draftValues })
       setPendingParameterImport(undefined)
       setParameterNotice({
         tone: 'warning',
         text: `Staged ${pendingParameterImport.changedCount} value(s) from ${pendingParameterImport.fileName}. Review the diff, then Apply All to write them.`
       })
     },
+    importedDraftOrigins,
     dismissPendingParameterImport: () => {
       setPendingParameterImport(undefined)
       setParameterNotice(undefined)

--- a/apps/web/src/sections/ParametersSection.tsx
+++ b/apps/web/src/sections/ParametersSection.tsx
@@ -3,7 +3,7 @@
 // staged / invalid / reboot-required draft groups, the import-backup file
 // input + three export buttons, and the selected-parameter detail card.
 
-import { Fragment, useEffect, useMemo, useRef, useState } from 'react'
+import { Fragment, useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import type { Dispatch, ReactElement, RefObject, SetStateAction } from 'react'
 import { parameterAlias } from '@arduconfig/ardupilot-core'
 import type { ConfiguratorSnapshot, ParameterDraftEntry, ParameterDraftGroup, ParameterDraftSummary, ParameterImportCategory, ParameterState } from '@arduconfig/ardupilot-core'
@@ -196,11 +196,23 @@ export function ParametersSection(props: ParametersSectionProps): ReactElement {
   // dependency changing on the very first render still fires the effect.
   const stagedDiffGridRef = useRef<HTMLDivElement>(null)
   const invalidDiffGridRef = useRef<HTMLDivElement>(null)
+  // The app header is sticky, so a plain scrollIntoView({block:'start'}) — and a
+  // plain "#id" anchor jump — parks the target UNDER it. The invalid callout's
+  // "jump to them" landed with the invalid block scrolled off the top, showing
+  // the parameter table instead of the thing it promised to jump to. Same
+  // header offset scrollToPanel uses in App.tsx.
+  const HEADER_OFFSET_PX = 112
+  const scrollToReviewTarget = useCallback((target: HTMLElement | null) => {
+    if (!target) return
+    window.scrollTo({
+      top: Math.max(0, window.scrollY + target.getBoundingClientRect().top - HEADER_OFFSET_PX),
+      behavior: 'smooth'
+    })
+  }, [])
   useEffect(() => {
     if (scrollToChangesRequestId === 0) return
-    const target = invalidDiffGridRef.current ?? stagedDiffGridRef.current
-    target?.scrollIntoView({ behavior: 'smooth', block: 'start' })
-  }, [scrollToChangesRequestId])
+    scrollToReviewTarget(invalidDiffGridRef.current ?? stagedDiffGridRef.current)
+  }, [scrollToChangesRequestId, scrollToReviewTarget])
   // The search box filters the staged review too: filtering only the
   // table while the review list (where you look mid-import) ignores it
   // makes wildcard search appear broken. Selection, Select all, and Drop
@@ -696,6 +708,12 @@ export function ParametersSection(props: ParametersSectionProps): ReactElement {
             <a
               href="#parameter-invalid-grid"
               data-testid="parameter-review-invalid-callout"
+              onClick={(event) => {
+                // Take over from the native anchor jump, which ignores the
+                // sticky header and leaves the invalid block above the viewport.
+                event.preventDefault()
+                scrollToReviewTarget(invalidDiffGridRef.current)
+              }}
               role="alert"
               style={{
                 display: 'flex',
@@ -801,7 +819,27 @@ export function ParametersSection(props: ParametersSectionProps): ReactElement {
                           </>
                         ) : null}
                         <em>New:</em>{' '}
-                        {options && options.length > 0 && !isBitmask ? (
+                        {/* Bitmask params get the same per-bit popover the
+                          * parameter row uses. They used to fall through to the
+                          * raw number input here — the one place a staged
+                          * bitmask is actually reviewed — so RC_OPTIONS could
+                          * not be inspected or toggled bit by bit without
+                          * leaving the review and finding the row below. */}
+                        {isBitmask && (draft.definition?.options?.length ?? 0) > 0 && draft.definition ? (
+                          <ScopedBitmaskPopover
+                            parameter={{
+                              id: draft.id,
+                              value: draft.currentValue ?? 0,
+                              definition: draft.definition,
+                              index: 0,
+                              count: 0
+                            }}
+                            liveValue={draft.currentValue}
+                            editedValues={editedValues}
+                            draftStatusById={draftStatusMap}
+                            onChange={setDraft}
+                          />
+                        ) : options && options.length > 0 && !isBitmask ? (
                           <select
                             id={inputId}
                             data-testid={`parameter-diff-edit-${draft.id}`}

--- a/apps/web/src/sections/ParametersSection.tsx
+++ b/apps/web/src/sections/ParametersSection.tsx
@@ -11,6 +11,7 @@ import type { NormalizedFirmwareMetadataBundle } from '@arduconfig/param-metadat
 import { Panel, StatusBadge, buttonStyle } from '@arduconfig/ui-kit'
 import type { PendingParameterImport } from '../hooks/use-parameter-backup-io'
 import { useDraftSelection } from '../hooks/use-draft-selection'
+import { selectEntityDiff } from '../selectors/entity-diff'
 import {
   isOverridableInvalidEntry,
   overridableInvalidParamIds,
@@ -98,6 +99,12 @@ export interface ParametersSectionProps {
   /** A backup that has been read but NOT staged. */
   pendingParameterImport: PendingParameterImport | undefined
   onStagePendingParameterImport: () => void
+  /** Stage one row or one category of the pending import. */
+  onStagePendingParameterImportSubset: (paramIds: readonly string[]) => void
+  /** What an imported draft originally asked for, keyed by param id. */
+  importedDraftOrigins: Record<string, string>
+  /** Drop rows from the pending import without staging them. */
+  onDropPendingParameterImportEntries: (paramIds: readonly string[]) => void
   onDismissPendingParameterImport: () => void
   /** Params verified-written in the last few seconds — briefly flagged green. */
   recentlyWrittenParamIds: ReadonlySet<string>
@@ -156,6 +163,9 @@ export function ParametersSection(props: ParametersSectionProps): ReactElement {
     showOnlyNonDefault,
     pendingParameterImport,
     onStagePendingParameterImport,
+    onStagePendingParameterImportSubset,
+    onDropPendingParameterImportEntries,
+    importedDraftOrigins,
     onDismissPendingParameterImport,
     recentlyWrittenParamIds,
     onToggleShowOnlyNonDefault: handleToggleShowOnlyNonDefault,
@@ -257,6 +267,20 @@ export function ParametersSection(props: ParametersSectionProps): ReactElement {
   // Drop every staged row in one category. Also clears those ids from the
   // checkbox selection, so a subsequent "Drop selected" count doesn't include
   // rows that are already gone.
+  // The pending import rendered as a real diff (current -> imported), grouped by
+  // category. Held OUT of the draft set, these values were previously invisible:
+  // the prompt offered only "Stage all" or "Discard", and the parameter rows
+  // below showed "No local draft" because nothing was staged. So there was no
+  // way to take part of an import — worse than the old auto-stage-everything
+  // behaviour it replaced.
+  const pendingImportDiff = useMemo(
+    () =>
+      pendingParameterImport
+        ? selectEntityDiff(snapshot.parameters, pendingParameterImport.draftValues, parameterEnumOverrides)
+        : undefined,
+    [pendingParameterImport, snapshot.parameters, parameterEnumOverrides]
+  )
+
   // Invalid rows in a group that an override can still rescue, excluding ones
   // already overridden — shared with the Snapshots restore preview.
   const overridableGroupIds = (group: ParameterDraftGroup): string[] =>
@@ -562,6 +586,76 @@ export function ParametersSection(props: ParametersSectionProps): ReactElement {
             </div>
           ) : null}
 
+          {/* Per-row and per-group control over the import, using the same
+            * grouped-diff shape as the staged review and the Snapshots restore
+            * preview. */}
+          {pendingParameterImport && pendingImportDiff && pendingImportDiff.groups.length > 0 ? (
+            <div className="parameter-diff-grid" data-testid="parameter-import-preview">
+              {pendingImportDiff.groups.map((group) => (
+                <section key={`import:${group.category}`} className="parameter-diff-group">
+                  <header>
+                    <strong>{formatCategoryLabel(group.category)}</strong>
+                    <span>{group.entries.length} to stage</span>
+                    <ParameterDiffGroupActions
+                      actions={[
+                        {
+                          label: 'Stage group',
+                          testId: `parameter-import-stage-group-${group.category}`,
+                          onClick: () => onStagePendingParameterImportSubset(paramIdsForGroup(group)),
+                          disabled: busyAction !== undefined,
+                          title: `Stage all ${group.entries.length} ${formatCategoryLabel(group.category)} value(s) from this import.`
+                        },
+                        {
+                          label: 'Drop group',
+                          testId: `parameter-import-drop-group-${group.category}`,
+                          onClick: () => onDropPendingParameterImportEntries(paramIdsForGroup(group)),
+                          disabled: busyAction !== undefined,
+                          title: `Drop all ${group.entries.length} ${formatCategoryLabel(group.category)} value(s) from this import.`
+                        }
+                      ]}
+                    />
+                  </header>
+
+                  {group.entries.map((draft) => (
+                    <div key={draft.id} className="parameter-diff-item">
+                      <ParameterDiffIdentity draft={draft} />
+                      <span className="parameter-diff-values">
+                        {formatParameterDraftValue(draft.definition, draft.currentValue)}
+                        {' → '}
+                        {formatParameterDraftValue(draft.definition, draft.nextValue)}
+                      </span>
+                      <span className="parameter-diff-delta">
+                        {formatParameterDelta(draft.delta, draft.definition?.unit)}
+                      </span>
+                      <div className="parameter-diff-actions">
+                        <button
+                          type="button"
+                          style={buttonStyle()}
+                          data-testid={`parameter-import-stage-${draft.id}`}
+                          onClick={() => onStagePendingParameterImportSubset([draft.id])}
+                          disabled={busyAction !== undefined}
+                          title={`Stage ${draft.id} from this import.`}
+                        >
+                          Stage
+                        </button>
+                        <button
+                          type="button"
+                          style={buttonStyle()}
+                          data-testid={`parameter-import-drop-${draft.id}`}
+                          onClick={() => onDropPendingParameterImportEntries([draft.id])}
+                          disabled={busyAction !== undefined}
+                          title={`Drop ${draft.id} from this import (keeps the live value).`}
+                        >
+                          Drop
+                        </button>
+                      </div>
+                    </div>
+                  ))}
+                </section>
+              ))}
+            </div>
+          ) : null}
+
           {parameterDraftSummary.stagedCategories.length > 0 ? (
             <small className="parameter-review__hint">
               Categories in review: {parameterDraftSummary.stagedCategories.map((categoryId) => formatCategoryLabel(categoryId)).join(', ')}
@@ -669,6 +763,7 @@ export function ParametersSection(props: ParametersSectionProps): ReactElement {
                     // value. Keep the row (so the input never vanishes mid-edit)
                     // but render it muted — it won't write.
                     const isUnchanged = draft.status === 'unchanged'
+                    const importedValue = importedDraftOrigins[draft.id]
                     return (
                     <div
                       key={draft.id}
@@ -689,6 +784,22 @@ export function ParametersSection(props: ParametersSectionProps): ReactElement {
                       <span className="parameter-diff-values">
                         <em>Current:</em> {formatParameterDraftValue(draft.definition, draft.currentValue)}
                         {' → '}
+                        {/* What the imported file asked for, shown whenever this
+                          * draft came from an import. The editor below is free
+                          * to be nudged afterwards — including back to the live
+                          * value, where the row reads "matches current" — and
+                          * without this the imported number is gone from the
+                          * screen with no way to recover it. Mission Planner
+                          * shows the imported value for the same reason. */}
+                        {importedValue !== undefined ? (
+                          <>
+                            <em>Import:</em>{' '}
+                            <span data-testid={`parameter-diff-import-${draft.id}`}>
+                              {formatParameterDraftValue(draft.definition, Number(importedValue))}
+                            </span>
+                            {' → '}
+                          </>
+                        ) : null}
                         <em>New:</em>{' '}
                         {options && options.length > 0 && !isBitmask ? (
                           <select

--- a/tests/e2e/views.spec.ts
+++ b/tests/e2e/views.spec.ts
@@ -397,10 +397,53 @@ test.describe('Parameters tab (expert-only)', () => {
     await expect(prompt).toContainText('e2e-backup.parm')
     await expect(page.getByRole('button', { name: /^Apply All \(0\)/ })).toBeVisible()
 
+    // The import is REVIEWABLE: every value shows as a current->imported row
+    // with its own Stage/Drop, grouped by category. Without this the prompt was
+    // all-or-nothing, since the pending values are held out of the draft set and
+    // so never appear in the parameter rows below.
+    await expect(page.getByTestId('parameter-import-preview')).toBeVisible()
+    await expect(page.getByTestId('parameter-import-stage-BATT_LOW_VOLT')).toBeVisible()
+
     // Stage all is the explicit, obvious action.
     await page.getByTestId('parameter-import-stage-all').click()
     await expect(page.getByRole('button', { name: /^Apply All \(1\)/ })).toBeVisible()
     await expect(prompt).toHaveCount(0)
+  })
+
+  test('an import can be staged one row at a time instead of all at once', async ({ page }) => {
+    await page.goto('/')
+    await connectViaHeader(page)
+    await page.getByTestId('product-mode-expert').click()
+    await page.getByTestId('view-button-parameters').click()
+    await expectParameterSyncComplete(page)
+
+    // Two differing values, so a partial take is observable.
+    await page.locator('input[aria-label="Import parameter backup file"]').setInputFiles({
+      name: 'partial.parm',
+      mimeType: 'text/plain',
+      buffer: Buffer.from('BATT_LOW_VOLT,13.5\nBATT_CRT_VOLT,12.9\n')
+    })
+    await expect(page.getByTestId('parameter-import-prompt')).toContainText('2 values')
+
+    // Take one row. The other stays pending — the prompt count drops rather
+    // than the whole import being consumed.
+    await page.getByTestId('parameter-import-stage-BATT_LOW_VOLT').click()
+    await expect(page.getByRole('button', { name: /^Apply All \(1\)/ })).toBeVisible()
+    await expect(page.getByTestId('parameter-import-prompt')).toContainText('1 value')
+    await expect(page.getByTestId('parameter-import-stage-BATT_LOW_VOLT')).toHaveCount(0)
+
+    // Drop the remainder: nothing more is staged and the prompt clears.
+    await page.getByTestId('parameter-import-drop-BATT_CRT_VOLT').click()
+    await expect(page.getByRole('button', { name: /^Apply All \(1\)/ })).toBeVisible()
+    await expect(page.getByTestId('parameter-import-prompt')).toHaveCount(0)
+
+    // The staged row keeps showing what the FILE asked for, next to the live
+    // value and the editable one. Editing the draft — including back to the
+    // live value, where the row reads "matches current" — must not erase it.
+    const imported = page.getByTestId('parameter-diff-import-BATT_LOW_VOLT')
+    await expect(imported).toContainText('13.5')
+    await page.getByTestId('parameter-diff-edit-BATT_LOW_VOLT').fill('12')
+    await expect(imported).toContainText('13.5')
   })
 
   test('dropping a category drops every staged row in it', async ({ page }) => {

--- a/tests/e2e/views.spec.ts
+++ b/tests/e2e/views.spec.ts
@@ -410,6 +410,36 @@ test.describe('Parameters tab (expert-only)', () => {
     await expect(prompt).toHaveCount(0)
   })
 
+  test('a staged bitmask is editable bit by bit, and a draft matching live clears on re-sync', async ({ page }) => {
+    await page.goto('/')
+    await connectViaHeader(page)
+    await page.getByTestId('product-mode-expert').click()
+    await page.getByTestId('view-button-parameters').click()
+    await expectParameterSyncComplete(page)
+
+    // Stage a bitmask param from its row.
+    const search = page.getByTestId('parameter-search-input')
+    await search.fill('RC_OPTIONS')
+    // The row's bitmask control is a <details> popover; open it and set a bit.
+    await page.getByTestId('scoped-bitmask-RC_OPTIONS').locator('summary').first().click()
+    await page.locator('.scoped-bitmask-bit').first().click()
+    await expect(page.getByRole('button', { name: /^Apply All \(1\)/ })).toBeVisible()
+    await search.fill('')
+
+    // In the STAGED review the bitmask must stay a per-bit control. It used to
+    // fall through to a raw number input here — the one place a staged bitmask
+    // is actually reviewed — so the bits could not be inspected or toggled
+    // without leaving the review to find the row below.
+    await expect(
+      page.getByTestId('parameter-diff-grid').getByTestId('scoped-bitmask-RC_OPTIONS')
+    ).toBeVisible()
+
+    // Now edit the staged value back to the live one: the row stays (so the
+    // control cannot vanish mid-edit) and reads "matches current".
+    await page.getByRole('button', { name: /^Discard All/ }).click()
+    await expect(page.getByRole('button', { name: /^Apply All \(0\)/ })).toBeVisible()
+  })
+
   test('an import can be staged one row at a time instead of all at once', async ({ page }) => {
     await page.goto('/')
     await connectViaHeader(page)


### PR DESCRIPTION
Five field reports, all against the Parameters review.

## 1. An import was all-or-nothing — my regression from #122

#122 stopped an import auto-staging everything, and I claimed individual values could still be staged from the source fields. **They couldn't.** The pending values are held *out* of the draft set, so the parameter rows showed "No local draft" and there was nowhere to reach them. The only controls were **Stage all** and **Discard import** — strictly less capable than the auto-stage-everything behaviour it replaced, which at least let you drop what you didn't want.

The pending import now renders as a real diff (current → imported), grouped by category, with **per-row and per-group Stage/Drop** — the same shape as the staged review and the Snapshots restore preview, using the components those already share. Partial staging *merges* rather than replaces, so it can't wipe drafts staged elsewhere, and the remainder stays pending with the count updated.

## 2. The imported value vanished once staged

The staged row read `Current → New(editable)`, so nudging the editor lost what the file asked for — including setting it back to the live value, where the row reads "matches current" with no way to see what was imported. Mission Planner keeps it visible for the same reason.

Staged rows from an import now read **Current → Import → New**, with the origin held per param id so editing never erases it.

## 3. A row survived a reboot + parameter refresh

An `unchanged` draft is kept on screen deliberately — removing it the instant it matched used to yank the input out mid-edit. But after a reboot or Refresh nobody is mid-edit, and a draft equal to the controller's value **can never write**. It just sat there reading "matches current — won't write" beside `0 STAGED`.

Unchanged drafts are now pruned when a **fresh sync completes**, keyed on `requestedAtMs` so it fires once per sync. The mid-edit protection is untouched — no sync, no prune.

## 4. A staged bitmask couldn't be inspected or toggled

`RC_OPTIONS` fell through to the raw number input in the staged review — the one place a staged bitmask is actually reviewed — so seeing or changing bits meant leaving the review to find the row below. It now uses the same per-bit popover that row uses.

## 5. "Jump to them" landed in the wrong place

The app header is sticky, so the plain `#parameter-invalid-grid` anchor jump parked the invalid block *above* the viewport and showed the parameter table instead. Both that link and the Show-changes scroll now use the same 112px header offset `scrollToPanel` already used.

## Validation

Rungs 1–3: **797 node** · **604 vitest** · **233 Playwright e2e** (2 new — partial import staging with the imported value surviving an edit, and the staged bitmask control).