### PR TITLE
fix(setup): stop the guided wizard forgetting progress during parameter sync

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -330,6 +330,7 @@ import { SetupWizardHeader } from './sections/SetupWizardHeader'
 import { SetupWizardDetail } from './sections/SetupWizardDetail'
 import { SetupBenchActions } from './sections/SetupBenchActions'
 import { StatusDfuCard } from './sections/StatusDfuCard'
+import { resolveSetupConfirmationRecord } from './view-models/setup-confirmation-resolve'
 import { buildSetupConfirmationSignatures } from './view-models/setup-confirmation-signatures'
 import { buildTuningTaskCards } from './view-models/tuning-task-cards'
 import { buildOutputTaskCards, recommendOutputTaskId, type OutputTaskCard } from './view-models/output-task-cards'
@@ -4802,13 +4803,14 @@ export function App() {
   )
 
   function getSetupConfirmationRecord(sectionId: string): SetupConfirmationRecord | undefined {
-    const record = setupConfirmations[sectionId]
-    const signature = setupConfirmationSignatures[sectionId]
-    if (!record || signature === undefined || record.signature !== signature) {
-      return undefined
-    }
-
-    return record
+    return resolveSetupConfirmationRecord({
+      record: setupConfirmations[sectionId],
+      signature: setupConfirmationSignatures[sectionId],
+      // Signatures are derived from parameters; mid-sync they are meaningless
+      // and must not be allowed to invalidate stored progress. See
+      // setup-confirmation-resolve.ts.
+      parameterSyncComplete: snapshot.parameterStats.status === 'complete'
+    })
   }
 
   const escReviewConfirmation = getSetupConfirmationRecord('esc-range')

--- a/apps/web/src/view-models/setup-confirmation-resolve.test.ts
+++ b/apps/web/src/view-models/setup-confirmation-resolve.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from 'vitest'
+
+import type { SetupConfirmationRecord } from '../app-types'
+import { resolveSetupConfirmationRecord } from './setup-confirmation-resolve'
+
+const record: SetupConfirmationRecord = {
+  signature: '{"accId":123,"offsets":[1,2,3]}',
+  confirmedAtMs: 1_700_000_000_000,
+  outcome: 'complete'
+}
+
+describe('resolveSetupConfirmationRecord', () => {
+  it('keeps a confirmation whose signature still matches', () => {
+    expect(
+      resolveSetupConfirmationRecord({
+        record,
+        signature: record.signature,
+        parameterSyncComplete: true
+      })
+    ).toEqual(record)
+  })
+
+  it('drops a confirmation once the configuration it signed off has changed', () => {
+    // The whole point of signatures: a re-run calibration or a changed airframe
+    // must stop counting as reviewed.
+    expect(
+      resolveSetupConfirmationRecord({
+        record,
+        signature: '{"accId":456,"offsets":[9,9,9]}',
+        parameterSyncComplete: true
+      })
+    ).toBeUndefined()
+  })
+
+  it('drops a confirmation for a section that has no signature at all', () => {
+    expect(
+      resolveSetupConfirmationRecord({
+        record,
+        signature: undefined,
+        parameterSyncComplete: true
+      })
+    ).toBeUndefined()
+  })
+
+  it('returns nothing when the operator never confirmed the section', () => {
+    expect(
+      resolveSetupConfirmationRecord({
+        record: undefined,
+        signature: record.signature,
+        parameterSyncComplete: true
+      })
+    ).toBeUndefined()
+  })
+
+  // The regression this module exists for. Mid-sync the signature is built from
+  // parameters that have not arrived, so it can never match what was stored.
+  // Invalidating on that mismatch regressed every section at once and resumed
+  // the wizard at "Continue to Airframe" on every reconnect.
+  it('holds the stored confirmation while parameters are still syncing', () => {
+    expect(
+      resolveSetupConfirmationRecord({
+        record,
+        signature: '{"accId":null,"offsets":[null,null,null]}',
+        parameterSyncComplete: false
+      })
+    ).toEqual(record)
+  })
+
+  it('holds the stored confirmation mid-sync even with no signature yet', () => {
+    expect(
+      resolveSetupConfirmationRecord({
+        record,
+        signature: undefined,
+        parameterSyncComplete: false
+      })
+    ).toEqual(record)
+  })
+
+  it('re-validates once the sync completes, so a genuine mismatch still drops', () => {
+    const staleSignature = '{"accId":456,"offsets":[9,9,9]}'
+    expect(
+      resolveSetupConfirmationRecord({ record, signature: staleSignature, parameterSyncComplete: false })
+    ).toEqual(record)
+    expect(
+      resolveSetupConfirmationRecord({ record, signature: staleSignature, parameterSyncComplete: true })
+    ).toBeUndefined()
+  })
+})

--- a/apps/web/src/view-models/setup-confirmation-resolve.ts
+++ b/apps/web/src/view-models/setup-confirmation-resolve.ts
@@ -1,0 +1,65 @@
+// Resolving a stored guided-Setup confirmation against the live signature.
+//
+// A section's confirmation is pinned to a signature of the configuration it
+// signed off (see setup-confirmation-signatures.ts). When the live signature
+// stops matching, the sign-off no longer counts — that is what makes a stale
+// confirmation stop hiding a changed airframe or a re-run calibration.
+//
+// The subtlety this exists to encode: those signatures are computed FROM
+// PARAMETERS (INS_ACC_ID, INS_ACCOFFS_*, AHRS_TRIM_*, FRAME_CLASS, ...). While
+// a freshly connected vehicle is still streaming its parameter table, none of
+// them exist yet, so the live signature is a JSON blob full of `undefined` that
+// cannot match anything ever stored. Reading that as "not confirmed" regressed
+// EVERY section simultaneously and resumed the wizard at step 1 — the reported
+// "Continue to Airframe every time I come back", along with a completed
+// accelerometer calibration reading as never done.
+//
+// So: a mismatch only means something once the parameters the signature is
+// derived from have actually arrived. Until then the last known state stands.
+//
+// This is safe rather than merely convenient — parameter writes are themselves
+// gated on a complete sync, so a provisionally-trusted confirmation cannot
+// authorise any action during the window in which it is trusted.
+
+import type { SetupConfirmationRecord } from '../app-types'
+
+export interface ResolveSetupConfirmationInputs {
+  /** The stored confirmation for this section, if the operator ever signed it off. */
+  record: SetupConfirmationRecord | undefined
+  /** The signature derived from the CURRENT snapshot, or undefined if the
+   *  section has no signature defined. */
+  signature: string | undefined
+  /** Whether the parameter table has finished syncing. False while a freshly
+   *  connected vehicle is still streaming — the window in which every
+   *  parameter-derived signature is meaningless. */
+  parameterSyncComplete: boolean
+}
+
+/**
+ * The stored confirmation if it still counts, otherwise undefined.
+ *
+ * Returns the record unvalidated while the parameter sync is incomplete: the
+ * comparison it would otherwise be subjected to cannot succeed yet, and
+ * failing it would silently discard the operator's progress.
+ */
+export function resolveSetupConfirmationRecord({
+  record,
+  signature,
+  parameterSyncComplete
+}: ResolveSetupConfirmationInputs): SetupConfirmationRecord | undefined {
+  if (!record) {
+    return undefined
+  }
+
+  // Parameters still arriving — the signature is not yet computable from real
+  // values, so hold the last known state instead of invalidating it.
+  if (!parameterSyncComplete) {
+    return record
+  }
+
+  if (signature === undefined || record.signature !== signature) {
+    return undefined
+  }
+
+  return record
+}


### PR DESCRIPTION
## Reported

> I came back to the guided setup beta and I like how it remembers where I left off, but looks like a bug... I am getting "continue to airframe" in the bottom each time I come back. And forgot I did the accel calibration.

Both symptoms are one bug.

## Cause

Section confirmations are pinned to a signature of the configuration they signed off, so a re-run calibration or a changed airframe correctly stops counting as reviewed. Those signatures are computed **from parameters** — `INS_ACC_ID`, `INS_ACCOFFS_*`, `INS_ACCSCAL_*`, `AHRS_TRIM_*`, `FRAME_CLASS`/`FRAME_TYPE`.

But `setupProgressKey` (`App.tsx:1529`) derives from `connection.kind` / `hardware.board` / `vehicle` — all known at HEARTBEAT. Stored progress is restored long before the parameter table finishes streaming.

In that window the live signature is a JSON blob full of `undefined` which cannot match anything ever stored, and `getSetupConfirmationRecord` read that mismatch as "not confirmed" — invalidating **every** section simultaneously and resuming the wizard at step 1. Hence "Continue to Airframe" on every return, and a completed accel calibration reading as never done.

There was no `parameterStats.status === 'complete'` guard on this path, though there are eleven elsewhere in `App.tsx`.

## Fix

A signature mismatch only means something once the parameters it is derived from have arrived. Until then the last known state stands.

Safe rather than merely convenient: parameter writes are themselves gated on a complete sync, so a provisionally-trusted confirmation cannot authorise any action during the window in which it is trusted.

It also avoids flashing every section to "unconfirmed" for the duration of the sync — what a naive guard would do, producing the same wrong banner just briefer.

Nothing was being lost from storage: `getSetupConfirmationRecord` out-votes rather than deletes, and the save effect writes records verbatim.

## Shape

Resolution moves into a pure builder under `view-models/` with a co-located test, per the established pattern. The stale-signature invalidation it exists to provide is covered directly, including that it re-validates and still drops a genuine mismatch once the sync completes.

## ArduCopter byte-identical

UI state only. No parameter is read differently, written, or branched on by vehicle type.

## Validation (rungs 1 and 3)

- `npm run typecheck` — clean
- `npm run test` — 794 pass / 0 fail
- web vitest — 611 pass / 0 fail (7 new)
- `npm run test:e2e` — 233 pass / 6 skipped (visual baselines)

**Rung 5 pending** — the reported symptom needs a real reconnect to a synced FC to confirm end-to-end.