### PR TITLE
feat(motors): finish the guided identify run with one Save changes

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -821,6 +821,9 @@ export function App() {
   // motor-reorder workbench and a direction-test surface so the operator
   // never has to leave the popout to spin a motor or flip a reversal.
   const [motorDialogTab, setMotorDialogTab] = useState<'reorder' | 'direction'>('reorder')
+  // Armed by the one-click "Save changes" finish; consumed by the effect that
+  // writes the reorder once the staged drafts have actually landed in state.
+  const [pendingMotorReorderSave, setPendingMotorReorderSave] = useState(false)
   // Guided motor-identify auto-spin: after the operator spins the FIRST motor,
   // automatically spin each subsequent motor once the previous test window has
   // fully closed, so they only ever click the position that moved. The wait is
@@ -2596,6 +2599,23 @@ export function App() {
     () => stagedParameterDrafts.filter((draft) => motorReorderDialogParamIds.has(draft.id)),
     [stagedParameterDrafts, motorReorderDialogParamIds]
   )
+  // "Save changes" completion: the drafts staged by handleSaveMotorReorder are
+  // only visible here on the following render, so the write is deferred to this
+  // effect rather than chained inline where it would see a stale empty list.
+  useEffect(() => {
+    if (!pendingMotorReorderSave || motorReorderDialogStagedDrafts.length === 0) {
+      return
+    }
+    setPendingMotorReorderSave(false)
+    void (async () => {
+      await handleApplyScopedParameterDrafts(motorReorderDialogStagedDrafts, 'motor-reorder:apply', 'Motor setup')
+      await handleGuidedAction('reboot-autopilot')
+    })()
+    // handleApplyScopedParameterDrafts / handleGuidedAction are stable function
+    // declarations on the component body; re-running on their identity would
+    // fire the write on every render.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [pendingMotorReorderSave, motorReorderDialogStagedDrafts])
   const {
     groups: setupAdditionalGroups,
     entries: setupAdditionalDraftEntries,
@@ -4370,9 +4390,17 @@ export function App() {
     }
   }
 
-  function handleStageMotorReorderDrafts(): void {
+  /**
+   * Stage the identified motor order as parameter drafts.
+   *
+   * `keepDialogOpen` exists for the one-click "Save changes" finish: staging
+   * normally closes the dialog and hands the operator off to Outputs to write,
+   * which reads as two disjoint steps across two screens. The save path stages
+   * and writes without ever leaving the dialog.
+   */
+  function handleStageMotorReorderDrafts(options: { keepDialogOpen?: boolean } = {}): number {
     if (!motorReorderCanStage) {
-      return
+      return 0
     }
 
     const nextAssignmentValues = new Map<string, string>()
@@ -4399,21 +4427,44 @@ export function App() {
 
     replaceDrafts(nextEditedValues)
     clearSetupSectionConfirmation('outputs')
-    setMotorReorderDialogOpen(false)
+    if (!options.keepDialogOpen) {
+      setMotorReorderDialogOpen(false)
+    }
 
     if (changedParamIds.length === 0) {
       setParameterNotice({
         tone: 'neutral',
         text: 'Motor output order already matches the selected layout.'
       })
-      return
+      return 0
     }
 
-    setSelectedParameterId(changedParamIds[0] ?? selectedParameterId)
-    setParameterNotice({
-      tone: 'warning',
-      text: `Staged ${changedParamIds.length} motor output remap change(s). Apply them from Outputs, then rerun the guarded motor direction check before flight.`
-    })
+    if (!options.keepDialogOpen) {
+      setSelectedParameterId(changedParamIds[0] ?? selectedParameterId)
+      setParameterNotice({
+        tone: 'warning',
+        text: `Staged ${changedParamIds.length} motor output remap change(s). Apply them from Outputs, then rerun the guarded motor direction check before flight.`
+      })
+    }
+    return changedParamIds.length
+  }
+
+  /**
+   * One-click finish for the guided identify run: stage the reorder and write
+   * it without closing the dialog.
+   *
+   * The write cannot happen in this same tick — `motorReorderDialogStagedDrafts`
+   * is derived from `stagedParameterDrafts`, which has not re-rendered yet, so
+   * applying here would write a stale (usually empty) list. Instead this arms
+   * `pendingMotorReorderSave` and an effect performs the write once the drafts
+   * actually land, reusing the normal scoped-apply path so validation, notices
+   * and rollback behave identically to the two-step flow.
+   */
+  function handleSaveMotorReorder(): void {
+    const staged = handleStageMotorReorderDrafts({ keepDialogOpen: true })
+    if (staged > 0) {
+      setPendingMotorReorderSave(true)
+    }
   }
 
   function handleStartMotorVerification(preferredOutputChannel?: number): void {
@@ -5654,7 +5705,8 @@ export function App() {
         onSpinGuidedReorderCurrent={handleSpinGuidedReorderCurrent}
         onToggleGuidedReorderAutoSpin={setGuidedReorderAutoSpin}
         onPickGuidedReorderPosition={handlePickGuidedReorderPosition}
-        onStageReorderDrafts={handleStageMotorReorderDrafts}
+        onStageReorderDrafts={() => handleStageMotorReorderDrafts()}
+        onSaveReorder={handleSaveMotorReorder}
         onSpinSingleMotor={handleDialogSpinSingleMotor}
         setDraft={setDraft}
         motorReorderStagedCount={motorReorderDialogStagedDrafts.length}

--- a/apps/web/src/sections/MotorReorderDialog.tsx
+++ b/apps/web/src/sections/MotorReorderDialog.tsx
@@ -66,6 +66,9 @@ export interface MotorReorderDialogProps {
   onToggleGuidedReorderAutoSpin: (next: boolean) => void
   onPickGuidedReorderPosition: (motorNumber: number) => void
   onStageReorderDrafts: () => void
+  /** One-click finish after a guided identify run: stage the reorder AND write
+   *  it, without closing the dialog or bouncing the operator to Outputs. */
+  onSaveReorder: () => void
   onSpinSingleMotor: (channelNumber: number) => void
   setDraft: (paramId: string, value: string) => void
 
@@ -120,6 +123,7 @@ export function MotorReorderDialog({
   onToggleGuidedReorderAutoSpin,
   onPickGuidedReorderPosition,
   onStageReorderDrafts,
+  onSaveReorder,
   onSpinSingleMotor,
   setDraft,
   motorReorderStagedCount,
@@ -425,15 +429,40 @@ export function MotorReorderDialog({
                 </button>
                 {/* Primary emphasis only after an identify run has produced
                  *  something to stage — an untested green button read as
-                 *  "click me" before any motor had ever spun. */}
-                <button
-                  type="button"
-                  style={buttonStyle(guidedReorderCompleted && motorReorderChangedCount > 0 ? 'primary' : undefined)}
-                  onClick={onStageReorderDrafts}
-                  disabled={!motorReorderCanStage}
-                >
-                  {motorReorderChangedCount > 0 ? `Stage Reorder (${motorReorderChangedCount})` : 'Stage Reorder'}
-                </button>
+                 *  "click me" before any motor had ever spun.
+                 *
+                 *  After a completed identify run this is a single "Save
+                 *  changes" that stages AND writes without closing the dialog.
+                 *  Staging used to close the dialog and hand the operator off
+                 *  to Outputs to write, which read as two disjoint steps across
+                 *  two screens. Outside that finish (manual edits, no identify
+                 *  run yet) it stays the plain stage action so the shared
+                 *  apply-bar can still batch reorder + reverse-mask into one
+                 *  write. */}
+                {guidedReorderCompleted && motorReorderChangedCount > 0 ? (
+                  <button
+                    type="button"
+                    style={buttonStyle('primary')}
+                    onClick={onSaveReorder}
+                    disabled={!motorReorderCanStage || !canApplyMotorDrafts || busyAction !== undefined}
+                    data-testid="motor-reorder-save"
+                  >
+                    {busyAction === 'motor-reorder:apply'
+                      ? 'Saving…'
+                      : busyAction === 'reboot-autopilot'
+                        ? 'Rebooting…'
+                        : `Save changes (${motorReorderChangedCount})`}
+                  </button>
+                ) : (
+                  <button
+                    type="button"
+                    style={buttonStyle()}
+                    onClick={onStageReorderDrafts}
+                    disabled={!motorReorderCanStage}
+                  >
+                    {motorReorderChangedCount > 0 ? `Stage Reorder (${motorReorderChangedCount})` : 'Stage Reorder'}
+                  </button>
+                )}
               </div>
             </div>
           </section>

--- a/tests/e2e/app.spec.ts
+++ b/tests/e2e/app.spec.ts
@@ -340,6 +340,12 @@ test.describe('browser configurator regression flows', () => {
     // Ack the safety gate in the inline panel (gates the guided spin).
     await page.getByTestId('motor-reorder-props-off-ack').locator('input').check()
 
+    // The one-click "Save changes" finish is gated on a COMPLETED identify run
+    // that actually changed something — before any motor has spun there is
+    // nothing to save, so only the plain Stage action is offered.
+    await expect(page.getByTestId('motor-reorder-save')).toHaveCount(0)
+    await expect(page.getByRole('button', { name: /Stage Reorder/ })).toBeVisible()
+
     const startButton = page.getByTestId('motor-reorder-guided-start')
     await expect(startButton).toBeVisible()
     await expect(startButton).toBeEnabled()


### PR DESCRIPTION
## Why

Field feedback while setting up a new build:

> Starting the process with the big green button "Identify motors interactively" is good. After going through all four motors I feel like it should just be "save changes" instead of "Stage reorder (4)" and then write changes

It wasn't only a label. `App.tsx` ended `handleStageMotorReorderDrafts` with `setMotorReorderDialogOpen(false)` — staging **closed the dialog** and handed the operator off to Outputs to find the write button. One logical action ("save the order I just identified") was two disjoint steps across two screens.

## What changed

After a completed identify run that produced changes, the reorder tab shows a single **"Save changes (N)"** that stages, writes and reboots without closing the dialog.

Outside that finish — manual edits, or before any motor has spun — it stays the plain "Stage Reorder" action, so the shared apply-bar can still batch a reorder together with the direction tab's reverse-mask toggles into one write.

`handleStageMotorReorderDrafts` now takes `{ keepDialogOpen }` and returns the staged count.

## The stale-draft trap

The write is deferred to an effect rather than chained inline. `motorReorderDialogStagedDrafts` is derived from `stagedParameterDrafts` and doesn't update until the next render, so an inline stage-then-apply would write a **stale empty list** — a silent no-op that presents as success. Routing through the effect also keeps the normal `handleApplyScopedParameterDrafts` path, so validation, notices and rollback are unchanged.

## ArduCopter byte-identical

UI flow only. The same `SERVOn_FUNCTION` drafts are produced and written through the same scoped-apply path; no parameter value, metadata or vehicle branch changes.

## Validation (rungs 1 and 3)

- `npm run typecheck` — clean
- `npm run test` — 794 pass / 0 fail
- web vitest — 604 pass / 0 fail
- `npm run test:e2e` — 233 pass / 6 skipped (visual baselines)

**Known gap:** the new e2e assertion locks the *gating* (Save absent until a run completes, Stage offered instead) but not the completed-run path — reaching that needs a full 4-motor walk and motor-test e2e is already in the known-flaky set. The save path writes `SERVOn_FUNCTION` and reboots, so it wants a props-off bench run (rung 5) before it's trusted on a new build.