### PR TITLE
feat(ui): make tabs obvious everywhere, and hand off after motor identify

### DIFF
--- a/apps/web/src/sections/MotorReorderDialog.tsx
+++ b/apps/web/src/sections/MotorReorderDialog.tsx
@@ -190,12 +190,12 @@ export function MotorReorderDialog({
          *  with a 6%/2.5s window); Direction tab gives the operator
          *  per-motor spin buttons plus the SERVO_BLH_RVMASK reverse
          *  toggles for DShot ESCs in one place. */}
-        <div className="motor-reorder-lightbox__tabs" role="tablist" data-testid="motor-reorder-lightbox-tabs">
+        <div className="tab-strip motor-reorder-lightbox__tabs" role="tablist" data-testid="motor-reorder-lightbox-tabs">
           <button
             type="button"
             role="tab"
             aria-selected={motorDialogTab === 'reorder'}
-            className={`motor-reorder-lightbox__tab${motorDialogTab === 'reorder' ? ' is-active' : ''}`}
+            className={`tab-strip__tab${motorDialogTab === 'reorder' ? ' is-active' : ''}`}
             onClick={() => onTabChange('reorder')}
             data-testid="motor-reorder-lightbox-tab-reorder"
           >
@@ -205,7 +205,7 @@ export function MotorReorderDialog({
             type="button"
             role="tab"
             aria-selected={motorDialogTab === 'direction'}
-            className={`motor-reorder-lightbox__tab${motorDialogTab === 'direction' ? ' is-active' : ''}`}
+            className={`tab-strip__tab${motorDialogTab === 'direction' ? ' is-active' : ''}`}
             onClick={() => onTabChange('direction')}
             data-testid="motor-reorder-lightbox-tab-direction"
           >
@@ -420,6 +420,31 @@ export function MotorReorderDialog({
               {guidedReorderCompleted && motorReorderChangedCount === 0 ? (
                 <div className="bf-note" data-testid="motor-reorder-no-changes">
                   <p>Motor order already matches — no changes needed.</p>
+                </div>
+              ) : null}
+
+              {/* Identifying the motors is only half the job — the order can be
+                * right while a motor still spins backwards. The flow used to
+                * end here silently, leaving the operator to notice the
+                * Direction tab on their own. Once a run completes, hand them
+                * the next step explicitly. Primary only when there is nothing
+                * left to save, so it never competes with Save changes. */}
+              {guidedReorderCompleted ? (
+                <div className="bf-note bf-note--accent" data-testid="motor-reorder-next-step">
+                  <p>
+                    Order identified.{' '}
+                    {motorReorderChangedCount > 0
+                      ? 'Save the changes, then check that each motor spins the right way.'
+                      : 'Next, check that each motor spins the right way.'}
+                  </p>
+                  <button
+                    type="button"
+                    style={buttonStyle(motorReorderChangedCount === 0 ? 'primary' : undefined)}
+                    data-testid="motor-reorder-next-direction"
+                    onClick={() => onTabChange('direction')}
+                  >
+                    Next: Check Motor Direction →
+                  </button>
                 </div>
               ) : null}
 

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -2491,10 +2491,16 @@ textarea:focus {
 
 /* Shared underline tab strip — Motors/Servos (Outputs), Receiver, and Tuning
    all use these classes so the sub-tab nav stays visually in sync. */
+/* Tabs read as outlined chips rather than muted text with a hairline
+ * underline. The old treatment was easy to miss entirely — operators did not
+ * register that a surface HAD tabs, so whole sections went unvisited. Every
+ * tab now carries a visible border; the active one is filled and outlined in
+ * the accent colour, so which one is selected is obvious at a glance. */
 .tab-strip {
   display: flex;
   flex-wrap: wrap;
-  gap: 4px;
+  gap: 6px;
+  padding-bottom: 8px;
   border-bottom: 1px solid var(--border);
 }
 
@@ -2502,24 +2508,38 @@ textarea:focus {
   display: inline-flex;
   align-items: center;
   gap: 8px;
-  padding: 9px 14px;
-  border: none;
-  border-bottom: 2px solid transparent;
-  margin-bottom: -1px;
-  background: transparent;
+  padding: 8px 14px;
+  border: 2px solid var(--border);
+  border-radius: 8px;
+  background: color-mix(in srgb, var(--text) 4%, transparent);
   color: var(--text-muted);
   font: inherit;
   font-weight: 600;
   cursor: pointer;
+  transition: border-color 120ms ease, background-color 120ms ease, color 120ms ease;
 }
 
 .tab-strip__tab:hover {
   color: var(--text);
+  border-color: color-mix(in srgb, var(--accent) 50%, var(--border));
+}
+
+.tab-strip__tab:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
 }
 
 .tab-strip__tab.is-active {
-  color: var(--text);
-  border-bottom-color: var(--accent);
+  color: var(--accent);
+  border-color: var(--accent);
+  background: color-mix(in srgb, var(--accent) 14%, transparent);
+}
+
+/* Reduced-motion users get the same states without the cross-fade. */
+@media (prefers-reduced-motion: reduce) {
+  .tab-strip__tab {
+    transition: none;
+  }
 }
 
 .outputs-tabs__detail {
@@ -9219,6 +9239,7 @@ details.metadata-settings-section:not([open]) > summary::after {
 /* BF-style tabs strip directly under the safety acks. The active tab gets
  * a primary-tinted underline so it reads at a glance against the dialog
  * surround. */
+/* Superseded by .tab-strip — kept only for any stale markup. */
 .motor-reorder-lightbox__tabs {
   display: inline-flex;
   gap: 4px;

--- a/apps/web/src/views/NetworkingView.tsx
+++ b/apps/web/src/views/NetworkingView.tsx
@@ -1,6 +1,5 @@
 import type { ReactNode } from 'react'
 
-import { buttonStyle } from '@arduconfig/ui-kit'
 
 export type NetworkingTab = 'fc' | 'dronenet'
 
@@ -21,8 +20,10 @@ export interface NetworkingViewProps {
   scanning: boolean
 }
 
-function tabStyle(active: boolean) {
-  return active ? buttonStyle('primary') : buttonStyle()
+/** Shared tab treatment — Networking previously rendered its tabs as ordinary
+ *  buttons, which made them read as actions rather than as navigation. */
+function tabClassName(active: boolean): string {
+  return `tab-strip__tab${active ? ' is-active' : ''}`
 }
 
 /**
@@ -44,12 +45,12 @@ export function NetworkingView({
 }: NetworkingViewProps) {
   return (
     <div data-testid="networking-view">
-      <div className="networking-tabs" role="tablist" style={{ display: 'flex', gap: 8, marginBottom: 12 }}>
+      <div className="tab-strip networking-tabs" role="tablist">
         <button
           type="button"
           role="tab"
           aria-selected={activeTab === 'fc'}
-          style={tabStyle(activeTab === 'fc')}
+          className={tabClassName(activeTab === 'fc')}
           onClick={() => onTabChange('fc')}
           data-testid="networking-tab-fc"
         >
@@ -59,7 +60,7 @@ export function NetworkingView({
           type="button"
           role="tab"
           aria-selected={activeTab === 'dronenet'}
-          style={tabStyle(activeTab === 'dronenet')}
+          className={tabClassName(activeTab === 'dronenet')}
           onClick={() => onTabChange('dronenet')}
           data-testid="networking-tab-dronenet"
         >

--- a/tests/e2e/app.spec.ts
+++ b/tests/e2e/app.spec.ts
@@ -371,6 +371,12 @@ test.describe('browser configurator regression flows', () => {
     await expect(banner).toContainText('2 / 4')
     await expect(banner).toContainText(/OUT\d+ spun/, { timeout: COMMAND_ACK_TIMEOUT })
 
+    // The hand-off to Direction only appears once a run COMPLETES — identifying
+    // the order is only half the job (the order can be right while a motor
+    // still spins backwards), but offering it mid-sequence would invite
+    // abandoning the run.
+    await expect(page.getByTestId('motor-reorder-next-direction')).toHaveCount(0)
+
     // Cancel cleanly even if mid-sequence.
     const cancel = page.getByTestId('motor-reorder-guided-cancel')
     if (await cancel.count()) {


### PR DESCRIPTION
Two field reports, both about not knowing where to go next.

## Tabs

> we should also make the tabs more prominent and maybe bold outline / or highlighted different colors / so tabs are more obvious across all menus

They were muted text with a 1px hairline underline on the active one — easy to miss that a surface *had* tabs at all, so whole sections went unvisited.

Every tab is now an outlined chip; the active one is filled and outlined in the accent colour, so which is selected reads at a glance.

**Applied across all five tablists, not just the shared ones.** Motor Setup and Networking each had bespoke treatments — Networking rendered its tabs as ordinary primary/secondary **buttons**, which made navigation read as actions — and both now use the shared `.tab-strip` classes. That's what makes this consistent rather than three similar-looking things.

Focus-visible outlines and a `prefers-reduced-motion` opt-out come with it.

## Motor identify hand-off

> On the motor test tab after you complete identifying, pop up a next button the user can click to move to check reverse motors

Identifying the order is only half the job — the order can be right while a motor still spins backwards — but the flow ended silently, leaving the operator to notice the Direction tab on their own.

A completed run now offers **"Next: Check Motor Direction →"**. Primary only when there's nothing left to save, so it never competes with Save changes, and absent mid-sequence so it can't invite abandoning the run.

## ArduCopter byte-identical

Presentation and navigation only. No parameter, no command, no vehicle branch.

## Validation

- `npm run typecheck` — clean
- `npm run test` — 829 pass / 0 fail
- web vitest — 624 pass / 0 fail
- `npm run test:e2e` — 234 pass / 6 skipped (adds the gate assertion that the hand-off is absent mid-run)

**The tab restyle is not snapshot-verified** — visual-regression baselines are skipped on this platform. It wants a look on a real screen, including at 390px where the phone-layout overflow gate lives.