### PR TITLE
feat(setup): add a Ports step early in guided setup

### DIFF
--- a/apps/web/src/setup-flow-helpers.ts
+++ b/apps/web/src/setup-flow-helpers.ts
@@ -52,6 +52,8 @@ export function panelAnchorForSetupSection(sectionId: string): { panelId: string
   switch (sectionId) {
     case 'link':
       return { panelId: 'setup-panel-link', panelLabel: 'Vehicle Link' }
+    case 'ports':
+      return { panelId: 'setup-panel-ports', panelLabel: 'Serial Ports' }
     case 'airframe':
     case 'outputs':
       return { panelId: 'setup-panel-outputs', panelLabel: 'Airframe & Outputs' }

--- a/apps/web/src/view-models/setup-flow-sections.ts
+++ b/apps/web/src/view-models/setup-flow-sections.ts
@@ -41,6 +41,7 @@ import type { ParameterFollowUp } from '../hooks/use-parameter-feedback'
 import type { RcDirectionResult } from './receiver-direction-check'
 import { canRunGuidedAction, deriveCompassStepSkipReason, guidedActionButtonLabel } from '../guided-action-helpers'
 import { readRoundedParameter } from '../selectors/parameter-read'
+import { buildSetupPortsEvidence, describeUnconfiguredPort } from './setup-ports-evidence'
 import { isReceiverSerialProtocol } from '../serial-port-helpers'
 import { batteryHealthLabel, describeBatteryMonitor, formatRemaining, formatVoltage } from '../device-display'
 import { failsafeActionLabel } from '../modes-failsafe-helpers'
@@ -200,6 +201,77 @@ export function buildSetupFlowSections(inputs: SetupFlowSectionsInputs): SetupFl
             disabled: busyAction !== undefined || !canRunGuidedAction(snapshot, 'request-parameters')
           })
           break
+        case 'ports': {
+          // Ports is the step that unblocks every peripheral after it. The
+          // failure it exists to prevent: a receiver wired to a pad whose
+          // SERIALn_PROTOCOL is still 2 (MAVLink2), which cannot work and
+          // which nothing else in the flow explains — the Radio step just
+          // never completes. uarts.txt already carries the evidence, so name
+          // the mismatch rather than leave it to be found with a scope.
+          const portsConfirmation = getSetupConfirmationRecord('ports')
+          confirmationOutcome = portsConfirmation?.outcome
+          const portsEvidence = buildSetupPortsEvidence({
+            rawText: snapshot.hardware.uartsFile?.rawText,
+            protocolByPort: Object.fromEntries(
+              Array.from({ length: 10 }, (_, port) => [
+                port,
+                readRoundedParameter(snapshot, `SERIAL${port}_PROTOCOL`)
+              ])
+            )
+          })
+          const portsMismatched = portsEvidence.unconfigured.length > 0
+          criteria = [
+            {
+              label: 'Serial port protocols are synced from the flight controller',
+              met: snapshot.parameterStats.status === 'complete'
+            },
+            {
+              // Blocks on a DETECTED mismatch only. Absent counters (demo, or
+              // a board that serves no uarts.txt) must not gate the flow —
+              // a step that blocks on evidence it may never receive is a dead
+              // end, not a safeguard. The summary says the check could not run
+              // rather than claiming the ports are right.
+              label: 'No port is receiving data while configured as unused',
+              met: !portsMismatched
+            }
+          ]
+          summary = portsMismatched
+            ? `${portsEvidence.unconfigured.length} port(s) receiving data but configured as unused.`
+            : portsEvidence.trafficUnknown
+              ? 'Port traffic counters are unavailable — review the assignments manually.'
+              : 'Configured port protocols match the ports that are carrying traffic.'
+          detail = portsMismatched
+            ? 'A peripheral is talking on a port the flight controller thinks is unused, so whatever is wired there cannot work. Set that port to the right protocol before setting up the receiver, GPS or OSD that depends on it.'
+            : 'Set each serial port to whatever is physically wired to it. Do this before the receiver, GPS and OSD steps — they configure peripherals that only work once their port is right.'
+          evidence = [
+            ...portsEvidence.unconfigured.slice(0, 2).map(describeUnconfiguredPort),
+            portsEvidence.trafficUnknown
+              ? 'Port traffic: counters unavailable'
+              : `Ports carrying traffic: ${portsEvidence.ports.filter((port) => port.rxBytes > 0).length}`,
+            portsConfirmation
+              ? `Review: confirmed at ${formatConfirmationTime(portsConfirmation.confirmedAtMs)}`
+              : 'Review: pending'
+          ].slice(0, 4)
+          if (panel) {
+            actions.unshift({
+              kind: 'scroll',
+              label: 'Open Ports',
+              panelId: panel.panelId
+            })
+          }
+          // Available as a record that the operator looked, but deliberately
+          // not a criterion: ports that are already correct should not demand
+          // ceremony on every setup.
+          actions.push({
+            kind: 'confirm-step',
+            label: portsConfirmation ? 'Clear Port Review' : 'Confirm Port Assignments',
+            tone: 'secondary',
+            sectionId: 'ports',
+            confirmationOutcome: 'complete',
+            disabled: busyAction !== undefined
+          })
+          break
+        }
         case 'airframe': {
           // An 'already-done' airframe sign-off is the orientation waiver: the
           // operator is asserting the frame geometry AND the horizon behaviour

--- a/apps/web/src/view-models/setup-ports-evidence.test.ts
+++ b/apps/web/src/view-models/setup-ports-evidence.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  buildSetupPortsEvidence,
+  describeUnconfiguredPort,
+  parseUartTraffic
+} from './setup-ports-evidence'
+
+// Captured verbatim from a real BROTHERHOBBYH743 with an ELRS receiver wired to
+// the RX/SBUS pad (SERIAL2) while SERIAL2_PROTOCOL was still 2 (MAVLink2). The
+// 80357 framing errors against 39 received bytes are what a 420000-baud CRSF
+// stream looks like sampled at 57600.
+const REAL_UARTS_TXT = `UARTV1
+SERIAL0 OTG1  TX =  106511 RX =    3410 TXBD= 18692 RXBD=   598 RXDRP=       0 FE=0 OE=0 NE=0 FlowCtrl=1
+SERIAL1 UART1 TX =       0 RX =      29 TXBD=     0 RXBD=     5 RXDRP=       0 FE=429 OE=0 NE=0 FlowCtrl=0
+SERIAL2 UART2 TX =    1322 RX*=      39 TXBD=   232 RXBD=     6 RXDRP=       0 FE=80357 OE=0 NE=81339 FlowCtrl=0
+SERIAL3 UART3 TX =       0 RX*=       0 TXBD=     0 RXBD=     0 RXDRP=       0 FE=0 OE=0 NE=0 FlowCtrl=0
+SERIAL5 EMPTY
+SERIAL7 UART7 TX =       0 RX =       0 TXBD=     0 RXBD=     0 RXDRP=       0 FE=0 OE=0 NE=0 FlowCtrl=0
+`
+
+describe('parseUartTraffic', () => {
+  it('reads the per-port counters, DMA marker and all', () => {
+    const ports = parseUartTraffic(REAL_UARTS_TXT)
+    const serial2 = ports.find((port) => port.portNumber === 2)
+    expect(serial2).toEqual({
+      portNumber: 2,
+      hardwarePort: 'UART2',
+      rxBytes: 39,
+      txBytes: 1322,
+      framingErrors: 80357
+    })
+  })
+
+  it('skips an unpopulated slot that prints no counters', () => {
+    expect(parseUartTraffic(REAL_UARTS_TXT).some((port) => port.portNumber === 5)).toBe(false)
+  })
+
+  it('returns nothing when the file was never fetched', () => {
+    expect(parseUartTraffic(undefined)).toEqual([])
+    expect(parseUartTraffic('')).toEqual([])
+  })
+})
+
+describe('buildSetupPortsEvidence', () => {
+  it('flags a port receiving real traffic while set to MAVLink2', () => {
+    // The reported case: receiver wired to SERIAL2, port still MAVLink2.
+    const evidence = buildSetupPortsEvidence({
+      rawText: REAL_UARTS_TXT,
+      protocolByPort: { 0: 2, 1: 23, 2: 2, 3: 5, 7: -1 },
+      minimumRxBytes: 8
+    })
+    expect(evidence.unconfigured).toHaveLength(1)
+    expect(evidence.unconfigured[0].portNumber).toBe(2)
+    expect(evidence.unconfigured[0].garbled).toBe(true)
+  })
+
+  it('never flags SERIAL0 — that is the USB link we are talking over', () => {
+    const evidence = buildSetupPortsEvidence({
+      rawText: REAL_UARTS_TXT,
+      protocolByPort: { 0: 2, 1: 23, 2: 23, 3: 5 }
+    })
+    expect(evidence.unconfigured.some((finding) => finding.portNumber === 0)).toBe(false)
+  })
+
+  it('stays quiet once the port is configured for what is on it', () => {
+    const evidence = buildSetupPortsEvidence({
+      rawText: REAL_UARTS_TXT,
+      protocolByPort: { 0: 2, 1: 23, 2: 23, 3: 5, 7: -1 }
+    })
+    expect(evidence.unconfigured).toEqual([])
+  })
+
+  it('ignores a stray byte on an otherwise dead pad', () => {
+    // SERIAL1 has 29 bytes and is set to RCIN here; drop the threshold and it
+    // would still not qualify, but a disabled port with a couple of noise bytes
+    // must not raise a finding either.
+    const evidence = buildSetupPortsEvidence({
+      rawText: REAL_UARTS_TXT,
+      protocolByPort: { 1: -1, 2: 23 },
+      minimumRxBytes: 32
+    })
+    expect(evidence.unconfigured).toEqual([])
+  })
+
+  it('reports traffic as unknown when uarts.txt was unavailable', () => {
+    // Absence of findings must not be presentable as "ports are correct".
+    const evidence = buildSetupPortsEvidence({ rawText: undefined, protocolByPort: {} })
+    expect(evidence.trafficUnknown).toBe(true)
+    expect(evidence.unconfigured).toEqual([])
+  })
+
+  it('does not report traffic as unknown once ports were parsed', () => {
+    expect(
+      buildSetupPortsEvidence({ rawText: REAL_UARTS_TXT, protocolByPort: {} }).trafficUnknown
+    ).toBe(false)
+  })
+
+  it('says nothing about a port whose protocol has not synced yet', () => {
+    // Unknown is not the same as misconfigured. Accusing a port of being wrong
+    // because its SERIALn_PROTOCOL has not arrived would fire on every
+    // connection during the sync window — the same class of mistake as judging
+    // stored setup progress against a half-synced snapshot.
+    const evidence = buildSetupPortsEvidence({
+      rawText: REAL_UARTS_TXT,
+      protocolByPort: {},
+      minimumRxBytes: 8
+    })
+    expect(evidence.unconfigured).toEqual([])
+  })
+})
+
+describe('describeUnconfiguredPort', () => {
+  it('names the port, the traffic and what it is wrongly set to', () => {
+    const [finding] = buildSetupPortsEvidence({
+      rawText: REAL_UARTS_TXT,
+      protocolByPort: { 2: 2 },
+      minimumRxBytes: 8
+    }).unconfigured
+    expect(describeUnconfiguredPort(finding)).toBe(
+      'SERIAL2 (UART2) is receiving 39 bytes, 80357 framing errors but is set to MAVLink2'
+    )
+  })
+})

--- a/apps/web/src/view-models/setup-ports-evidence.ts
+++ b/apps/web/src/view-models/setup-ports-evidence.ts
@@ -1,0 +1,142 @@
+// Guided-setup Ports step evidence: what the FC is actually receiving on each
+// serial port, versus what that port is configured as.
+//
+// The motivating failure: a receiver wired to the board's RX pad while
+// SERIAL2_PROTOCOL was still 2 (MAVLink2). The bytes arrive, the UART cannot
+// frame them, and nothing anywhere says so — the operator sees a Radio step
+// that simply never completes. @SYS/uarts.txt already carries per-port RX/TX
+// byte counts and framing-error counts, so the wizard can name the mismatch
+// instead of leaving it to be discovered with a logic analyser.
+//
+// Pure parsing + comparison: no runtime, no MAVLink, no React.
+
+/** SERIALn_PROTOCOL values that mean "nothing meaningful is expected here". */
+const PROTOCOL_NONE = -1
+/** SERIALn_PROTOCOL = 2 is MAVLink2 — the default on unused ports, and so the
+ *  overwhelmingly common value to find still sitting on a port that has had a
+ *  peripheral soldered to it. */
+const PROTOCOL_MAVLINK2 = 2
+
+export interface UartPortTraffic {
+  /** SERIALn index, as printed by uarts.txt. */
+  portNumber: number
+  /** Hardware name (UART1, OTG1, EMPTY, ...). */
+  hardwarePort: string
+  rxBytes: number
+  txBytes: number
+  /** Framing errors — high relative to rxBytes means the UART cannot frame
+   *  what is arriving, i.e. a baud or protocol mismatch rather than silence. */
+  framingErrors: number
+}
+
+/**
+ * Parse the per-port counters out of an @SYS/uarts.txt body.
+ *
+ * Lines look like:
+ *   SERIAL2 UART2 TX =    1322 RX*=      39 TXBD=   232 RXBD=     6 RXDRP= 0 FE=80357 ...
+ * The `*` marks a DMA-enabled direction and is not otherwise significant here.
+ * Note the space before `=` on the non-DMA form (`RX =`) but not the DMA form
+ * (`RX*=`), hence the optional whitespace on both sides.
+ */
+export function parseUartTraffic(rawText: string | undefined): UartPortTraffic[] {
+  if (!rawText) {
+    return []
+  }
+
+  const ports: UartPortTraffic[] = []
+  for (const line of rawText.split('\n')) {
+    const match = /^SERIAL(\d+)\s+(\S+)/.exec(line.trim())
+    if (!match) {
+      continue
+    }
+    // An unpopulated slot prints "SERIAL5 EMPTY" with no counters at all.
+    const rx = /RX\*?\s*=\s*(\d+)/.exec(line)
+    const tx = /TX\*?\s*=\s*(\d+)/.exec(line)
+    if (!rx || !tx) {
+      continue
+    }
+    const fe = /FE=(\d+)/.exec(line)
+    ports.push({
+      portNumber: Number(match[1]),
+      hardwarePort: match[2],
+      rxBytes: Number(rx[1]),
+      txBytes: Number(tx[1]),
+      framingErrors: fe ? Number(fe[1]) : 0
+    })
+  }
+  return ports
+}
+
+export interface UnconfiguredPortFinding {
+  portNumber: number
+  hardwarePort: string
+  rxBytes: number
+  framingErrors: number
+  /** The SERIALn_PROTOCOL currently set, or undefined if not synced. */
+  protocolValue: number | undefined
+  /** True when the traffic is arriving but cannot be framed — the signature of
+   *  a peripheral talking at a rate/protocol the port is not set up for. */
+  garbled: boolean
+}
+
+export interface SetupPortsEvidenceInputs {
+  rawText: string | undefined
+  /** SERIALn_PROTOCOL by port number, as synced. */
+  protocolByPort: Record<number, number | undefined>
+  /** Ignore ports below this many received bytes — avoids flagging a stray
+   *  line-noise byte on a genuinely empty pad. */
+  minimumRxBytes?: number
+}
+
+export interface SetupPortsEvidence {
+  ports: UartPortTraffic[]
+  /** Ports receiving real traffic while configured as None or MAVLink2. */
+  unconfigured: UnconfiguredPortFinding[]
+  /** True when uarts.txt was unavailable, so absence of findings proves
+   *  nothing and the step must not claim the ports are correct. */
+  trafficUnknown: boolean
+}
+
+/**
+ * Ports that are receiving data while configured as if nothing were attached.
+ *
+ * SERIAL0 is excluded: it is the USB/GCS link, which is by definition busy with
+ * MAVLink and is how the configurator is talking to the vehicle right now.
+ */
+export function buildSetupPortsEvidence({
+  rawText,
+  protocolByPort,
+  minimumRxBytes = 32
+}: SetupPortsEvidenceInputs): SetupPortsEvidence {
+  const ports = parseUartTraffic(rawText)
+  const unconfigured: UnconfiguredPortFinding[] = []
+
+  for (const port of ports) {
+    if (port.portNumber === 0 || port.rxBytes < minimumRxBytes) {
+      continue
+    }
+    const protocolValue = protocolByPort[port.portNumber]
+    if (protocolValue !== PROTOCOL_NONE && protocolValue !== PROTOCOL_MAVLINK2) {
+      continue
+    }
+    unconfigured.push({
+      portNumber: port.portNumber,
+      hardwarePort: port.hardwarePort,
+      rxBytes: port.rxBytes,
+      framingErrors: port.framingErrors,
+      protocolValue,
+      // A tenth of the received bytes failing to frame is well beyond
+      // incidental noise and means the port is mis-clocked for what is on it.
+      garbled: port.framingErrors > port.rxBytes / 10
+    })
+  }
+
+  return { ports, unconfigured, trafficUnknown: ports.length === 0 }
+}
+
+/** One-line description of a finding, for the wizard's evidence pills. */
+export function describeUnconfiguredPort(finding: UnconfiguredPortFinding): string {
+  const configured = finding.protocolValue === PROTOCOL_NONE ? 'disabled' : 'MAVLink2'
+  const garbled = finding.garbled ? `, ${finding.framingErrors} framing errors` : ''
+  return `SERIAL${finding.portNumber} (${finding.hardwarePort}) is receiving ${finding.rxBytes} bytes${garbled} but is set to ${configured}`
+}

--- a/packages/param-metadata/src/arducopter.ts
+++ b/packages/param-metadata/src/arducopter.ts
@@ -3568,6 +3568,19 @@ export const arducopterMetadata: FirmwareMetadataBundle = {
       actions: ['request-parameters']
     },
     {
+      // Ports comes BEFORE everything that depends on a peripheral. A receiver
+      // cannot be set up while the UART feeding it is still SERIALn_PROTOCOL=2
+      // (MAVLink2), and the same is true of GPS, ESC telemetry and DisplayPort
+      // OSD. Putting this after `link` means every later step inherits a
+      // correct port map instead of discovering a missing one — and it matches
+      // the physical build order: wire the craft, tell the FC what is on each
+      // wire, then configure the things on those wires.
+      id: 'ports',
+      title: 'Ports',
+      description: 'Tell the flight controller what is wired to each serial port before setting up the peripherals on them.',
+      requiredParameters: ['SERIAL1_PROTOCOL', 'SERIAL2_PROTOCOL']
+    },
+    {
       id: 'airframe',
       title: 'Airframe',
       description: 'Verify the frame class and geometry before motor output setup.',

--- a/tests/e2e/views.spec.ts
+++ b/tests/e2e/views.spec.ts
@@ -2987,12 +2987,14 @@ test.describe('ArduPlane demo', () => {
     await openView(page, 'guided-setup')
     await expect(page.getByTestId('setup-wizard')).toBeVisible()
 
+    // Step numbering: Link (1), Ports (2), Airframe (3), Outputs (4). Ports was
+    // inserted after Link so every peripheral step inherits a correct port map.
     // Locked: the Outputs step cannot be selected while Airframe is incomplete.
-    const outputsStep = page.getByRole('button', { name: /Step 3/ })
+    const outputsStep = page.getByRole('button', { name: /Step 4/ })
     await expect(outputsStep).toBeDisabled()
 
     // Airframe unlocks as soon as the initial parameter sync finishes.
-    const airframeStep = page.getByRole('button', { name: /Step 2/ })
+    const airframeStep = page.getByRole('button', { name: /Step 3/ })
     await expect(airframeStep).toBeEnabled({ timeout: VEHICLE_CONNECT_TIMEOUT })
     await airframeStep.click()
 


### PR DESCRIPTION
## Reported

> I'm trying to take this from start to finish only using configurator. From a workflow perspective, a user won't be able to set up the receiver unless the params are set up right first. Working through the order of the tabs, this should be self explanatory, in guided mode though setting the ports should be done early on.

## Cause

There was **no ports step at all**. The order was:

```
link → airframe → outputs → accelerometer → level → compass → radio → failsafe → modes → power
```

So the flow asks you to complete **Radio** while never offering `SERIALn_PROTOCOL`. A receiver wired correctly to a pad still set to MAVLink2 produces a Radio step that never completes, with nothing explaining why — the exact failure this session spent an evening diagnosing on real hardware.

## Placement

Directly after Vehicle Link, **ahead of Outputs** — not merely ahead of Radio. Ports feed ESC telemetry, GPS and DisplayPort OSD too, so every later step inherits a correct port map rather than discovering a missing one. It also matches the physical build order: wire the craft, tell the FC what's on each wire, then configure the things on those wires.

## It reads the actual traffic

`@SYS/uarts.txt` is already fetched into `snapshot.hardware.uartsFile`. The step parses the per-port RX/TX and framing-error counters and names the mismatch:

> SERIAL2 (UART2) is receiving 39 bytes, 80357 framing errors but is set to MAVLink2

(That string is from the real capture off the bench FC — 80357 framing errors against 39 bytes is what 420000-baud CRSF looks like sampled at 57600.)

## What it will and won't block on

- **Blocks on a detected mismatch only.** Absent counters — demo, or a board serving no `uarts.txt` — do not gate the flow. A step that blocks on evidence it may never receive is a dead end, not a safeguard; the summary says the check couldn't run instead of claiming the ports are right.
- **The operator sign-off is offered but is not a criterion.** Ports that are already correct shouldn't demand ceremony on every setup.
- **An unsynced `SERIALn_PROTOCOL` is unknown, not misconfigured**, so the step can't spray false findings during the sync window.

## ArduCopter byte-identical

Guided-flow surface only. No parameter written, no command sent; the evidence comes from a file the app already fetches.

## Validation (rungs 1 and 3)

- `npm run typecheck` — clean
- `npm run test` — 802 pass / 0 fail
- web vitest — 622 pass / 0 fail (11 new)
- `npm run test:e2e` — 233 pass / 6 skipped (visual baselines)

The ArduPlane waiver e2e was updated for the shifted step numbers (Airframe 2→3, Outputs 3→4) — an intended consequence of inserting the step, not a masked regression. My first cut *did* regress two e2e tests by gating the flow on evidence the demo never provides; that's what drove the block-on-detected-mismatch-only design above.