### PR TITLE
feat(flash): show the bootloader's git version on the Flash tab

### DIFF
--- a/apps/web/src/firmware/FirmwareFlasher.tsx
+++ b/apps/web/src/firmware/FirmwareFlasher.tsx
@@ -1330,6 +1330,14 @@ export function FirmwareFlasher(props: FirmwareFlasherProps) {
             <span>Board id {formatBoardId(identity.boardId)}</span>
             <span>BL rev {identity.bootloaderRevision}</span>
             <span>{Math.round(identity.flashSize / 1024)} KiB flash</span>
+            {/* The bootloader's own git version, readable ONLY here — running
+              * firmware never learns which bootloader is installed. Absent on
+              * boards built without PROTO_GET_VERSION (smaller-flash targets),
+              * which is normal rather than a fault, so the pill is simply
+              * omitted instead of showing an error. */}
+            {identity.bootloaderVersion ? (
+              <span data-testid="firmware-bootloader-version">BL {identity.bootloaderVersion}</span>
+            ) : null}
           </div>
         ) : null}
 

--- a/packages/firmware-flash/src/bootloader.ts
+++ b/packages/firmware-flash/src/bootloader.ts
@@ -29,6 +29,13 @@ const CHIP_VERIFY = 0x24
 const PROG_MULTI = 0x27
 const READ_MULTI = 0x28
 const GET_CRC = 0x29
+// PROTO_GET_VERSION (bl_protocol.cpp:110): replies <length:4><git version
+// string>/INSYNC/OK. Compiled in only when HAL_PROGRAM_SIZE_LIMIT_KB > 1024,
+// so smaller-flash boards answer INVALID and simply do not report a version.
+const GET_VERSION = 0x2f
+// MAX_VERSION_LENGTH in bl_protocol.h — the bootloader truncates to this, so a
+// longer declared length means the reply is not a version string.
+const MAX_VERSION_LENGTH = 32
 const REBOOT = 0x30
 
 // extflash opcodes for dual-image boards (CubeOrange+, Pixhawk6X,
@@ -72,6 +79,17 @@ export interface BoardIdentity {
   boardId: number
   boardRevision: number
   flashSize: number
+  /**
+   * The bootloader's own git version (GIT_VERSION_EXTENDED), when the board
+   * reports one. Undefined on boards built without PROTO_GET_VERSION — that is
+   * a normal outcome for smaller-flash targets, not an error.
+   *
+   * This is the ONLY way to learn which bootloader is installed: running
+   * firmware never knows. AP_HAL_ChibiOS/Util.cpp flash_bootloader() only
+   * memcmps the whole image against the copy in its own ROMFS, so it can tell
+   * "same as mine" from "different" but can never name what is there.
+   */
+  bootloaderVersion?: string
 }
 
 export type FlashPhase =
@@ -165,7 +183,39 @@ export class BootloaderClient {
     const boardId = await this.getInfo(INFO_BOARD_ID)
     const boardRevision = await this.getInfo(INFO_BOARD_REV)
     const flashSize = await this.getInfo(INFO_FLASH_SIZE)
-    return { bootloaderRevision, boardId, boardRevision, flashSize }
+    const bootloaderVersion = await this.getVersion()
+    return { bootloaderRevision, boardId, boardRevision, flashSize, bootloaderVersion }
+  }
+
+  /**
+   * The bootloader's git version string, or undefined when this board does not
+   * implement PROTO_GET_VERSION.
+   *
+   * Never throws: an unsupported command answers INVALID, and identify() must
+   * not fail — losing the board identity over a missing nice-to-have would
+   * break flashing on every smaller-flash target. A failed attempt leaves
+   * unread bytes, so the link is re-synced before returning.
+   */
+  async getVersion(): Promise<string | undefined> {
+    try {
+      await this.io.flushInput?.()
+      await this.io.write(new Uint8Array([GET_VERSION, EOC]))
+      const lengthBytes = await this.io.read(4, SYNC_TIMEOUT_MS)
+      const length = (lengthBytes[0] | (lengthBytes[1] << 8) | (lengthBytes[2] << 16) | (lengthBytes[3] << 24)) >>> 0
+      if (length === 0 || length > MAX_VERSION_LENGTH) {
+        // Not a version reply — most likely INSYNC/INVALID misread as a
+        // length. Re-sync so the next command starts clean.
+        await this.sync().catch(() => {})
+        return undefined
+      }
+      const raw = await this.io.read(length, SYNC_TIMEOUT_MS)
+      await this.getSync()
+      const text = new TextDecoder().decode(raw).replace(/\0+$/, '').trim()
+      return text.length > 0 ? text : undefined
+    } catch {
+      await this.sync().catch(() => {})
+      return undefined
+    }
   }
 
   private async trySync(): Promise<boolean> {

--- a/tests/firmware-flash.test.mjs
+++ b/tests/firmware-flash.test.mjs
@@ -257,14 +257,19 @@ test('identify(): handshake, BL-rev gate, board id / flash size', async () => {
     ...le32(5), INSYNC, OK, // BL_REV = 5
     ...le32(50), INSYNC, OK, // BOARD_ID
     ...le32(0), INSYNC, OK, // BOARD_REV
-    ...le32(2080768), INSYNC, OK // FLASH_SIZE (~2MB)
+    ...le32(2080768), INSYNC, OK, // FLASH_SIZE (~2MB)
+    // PROTO_GET_VERSION reply: <length:4><git string>/INSYNC/OK. This is the
+    // ONLY way to learn which bootloader is installed — running firmware never
+    // knows (flash_bootloader() only memcmps against its own ROMFS copy).
+    ...le32(7), 0x61, 0x62, 0x63, 0x31, 0x32, 0x33, 0x34, INSYNC, OK
   ])
   const id = await new BootloaderClient(io).identify()
   assert.deepEqual(id, {
     bootloaderRevision: 5,
     boardId: 50,
     boardRevision: 0,
-    flashSize: 2080768
+    flashSize: 2080768,
+    bootloaderVersion: 'abc1234'
   })
   // First write is GET_SYNC + EOC; the four queries are GET_DEVICE,param,EOC.
   assert.deepEqual(io.writes[0], [0x21, 0x20])
@@ -273,6 +278,42 @@ test('identify(): handshake, BL-rev gate, board id / flash size', async () => {
 
   const stale = new ScriptedSerial([INSYNC, OK, ...le32(99), INSYNC, OK])
   await assert.rejects(() => new BootloaderClient(stale).identify(), /unsupported protocol revision 99/)
+})
+
+test('identify(): a board without PROTO_GET_VERSION still identifies cleanly', async () => {
+  // PROTO_GET_VERSION is compiled in only when HAL_PROGRAM_SIZE_LIMIT_KB > 1024,
+  // so smaller-flash boards answer INVALID. That must NOT cost us the board
+  // identity — losing it would break flashing entirely over a nice-to-have.
+  const io = new ScriptedSerial([
+    INSYNC, OK, // sync()
+    ...le32(5), INSYNC, OK, // BL_REV
+    ...le32(50), INSYNC, OK, // BOARD_ID
+    ...le32(0), INSYNC, OK, // BOARD_REV
+    ...le32(1032192), INSYNC, OK, // FLASH_SIZE (1MB board)
+    INSYNC, INVALID, // GET_VERSION unsupported
+    INSYNC, OK // the re-sync getVersion() issues before giving up
+  ])
+  const id = await new BootloaderClient(io).identify()
+  assert.equal(id.boardId, 50, 'board identity survives an unsupported GET_VERSION')
+  assert.equal(id.flashSize, 1032192)
+  assert.equal(id.bootloaderVersion, undefined, 'no version reported, and that is not an error')
+})
+
+test('identify(): a nonsense GET_VERSION length is ignored rather than trusted', async () => {
+  // A length beyond MAX_VERSION_LENGTH (32) means we misread something that is
+  // not a version reply; reading it as a string would emit garbage.
+  const io = new ScriptedSerial([
+    INSYNC, OK,
+    ...le32(5), INSYNC, OK,
+    ...le32(50), INSYNC, OK,
+    ...le32(0), INSYNC, OK,
+    ...le32(2080768), INSYNC, OK,
+    ...le32(9999), // implausible length
+    INSYNC, OK // re-sync
+  ])
+  const id = await new BootloaderClient(io).identify()
+  assert.equal(id.bootloaderVersion, undefined)
+  assert.equal(id.boardId, 50)
 })
 
 test('identify(): BL rev floor is 2 (audit-24 accepts rev 2 via byte-compare verify)', async () => {


### PR DESCRIPTION
## Requested

> Can we show bootloader githash? near FW githash
> im not sure there is a way to ask for that info :)

## It can't go near the FW githash

Running firmware never learns which bootloader is installed. `AP_HAL_ChibiOS/Util.cpp:252` — `flash_bootloader()` does a raw `memcmp` of the ROMFS-embedded image against flash page 0, so the autopilot can tell "byte-identical to mine" from "different", but can never *name* what is there.

`AUTOPILOT_VERSION` carries flight/middleware/OS hashes and has no bootloader field. There's no `@SYS` file for it (checked the full `sysfs_file_list`) and no parameter.

## But the bootloader reports it itself

`PROTO_GET_VERSION` (0x2f, `bl_protocol.cpp:110`) replies `<length:4><GIT_VERSION_EXTENDED>/INSYNC/OK`.

That's only reachable with the board **in** the bootloader — which is exactly when it's useful, since that's when you're deciding whether to update it, and the Flash tab already puts the board there.

`BootloaderClient` gains `getVersion()`, called from `identify()`, surfaced as a `BL <hash>` pill beside board id / BL rev / flash size.

## Degrading gracefully is the load-bearing part

`PROTO_GET_VERSION` is compiled in only when `HAL_PROGRAM_SIZE_LIMIT_KB > 1024`, so smaller-flash boards answer INVALID. Letting that propagate would cost the board identity and **break flashing entirely** over a nice-to-have.

- Unsupported board → no version, pill omitted. A normal outcome, not an error shown to the operator.
- A declared length beyond `MAX_VERSION_LENGTH` (32, `bl_protocol.h`) is treated as a misread rather than decoded into garbage.
- Any failed attempt re-syncs, so the next command starts clean.

Both paths are tested, including that `identify()` still returns a usable board on a 1MB-style board that refuses the command.

## ArduCopter byte-identical

Bootloader-protocol only. No MAVLink, no parameter read or written.

## Validation (rungs 1 and 3)

- `npm run typecheck` — clean
- `npm run test` — 809 pass / 0 fail (2 new; the `identify()` shape test extended to cover the version reply)
- web vitest — 624 pass / 0 fail
- `npm run test:e2e` — 233 pass / 6 skipped

**Rung 5 pending** — needs a real board caught in bootloader mode, plus ideally a 1MB board to confirm the unsupported path degrades as intended.