### PR TITLE
feat(modes): allow VALT (29) when the fork build advertises it

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -30,6 +30,8 @@ import {
   formatRcAxisLabel,
   type MotorTestRequest,
   applyArducopter47CatalogOverrides,
+  applySfdValtCatalogOverrides,
+  detectSfdValtMode,
   type ParameterBackupFile,
   type ParameterBackupImportOptions,
   type ParameterBatchWriteProgress,
@@ -576,14 +578,30 @@ export function App() {
   // The Params view reads definitions from this catalog. Apply the version-gated
   // ArduCopter 4.7 overrides when a >= 4.7 build is detected; pre-connect /
   // Unknown / 4.6 / non-copter get the untouched base catalog.
+  // VALT (mode 29) exists only on fork builds with MODE_VALT_ENABLED; detected
+  // by the presence of VALT_POS_EXPO rather than by a version-string match.
+  const valtModeAvailable = useMemo(
+    () => detectSfdValtMode(snapshot.parameters.map((parameter) => parameter.id)),
+    [snapshot.parameters]
+  )
   const metadataCatalog = useMemo(
     () =>
-      applyArducopter47CatalogOverrides(
-        normalizeFirmwareMetadata(activeMetadataBundle),
-        snapshot.hardware.board?.firmwareVersionParts,
-        snapshot.vehicle?.vehicle === 'ArduCopter'
+      // Fork gate runs AFTER the version gate: it only ever appends VALT to the
+      // flight-mode enums, and returns the catalog by identity on stock builds.
+      applySfdValtCatalogOverrides(
+        applyArducopter47CatalogOverrides(
+          normalizeFirmwareMetadata(activeMetadataBundle),
+          snapshot.hardware.board?.firmwareVersionParts,
+          snapshot.vehicle?.vehicle === 'ArduCopter'
+        ),
+        valtModeAvailable
       ),
-    [activeMetadataBundle, snapshot.hardware.board?.firmwareVersionParts, snapshot.vehicle?.vehicle]
+    [
+      activeMetadataBundle,
+      snapshot.hardware.board?.firmwareVersionParts,
+      snapshot.vehicle?.vehicle,
+      valtModeAvailable
+    ]
   )
   const setupSectionIds = useMemo(
     () => activeMetadataBundle.setupSections.map((section) => section.id),

--- a/packages/ardupilot-core/src/firmware-overrides.ts
+++ b/packages/ardupilot-core/src/firmware-overrides.ts
@@ -43,3 +43,91 @@ export function applyArducopter47CatalogOverrides<
   }
   return { ...catalog, parameters }
 }
+
+// ---------------------------------------------------------------------------
+// SFD fork feature gate: the VALT flight mode.
+//
+// The fork adds `VALT = 29, // Velocity-controlled alt hold` (ArduCopter
+// mode.h), compile-gated on MODE_VALT_ENABLED. Stock ArduCopter's mode enum
+// stops at 28 (Turtle), so 29 fails enum validation everywhere — the Modes
+// dropdown AND the raw parameter editor, since draft validation reads the same
+// options.
+//
+// Detection is by PARAMETER PRESENCE, not by sniffing "-SFD" out of the version
+// string: VALT_POS_EXPO (ArduCopter Parameters.cpp, ParametersG2 index 30)
+// lives inside the same `#if MODE_VALT_ENABLED` block as the mode itself, so it
+// exists on the wire exactly when the mode does. A version-string match would
+// break on any rebuild, rename or backport; presence cannot.
+//
+// Stock firmware never sees a changed enum — the catalog is returned by
+// identity — which is what keeps the ArduCopter byte-identical invariant.
+
+/** The fork parameter whose presence proves MODE_VALT_ENABLED was compiled in. */
+export const SFD_VALT_DETECTION_PARAM_ID = 'VALT_POS_EXPO'
+
+/** ArduCopter mode number for VALT (mode.h: `VALT = 29`). */
+export const SFD_VALT_FLIGHT_MODE_VALUE = 29
+
+/** Label shown for mode 29. Mirrors the fork's full mode name ("VALT Hold"). */
+export const SFD_VALT_FLIGHT_MODE_LABEL = 'VALT Hold'
+
+/** The FLTMODEn params whose enum gains VALT when the fork feature is present. */
+const FLIGHT_MODE_PARAM_IDS = ['FLTMODE1', 'FLTMODE2', 'FLTMODE3', 'FLTMODE4', 'FLTMODE5', 'FLTMODE6']
+
+/**
+ * True when the synced parameter set proves this build has VALT compiled in.
+ * Takes the ids rather than the snapshot so it stays free of runtime types.
+ */
+export function detectSfdValtMode(parameterIds: Iterable<string>): boolean {
+  for (const id of parameterIds) {
+    if (id === SFD_VALT_DETECTION_PARAM_ID) {
+      return true
+    }
+  }
+  return false
+}
+
+/**
+ * Add VALT (29) to the flight-mode enums when the fork feature is detected.
+ *
+ * Returns the SAME catalog object when it is not, so stock ArduCopter — and
+ * every pre-connect / Unknown path — is untouched by identity.
+ */
+export function applySfdValtCatalogOverrides<
+  T extends { parameters: Record<string, ParameterDefinition> }
+>(catalog: T, valtModeAvailable: boolean): T {
+  if (!valtModeAvailable) {
+    return catalog
+  }
+
+  const parameters = { ...catalog.parameters }
+  // The detection param itself would otherwise render as a bare number in the
+  // parameter list. Copy comes from the fork's @Param block.
+  if (!parameters[SFD_VALT_DETECTION_PARAM_ID]) {
+    parameters[SFD_VALT_DETECTION_PARAM_ID] = {
+      id: SFD_VALT_DETECTION_PARAM_ID,
+      label: 'VALT position-authority blend expo',
+      description:
+        'In VALT (velocity alt hold) this blends position control back in near stick centre and near the stick edges. 0 disables the blend (pure velocity control whenever the stick is off centre). With a positive value the position authority follows a valley in stick deflection: full at centre (altitude hold) and at full deflection, lowest in between. Higher values widen the velocity region.',
+      category: 'modes',
+      minimum: 0,
+      maximum: 8,
+      step: 0.5
+    }
+  }
+  for (const id of FLIGHT_MODE_PARAM_IDS) {
+    const base = parameters[id]
+    if (!base?.options) {
+      continue
+    }
+    // Idempotent: never append a duplicate if the enum already carries VALT.
+    if (base.options.some((option) => option.value === SFD_VALT_FLIGHT_MODE_VALUE)) {
+      continue
+    }
+    parameters[id] = {
+      ...base,
+      options: [...base.options, { value: SFD_VALT_FLIGHT_MODE_VALUE, label: SFD_VALT_FLIGHT_MODE_LABEL }]
+    }
+  }
+  return { ...catalog, parameters }
+}

--- a/tests/sfd-valt-flight-mode.test.mjs
+++ b/tests/sfd-valt-flight-mode.test.mjs
@@ -1,0 +1,97 @@
+// The SFD fork's VALT flight mode (29) in the flight-mode enums.
+//
+// Stock ArduCopter's mode enum stops at 28 (Turtle), so assigning 29 failed
+// validation in BOTH the Modes dropdown and the raw parameter editor — draft
+// validation reads the same options. The fork adds `VALT = 29` (ArduCopter
+// mode.h), compile-gated on MODE_VALT_ENABLED.
+//
+// Detection is by parameter presence, not by matching "-SFD" in the version
+// string: VALT_POS_EXPO sits inside the same `#if MODE_VALT_ENABLED` block as
+// the mode, so it is on the wire exactly when the mode exists. The version
+// string would break on any rebuild or rename.
+//
+// The load-bearing assertion here is the NEGATIVE one: a stock catalog must
+// come back unchanged BY IDENTITY, which is what keeps ArduCopter
+// byte-identical.
+
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import {
+  applySfdValtCatalogOverrides,
+  detectSfdValtMode,
+  SFD_VALT_DETECTION_PARAM_ID,
+  SFD_VALT_FLIGHT_MODE_VALUE
+} from '../packages/ardupilot-core/dist/index.js'
+import { arducopterMetadata, normalizeFirmwareMetadata } from '../packages/param-metadata/dist/index.js'
+
+const FLIGHT_MODE_PARAM_IDS = ['FLTMODE1', 'FLTMODE2', 'FLTMODE3', 'FLTMODE4', 'FLTMODE5', 'FLTMODE6']
+
+function baseCatalog() {
+  return normalizeFirmwareMetadata(arducopterMetadata)
+}
+
+test('VALT is mode 29, matching ArduCopter mode.h', () => {
+  assert.equal(SFD_VALT_FLIGHT_MODE_VALUE, 29)
+})
+
+test('detection keys on VALT_POS_EXPO, not on the firmware version string', () => {
+  assert.equal(SFD_VALT_DETECTION_PARAM_ID, 'VALT_POS_EXPO')
+  assert.equal(detectSfdValtMode(['FLTMODE1', 'VALT_POS_EXPO', 'INS_ACC_ID']), true)
+  assert.equal(detectSfdValtMode(['FLTMODE1', 'INS_ACC_ID']), false)
+  assert.equal(detectSfdValtMode([]), false)
+})
+
+test('stock ArduCopter mode enums stop at 28 — 29 is genuinely absent', () => {
+  const catalog = baseCatalog()
+  for (const id of FLIGHT_MODE_PARAM_IDS) {
+    const values = catalog.parameters[id].options.map((option) => option.value)
+    assert.ok(values.includes(28), `${id} should offer Turtle (28)`)
+    assert.ok(!values.includes(29), `${id} must not offer VALT (29) on stock firmware`)
+  }
+})
+
+test('a stock build gets the SAME catalog object back — ArduCopter byte-identical', () => {
+  const catalog = baseCatalog()
+  // Identity, not deep equality: the stock path must not even rebuild the map.
+  assert.equal(applySfdValtCatalogOverrides(catalog, false), catalog)
+})
+
+test('a fork build gains VALT (29) on every FLTMODEn', () => {
+  const patched = applySfdValtCatalogOverrides(baseCatalog(), true)
+  for (const id of FLIGHT_MODE_PARAM_IDS) {
+    const option = patched.parameters[id].options.find((entry) => entry.value === 29)
+    assert.ok(option, `${id} should offer VALT (29) on a fork build`)
+    assert.equal(option.label, 'VALT Hold')
+  }
+})
+
+test('adding VALT leaves every stock mode option untouched', () => {
+  const base = baseCatalog()
+  const patched = applySfdValtCatalogOverrides(baseCatalog(), true)
+  for (const id of FLIGHT_MODE_PARAM_IDS) {
+    const before = base.parameters[id].options
+    const after = patched.parameters[id].options
+    assert.equal(after.length, before.length + 1, `${id} should gain exactly one option`)
+    assert.deepEqual(after.slice(0, before.length), before, `${id} stock options must be unchanged`)
+  }
+})
+
+test('the detection parameter itself gets metadata instead of rendering bare', () => {
+  const patched = applySfdValtCatalogOverrides(baseCatalog(), true)
+  const definition = patched.parameters.VALT_POS_EXPO
+  assert.ok(definition, 'VALT_POS_EXPO should gain a definition on a fork build')
+  // @Range: 0 8 in the fork's @Param block.
+  assert.equal(definition.minimum, 0)
+  assert.equal(definition.maximum, 8)
+  assert.ok(definition.description.length > 0)
+})
+
+test('applying twice does not duplicate the VALT option', () => {
+  const once = applySfdValtCatalogOverrides(baseCatalog(), true)
+  const twice = applySfdValtCatalogOverrides(once, true)
+  for (const id of FLIGHT_MODE_PARAM_IDS) {
+    const valtOptions = twice.parameters[id].options.filter((entry) => entry.value === 29)
+    assert.equal(valtOptions.length, 1, `${id} should carry exactly one VALT option`)
+  }
+})


### PR DESCRIPTION
## Reported

> When detecting SFD firmware, we should allow flight mode 29 (VALT) to be assigned. Right now it's saying invalid and even in the param list I cannot assign this

## Cause

`ARDUCOPTER_FLIGHT_MODE_LABELS` stops at 28 (Turtle) — stock ArduCopter's last mode. 29 isn't in the map, so it fails enum validation in the Modes dropdown *and* in the raw parameter editor, since draft validation reads the same options. No back door.

## From the fork's source

- `ArduCopter/mode.h:104` — `VALT = 29, // Velocity-controlled alt hold`
- `ArduCopter/mode.h:2092` — full name "VALT Hold"
- Compile-gated on `MODE_VALT_ENABLED`

## Detection

By **parameter presence**, not by matching `-SFD` in the version string.

`VALT_POS_EXPO` (`ArduCopter/Parameters.cpp:1252`, ParametersG2 index 30) sits inside the same `#if MODE_VALT_ENABLED` block as the mode itself, so it is on the wire exactly when the mode exists. A version-string match would break on any rebuild, rename or backport; presence cannot. Same pattern `OSD_MSG_ABBR` already uses to gate the OSD message panel.

`VALT_POS_EXPO` also gains metadata (label, description, `@Range: 0 8`) lifted from the fork's own `@Param` block, so the detection param doesn't render as a bare number.

## ArduCopter byte-identical

A stock build gets the **same catalog object back by identity** — the stock path doesn't even rebuild the parameter map. Tests pin that, plus stock enums stopping at 28, and every pre-existing mode option surviving the append unchanged.

## Validation (rungs 1 and 3)

- `npm run typecheck` — clean
- `npm run test` — 802 pass / 0 fail (8 new)
- web vitest — 611 pass / 0 fail
- `npm run test:e2e` — 233 pass / 6 skipped (visual baselines)

**Rung 5 pending** — assigning VALT on the SFD FC and confirming the mode engages.