### PR TITLE
fix(setup): stop calling a working MAVLink link a misconfigured port

### DIFF
--- a/apps/web/src/view-models/guided-setup-overview.ts
+++ b/apps/web/src/view-models/guided-setup-overview.ts
@@ -163,8 +163,16 @@ export function buildGuidedSetupOverview(inputs: GuidedSetupOverviewInputs): Gui
               action !== guidedSetupTaskAction && action.kind !== 'scroll' && action.kind !== 'clear-confirmation'
           ) ??
           selectedSetupSection?.actions[0]
-  const guidedSetupContextAction =
-    selectedSetupSection?.actions.find((action) => action.kind === 'scroll' && action.panelId !== 'setup-panel-guided')
+  // Must not re-offer whatever became the primary action. When a section's ONLY
+  // action is a scroll (Ports), the primary chain falls through to actions[0]
+  // and picks it — and this then picked the same object again, rendering the
+  // identical button twice, once as the hero and once beneath it.
+  const guidedSetupContextAction = selectedSetupSection?.actions.find(
+    (action) =>
+      action !== guidedSetupPrimaryAction &&
+      action.kind === 'scroll' &&
+      action.panelId !== 'setup-panel-guided'
+  )
   const guidedSetupSupportActions =
     selectedSetupSection?.actions.filter(
       (action) =>

--- a/apps/web/src/view-models/setup-ports-evidence.test.ts
+++ b/apps/web/src/view-models/setup-ports-evidence.test.ts
@@ -43,8 +43,9 @@ describe('parseUartTraffic', () => {
 })
 
 describe('buildSetupPortsEvidence', () => {
-  it('flags a port receiving real traffic while set to MAVLink2', () => {
-    // The reported case: receiver wired to SERIAL2, port still MAVLink2.
+  it('flags a port receiving UNDECODABLE traffic while set to MAVLink2', () => {
+    // The reported case: receiver wired to SERIAL2, port still MAVLink2, and
+    // the stream unframeable as a result.
     const evidence = buildSetupPortsEvidence({
       rawText: REAL_UARTS_TXT,
       protocolByPort: { 0: 2, 1: 23, 2: 2, 3: 5, 7: -1 },
@@ -70,19 +71,48 @@ SERIAL9 OTG2  TX =       0 RX =    1128 TXBD=     0 RXBD=   235 RXDRP=       0 F
     expect(evidence.unconfigured).toEqual([])
   })
 
-  it('still flags a real UART carrying traffic on the same board', () => {
-    // The genuine finding that must survive the USB exclusion: the GPS pad
-    // receiving heavily while the port is still MAVLink2.
-    const withGpsPad = `UARTV1
+  it('does NOT flag a MAVLink2 port carrying clean traffic — that is a working link', () => {
+    // Field report: SERIAL7 (TELEM2) was deliberately MAVLink2 for an ATAK
+    // integration and was flagged as misconfigured simply for carrying data.
+    // A telemetry radio, companion computer or ATAK link is a port doing its
+    // job. It is the GARBLE that identifies a mismatch, not the traffic —
+    // calling a working link broken trains operators to ignore this step.
+    const withTelemetry = `UARTV1
 SERIAL0 OTG1  TX =  106511 RX =    3410 TXBD= 18692 RXBD=   598 RXDRP=       0 FE=0 OE=0 NE=0 FlowCtrl=1
-SERIAL7 UART7 TX =       0 RX =   72144 TXBD=     0 RXBD= 12024 RXDRP=       0 FE=0 OE=0 NE=0 FlowCtrl=0
+SERIAL7 UART7 TX =   40000 RX =   40061 TXBD=  6600 RXBD=  6677 RXDRP=       0 FE=0 OE=0 NE=0 FlowCtrl=0
 SERIAL9 OTG2  TX =       0 RX =    1128 TXBD=     0 RXBD=   235 RXDRP=       0 FE=0 OE=0 NE=0 FlowCtrl=1
 `
     const evidence = buildSetupPortsEvidence({
-      rawText: withGpsPad,
+      rawText: withTelemetry,
       protocolByPort: { 0: 2, 7: 2, 9: 2 }
     })
-    expect(evidence.unconfigured.map((finding) => finding.portNumber)).toEqual([7])
+    expect(evidence.unconfigured).toEqual([])
+  })
+
+  it('DOES flag a MAVLink2 port whose traffic cannot be framed', () => {
+    // The original motivating failure: a receiver wired to a pad still set to
+    // MAVLink2, producing far more framing errors than bytes.
+    const evidence = buildSetupPortsEvidence({
+      rawText: REAL_UARTS_TXT,
+      protocolByPort: { 0: 2, 2: 2 },
+      minimumRxBytes: 8
+    })
+    expect(evidence.unconfigured.map((finding) => finding.portNumber)).toEqual([2])
+    expect(evidence.unconfigured[0].garbled).toBe(true)
+  })
+
+  it('flags a DISABLED port carrying traffic however cleanly it frames', () => {
+    // Nothing should be listening on a -1 port, so clean traffic there is still
+    // worth reporting — unlike MAVLink2, which is a legitimate listener.
+    const cleanOnDisabled = `UARTV1
+SERIAL3 UART3 TX =       0 RX =    9000 TXBD=     0 RXBD=  1500 RXDRP=       0 FE=0 OE=0 NE=0 FlowCtrl=0
+`
+    const evidence = buildSetupPortsEvidence({
+      rawText: cleanOnDisabled,
+      protocolByPort: { 3: -1 }
+    })
+    expect(evidence.unconfigured.map((finding) => finding.portNumber)).toEqual([3])
+    expect(describeUnconfiguredPort(evidence.unconfigured[0])).toContain('the port is disabled')
   })
 
   it('never flags SERIAL0 — that is the USB link we are talking over', () => {
@@ -141,14 +171,17 @@ SERIAL9 OTG2  TX =       0 RX =    1128 TXBD=     0 RXBD=   235 RXDRP=       0 F
 })
 
 describe('describeUnconfiguredPort', () => {
-  it('names the port, the traffic and what it is wrongly set to', () => {
+  it('says the traffic cannot be DECODED, not merely that the port carries data', () => {
+    // Wording matters here: "receiving data but set to MAVLink2" described a
+    // working telemetry link just as well as a broken receiver, which is how a
+    // deliberate ATAK link on TELEM2 came to be reported as misconfigured.
     const [finding] = buildSetupPortsEvidence({
       rawText: REAL_UARTS_TXT,
       protocolByPort: { 2: 2 },
       minimumRxBytes: 8
     }).unconfigured
     expect(describeUnconfiguredPort(finding)).toBe(
-      'SERIAL2 (UART2) is receiving 39 bytes, 80357 framing errors but is set to MAVLink2'
+      'SERIAL2 (UART2) is receiving 39 bytes it cannot decode (80357 framing errors) while set to MAVLink2'
     )
   })
 })

--- a/apps/web/src/view-models/setup-ports-evidence.ts
+++ b/apps/web/src/view-models/setup-ports-evidence.ts
@@ -122,15 +122,30 @@ export function buildSetupPortsEvidence({
     if (protocolValue !== PROTOCOL_NONE && protocolValue !== PROTOCOL_MAVLINK2) {
       continue
     }
+    // A tenth of the received bytes failing to frame is well beyond incidental
+    // noise and means the port is mis-clocked for what is on it.
+    const garbled = port.framingErrors > port.rxBytes / 10
+
+    // MAVLink2 carrying CLEAN traffic is a port doing its job — a telemetry
+    // radio, a companion computer, an ATAK link. Flagging it was wrong: the
+    // original failure was a receiver on a MAVLink2 port producing 80357
+    // framing errors against 39 bytes, and it is the GARBLE that identifies a
+    // mismatch, not the traffic. A working telemetry link is not a
+    // misconfiguration, and saying so trains operators to ignore this step.
+    //
+    // A DISABLED port (-1) is different: nothing should be listening at all, so
+    // any real traffic there is worth reporting however cleanly it frames.
+    if (protocolValue === PROTOCOL_MAVLINK2 && !garbled) {
+      continue
+    }
+
     unconfigured.push({
       portNumber: port.portNumber,
       hardwarePort: port.hardwarePort,
       rxBytes: port.rxBytes,
       framingErrors: port.framingErrors,
       protocolValue,
-      // A tenth of the received bytes failing to frame is well beyond
-      // incidental noise and means the port is mis-clocked for what is on it.
-      garbled: port.framingErrors > port.rxBytes / 10
+      garbled
     })
   }
 
@@ -139,7 +154,10 @@ export function buildSetupPortsEvidence({
 
 /** One-line description of a finding, for the wizard's evidence pills. */
 export function describeUnconfiguredPort(finding: UnconfiguredPortFinding): string {
-  const configured = finding.protocolValue === PROTOCOL_NONE ? 'disabled' : 'MAVLink2'
-  const garbled = finding.garbled ? `, ${finding.framingErrors} framing errors` : ''
-  return `SERIAL${finding.portNumber} (${finding.hardwarePort}) is receiving ${finding.rxBytes} bytes${garbled} but is set to ${configured}`
+  if (finding.protocolValue === PROTOCOL_NONE) {
+    return `SERIAL${finding.portNumber} (${finding.hardwarePort}) is receiving ${finding.rxBytes} bytes but the port is disabled`
+  }
+  // Only reachable when the stream cannot be framed — a clean MAVLink2 port is
+  // not a finding at all.
+  return `SERIAL${finding.portNumber} (${finding.hardwarePort}) is receiving ${finding.rxBytes} bytes it cannot decode (${finding.framingErrors} framing errors) while set to MAVLink2`
 }


### PR DESCRIPTION
## Reported

> Serial7 (telem2) is set to mavlink to test integration with atak. Looks like configurator is expecting it to be something more traditional like rc in.

## The heuristic was wrong, not the configuration

It treated MAVLink2 as "nothing is meant to be here" and flagged **any** port carrying traffic. But a MAVLink2 port receiving data is a port doing its job — a telemetry radio, a companion computer, an ATAK link.

The original motivating failure was a receiver on a MAVLink2 pad producing **80357 framing errors against 39 bytes**. It's the *garble* that identifies a mismatch, not the traffic.

Calling a working link broken is worse than saying nothing: it teaches operators to ignore the step, which then fails to surface the real thing when it appears.

## What changed

- A **MAVLink2** port is flagged only when its traffic cannot be framed.
- A **disabled** port (-1) still reports any real traffic however cleanly it frames — nothing should be listening there at all, so that remains worth knowing.
- The evidence wording changed with it. `receiving N bytes it cannot decode (N framing errors)` states the actual problem; the old `receiving data but is set to MAVLink2` described a healthy telemetry link equally well.

## Duplicate button

Same screenshot showed **"Open Serial Ports" twice** — once as the yellow hero, once green beneath it.

When a section's only action is a `scroll`, the primary-action chain falls through to `actions[0]` and selects it, and the context-action lookup then found the same object again. The context action now excludes whatever became primary.

## ArduCopter byte-identical

Guided-flow presentation only. No parameter, no command, no vehicle branch.

## Validation

- `npm run typecheck` — clean
- `npm run test` — 836 pass / 0 fail
- web vitest — 632 pass / 0 fail
- `npm run test:e2e` — 234 pass / 6 skipped

**Two existing tests asserted the old behaviour** — one flagged a clean MAVLink2 port as a finding (exactly the reported bug, encoded as expected) and one pinned the old wording. Both rewritten rather than deleted, and the clean-vs-garbled distinction is now covered in both directions.