### PR TITLE
feat(parameters): show each parameter's firmware default, and pull it

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -949,6 +949,10 @@ export function App() {
   // changed" filter and the non-default export. Declared here (above the export
   // hook) so the export can honour the same set.
   const [nonDefaultParamIds, setNonDefaultParamIds] = useState<ReadonlySet<string> | null>(null)
+  // Firmware default per parameter, from the same param.pck fetch. Known for
+  // EVERY parameter, not just changed ones — an unflagged param sits at its
+  // default, so its value doubles as one.
+  const [parameterDefaults, setParameterDefaults] = useState<ReadonlyMap<string, number> | null>(null)
   const [showOnlyNonDefault, setShowOnlyNonDefault] = useState(false)
   // Params written successfully in the last few seconds. Purely a visual
   // confirmation: a staged row reads yellow, and on a verified write it turns
@@ -3186,31 +3190,73 @@ export function App() {
   // derive the non-default set that drives "Show only changed" + the non-default
   // export. Parse is pure (parseParamPck); the flag on each entry IS the
   // non-default signal, so no value/default comparison is needed here.
-  async function handleFetchParamDefaults(): Promise<void> {
+  /**
+   * Pull the FC's defaults the first time a parameter row is expanded.
+   *
+   * Defaults previously loaded only as a side effect of switching on the
+   * "changed only" filter, so the per-row Default line would sit empty for
+   * anyone who never touched that toggle. A ref guard makes this fire at most
+   * once per session: the fetch is a MAVFTP transfer, and a firmware that
+   * cannot serve it (pre-4.5, or no MAVFTP) must not be re-asked on every
+   * click. The explicit filter toggle still retries on demand.
+   */
+  const autoFetchedDefaultsRef = useRef(false)
+  useEffect(() => {
+    if (
+      selectedParameterId === undefined ||
+      parameterDefaults !== null ||
+      autoFetchedDefaultsRef.current ||
+      fetchDefaultsBusy ||
+      snapshot.connection.kind !== 'connected' ||
+      snapshot.parameterStats.status !== 'complete'
+    ) {
+      return
+    }
+    autoFetchedDefaultsRef.current = true
+    void handleFetchParamDefaults({ silent: true })
+    // handleFetchParamDefaults is a stable function declaration on the body.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [selectedParameterId, parameterDefaults, fetchDefaultsBusy, snapshot.connection.kind, snapshot.parameterStats.status])
+
+  async function handleFetchParamDefaults(options: { silent?: boolean } = {}): Promise<void> {
     setFetchDefaultsBusy(true)
     try {
       const result = parseParamPck(await runtime.downloadParamPack())
       if (!result.withDefaults) {
         setNonDefaultParamIds(new Set())
-        setParameterNotice({
-          tone: 'warning',
-          text: 'This firmware returned params without default flags — update to ArduPilot 4.5+ to use the "changed only" filter.'
-        })
+        setParameterDefaults(null)
+        if (!options.silent) {
+          setParameterNotice({
+            tone: 'warning',
+            text: 'This firmware returned params without default flags — update to ArduPilot 4.5+ to use the "changed only" filter.'
+          })
+        }
         return
       }
       setNonDefaultParamIds(result.nonDefaultParamIds)
+      setParameterDefaults(result.defaultsByParamId)
+      if (options.silent) {
+        // Opening a row asked for a Default line, not a filter change or a
+        // banner — populate quietly and leave the view as the operator left it.
+        return
+      }
       setShowOnlyNonDefault(true)
       setParameterNotice({
         tone: 'neutral',
         text: `Defaults fetched: ${result.nonDefaultParamIds.size} of ${result.entries.length} params differ from firmware default.`
       })
     } catch (error) {
-      setParameterNotice({
-        tone: 'danger',
-        text: `Couldn't fetch packed defaults over MAVFTP (needs a MAVFTP-capable FC on ArduPilot 4.5+): ${
-          error instanceof Error ? error.message : String(error)
-        }`
-      })
+      // A silent pull was speculative — the operator expanded a row, they did
+      // not ask for a MAVFTP transfer. A board that cannot serve defaults just
+      // shows no Default line rather than an error they did not provoke.
+      if (!options.silent) {
+        setParameterNotice({
+          tone: 'danger',
+          text: `Couldn't fetch packed defaults over MAVFTP (needs a MAVFTP-capable FC on ArduPilot 4.5+): ${
+            error instanceof Error ? error.message : String(error)
+          }`
+        })
+      }
     } finally {
       setFetchDefaultsBusy(false)
     }
@@ -8865,6 +8911,7 @@ export function App() {
           onToggleParameterEnumOverride={handleToggleParameterEnumOverride}
           onRequestReboot={() => void handleGuidedAction('reboot-autopilot')}
           nonDefaultParamIds={nonDefaultParamIds}
+          parameterDefaults={parameterDefaults}
           showOnlyNonDefault={showOnlyNonDefault}
           // Ticking "show only changed" fetches the firmware defaults it needs,
           // rather than requiring the operator to press a separate button first.

--- a/apps/web/src/sections/ParametersSection.tsx
+++ b/apps/web/src/sections/ParametersSection.tsx
@@ -97,6 +97,8 @@ export interface ParametersSectionProps {
   /** Params the FC reports as differing from firmware default (from MAVFTP
    *  param.pck?withdefaults, 4.5+). null = not fetched yet. */
   nonDefaultParamIds: ReadonlySet<string> | null
+  /** Firmware defaults from param.pck, once fetched. Null = not fetched. */
+  parameterDefaults?: ReadonlyMap<string, number> | null
   /** "Show only changed" — restrict the table (and export) to non-default params. */
   showOnlyNonDefault: boolean
   /** A backup that has been read but NOT staged. */
@@ -164,6 +166,7 @@ export function ParametersSection(props: ParametersSectionProps): ReactElement {
     onToggleParameterEnumOverride: handleToggleParameterEnumOverride,
     onRequestReboot: handleRequestReboot,
     nonDefaultParamIds,
+    parameterDefaults,
     showOnlyNonDefault,
     pendingParameterImport,
     onStagePendingParameterImport,
@@ -1170,6 +1173,7 @@ export function ParametersSection(props: ParametersSectionProps): ReactElement {
                     editedValues={editedValues}
                     onChange={setDraft}
                     draftStatusById={draftStatusMap}
+                    defaultValue={parameterDefaults?.get(parameter.id)}
                   />
                 </div>
               ) : null}

--- a/apps/web/src/view-models/param-pck.test.ts
+++ b/apps/web/src/view-models/param-pck.test.ts
@@ -102,6 +102,50 @@ describe('parseParamPck', () => {
     expect(result.nonDefaultParamIds.size).toBe(0)
   })
 
+  // The FIRMWARE DEFAULT is what makes "show the default" possible at all. The
+  // parser used to skip these bytes outright.
+  it('reads the firmware default that follows a changed value', () => {
+    const bytes = buildPck(0x671c, [
+      { type: 4, name: 'ATC_RAT_RLL_P', value: 0.25, nonDefault: true, def: 0.135 }
+    ])
+    const [entry] = parseParamPck(bytes).entries
+    expect(entry.value).not.toBe(entry.defaultValue)
+    expect(entry.defaultValue).toBeCloseTo(0.135, 5)
+  })
+
+  it('treats an unflagged parameter as sitting AT its default', () => {
+    // No default is transmitted when the flag is clear, because the value IS
+    // the default — which is what lets every parameter report one, not just
+    // the changed ones.
+    const bytes = buildPck(0x671c, [
+      { type: 2, name: 'SERIAL1_PROTOCOL', value: 23, nonDefault: false }
+    ])
+    const result = parseParamPck(bytes)
+    expect(result.entries[0].defaultValue).toBe(23)
+    expect(result.defaultsByParamId.get('SERIAL1_PROTOCOL')).toBe(23)
+  })
+
+  it('builds a default map covering changed and unchanged parameters alike', () => {
+    const bytes = buildPck(0x671c, [
+      { type: 3, name: 'BATT_CAPACITY', value: 5200, nonDefault: true, def: 3300 },
+      { type: 3, name: 'BATT_MONITOR', value: 4, nonDefault: false }
+    ])
+    const { defaultsByParamId, nonDefaultParamIds } = parseParamPck(bytes)
+    expect(defaultsByParamId.get('BATT_CAPACITY')).toBe(3300)
+    expect(defaultsByParamId.get('BATT_MONITOR')).toBe(4)
+    expect([...nonDefaultParamIds]).toEqual(['BATT_CAPACITY'])
+  })
+
+  it('reports no defaults at all for a pack fetched without ?withdefaults', () => {
+    // A 0x671b pack carries no defaults; inventing them from values would
+    // claim every parameter is at its default, which is worse than saying
+    // nothing.
+    const bytes = buildPck(0x671b, [{ type: 1, name: 'A', value: 7, nonDefault: false }])
+    const result = parseParamPck(bytes)
+    expect(result.defaultsByParamId.size).toBe(0)
+    expect(result.entries[0].defaultValue).toBeUndefined()
+  })
+
   it('rejects a blob with the wrong magic', () => {
     expect(isParamPck(new Uint8Array([0, 0, 0, 0, 0, 0]))).toBe(false)
     expect(() => parseParamPck(new Uint8Array([1, 2, 3, 4, 5, 6]))).toThrow(/magic/)

--- a/apps/web/src/view-models/param-pck.ts
+++ b/apps/web/src/view-models/param-pck.ts
@@ -13,13 +13,22 @@
 //         high nibble = (name_len - 1)
 //     name suffix: name_len bytes (append to prev-name[0..common])
 //     value: type_len bytes, little-endian (int8/16/32 signed, float32)
-//     default: type_len bytes, only when the flag is set (we skip it)
+//     default: type_len bytes, only when the flag is set
 
 export interface ParamPckEntry {
   name: string
   value: number
   /** FC flagged this param as differing from its default (i.e. non-default). */
   nonDefault: boolean
+  /**
+   * The firmware default.
+   *
+   * Known for EVERY parameter, not just changed ones: when the non-default flag
+   * is set the FC appends the default after the value, and when it is clear the
+   * parameter IS its default, so the value doubles as it. Undefined only when
+   * the pack was fetched without ?withdefaults=1.
+   */
+  defaultValue?: number
 }
 
 export interface ParamPckResult {
@@ -27,6 +36,8 @@ export interface ParamPckResult {
   entries: ParamPckEntry[]
   /** Names the FC reported as non-default (empty when !withDefaults). */
   nonDefaultParamIds: Set<string>
+  /** Firmware default per parameter id (empty when !withDefaults). */
+  defaultsByParamId: Map<string, number>
 }
 
 const TYPE_SIZE: Record<number, number> = { 1: 1, 2: 2, 3: 4, 4: 4 }
@@ -46,6 +57,7 @@ export function parseParamPck(bytes: Uint8Array): ParamPckResult {
 
   const entries: ParamPckEntry[] = []
   const nonDefaultParamIds = new Set<string>()
+  const defaultsByParamId = new Map<string, number>()
   let lastName = ''
   let ofs = 6 // sizeof(header)
 
@@ -78,14 +90,25 @@ export function parseParamPck(bytes: Uint8Array): ParamPckResult {
     const name = lastName.slice(0, commonLen) + suffix
     lastName = name
 
-    entries.push({ name, value: readTypedValue(view, valueOfs, type), nonDefault: hasDefault })
+    const value = readTypedValue(view, valueOfs, type)
+    // hasDefault set  -> the default follows the value.
+    // hasDefault clear -> the param sits AT its default, so value is the default.
+    const defaultValue = withDefaults
+      ? hasDefault
+        ? readTypedValue(view, valueOfs + typeSize, type)
+        : value
+      : undefined
+    entries.push({ name, value, nonDefault: hasDefault, defaultValue })
     if (hasDefault) {
       nonDefaultParamIds.add(name)
+    }
+    if (defaultValue !== undefined) {
+      defaultsByParamId.set(name, defaultValue)
     }
     ofs = next
   }
 
-  return { withDefaults, entries, nonDefaultParamIds }
+  return { withDefaults, entries, nonDefaultParamIds, defaultsByParamId }
 }
 
 function readTypedValue(view: DataView, ofs: number, type: number): number {

--- a/apps/web/src/views/ParameterDetail.tsx
+++ b/apps/web/src/views/ParameterDetail.tsx
@@ -19,6 +19,12 @@ export interface ParameterDetailProps {
   editedValues: Record<string, string>
   onChange: (paramId: string, value: string) => void
   draftStatusById: ScopedFieldDraftMap
+  /**
+   * Firmware default from the FC's own param.pck, when it has been fetched.
+   * Undefined means "not known", NOT "no default" — the app must not guess one
+   * from metadata, since the authoritative value depends on the board and build.
+   */
+  defaultValue?: number
 }
 
 export function ParameterDetail({
@@ -27,7 +33,8 @@ export function ParameterDetail({
   alias,
   editedValues,
   onChange,
-  draftStatusById
+  draftStatusById,
+  defaultValue
 }: ParameterDetailProps) {
   const options = definition?.options ?? []
   const isBitmask = definition?.bitmask === true
@@ -61,6 +68,33 @@ export function ParameterDetail({
             <dt>Range</dt>
             <dd>
               {definition?.minimum ?? '−∞'} – {definition?.maximum ?? '∞'}
+            </dd>
+          </div>
+        ) : null}
+        {defaultValue !== undefined ? (
+          <div data-testid={`parameter-detail-default-${parameter.id}`}>
+            <dt>Default</dt>
+            <dd>
+              {defaultValue}
+              {/* Restoring is offered only when the live value actually differs,
+                * so the control never appears as a no-op. It stages a draft like
+                * any other edit rather than writing — nothing reaches the FC
+                * without the usual review and Apply. */}
+              {defaultValue !== parameter.value ? (
+                <>
+                  {' '}
+                  <button
+                    type="button"
+                    className="parameter-detail__restore"
+                    data-testid={`parameter-restore-default-${parameter.id}`}
+                    onClick={() => onChange(parameter.id, String(defaultValue))}
+                  >
+                    Restore default
+                  </button>
+                </>
+              ) : (
+                <span className="parameter-detail__at-default"> (at default)</span>
+              )}
             </dd>
           </div>
         ) : null}


### PR DESCRIPTION
## Requested

> parameters: should show default somewhere and pull it

## The FC was already sending it

`param.pck?withdefaults=1` appends the firmware default after the value whenever a parameter differs from it. The parser's own comment said so:

> `default: type_len bytes, only when the flag is set` **(we skip it)**

Only the boolean non-default *flag* was kept, to drive the "changed only" filter. The actual default was parsed past and discarded.

## Known for every parameter, not just changed ones

When the flag is **set**, the default follows the value. When it's **clear**, the parameter *is* its default — so the value doubles as one. That makes a complete default map derivable from a single fetch.

An expanded row now shows a **Default** line, plus **Restore default** which stages it as an ordinary draft. Offered only when the live value actually differs, so it's never a no-op; and it stages rather than writes, so nothing reaches the FC without the usual review and Apply.

## Pulling

Defaults previously loaded only as a side effect of switching the "changed only" filter on — so the Default line would sit empty for anyone who never touched that toggle.

Expanding a row now pulls them once, silently:

- **At most once per session** (ref guard). It's a MAVFTP transfer, and firmware that can't serve it (pre-4.5, or no MAVFTP) must not be re-asked on every click.
- **Quiet on failure.** The operator expanded a row; they didn't ask for a transfer. A board that can't serve defaults shows no Default line rather than an error they didn't provoke.
- The explicit filter toggle still retries on demand and still reports loudly.

No new button — the previous "Refresh defaults" button was removed by earlier feedback and stays removed.

## Not sourced from our metadata

Deliberate: the authoritative default depends on the board and the build. An undefined value here means **"not known"**, never "no default". Guessing one from the catalog would be worse than showing nothing.

## ArduCopter byte-identical

Read path only. No parameter written; Restore stages a draft like any manual edit.

## Validation

- `npm run typecheck` — clean
- `npm run test` — 830 pass / 0 fail
- web vitest — 628 pass / 0 fail (4 new: the appended default, the unflagged-equals-default case, the combined map, and a no-defaults pack correctly reporting nothing)
- `npm run test:e2e` — 234 pass / 6 skipped

**Rung 5 pending** — wants a real 4.5+ FC to confirm the pulled defaults match the board's actual firmware defaults.