### PR TITLE
fix(setup): drop the Ports step's dead confirm and stop flagging USB ports

### DIFF
--- a/apps/web/src/view-models/setup-flow-sections.ts
+++ b/apps/web/src/view-models/setup-flow-sections.ts
@@ -208,8 +208,6 @@ export function buildSetupFlowSections(inputs: SetupFlowSectionsInputs): SetupFl
           // which nothing else in the flow explains — the Radio step just
           // never completes. uarts.txt already carries the evidence, so name
           // the mismatch rather than leave it to be found with a scope.
-          const portsConfirmation = getSetupConfirmationRecord('ports')
-          confirmationOutcome = portsConfirmation?.outcome
           const portsEvidence = buildSetupPortsEvidence({
             rawText: snapshot.hardware.uartsFile?.rawText,
             protocolByPort: Object.fromEntries(
@@ -248,28 +246,18 @@ export function buildSetupFlowSections(inputs: SetupFlowSectionsInputs): SetupFl
             portsEvidence.trafficUnknown
               ? 'Port traffic: counters unavailable'
               : `Ports carrying traffic: ${portsEvidence.ports.filter((port) => port.rxBytes > 0).length}`,
-            portsConfirmation
-              ? `Review: confirmed at ${formatConfirmationTime(portsConfirmation.confirmedAtMs)}`
-              : 'Review: pending'
+            // No "Review: pending" pill — there is no confirm action on this
+            // step, so promising a review would describe a control that does
+            // not exist.
+            ...section.notes
           ].slice(0, 4)
-          if (panel) {
-            actions.unshift({
-              kind: 'scroll',
-              label: 'Open Ports',
-              panelId: panel.panelId
-            })
-          }
-          // Available as a record that the operator looked, but deliberately
-          // not a criterion: ports that are already correct should not demand
-          // ceremony on every setup.
-          actions.push({
-            kind: 'confirm-step',
-            label: portsConfirmation ? 'Clear Port Review' : 'Confirm Port Assignments',
-            tone: 'secondary',
-            sectionId: 'ports',
-            confirmationOutcome: 'complete',
-            disabled: busyAction !== undefined
-          })
+          // No confirm-step action here. Completion is driven entirely by the
+          // traffic check, so a sign-off button would record a confirmation
+          // that satisfies no criterion and changes nothing on screen — it
+          // read as a dead button promoted to "do this now". When a mismatch
+          // IS found the remedy is to fix the port protocol, which is what the
+          // generic panel action already offers; that action is left as the
+          // step's own navigation rather than adding a second one beside it.
           break
         }
         case 'airframe': {

--- a/apps/web/src/view-models/setup-ports-evidence.test.ts
+++ b/apps/web/src/view-models/setup-ports-evidence.test.ts
@@ -55,6 +55,36 @@ describe('buildSetupPortsEvidence', () => {
     expect(evidence.unconfigured[0].garbled).toBe(true)
   })
 
+  it('never flags a second USB port either (OTG2 / SERIAL9)', () => {
+    // Field report: SERIAL9 (OTG2) was reported as a misconfigured peripheral.
+    // H743 boards expose two USB ports; both legitimately carry MAVLink, and
+    // excluding only SERIAL0 by index missed the other one.
+    const twoUsbPorts = `UARTV1
+SERIAL0 OTG1  TX =  106511 RX =    3410 TXBD= 18692 RXBD=   598 RXDRP=       0 FE=0 OE=0 NE=0 FlowCtrl=1
+SERIAL9 OTG2  TX =       0 RX =    1128 TXBD=     0 RXBD=   235 RXDRP=       0 FE=0 OE=0 NE=0 FlowCtrl=1
+`
+    const evidence = buildSetupPortsEvidence({
+      rawText: twoUsbPorts,
+      protocolByPort: { 0: 2, 9: 2 }
+    })
+    expect(evidence.unconfigured).toEqual([])
+  })
+
+  it('still flags a real UART carrying traffic on the same board', () => {
+    // The genuine finding that must survive the USB exclusion: the GPS pad
+    // receiving heavily while the port is still MAVLink2.
+    const withGpsPad = `UARTV1
+SERIAL0 OTG1  TX =  106511 RX =    3410 TXBD= 18692 RXBD=   598 RXDRP=       0 FE=0 OE=0 NE=0 FlowCtrl=1
+SERIAL7 UART7 TX =       0 RX =   72144 TXBD=     0 RXBD= 12024 RXDRP=       0 FE=0 OE=0 NE=0 FlowCtrl=0
+SERIAL9 OTG2  TX =       0 RX =    1128 TXBD=     0 RXBD=   235 RXDRP=       0 FE=0 OE=0 NE=0 FlowCtrl=1
+`
+    const evidence = buildSetupPortsEvidence({
+      rawText: withGpsPad,
+      protocolByPort: { 0: 2, 7: 2, 9: 2 }
+    })
+    expect(evidence.unconfigured.map((finding) => finding.portNumber)).toEqual([7])
+  })
+
   it('never flags SERIAL0 — that is the USB link we are talking over', () => {
     const evidence = buildSetupPortsEvidence({
       rawText: REAL_UARTS_TXT,

--- a/apps/web/src/view-models/setup-ports-evidence.ts
+++ b/apps/web/src/view-models/setup-ports-evidence.ts
@@ -100,8 +100,11 @@ export interface SetupPortsEvidence {
 /**
  * Ports that are receiving data while configured as if nothing were attached.
  *
- * SERIAL0 is excluded: it is the USB/GCS link, which is by definition busy with
- * MAVLink and is how the configurator is talking to the vehicle right now.
+ * USB ports are excluded, identified by their OTG hardware name rather than by
+ * index: a board exposes more than one (OTG1 as SERIAL0, OTG2 as SERIAL9 on
+ * H743), both legitimately carry MAVLink, and one of them is how the
+ * configurator is talking to the vehicle right now. Excluding only SERIAL0
+ * reported the second USB port as a misconfigured peripheral.
  */
 export function buildSetupPortsEvidence({
   rawText,
@@ -112,7 +115,7 @@ export function buildSetupPortsEvidence({
   const unconfigured: UnconfiguredPortFinding[] = []
 
   for (const port of ports) {
-    if (port.portNumber === 0 || port.rxBytes < minimumRxBytes) {
+    if (port.hardwarePort.toUpperCase().startsWith('OTG') || port.rxBytes < minimumRxBytes) {
       continue
     }
     const protocolValue = protocolByPort[port.portNumber]


### PR DESCRIPTION
Follow-up to #134, from a field report with a screenshot.

> Not sure if Confirm Port Assignments should do something, I assume it should. I can't click it.

## The dead confirm button

#134 deliberately made the operator sign-off **not** a completion criterion — ports that are already correct shouldn't demand ceremony on every setup — but still offered the button, and the wizard promoted it as the step's DO-THIS-NOW action.

Clicking it recorded a confirmation that satisfied no criterion and changed nothing on screen. That is indistinguishable from a broken control, which is exactly how it was reported.

Completion is driven entirely by the traffic check, and when a mismatch *is* found the remedy is to fix the port protocol — so the sign-off had no role at all. Removed, along with:

- the `Review: pending` evidence pill, which promised a control that no longer exists
- the duplicate `Open Ports` action sitting beside the generic panel action that already offered the same navigation

## The USB false positive

`SERIAL9 (OTG2)` was reported as a misconfigured peripheral. USB ports are now excluded by their **OTG hardware name** rather than by index: a board exposes more than one — OTG1 as SERIAL0, OTG2 as SERIAL9 on H743 — both legitimately carry MAVLink, and one of them is the link the configurator is talking over. Excluding only SERIAL0 by index missed the other.

The genuine finding on the same board survives, and is what the step exists for:

> SERIAL7 (UART7) is receiving 72144 bytes but is set to MAVLink2

A test pins both halves against that board's real port layout, so the USB exclusion can't silently swallow a real UART.

## ArduCopter byte-identical

Guided-flow surface only. No parameter written, no command sent.

## Validation (rungs 1 and 3)

- `npm run typecheck` — clean
- `npm run test` — 802 pass / 0 fail
- web vitest — 624 pass / 0 fail (2 new)
- `npm run test:e2e` — 233 pass / 6 skipped (visual baselines)