### PR TITLE
feat(parameters): Default column, de-duplicated editor, and a bitmask ceiling

### DIFF
--- a/apps/web/src/sections/ParametersSection.tsx
+++ b/apps/web/src/sections/ParametersSection.tsx
@@ -1030,6 +1030,7 @@ export function ParametersSection(props: ParametersSectionProps): ReactElement {
           <div className="parameter-row parameter-row--header">
             <span>Parameter</span>
             <span>Description</span>
+            <span>Default</span>
             <span>Current</span>
             <span>Draft</span>
             <span>Actions</span>
@@ -1075,6 +1076,26 @@ export function ParametersSection(props: ParametersSectionProps): ReactElement {
                   {definition?.description ?? 'Metadata to be expanded from upstream ArduPilot bundles.'}
                   {definition?.unit ? <small>Unit: {definition.unit}</small> : null}
                 </span>
+                {/* Firmware default, from the FC's own param.pck. Blank until
+                  * the defaults have been pulled — an empty cell says "not
+                  * known", which is honest, where a guessed value would not
+                  * be. */}
+                <span className="parameter-row__default">
+                  {(() => {
+                    const defaultValue = parameterDefaults?.get(parameter.id)
+                    if (defaultValue === undefined) {
+                      return <small className="parameter-row__default-unknown">—</small>
+                    }
+                    return (
+                      <>
+                        <span>{formatParameterValue(defaultValue, definition?.unit)}</span>
+                        {defaultValue === parameter.value ? null : (
+                          <small className="parameter-row__default-differs">changed</small>
+                        )}
+                      </>
+                    )
+                  })()}
+                </span>
                 <span className="parameter-row__value">
                   <strong>{formatParameterValue(parameter.value, definition?.unit)}</strong>
                   {draft?.status === 'staged' ? (
@@ -1113,6 +1134,7 @@ export function ParametersSection(props: ParametersSectionProps): ReactElement {
                   ) : (
                     <input
                       type="number"
+                      data-testid={`parameter-row-input-${parameter.id}`}
                       aria-label={`${parameter.id} value`}
                       value={editedValues[parameter.id] ?? String(parameter.value)}
                       onChange={(event) =>

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -11368,7 +11368,10 @@ details.metadata-settings-section:not([open]) > summary::after {
 
 .parameter-row {
   display: grid;
-  grid-template-columns: minmax(150px, 1fr) minmax(240px, 1.9fr) minmax(120px, 0.8fr) minmax(160px, 1fr) minmax(160px, 1fr);
+  /* Parameter | Description | Default | Current | Draft | Actions.
+   * Default sits immediately left of Current so the pair reads as a
+   * comparison rather than as two unrelated numbers. */
+  grid-template-columns: minmax(150px, 1fr) minmax(240px, 1.7fr) minmax(90px, 0.6fr) minmax(110px, 0.7fr) minmax(160px, 1fr) minmax(160px, 1fr);
   gap: 10px;
   align-items: center;
   padding: 5px 12px;
@@ -15946,4 +15949,48 @@ button.mavlink-inspector__sent-row {
    * the 390px e2e fails on horizontal overflow. */
   flex: 1 1 16rem;
   min-width: 0;
+}
+
+
+.parameter-row__default {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  color: var(--text-muted);
+  min-width: 0;
+}
+
+.parameter-row__default-unknown {
+  opacity: 0.5;
+}
+
+/* Flags the row as differing from firmware default WITHOUT competing with the
+ * staged/written row colours, which mean something else entirely. */
+.parameter-row__default-differs {
+  color: var(--text-muted);
+  font-size: 11px;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+/* Parameter detail: prose left, numbers + editor right on a wide screen. The
+ * meta and editor previously sat under the description with a large empty
+ * gutter beside them on desktop. Single column below 900px — a phone needs the
+ * description at full width, not squeezed into a ribbon. */
+.parameter-detail__body {
+  display: grid;
+  grid-template-columns: minmax(0, 1.6fr) minmax(260px, 1fr);
+  gap: var(--space-3, 12px) 24px;
+  align-items: start;
+}
+
+.parameter-detail__prose,
+.parameter-detail__side {
+  min-width: 0;
+}
+
+@media (max-width: 900px) {
+  .parameter-detail__body {
+    grid-template-columns: minmax(0, 1fr);
+  }
 }

--- a/apps/web/src/views/ParameterDetail.tsx
+++ b/apps/web/src/views/ParameterDetail.tsx
@@ -54,7 +54,15 @@ export function ParameterDetail({
         ) : null}
       </div>
 
+      {/* Two columns on a wide screen: prose on the left, the numbers and the
+        * editor in the dead space on the right, which is otherwise empty on a
+        * desktop. Collapses back to a single stack below 900px — the same
+        * layout on a phone would squeeze the description to a ribbon. */}
+      <div className="parameter-detail__body">
+        <div className="parameter-detail__prose">
       {definition?.description ? <p className="parameter-detail__desc">{definition.description}</p> : null}
+        </div>
+        <div className="parameter-detail__side">
 
       <dl className="parameter-detail__meta">
         {definition?.unit ? (
@@ -121,19 +129,11 @@ export function ParameterDetail({
           />
         ) : (
           <div className="parameter-detail__value-row">
-            {/* Type the raw value directly… */}
-            <label className="parameter-detail__field">
-              <span>Value</span>
-              <input
-                type="number"
-                step="any"
-                data-testid={`parameter-detail-input-${parameter.id}`}
-                value={raw}
-                onChange={(event) => onChange(parameter.id, event.target.value)}
-                aria-label={`Edit ${parameter.id}`}
-              />
-            </label>
-            {/* …or pick a named option (enums only). Both edit the same draft. */}
+            {/* No raw number field here: the row's own Draft cell already edits
+              * this parameter, and having both meant typing into one while
+              * staring at the other. The bitmask branch above keeps ITS value
+              * box, because a bitmask row shows chips rather than a number and
+              * there would otherwise be nowhere to enter a raw value. */}
             {isEnum ? (
               <label className="parameter-detail__field">
                 <span>Pick</span>
@@ -158,6 +158,8 @@ export function ParameterDetail({
             ) : null}
           </div>
         )}
+      </div>
+        </div>
       </div>
     </div>
   )

--- a/packages/ardupilot-core/src/parameter-drafts.ts
+++ b/packages/ardupilot-core/src/parameter-drafts.ts
@@ -184,7 +184,13 @@ function deriveParameterDraftEntry(
     }
   }
 
-  if (parameter.definition?.maximum !== undefined && parsedValue > parameter.definition.maximum) {
+  // ArduPilot ships no @Range for bitmask params, so an out-of-range bitmask
+  // (a typo'd 500 into an 8-bit mask) sailed through unchallenged. The ceiling
+  // is derivable: `options` on a bitmask enumerate BIT INDICES, so the highest
+  // representable value is every documented bit set.
+  const effectiveMaximum =
+    parameter.definition?.maximum ?? bitmaskMaximum(parameter.definition)
+  if (effectiveMaximum !== undefined && parsedValue > effectiveMaximum) {
     if (!enumOverride) {
       return {
         id: paramId,
@@ -195,7 +201,10 @@ function deriveParameterDraftEntry(
         currentValue: parameter.value,
         nextValue: parsedValue,
         status: 'invalid',
-        reason: `Value is above the documented maximum of ${parameter.definition.maximum}.`,
+        reason:
+          parameter.definition?.maximum !== undefined
+            ? `Value is above the documented maximum of ${effectiveMaximum}.`
+            : `Value is above ${effectiveMaximum}, the highest value these ${parameter.definition?.options?.length ?? 0} bits can represent.`,
         overridable: true
       }
     }
@@ -278,4 +287,38 @@ function compareParameterDraftEntries(left: ParameterDraftEntry, right: Paramete
   }
 
   return left.id.localeCompare(right.id)
+}
+
+/**
+ * Highest value a bitmask parameter can represent — every documented bit set.
+ *
+ * ArduPilot does not publish an @Range for bitmask params (verified against the
+ * EK3_GPS_CHECK metadata), so without this a typo'd value far beyond the mask's
+ * width was accepted as valid and written to the FC.
+ *
+ * `options` on a bitmask hold BIT INDICES (0, 1, 2 …), not values — see
+ * ParameterDefinition.bitmask — so the ceiling is the OR of 1 << index.
+ * Returns undefined for anything that is not a bitmask with documented bits,
+ * so a plain parameter keeps whatever range its metadata declares.
+ */
+export function bitmaskMaximum(
+  definition: { bitmask?: boolean; options?: readonly { value: number }[] } | undefined
+): number | undefined {
+  if (definition?.bitmask !== true) {
+    return undefined
+  }
+  const options = definition.options
+  if (!options || options.length === 0) {
+    return undefined
+  }
+  let mask = 0
+  for (const option of options) {
+    // Guard the 32-bit boundary: 1 << 31 is negative in JS bitwise ops, and a
+    // bit index beyond that cannot be represented at all.
+    if (!Number.isInteger(option.value) || option.value < 0 || option.value > 30) {
+      return undefined
+    }
+    mask |= 1 << option.value
+  }
+  return mask >>> 0
 }

--- a/tests/bitmask-maximum.test.mjs
+++ b/tests/bitmask-maximum.test.mjs
@@ -1,0 +1,66 @@
+// Bitmask parameters get a computed ceiling.
+//
+// Reported: EK3_GPS_CHECK accepted any value, because ArduPilot publishes no
+// @Range for bitmask params — confirmed against its metadata. Without a
+// maximum, a typo'd 500 into an 8-bit mask validated cleanly and would have
+// been written to the flight controller.
+//
+// The ceiling is derivable rather than curated: `options` on a bitmask hold BIT
+// INDICES, so the highest representable value is every documented bit set.
+// Deriving it means a fork that adds a bit gets the right ceiling for free,
+// where a hand-maintained number would quietly go stale.
+
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { bitmaskMaximum } from '../packages/ardupilot-core/dist/index.js'
+import { arducopterMetadata, normalizeFirmwareMetadata } from '../packages/param-metadata/dist/index.js'
+
+const catalog = normalizeFirmwareMetadata(arducopterMetadata)
+
+test('every documented bit set is the ceiling', () => {
+  // Bits 0..7 -> 255, which is exactly what EK3_GPS_CHECK's own description
+  // says ("Set to 255 perform all checks").
+  const eightBits = { bitmask: true, options: Array.from({ length: 8 }, (_, bit) => ({ value: bit })) }
+  assert.equal(bitmaskMaximum(eightBits), 255)
+
+  assert.equal(bitmaskMaximum({ bitmask: true, options: [{ value: 0 }] }), 1)
+  assert.equal(bitmaskMaximum({ bitmask: true, options: [{ value: 0 }, { value: 3 }] }), 0b1001)
+})
+
+test('sparse bit lists do not imply the bits in between', () => {
+  // Only the DOCUMENTED bits count; assuming a contiguous range would permit
+  // values with undefined bits set.
+  assert.equal(bitmaskMaximum({ bitmask: true, options: [{ value: 1 }, { value: 5 }] }), 0b100010)
+})
+
+test('a non-bitmask parameter keeps whatever range its metadata declares', () => {
+  assert.equal(bitmaskMaximum({ bitmask: false, options: [{ value: 3 }] }), undefined)
+  assert.equal(bitmaskMaximum({ options: [{ value: 3 }] }), undefined)
+  assert.equal(bitmaskMaximum(undefined), undefined)
+})
+
+test('a bitmask with no documented bits yields no ceiling — better than a wrong one', () => {
+  assert.equal(bitmaskMaximum({ bitmask: true, options: [] }), undefined)
+  assert.equal(bitmaskMaximum({ bitmask: true }), undefined)
+})
+
+test('bit indices past the 32-bit boundary yield no ceiling rather than a negative one', () => {
+  // 1 << 31 is negative under JS bitwise ops; silently returning a negative
+  // maximum would reject every legitimate value.
+  assert.equal(bitmaskMaximum({ bitmask: true, options: [{ value: 31 }] }), undefined)
+  assert.equal(bitmaskMaximum({ bitmask: true, options: [{ value: -1 }] }), undefined)
+  assert.equal(bitmaskMaximum({ bitmask: true, options: [{ value: 1.5 }] }), undefined)
+})
+
+test('the real EK3_GPS_CHECK definition produces a sane ceiling', () => {
+  const definition = catalog.parameters.EK3_GPS_CHECK
+  if (!definition?.bitmask) {
+    return // not curated as a bitmask in this bundle; nothing to assert
+  }
+  const ceiling = bitmaskMaximum(definition)
+  assert.ok(ceiling !== undefined, 'a curated bitmask should yield a ceiling')
+  assert.ok(ceiling > 0 && ceiling <= 0xffffffff)
+  // Its description states 255 performs all checks.
+  assert.ok(ceiling <= 255, `expected an 8-bit-or-smaller mask, got ${ceiling}`)
+})

--- a/tests/e2e/views.spec.ts
+++ b/tests/e2e/views.spec.ts
@@ -365,10 +365,14 @@ test.describe('Parameters tab (expert-only)', () => {
     await expect(detail).toContainText('9 — DroneCAN')
 
     // Type-or-pick editor, both edit the same draft.
+    // The detail no longer carries its own number field — the row's Draft cell
+    // is the single editor, so the named-option Pick and that field drive the
+    // same draft. Two number inputs for one parameter meant typing into one
+    // while watching the other.
     await page.getByTestId('parameter-detail-select-GPS_TYPE').selectOption('2')
-    await expect(page.getByTestId('parameter-detail-input-GPS_TYPE')).toHaveValue('2')
+    await expect(page.getByTestId('parameter-row-input-GPS_TYPE')).toHaveValue('2')
     await expect(page.getByRole('button', { name: /Apply All \(1\)/ })).toBeVisible()
-    await page.getByTestId('parameter-detail-input-GPS_TYPE').fill('5')
+    await page.getByTestId('parameter-row-input-GPS_TYPE').fill('5')
     await expect(page.getByTestId('parameter-detail-select-GPS_TYPE')).toHaveValue('5')
   })
 


### PR DESCRIPTION
Five things from a screenshot review of the Parameters tab.

## Default as a column

> ideally default is a column to the left of current — default shows up now but only when i click a param

It only appeared inside an expanded row, so comparing a list against defaults meant opening each one. Default is now a column immediately **left of Current**, so the pair reads as a comparison rather than as two unrelated numbers.

An unpulled default shows an em-dash — blank means **"not known"**, not "no default".

## The duplicate value box is gone

> the highlighted box seems redundant?

It was. An expanded row carried its own number field editing the same draft as the row's Draft cell — two inputs for one parameter, so you typed into one while watching the other. The row's cell is now the single editor.

**Except for bitmasks, deliberately:**

> oh only thing though is if you remove that value... we need to be able to type values for bitmask somewhere

Right — a bitmask row shows per-bit chips rather than a number, so removing the detail's value box would have left nowhere to enter a raw value. That branch keeps it.

## Wide-screen layout

> maybe move these details over here depending on screen size? But it might be really bad on a phone lol. / Im on a wide screen

Range/Default/Restore and the editor sat under the description with a large empty gutter beside them. They now move into that space on a wide screen, and collapse back to a single stack **below 900px** — the same two-column layout on a phone would squeeze the description into a ribbon.

## Bitmask ceiling

> Should check bitmasks have a proper maximum computed — i checked and ardupilot doesnt set the maximum from what i can see for this param in metadata

Confirmed. Validation only consulted `definition.maximum`, so a typo'd 500 into an 8-bit mask validated cleanly and would have been written to the FC.

The ceiling is now **derived**: `options` on a bitmask hold bit *indices*, so the highest representable value is every documented bit set — bits 0..7 → 255, matching EK3_GPS_CHECK's own "Set to 255 perform all checks".

Derived rather than curated, so a fork adding a bit gets the right ceiling for free. Sparse bit lists don't imply the bits between them, and a bitmask with **no** documented bits yields no ceiling rather than a wrong one.

## ArduCopter byte-identical

Display, layout and validation only. No parameter is written by any of this. The new ceiling only rejects values previously accepted unchecked, and stays overridable like every other range rejection.

## Validation

- `npm run typecheck` — clean
- `npm run test` — 836 pass / 0 fail (6 new)
- web vitest — 628 pass / 0 fail
- `npm run test:e2e` — 234 pass / 6 skipped

The type-or-pick e2e drove the removed field; it now drives the row's Draft cell — the same draft it always edited.

**Not snapshot-verified** — visual baselines are skipped on this platform, so the Default column and the two-column detail want a look on a real screen, phone width included.