### PR TITLE
fix(setup): give the guided compass step the position control it needs

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -330,6 +330,7 @@ import { SetupWizardHeader } from './sections/SetupWizardHeader'
 import { SetupWizardDetail } from './sections/SetupWizardDetail'
 import { SetupBenchActions } from './sections/SetupBenchActions'
 import { StatusDfuCard } from './sections/StatusDfuCard'
+import { CalibrationLocationButton } from './sections/CalibrationLocationCard'
 import { resolveSetupConfirmationRecord } from './view-models/setup-confirmation-resolve'
 import { buildSetupConfirmationSignatures } from './view-models/setup-confirmation-signatures'
 import { buildTuningTaskCards } from './view-models/tuning-task-cards'
@@ -7558,7 +7559,17 @@ export function App() {
                         </div>
                       ) : null}
 
-                      <SetupWizardDetail selectedSetupSection={selectedSetupSection} snapshot={snapshot} />
+                      <SetupWizardDetail
+                        selectedSetupSection={selectedSetupSection}
+                        snapshot={snapshot}
+                        // Compass cal stalls without a position; give the
+                        // guided step the same fake-GPS control the
+                        // Calibration tab has instead of leaving the operator
+                        // to discover it two tabs over.
+                        compassLocationSlot={
+                          runtime ? <CalibrationLocationButton snapshot={snapshot} runtime={runtime} /> : undefined
+                        }
+                      />
 
                       {['airframe', 'accelerometer', 'compass'].includes(selectedSetupSection.id) ? (
                         <details className="setup-wizard__advanced-disclosure" data-testid="setup-wizard-advanced">

--- a/apps/web/src/sections/SetupWizardDetail.tsx
+++ b/apps/web/src/sections/SetupWizardDetail.tsx
@@ -6,7 +6,7 @@
 // view decomposition. Purely presentational over the selected section
 // descriptor and the live snapshot. Behavior-preserving.
 
-import type { ReactElement } from 'react'
+import type { ReactElement, ReactNode } from 'react'
 
 import type { ConfiguratorSnapshot } from '@arduconfig/ardupilot-core'
 
@@ -17,9 +17,19 @@ import type { SetupFlowSectionDescriptor } from '../app-types'
 export interface SetupWizardDetailProps {
   selectedSetupSection: SetupFlowSectionDescriptor
   snapshot: ConfiguratorSnapshot
+  /** "Set location (no GPS)" control, rendered on the compass step only.
+   *  Compass calibration needs the EKF to have a position to finish yaw
+   *  alignment, so without a fix it starts and then never progresses. The
+   *  control needs the runtime (it streams synthetic GPS_INPUT), which this
+   *  presentational component must not import — hence a slot. */
+  compassLocationSlot?: ReactNode
 }
 
-export function SetupWizardDetail({ selectedSetupSection, snapshot }: SetupWizardDetailProps): ReactElement {
+export function SetupWizardDetail({
+  selectedSetupSection,
+  snapshot,
+  compassLocationSlot
+}: SetupWizardDetailProps): ReactElement {
   // The criteria list is what actually gates the step, but it lived inside a
   // collapsed <details> and the header only showed "2/5 criteria" — never WHICH
   // one was unmet. That is the mechanical reason a blocked step reads as
@@ -39,6 +49,12 @@ export function SetupWizardDetail({ selectedSetupSection, snapshot }: SetupWizar
         <p className="setup-wizard__next-criterion" data-testid="setup-wizard-next-criterion">
           <strong>Still needed:</strong> {nextUnmetCriterion.label}
         </p>
+      ) : null}
+
+      {selectedSetupSection.id === 'compass' && compassLocationSlot ? (
+        <div className="setup-wizard__compass-location" data-testid="setup-wizard-compass-location">
+          {compassLocationSlot}
+        </div>
       ) : null}
 
       {selectedSetupSection.id === 'accelerometer' ? (

--- a/apps/web/src/view-models/setup-flow-sections.ts
+++ b/apps/web/src/view-models/setup-flow-sections.ts
@@ -587,6 +587,13 @@ export function buildSetupFlowSections(inputs: SetupFlowSectionsInputs): SetupFl
           confirmationOutcome = compassConfirmation?.outcome
           const compassCalibrationRecorded =
             actionState.status === 'succeeded' || compassConfirmation !== undefined
+          // A live global position — from a real GPS fix or the synthetic
+          // GPS_INPUT the "Set location (no GPS)" control streams. Either
+          // satisfies the EKF; the cal cannot complete without one.
+          const hasCompassCalibrationPosition =
+            snapshot.liveVerification.globalPosition.verified &&
+            snapshot.liveVerification.globalPosition.latitudeDeg !== undefined &&
+            snapshot.liveVerification.globalPosition.longitudeDeg !== undefined
           if (compassConfirmation?.outcome === 'not-applicable') {
             criteria = [
               {
@@ -700,6 +707,16 @@ export function buildSetupFlowSections(inputs: SetupFlowSectionsInputs): SetupFl
             }
           } else {
             criteria = [
+              // Compass calibration needs the EKF to have a position to finish
+              // yaw alignment. Without a fix it starts and then silently never
+              // progresses — the reported "doesn't progress in guided setup,
+              // works in the Calibration tab", where a fake-GPS control exists.
+              // Naming it as a criterion makes a stalled cal explain itself
+              // instead of just sitting at 0%.
+              {
+                label: 'Vehicle has a position (GPS fix, or a location set below) for yaw alignment',
+                met: hasCompassCalibrationPosition
+              },
               {
                 label: 'Compass calibration completed successfully',
                 met: actionState.status === 'succeeded' || section.status === 'complete'


### PR DESCRIPTION
## Reported

> Compass calibration in guided setup doesn't progress. Compass calibration in the calibration tab does work though.

## Cause

Not a state bug. The guided step reads the same `guidedActions['calibrate-compass']` the Calibration tab does, and the gating (`guided-action-helpers.ts:94`) only blocks on zero enabled compasses.

It was a **missing control**. Compass calibration needs the EKF to have a position to finish yaw alignment — normally a GPS fix. Without one the cal starts and then silently sits at zero.

The Calibration tab renders `CalibrationLocationButton` for this step (`CalibrationSection.tsx:187`) — "Set location (no GPS)", which streams synthetic `GPS_INPUT` at an operator-picked point so the cal can run on a bench with no GPS, then restores the GPS backend on Stop.

The guided step (`setup-flow-sections.ts:584`) offered only the guided-action button and confirm/skip. So the requirement was invisible and the remedy lived two tabs away — the same action stalling in one surface while succeeding in another.

## Fix

The same control now renders on the guided compass step, passed as a `ReactNode` slot: it needs the `runtime` and `SetupWizardDetail` must stay presentational. That's the pattern already used there for the accelerometer pose guide.

A criterion is added naming the requirement, so a stalled calibration explains itself rather than sitting at 0% with nothing showing as unmet. It's satisfied by a real GPS fix **or** by the synthetic position, since either satisfies the EKF.

## ArduCopter byte-identical

UI only. No new command, no parameter write, no change to the calibration itself or to any vehicle branch.

## Validation (rungs 1 and 3)

- `npm run typecheck` — clean
- `npm run test` — 794 pass / 0 fail
- web vitest — 611 pass / 0 fail
- `npm run test:e2e` — 233 pass / 6 skipped (visual baselines)

**Rung 5 pending.** This makes the control reachable and the requirement legible; that the calibration then *completes* is bench work. Worth flagging that the fake-GPS path is itself recorded as SITL-validated rather than hardware-validated.