### PR TITLE
feat(flash): add an Update Bootloader button to the Flash tab

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -8588,6 +8588,20 @@ export function App() {
                 ? 'Disarm the vehicle before requesting a DFU reboot.'
                 : undefined
           }
+          onFlashBootloader={
+            // Re-flashes the bootloader embedded in the RUNNING firmware, so it
+            // needs a live MAVLink link and no DFU cable.
+            runtime && snapshot.connection.kind === 'connected'
+              ? async () => { await runtime.flashBootloader() }
+              : undefined
+          }
+          flashBootloaderDisabledReason={
+            snapshot.connection.kind !== 'connected'
+              ? 'Connect to a vehicle first to update the bootloader.'
+              : snapshot.vehicle?.armed
+                ? 'Disarm the vehicle before updating the bootloader.'
+                : undefined
+          }
           onReboot={
             runtime && snapshot.connection.kind === 'connected'
               ? async () => { await runtime.reboot() }

--- a/apps/web/src/firmware/FirmwareFlasher.tsx
+++ b/apps/web/src/firmware/FirmwareFlasher.tsx
@@ -54,6 +54,13 @@ export interface FirmwareFlasherProps {
   /** Optional: send a normal reboot (MAV_CMD_PREFLIGHT_REBOOT_SHUTDOWN
    *  param1=1). Surfaces a "Request Reboot" button above the DFU control;
    *  hidden when omitted (e.g. the disconnected modal landing path). */
+  /** Re-flash the bootloader from the image embedded in the RUNNING firmware
+   *  (MAV_CMD_FLASH_BOOTLOADER). Not a file upload — the firmware currently on
+   *  the board decides which bootloader you get. Wired only over a live
+   *  MAVLink link. */
+  onFlashBootloader?: () => Promise<void>
+  /** Why the bootloader update cannot run right now (disconnected/armed). */
+  flashBootloaderDisabledReason?: string
   onReboot?: () => Promise<void>
   /** Disabled reason for the reboot button, same contract as the DFU one. */
   rebootDisabledReason?: string
@@ -202,7 +209,15 @@ function persistCustomServer(value: string): void {
 }
 
 export function FirmwareFlasher(props: FirmwareFlasherProps) {
-  const { onClose, onEnterDfu, enterDfuDisabledReason, onReboot, rebootDisabledReason } = props
+  const {
+    onClose,
+    onEnterDfu,
+    enterDfuDisabledReason,
+    onReboot,
+    rebootDisabledReason,
+    onFlashBootloader,
+    flashBootloaderDisabledReason
+  } = props
   const requestPort = props.requestPort ?? defaultRequestPort
   const listPorts = props.listPorts ?? defaultListPorts
   const inflate = props.inflate ?? inflateZlib
@@ -250,6 +265,10 @@ export function FirmwareFlasher(props: FirmwareFlasherProps) {
   // a confirm/cancel pair, the confirm actually sends the command.
   const [dfuConfirmArmed, setDfuConfirmArmed] = useState(false)
   const [rebootBusy, setRebootBusy] = useState(false)
+  // Rewriting the bootloader sector can brick the board if it is interrupted,
+  // so it gets the same two-click arm/confirm gate as the DFU reboot.
+  const [bootloaderConfirmArmed, setBootloaderConfirmArmed] = useState(false)
+  const [bootloaderBusy, setBootloaderBusy] = useState(false)
 
   const serialRef = useRef<WebSerialBootloaderSerial | null>(null)
   const closeButtonRef = useRef<HTMLButtonElement | null>(null)
@@ -326,6 +345,26 @@ export function FirmwareFlasher(props: FirmwareFlasherProps) {
       setRebootBusy(false)
     }
   }, [onReboot])
+
+  const handleFlashBootloader = useCallback(async () => {
+    if (!onFlashBootloader) return
+    setBootloaderConfirmArmed(false)
+    setBootloaderBusy(true)
+    setDfuNotice('Updating bootloader — do not unplug the board.')
+    try {
+      await onFlashBootloader()
+      // ArduPilot answers ACCEPTED for both OK and NO_CHANGE, so a board that
+      // was already current reports success rather than an error.
+      setDfuNotice(
+        'Bootloader updated (or already current). Reboot the board for the new bootloader to be used.'
+      )
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Failed to update the bootloader.'
+      setDfuNotice(message)
+    } finally {
+      setBootloaderBusy(false)
+    }
+  }, [onFlashBootloader])
 
   useEffect(
     () => () => {
@@ -989,6 +1028,44 @@ export function FirmwareFlasher(props: FirmwareFlasherProps) {
                 onClick={() => setDfuConfirmArmed(true)}
               >
                 Activate Bootloader (DFU)
+              </button>
+            )
+          ) : null}
+          {onFlashBootloader ? (
+            bootloaderConfirmArmed ? (
+              <span
+                className="firmware-wizard__dfu-confirm"
+                data-testid="firmware-flash-bootloader-confirm-row"
+              >
+                <button
+                  type="button"
+                  className="firmware-wizard__dfu-button firmware-wizard__dfu-button--danger"
+                  data-testid="firmware-flash-bootloader-confirm"
+                  disabled={bootloaderBusy}
+                  onClick={() => void handleFlashBootloader()}
+                >
+                  {bootloaderBusy ? 'Updating…' : 'Confirm: update bootloader'}
+                </button>
+                <button
+                  type="button"
+                  className="firmware-wizard__dfu-cancel"
+                  data-testid="firmware-flash-bootloader-cancel"
+                  disabled={bootloaderBusy}
+                  onClick={() => setBootloaderConfirmArmed(false)}
+                >
+                  Cancel
+                </button>
+              </span>
+            ) : (
+              <button
+                type="button"
+                className="firmware-wizard__dfu-button"
+                data-testid="firmware-flash-bootloader"
+                disabled={bootloaderBusy || Boolean(flashBootloaderDisabledReason)}
+                title={flashBootloaderDisabledReason}
+                onClick={() => setBootloaderConfirmArmed(true)}
+              >
+                Update Bootloader
               </button>
             )
           ) : null}

--- a/packages/ardupilot-core/src/runtime.ts
+++ b/packages/ardupilot-core/src/runtime.ts
@@ -195,6 +195,9 @@ export interface ArduPilotConfiguratorRuntimeOptions {
 // pass their own short timeoutMs.
 // SCRIPTING_CMD values (ardupilotmega.xml). Only the two AP_Scripting actually
 // accepts — REPL_START (0) / REPL_STOP (1) return MAV_RESULT_DENIED.
+/** MAV_CMD_FLASH_BOOTLOADER param5. GCS_Common.cpp rejects anything else with
+ *  "Magic not set" — it exists so a stray command cannot rewrite a bootloader. */
+const FLASH_BOOTLOADER_MAGIC = 290876
 const SCRIPTING_CMD_STOP = 2
 const SCRIPTING_CMD_STOP_AND_RESTART = 3
 
@@ -1459,6 +1462,31 @@ export class ArduPilotConfiguratorRuntime {
     await this.sendCommand(MAV_CMD.PREFLIGHT_REBOOT_SHUTDOWN, [3, 0, 0, 0, 0, 0, 0], {
       waitForAck: true,
       ackTimeoutMs: 3000
+    })
+  }
+
+  /**
+   * Re-flash the bootloader from the image embedded in the RUNNING firmware
+   * (MAV_CMD_FLASH_BOOTLOADER, param5 = the 290876 magic).
+   *
+   * This is not a file upload: the autopilot writes the bootloader it was
+   * built with, so the firmware currently flashed determines the bootloader
+   * you get. It is the recommended way to update a bootloader in the field
+   * because it needs no DFU cable and no external tooling.
+   *
+   * Deliberately NOT wrapped in discardStaleLink(): unlike rebootToBootloader
+   * this leaves the vehicle running the same firmware with the same parameter
+   * table, so there is nothing stale to drop. ArduPilot answers ACCEPTED on
+   * both OK and NO_CHANGE (an already-current bootloader is a success, not an
+   * error the operator should see).
+   */
+  async flashBootloader(): Promise<void> {
+    await this.sendCommand(MAV_CMD.FLASH_BOOTLOADER, [0, 0, 0, 0, FLASH_BOOTLOADER_MAGIC, 0, 0], {
+      waitForAck: true,
+      // Erasing and rewriting the bootloader sector takes appreciably longer
+      // than a normal command round-trip.
+      ackTimeoutMs: 20000,
+      rejectAckOnFailure: true
     })
   }
 

--- a/packages/protocol-mavlink/src/constants.ts
+++ b/packages/protocol-mavlink/src/constants.ts
@@ -253,6 +253,19 @@ export const MAV_CMD = {
   PREFLIGHT_REBOOT_SHUTDOWN: 246,
   /** ArduPilot-specific: control onboard Lua scripting (ardupilotmega.xml). */
   SCRIPTING: 42701,
+  /**
+   * Re-flash the bootloader from the image embedded in the running firmware
+   * (ardupilotmega.xml, "Update the bootloader"). param5 must be the magic
+   * 290876 or ArduPilot answers "Magic not set" and FAILED — see
+   * GCS_Common.cpp handle_command_flash_bootloader, which reads it from the
+   * COMMAND_INT `x` field. The entry is hasLocation="false", so the autopilot's
+   * COMMAND_LONG -> COMMAND_INT conversion copies param5 into x WITHOUT the
+   * 1e7 latitude scaling that location commands get.
+   *
+   * Compile-gated behind AP_BOOTLOADER_FLASHING_ENABLED: a build without it
+   * answers UNSUPPORTED rather than failing silently.
+   */
+  FLASH_BOOTLOADER: 42650,
   // Put the RC receiver into bind/pair mode. ArduPilot routes this to the
   // active RC protocol's bind: CRSF/ExpressLRS sends the CRSF bind command
   // frame to the RX, Spektrum pulses the satellite bind. Params are ignored

--- a/tests/e2e/views.spec.ts
+++ b/tests/e2e/views.spec.ts
@@ -1472,6 +1472,16 @@ test.describe('Flash view', () => {
     await expect(page.getByTestId('firmware-enter-dfu')).toBeVisible()
     await expect(page.getByTestId('firmware-enter-dfu-confirm')).toHaveCount(0)
 
+    // Update Bootloader (MAV_CMD_FLASH_BOOTLOADER) gets the same two-step gate:
+    // rewriting the bootloader sector can brick the board if interrupted, so
+    // the first click must only arm, never send.
+    await expect(page.getByTestId('firmware-flash-bootloader')).toBeVisible()
+    await page.getByTestId('firmware-flash-bootloader').click()
+    await expect(page.getByTestId('firmware-flash-bootloader-confirm')).toBeVisible()
+    await page.getByTestId('firmware-flash-bootloader-cancel').click()
+    await expect(page.getByTestId('firmware-flash-bootloader')).toBeVisible()
+    await expect(page.getByTestId('firmware-flash-bootloader-confirm')).toHaveCount(0)
+
     // Custom server toggle expands a URL + token panel.
     await expect(page.getByTestId('firmware-custom-server')).toHaveCount(0)
     await page.getByTestId('firmware-toggle-custom-server').click()

--- a/tests/flash-bootloader.test.mjs
+++ b/tests/flash-bootloader.test.mjs
@@ -1,0 +1,128 @@
+// Updating the bootloader over MAVLink (MAV_CMD_FLASH_BOOTLOADER).
+//
+// The command id and the magic number are the entire risk surface: ArduPilot
+// answers "Magic not set" + FAILED for any param5 other than 290876, and an
+// unrecognised command id is simply UNSUPPORTED. Both fail in ways that look
+// like "nothing happened" rather than an obvious error, so they are asserted
+// against the values read out of GCS_Common.cpp and ardupilotmega.xml.
+//
+// This re-flashes the bootloader image embedded in the RUNNING firmware — it
+// is not a file upload, and it must NOT reboot the vehicle by itself.
+
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { ArduPilotConfiguratorRuntime } from '../packages/ardupilot-core/dist/index.js'
+import { arducopterMetadata } from '../packages/param-metadata/dist/index.js'
+import { MAV_CMD, MAV_RESULT } from '../packages/protocol-mavlink/dist/index.js'
+
+/** ardupilotmega.xml entry value="42650". */
+const MAV_CMD_FLASH_BOOTLOADER = 42650
+/** GCS_Common.cpp: `if (packet.x != 290876) { "Magic not set"; FAILED }`. */
+const FLASH_BOOTLOADER_MAGIC = 290876
+
+function createSession(sent, { result = MAV_RESULT.ACCEPTED } = {}) {
+  const statusListeners = []
+  const messageListeners = []
+  const emit = (message) =>
+    messageListeners.forEach((listener) =>
+      listener({ header: { systemId: 1, componentId: 1, sequence: 0 }, message, timestampMs: Date.now() })
+    )
+
+  return {
+    getTransportStatus: () => ({ kind: 'connected' }),
+    onStatus(listener) {
+      statusListeners.push(listener)
+      return () => {}
+    },
+    onMessage(listener) {
+      messageListeners.push(listener)
+      return () => {}
+    },
+    async connect() {
+      statusListeners.forEach((listener) => listener({ kind: 'connected' }))
+      emit({
+        type: 'HEARTBEAT',
+        autopilot: 3,
+        vehicleType: 2,
+        baseMode: 0,
+        customMode: 0,
+        systemStatus: 4,
+        mavlinkVersion: 3
+      })
+    },
+    async disconnect() {
+      statusListeners.forEach((listener) => listener({ kind: 'disconnected', reason: 'test' }))
+    },
+    destroy() {},
+    async send(message) {
+      sent.push(message)
+      if (message.command === MAV_CMD_FLASH_BOOTLOADER) {
+        emit({
+          type: 'COMMAND_ACK',
+          command: MAV_CMD_FLASH_BOOTLOADER,
+          result,
+          progress: 0,
+          resultParam2: 0,
+          targetSystem: 1,
+          targetComponent: 1
+        })
+      }
+    }
+  }
+}
+
+async function withRuntime(run, options) {
+  const sent = []
+  const runtime = new ArduPilotConfiguratorRuntime(createSession(sent, options), arducopterMetadata)
+  try {
+    await runtime.connect()
+    await run(runtime, sent)
+  } finally {
+    await runtime.disconnect().catch(() => {})
+    runtime.destroy()
+  }
+}
+
+test('the command id matches ardupilotmega.xml', () => {
+  assert.equal(MAV_CMD.FLASH_BOOTLOADER, MAV_CMD_FLASH_BOOTLOADER)
+})
+
+test('flashBootloader sends the 290876 magic in param5', async () => {
+  await withRuntime(async (runtime, sent) => {
+    await runtime.flashBootloader()
+    const command = sent.find((message) => message.command === MAV_CMD_FLASH_BOOTLOADER)
+    assert.ok(command, 'a MAV_CMD_FLASH_BOOTLOADER (42650) command was sent')
+    // params[4] is param5, which the autopilot reads as COMMAND_INT `x`.
+    // Anything else gets "Magic not set" and FAILED.
+    assert.equal(command.params[4], FLASH_BOOTLOADER_MAGIC)
+  })
+})
+
+test('every other parameter is empty, per the command definition', async () => {
+  await withRuntime(async (runtime, sent) => {
+    await runtime.flashBootloader()
+    const command = sent.find((message) => message.command === MAV_CMD_FLASH_BOOTLOADER)
+    assert.deepEqual(command.params, [0, 0, 0, 0, FLASH_BOOTLOADER_MAGIC, 0, 0])
+  })
+})
+
+test('it does not reboot the vehicle by itself', async () => {
+  // A reboot here would drop the link mid-write. The operator reboots after.
+  await withRuntime(async (runtime, sent) => {
+    await runtime.flashBootloader()
+    const reboots = sent.filter((message) => message.command === 246)
+    assert.deepEqual(reboots, [], 'no PREFLIGHT_REBOOT_SHUTDOWN may be sent')
+  })
+})
+
+test('a refusing autopilot surfaces as a rejection, not a silent success', async () => {
+  // A build without AP_BOOTLOADER_FLASHING_ENABLED answers UNSUPPORTED, and a
+  // wrong magic answers FAILED. Either must reach the operator.
+  await withRuntime(
+    async (runtime) => {
+      await assert.rejects(() => runtime.flashBootloader())
+    },
+    { result: MAV_RESULT.UNSUPPORTED }
+  )
+})


### PR DESCRIPTION
## Requested

> Flash tab: Please add a update bootloader Button. This is a mavlink message you can send to AP when connected over serial

## What it does

Sends `MAV_CMD_FLASH_BOOTLOADER` (42650) over the live MAVLink link — no DFU cable, no external tooling.

Worth being precise: this re-flashes the bootloader image **embedded in the running firmware**. It is not a file upload — whatever firmware is currently on the board decides which bootloader you get.

## The magic number is the whole risk surface

`GCS_Common.cpp handle_command_flash_bootloader` rejects any param5 other than **290876** with "Magic not set" and `MAV_RESULT_FAILED`, reading it from the COMMAND_INT `x` field.

The `ardupilotmega.xml` entry is `hasLocation="false"`, so the autopilot's COMMAND_LONG → COMMAND_INT conversion copies param5 into `x` **without** the 1e7 latitude scaling that location commands get — which is why sending it as a COMMAND_LONG is correct here.

Both the magic and the command id fail in ways that look like "nothing happened" rather than a visible error, so both are pinned by tests against the source values.

## Safety

- **Two-click arm/confirm**, matching the existing DFU reboot gate. Rewriting the bootloader sector can brick the board if interrupted, so the first click only arms.
- Disabled while disconnected or armed, with the reason surfaced in the title.
- **Deliberately does not reboot** — a reboot here would drop the link mid-write. The operator is told to reboot afterwards.
- ArduPilot answers ACCEPTED for both `OK` and `NO_CHANGE`, so an already-current bootloader reports success rather than an error the operator has to interpret.
- A build without `AP_BOOTLOADER_FLASHING_ENABLED` answers UNSUPPORTED, which surfaces as a rejection rather than a silent no-op.

## ArduCopter byte-identical

No parameter is read, written or branched on. The command is only ever sent by an explicit two-click operator action.

## Validation

- `npm run typecheck` — clean
- `npm run test` — 807 pass / 0 fail (5 new)
- web vitest — 624 pass / 0 fail
- `npm run test:e2e` — 233 pass / 6 skipped (extends the existing DFU block with the new gate)

**Rung 5 not done, and materially riskier than usual here** — this rewrites a bootloader on real hardware. Worth trying first on a board you can recover over DFU.