### PR TITLE
feat(parameters): add Reset to Defaults to Parameters and Snapshots

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -332,6 +332,7 @@ import { SetupWizardHeader } from './sections/SetupWizardHeader'
 import { SetupWizardDetail } from './sections/SetupWizardDetail'
 import { SetupBenchActions } from './sections/SetupBenchActions'
 import { StatusDfuCard } from './sections/StatusDfuCard'
+import { ResetToDefaultsButton } from './views/ResetToDefaultsButton'
 import { CalibrationLocationButton } from './sections/CalibrationLocationCard'
 import { resolveSetupConfirmationRecord } from './view-models/setup-confirmation-resolve'
 import { buildSetupConfirmationSignatures } from './view-models/setup-confirmation-signatures'
@@ -8075,6 +8076,28 @@ export function App() {
 
       {activeViewId === 'snapshots' ? (
         <SnapshotsSection
+          resetToDefaultsSlot={
+            <ResetToDefaultsButton
+              // Same gated handler the Presets view uses — one destructive
+              // code path, one set of guards, rather than a second
+              // reimplementation per surface.
+              onReset={
+                runtime && snapshot.connection.kind === 'connected'
+                  ? () => void handleEraseSettings()
+                  : undefined
+              }
+              disabledReason={
+                snapshot.connection.kind !== 'connected'
+                  ? 'Connect to a vehicle first.'
+                  : snapshot.vehicle?.armed
+                    ? 'Disarm the vehicle before erasing settings.'
+                    : undefined
+              }
+              isResetting={busyAction === 'presets:erase'}
+              isBusy={busyAction !== undefined}
+              suggestSnapshot={false}
+            />
+          }
           snapshot={snapshot}
           desktopBridge={desktopBridge}
           desktopSnapshotLibraryPath={desktopSnapshotLibraryPath}
@@ -8761,6 +8784,28 @@ export function App() {
 
       {activeViewId === 'parameters' ? (
         <ParametersSection
+          resetToDefaultsSlot={
+            <ResetToDefaultsButton
+              // Same gated handler the Presets view uses — one destructive
+              // code path, one set of guards, rather than a second
+              // reimplementation per surface.
+              onReset={
+                runtime && snapshot.connection.kind === 'connected'
+                  ? () => void handleEraseSettings()
+                  : undefined
+              }
+              disabledReason={
+                snapshot.connection.kind !== 'connected'
+                  ? 'Connect to a vehicle first.'
+                  : snapshot.vehicle?.armed
+                    ? 'Disarm the vehicle before erasing settings.'
+                    : undefined
+              }
+              isResetting={busyAction === 'presets:erase'}
+              isBusy={busyAction !== undefined}
+              suggestSnapshot={true}
+            />
+          }
           snapshot={snapshot}
           metadataCatalog={metadataCatalog}
           canApplyDraftParameters={canApplyDraftParameters}

--- a/apps/web/src/sections/ParametersSection.tsx
+++ b/apps/web/src/sections/ParametersSection.tsx
@@ -4,7 +4,7 @@
 // input + three export buttons, and the selected-parameter detail card.
 
 import { Fragment, useCallback, useEffect, useMemo, useRef, useState } from 'react'
-import type { Dispatch, ReactElement, RefObject, SetStateAction } from 'react'
+import type { Dispatch, ReactElement, ReactNode, RefObject, SetStateAction } from 'react'
 import { parameterAlias } from '@arduconfig/ardupilot-core'
 import type { ConfiguratorSnapshot, ParameterDraftEntry, ParameterDraftGroup, ParameterDraftSummary, ParameterImportCategory, ParameterState } from '@arduconfig/ardupilot-core'
 import type { NormalizedFirmwareMetadataBundle } from '@arduconfig/param-metadata'
@@ -37,6 +37,9 @@ export interface ParametersSectionProps {
   metadataCatalog: NormalizedFirmwareMetadataBundle
   canApplyDraftParameters: boolean
   canApplyAllDraftParameters: boolean
+  /** "Reset to Defaults" control, rendered near the top — see
+   *  ResetToDefaultsButton. */
+  resetToDefaultsSlot?: ReactNode
   busyAction: string | undefined
   /** Label for the Apply-All button while the batch write is in flight, e.g. "Writing… (12/200)". */
   applyAllBusyLabel: string
@@ -121,6 +124,7 @@ export function ParametersSection(props: ParametersSectionProps): ReactElement {
     metadataCatalog,
     canApplyDraftParameters,
     canApplyAllDraftParameters,
+    resetToDefaultsSlot,
     busyAction,
     applyAllBusyLabel,
     editedValues,
@@ -327,6 +331,12 @@ export function ParametersSection(props: ParametersSectionProps): ReactElement {
           <StatusBadge tone="warning">expert</StatusBadge>
           <p>Raw parameter editing is an Expert surface. Use Setup, Ports, Receiver, Outputs, and Power for routine workflow changes first.</p>
         </div>
+
+        {resetToDefaultsSlot ? (
+          <div className="parameter-reset-row" data-testid="parameters-reset-row">
+            {resetToDefaultsSlot}
+          </div>
+        ) : null}
 
         <div className="parameter-toolbar">
           <input

--- a/apps/web/src/sections/SnapshotsSection.tsx
+++ b/apps/web/src/sections/SnapshotsSection.tsx
@@ -9,7 +9,7 @@
 // from the original block.
 
 import { useMemo } from 'react'
-import type { ChangeEvent, ReactElement, RefObject } from 'react'
+import type { ChangeEvent, ReactElement, ReactNode, RefObject } from 'react'
 import type {
   ConfiguratorSnapshot,
   ParameterDraftEntry,
@@ -175,6 +175,8 @@ export interface SnapshotsSectionProps {
   canApplyDraftParameters: boolean
   parameterFollowUp: ParameterFollowUp | undefined
   isExpertMode: boolean
+  /** Rendered near the top of the page — see ResetToDefaultsButton. */
+  resetToDefaultsSlot?: ReactNode
   snapshotNotice: ParameterNotice | undefined
   provisioningNotice: ParameterNotice | undefined
   formatCategoryLabel: (categoryId: string | undefined) => string
@@ -356,6 +358,7 @@ export function SnapshotsSection(props: SnapshotsSectionProps): ReactElement {
         snapshotsCount={savedSnapshots.length}
         profilesCount={savedProvisioningProfiles.length}
         activeDiffCount={selectedSnapshotChangedEntries.length + selectedProvisioningProfileChangedEntries.length}
+        resetToDefaultsSlot={props.resetToDefaultsSlot}
         hiddenInputsSlot={
           <>
             <input

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -15893,3 +15893,36 @@ button.mavlink-inspector__sent-row {
   flex-wrap: wrap;
   gap: 8px;
 }
+
+/* "Reset to Defaults" on Parameters and Snapshots. Mirrors the Flash tab's
+ * arm/confirm treatment so a destructive control looks the same everywhere it
+ * appears, rather than reading as an ordinary toolbar button. */
+.parameter-reset-row,
+.snapshots-page__reset {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.5rem;
+  margin-bottom: 0.75rem;
+}
+
+.reset-defaults-button--danger {
+  border-color: var(--danger, #e2123f);
+  color: var(--danger, #e2123f);
+}
+
+.reset-defaults-confirm {
+  display: inline-flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.reset-defaults-confirm__warning {
+  color: var(--danger, #e2123f);
+  font-size: 0.85rem;
+  /* Keep the warning from pushing the buttons off a phone-width viewport —
+   * the 390px e2e fails on horizontal overflow. */
+  flex: 1 1 16rem;
+  min-width: 0;
+}

--- a/apps/web/src/views/ResetToDefaultsButton.tsx
+++ b/apps/web/src/views/ResetToDefaultsButton.tsx
@@ -1,0 +1,93 @@
+// "Reset to Defaults" — erase every parameter back to firmware defaults.
+//
+// The underlying action already existed in the Presets view; this makes it
+// reachable from Parameters and Snapshots, which is where operators actually
+// are when they decide they want a clean slate.
+//
+// Two-click arm/confirm, deliberately. In Presets this sits in a
+// destructive-actions context you arrive at on purpose; near the top of
+// Parameters it is adjacent to controls used constantly, and a misclick costs a
+// full retune. The same shape the Flash tab uses for DFU and bootloader writes.
+//
+// Presentational only: the caller owns the erase itself, so the gating,
+// verified-write and reboot behaviour stay in one place rather than being
+// reimplemented per surface.
+
+import { useState, type ReactElement } from 'react'
+
+import { buttonStyle } from '@arduconfig/ui-kit'
+
+export interface ResetToDefaultsButtonProps {
+  /** Erase all parameters and reboot. Undefined when there is no live link. */
+  onReset: (() => void | Promise<void>) | undefined
+  /** Why the reset cannot run (disconnected / armed), shown as the title. */
+  disabledReason: string | undefined
+  /** True while the erase is in flight. */
+  isResetting: boolean
+  /** True while any other action holds the runtime. */
+  isBusy: boolean
+  /** Surface name, so the confirm copy can say where snapshots live. */
+  suggestSnapshot?: boolean
+}
+
+export function ResetToDefaultsButton({
+  onReset,
+  disabledReason,
+  isResetting,
+  isBusy,
+  suggestSnapshot = false
+}: ResetToDefaultsButtonProps): ReactElement | null {
+  const [armed, setArmed] = useState(false)
+
+  if (!onReset) {
+    return null
+  }
+
+  if (!armed) {
+    return (
+      <button
+        type="button"
+        style={buttonStyle()}
+        className="reset-defaults-button"
+        data-testid="reset-to-defaults"
+        disabled={isResetting || isBusy || Boolean(disabledReason)}
+        title={disabledReason}
+        onClick={() => setArmed(true)}
+      >
+        Reset to Defaults
+      </button>
+    )
+  }
+
+  return (
+    <span className="reset-defaults-confirm" data-testid="reset-to-defaults-confirm-row">
+      <span className="reset-defaults-confirm__warning" data-testid="reset-to-defaults-warning">
+        Erase every parameter back to firmware defaults and reboot? Your tuning, calibrations and
+        port setup are all lost.
+        {suggestSnapshot ? ' Capture a snapshot first if you want a way back.' : ''}
+      </span>
+      <button
+        type="button"
+        style={buttonStyle()}
+        className="reset-defaults-button reset-defaults-button--danger"
+        data-testid="reset-to-defaults-confirm"
+        disabled={isResetting}
+        onClick={() => {
+          setArmed(false)
+          void onReset()
+        }}
+      >
+        {isResetting ? 'Erasing…' : 'Confirm: erase all settings'}
+      </button>
+      <button
+        type="button"
+        style={buttonStyle()}
+        data-testid="reset-to-defaults-cancel"
+        disabled={isResetting}
+        onClick={() => setArmed(false)}
+      >
+        Cancel
+      </button>
+    </span>
+  )
+}

--- a/apps/web/src/views/Snapshots.tsx
+++ b/apps/web/src/views/Snapshots.tsx
@@ -6,6 +6,9 @@ export interface SnapshotsViewProps {
   profilesCount: number
   activeDiffCount: number
   hiddenInputsSlot?: ReactNode
+  /** "Reset to Defaults" control, near the top where the operator already is
+   *  when deciding they want a clean slate. */
+  resetToDefaultsSlot?: ReactNode
   libraryFormSlot: ReactNode
   selectedSnapshotSlot: ReactNode
   provisioningFormSlot: ReactNode
@@ -18,6 +21,7 @@ export function SnapshotsView(props: SnapshotsViewProps) {
     profilesCount,
     activeDiffCount,
     hiddenInputsSlot,
+    resetToDefaultsSlot,
     libraryFormSlot,
     selectedSnapshotSlot,
     provisioningFormSlot,
@@ -54,6 +58,12 @@ export function SnapshotsView(props: SnapshotsViewProps) {
               </div>
             </div>
           </div>
+
+          {resetToDefaultsSlot ? (
+            <div className="snapshots-page__reset" data-testid="snapshots-reset-row">
+              {resetToDefaultsSlot}
+            </div>
+          ) : null}
 
           <section className="snapshots-slab snapshots-slab--library">
             {libraryFormSlot}

--- a/tests/e2e/views.spec.ts
+++ b/tests/e2e/views.spec.ts
@@ -1102,6 +1102,31 @@ test.describe('Calibration tab — motor-spin (ESC)', () => {
     await expect(page.getByTestId('cal-area-ack')).toBeVisible()
   })
 
+  test('Reset to Defaults is armed before it can erase, on Parameters and Snapshots', async ({ page }) => {
+    // Erasing every parameter sits near the top of two high-traffic screens, so
+    // the first click must only arm — a misclick here costs a full retune.
+    await page.goto('/')
+    await connectViaHeader(page)
+    // Raw parameter editing is an Expert surface, so the tab only exists here.
+    await page.getByTestId('product-mode-expert').check()
+
+    for (const view of ['parameters', 'snapshots'] as const) {
+      await openView(page, view)
+      const reset = page.getByTestId('reset-to-defaults')
+      await expect(reset).toBeVisible()
+      await expect(page.getByTestId('reset-to-defaults-confirm')).toHaveCount(0)
+
+      await reset.click()
+      await expect(page.getByTestId('reset-to-defaults-warning')).toBeVisible()
+      await expect(page.getByTestId('reset-to-defaults-confirm')).toBeVisible()
+
+      // Cancel returns to the unarmed state without erasing anything.
+      await page.getByTestId('reset-to-defaults-cancel').click()
+      await expect(page.getByTestId('reset-to-defaults')).toBeVisible()
+      await expect(page.getByTestId('reset-to-defaults-confirm')).toHaveCount(0)
+    }
+  })
+
   test('motor-spin calibrations are hidden on a plane', async ({ page }) => {
     await page.goto('/')
     await page.getByTestId('transport-mode-select').selectOption('demo-plane')


### PR DESCRIPTION
## Requested

> Parameters & Snapshots: Both should have a "Reset to Defaults" button near the top

## Not new functionality — reachability

The erase already existed in the Presets view, wired to `runtime.resetParametersToDefaults()` (`PREFLIGHT_STORAGE` param1=2), gated on connected + disarmed, rebooting afterwards.

This surfaces it where an operator actually is when they decide they want a clean slate. `handleEraseSettings` is **reused, not reimplemented**, so there stays exactly one destructive code path with one set of guards.

## Two-click arm/confirm

In Presets this sits in a destructive-actions context you reach on purpose. Near the top of Parameters it is adjacent to controls used constantly, and a misclick costs a full retune — so the first click only arms.

Same treatment the Flash tab gives DFU and bootloader writes, so a destructive control looks the same everywhere it appears rather than reading as an ordinary toolbar button.

On **Parameters** the confirm also suggests capturing a snapshot first. On **Snapshots** it doesn't — the operator is already standing in front of the way back.

## Shared, not duplicated

Rendered through a shared `ResetToDefaultsButton` passed as a slot to both surfaces, so they can't drift apart. Continues the Snapshots/Parameters sharing this repo has been moving toward.

The warning text flexes rather than pushing the buttons sideways, keeping the 390px phone-layout overflow gate green.

## ArduCopter byte-identical

No new command, no parameter written, no vehicle branch changed. The erase itself is untouched.

## Validation (rungs 1 and 3)

- `npm run typecheck` — clean
- `npm run test` — 813 pass / 0 fail
- web vitest — 624 pass / 0 fail
- `npm run test:e2e` — 234 pass / 6 skipped (1 new: the first click only arms, and Cancel erases nothing — asserted on **both** surfaces)

Rung 5 isn't applicable to the gate; the erase path itself is unchanged and already shipped.