### PR TITLE
fix(calibration): unblock the battery-current load spin; flag orientation reboot

### DIFF
--- a/apps/web/src/sections/CalibrationSection.tsx
+++ b/apps/web/src/sections/CalibrationSection.tsx
@@ -6,6 +6,7 @@
 import { useState, type ReactElement } from 'react'
 import type { ConfiguratorSnapshot, AirframeSummary } from '@arduconfig/ardupilot-core'
 import type { ArduPilotConfiguratorRuntime, ParameterWriteOptions } from '@arduconfig/ardupilot-core'
+import { MAX_MOTOR_TEST_DURATION_SECONDS } from '@arduconfig/ardupilot-core'
 import { Panel, StatusBadge, buttonStyle } from '@arduconfig/ui-kit'
 import { formatArducopterMotorPwmType } from '@arduconfig/param-metadata'
 
@@ -44,6 +45,12 @@ export interface CalibrationSectionProps {
   handleGuidedAction: (actionId: GuidedActionId) => void | Promise<void>
   handleCancelGuidedAction: (actionId: GuidedActionId) => void
 }
+
+/** Load-spin duration for battery-current calibration. Pinned to the shared
+ *  motor-test cap: the card used to hardcode 8 s, which every non-Expert
+ *  session rejected outright with "Duration must stay between ...", so the
+ *  button could never work. */
+const BATTERY_CURRENT_LOAD_SECONDS = MAX_MOTOR_TEST_DURATION_SECONDS
 
 export function CalibrationSection(props: CalibrationSectionProps): ReactElement {
   // Throttle used for the current-calibration load spin. Local to this card:
@@ -464,11 +471,11 @@ export function CalibrationSection(props: CalibrationSectionProps): ReactElement
                                       await runtime.runMotorTest({
                                         runAllOutputsSimultaneous: true,
                                         throttlePercent,
-                                        durationSeconds: 8
+                                        durationSeconds: BATTERY_CURRENT_LOAD_SECONDS
                                       })
                                       setBatteryCalNotice({
                                         tone: 'warning',
-                                        text: `Spinning all motors at ${throttlePercent}% for 8 s — read your meter NOW and type the value below.`
+                                        text: `Spinning all motors at ${throttlePercent}% for ${BATTERY_CURRENT_LOAD_SECONDS} s — read your meter NOW and type the value below.`
                                       })
                                     } catch (error) {
                                       setBatteryCalNotice({
@@ -479,7 +486,7 @@ export function CalibrationSection(props: CalibrationSectionProps): ReactElement
                                   })()
                                 }}
                               >
-                                {snapshot.motorTest.status === 'running' ? 'Motors spinning…' : 'Spin motors for 8 s'}
+                                {snapshot.motorTest.status === 'running' ? 'Motors spinning…' : `Spin motors for ${BATTERY_CURRENT_LOAD_SECONDS} s`}
                               </button>
                               {!(propsRemovedAcknowledged && testAreaAcknowledged) ? (
                                 <small>Acknowledge the motor-spin safety checks below before applying a load.</small>
@@ -693,15 +700,24 @@ export function CalibrationSection(props: CalibrationSectionProps): ReactElement
                       : undefined
                 return (
                   <>
-                    {/* Motor-spin safety acks gate ESC calibration; hide them when
-                      * ESC cal isn't applicable (DShot/Brushed/etc.) — nothing spins. */}
-                    {!escCalUnsupported ? (
-                      <article className="calibration-card calibration-card--danger" data-testid="calibration-card-motor-safety">
+                    {/* These acks gate EVERY motor-spinning action on this page,
+                      * not just ESC calibration — the battery-current load spin
+                      * uses them too. They used to be hidden whenever ESC cal was
+                      * inapplicable (DShot/Brushed/PWMRange), which on any DShot
+                      * build left the current-calibration card telling the
+                      * operator to "acknowledge the checks below" with no
+                      * checkboxes anywhere: permanently blocked. Always shown for
+                      * a copter; the copy names whichever action still applies. */}
+                    <article className="calibration-card calibration-card--danger" data-testid="calibration-card-motor-safety">
                         <div className="calibration-card__header">
                           <strong>Motor-spin safety</strong>
                           <StatusBadge tone={motorSafetyOk ? 'success' : 'warning'}>{motorSafetyOk ? 'acknowledged' : 'required'}</StatusBadge>
                         </div>
-                        <p>ESC calibration spins the motors. Confirm before running it.</p>
+                        <p>
+                          {escCalUnsupported
+                            ? 'Applying a battery-current load spins the motors. Confirm before running it.'
+                            : 'ESC calibration and the battery-current load both spin the motors. Confirm before running either.'}
+                        </p>
                         <label className="scoped-checkbox-option">
                           <input type="checkbox" checked={propsRemovedAcknowledged} onChange={(e) => setPropsRemovedAcknowledged(e.target.checked)} data-testid="cal-props-ack" />
                           <span>All propellers are removed.</span>
@@ -711,7 +727,6 @@ export function CalibrationSection(props: CalibrationSectionProps): ReactElement
                           <span>The vehicle is restrained and the area is clear.</span>
                         </label>
                       </article>
-                    ) : null}
 
                     {/* CompassMot was removed from the Calibration tab — the
                       * bench procedure (spin motors at fixed throttle, log

--- a/packages/param-metadata/src/arducopter.ts
+++ b/packages/param-metadata/src/arducopter.ts
@@ -1204,12 +1204,24 @@ export const arducopterMetadata: FirmwareMetadataBundle = {
     AHRS_ORIENTATION: {
       id: 'AHRS_ORIENTATION',
       label: 'Board Orientation',
-      description: 'Mounting orientation for the flight controller.',
+      description: 'Mounting orientation for the flight controller. Takes effect on the next boot.',
       category: 'sensors',
       minimum: 0,
       maximum: 102,
       options: AHRS_ORIENTATION_OPTIONS,
-      notes: ['If the board orientation changes, repeat accelerometer calibration before flight.']
+      // AP_AHRS.cpp @Param: ORIENTATION — "This option takes affect on next
+      // boot. After changing you will need to re-level your vehicle."
+      //
+      // ArduPilot states that in the DESCRIPTION PROSE and does NOT tag the
+      // parameter @RebootRequired: True, so a metadata scrape of apm.pdef.json
+      // misses it entirely — which is how this shipped untagged. Written by
+      // hand, and pinned by a test, because regenerating from upstream would
+      // silently drop it again.
+      rebootRequired: true,
+      notes: [
+        'Takes effect on the next boot — reboot the flight controller after changing it.',
+        'After changing orientation, re-level the vehicle and repeat accelerometer calibration before flight.'
+      ]
     },
     COMPASS_USE: {
       id: 'COMPASS_USE',

--- a/tests/ahrs-orientation-reboot.test.mjs
+++ b/tests/ahrs-orientation-reboot.test.mjs
@@ -1,0 +1,59 @@
+// AHRS_ORIENTATION takes effect on the next boot.
+//
+// Field report: changing board orientation appeared to do nothing, because the
+// app never told the operator to reboot.
+//
+// ArduPilot says so only in the DESCRIPTION PROSE of AP_AHRS.cpp @Param:
+// ORIENTATION — "This option takes affect on next boot. After changing you
+// will need to re-level your vehicle." — and does NOT tag the parameter
+// @RebootRequired: True. A metadata scrape of apm.pdef.json therefore misses
+// it, which is exactly how it shipped untagged.
+//
+// So this is asserted here rather than left to upstream: a future regeneration
+// that trusts the @RebootRequired tag would silently drop the flag and
+// reintroduce the bug with nothing failing.
+
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { arducopterMetadata, normalizeFirmwareMetadata } from '../packages/param-metadata/dist/index.js'
+
+const catalog = normalizeFirmwareMetadata(arducopterMetadata)
+
+test('AHRS_ORIENTATION is flagged reboot-required', () => {
+  const definition = catalog.parameters.AHRS_ORIENTATION
+  assert.ok(definition, 'AHRS_ORIENTATION should be in the catalog')
+  assert.equal(
+    definition.rebootRequired,
+    true,
+    'ArduPilot applies board orientation on next boot only — the app must prompt for one'
+  )
+})
+
+test('the operator is told to reboot AND to re-level, not just one of them', () => {
+  const notes = (catalog.parameters.AHRS_ORIENTATION.notes ?? []).join(' ').toLowerCase()
+  assert.match(notes, /reboot/, 'a reboot is required for the new orientation to take effect')
+  // Re-levelling matters as much: the old AHRS trims describe the old mounting.
+  assert.match(notes, /re-level|level/, 'the vehicle must be re-levelled after an orientation change')
+  assert.match(notes, /accelerometer/, 'accel calibration should be repeated')
+})
+
+test('the description states the next-boot behaviour', () => {
+  // The dropdown shows the description; leaving it silent is what made the
+  // change look like it had done nothing.
+  assert.match(catalog.parameters.AHRS_ORIENTATION.description.toLowerCase(), /next boot|reboot/)
+})
+
+test('the reboot flag is not applied indiscriminately to sibling rotations', () => {
+  // COMPASS_ORIENT shares the rotation enum but is NOT documented as
+  // next-boot-only upstream, so tagging it would train operators to ignore the
+  // prompt. Only AHRS_ORIENTATION carries the "takes affect on next boot" text.
+  const compassOrient = catalog.parameters.COMPASS_ORIENT
+  if (compassOrient) {
+    assert.notEqual(
+      compassOrient.rebootRequired,
+      true,
+      'COMPASS_ORIENT is not documented as next-boot-only in AP_Compass'
+    )
+  }
+})

--- a/tests/e2e/views.spec.ts
+++ b/tests/e2e/views.spec.ts
@@ -1080,7 +1080,12 @@ test.describe('Calibration tab — motor-spin (ESC)', () => {
     // The demo copter is DShot300 (MOT_PWM_TYPE = 5). ESC endpoint calibration is
     // a PWM-era procedure and must NOT be offered for DShot (digital, no
     // endpoints) — the card shows a "not applicable" explanation instead of the
-    // arm/confirm flow, and the motor-safety acks (which only gate ESC cal) hide.
+    // arm/confirm flow.
+    //
+    // The motor-safety acks DO stay, though: they gate every motor-spinning
+    // action here, including the battery-current load spin. Hiding them on DShot
+    // (i.e. on most modern quads) left that card telling the operator to
+    // "acknowledge the checks below" with no checkboxes anywhere on the page.
     await page.goto('/')
     await connectViaHeader(page)
     await openView(page, 'calibration')
@@ -1089,9 +1094,12 @@ test.describe('Calibration tab — motor-spin (ESC)', () => {
     const unsupported = page.getByTestId('esc-cal-unsupported')
     await expect(unsupported).toBeVisible()
     await expect(unsupported).toContainText('DShot')
-    // The arm button + safety-ack card are not rendered for DShot.
+    // The arm button is not rendered for DShot...
     await expect(page.getByTestId('esc-cal-arm')).toHaveCount(0)
-    await expect(page.getByTestId('calibration-card-motor-safety')).toHaveCount(0)
+    // ...but the safety acks are, so battery-current calibration stays usable.
+    await expect(page.getByTestId('calibration-card-motor-safety')).toBeVisible()
+    await expect(page.getByTestId('cal-props-ack')).toBeVisible()
+    await expect(page.getByTestId('cal-area-ack')).toBeVisible()
   })
 
   test('motor-spin calibrations are hidden on a plane', async ({ page }) => {


### PR DESCRIPTION
Three field reports, two of which share a card.

## "There is no box to enable the motors"

The battery-current card said *"Acknowledge the motor-spin safety checks below"* while no checkboxes existed anywhere on the page.

Those acks live in the **Motor-spin safety** card, which rendered only when ESC calibration applied — hidden for DShot/Brushed/PWMRange on the reasoning that "nothing spins". That reasoning predates the battery-current load spin, which gates on the *same* acks.

So on any DShot build — most modern quads, including the demo copter at `MOT_PWM_TYPE=5` — the card was permanently blocked with no way to satisfy it. This is the wizard↔UI coupling failure mode again: a step gating on state that some *other* UI is responsible for setting.

The acks now always render for a copter, and the copy names whichever action still applies.

## "Also says duration must be between 0.5-8s"

The same card hardcoded `durationSeconds: 8`, while `MAX_MOTOR_TEST_DURATION_SECONDS` is **5** outside Expert mode — so the spin was rejected before it started. It now derives from that shared constant, and the button label derives from the same value, so the two can't drift apart again.

## "Changing board orientation requires a reboot"

`AHRS_ORIENTATION` wasn't flagged `rebootRequired`, so changing it looked like it had done nothing.

ArduPilot states it only in the **description prose** of `AP_AHRS.cpp:145`:

> This option takes affect on next boot. After changing you will need to re-level your vehicle.

There is no `@RebootRequired: True` tag, so a scrape of `apm.pdef.json` misses it entirely — which is how it shipped untagged. Written by hand and pinned by a test, because regenerating from upstream would silently drop it again.

Only `AHRS_ORIENTATION` carries that phrasing upstream. `COMPASS_ORIENT` is deliberately left alone, and a test guards against tagging siblings indiscriminately (training operators to ignore the prompt is its own failure).

## Test that was asserting the bug

The DShot e2e claimed *"the motor-safety acks (which only gate ESC cal) hide"*. That premise was factually wrong; it now asserts the acks stay, so battery-current calibration remains usable.

## ArduCopter byte-identical

Metadata + UI gating only. No new command, no parameter written, no vehicle branch changed. The motor-test request now asks for a duration the eligibility guard actually permits, rather than one it rejected.

## Validation (rungs 1 and 3)

- `npm run typecheck` — clean
- `npm run test` — 813 pass / 0 fail (4 new)
- web vitest — 624 pass / 0 fail
- `npm run test:e2e` — 233 pass / 6 skipped

**Rung 5 pending** — the load spin wants a props-off bench run to confirm it now starts, and that 5 s is long enough to read a meter. If it isn't, the honest fix is Expert mode (cap 30 s) rather than raising the default cap.