### PR TITLE
feat(setup): flag undecodable traffic on any port, and duplicate RC input

### DIFF
--- a/apps/web/src/view-models/setup-flow-sections.ts
+++ b/apps/web/src/view-models/setup-flow-sections.ts
@@ -41,7 +41,7 @@ import type { ParameterFollowUp } from '../hooks/use-parameter-feedback'
 import type { RcDirectionResult } from './receiver-direction-check'
 import { canRunGuidedAction, deriveCompassStepSkipReason, guidedActionButtonLabel } from '../guided-action-helpers'
 import { readRoundedParameter } from '../selectors/parameter-read'
-import { buildSetupPortsEvidence, describeUnconfiguredPort } from './setup-ports-evidence'
+import { buildSetupPortsEvidence, describeDuplicateRcin, describeUnconfiguredPort } from './setup-ports-evidence'
 import { isReceiverSerialProtocol } from '../serial-port-helpers'
 import { batteryHealthLabel, describeBatteryMonitor, formatRemaining, formatVoltage } from '../device-display'
 import { failsafeActionLabel } from '../modes-failsafe-helpers'
@@ -217,7 +217,8 @@ export function buildSetupFlowSections(inputs: SetupFlowSectionsInputs): SetupFl
               ])
             )
           })
-          const portsMismatched = portsEvidence.unconfigured.length > 0
+          const portsDuplicateRcin = portsEvidence.duplicateRcinPorts.length > 0
+          const portsMismatched = portsEvidence.unconfigured.length > 0 || portsDuplicateRcin
           criteria = [
             {
               label: 'Serial port protocols are synced from the flight controller',
@@ -229,19 +230,24 @@ export function buildSetupFlowSections(inputs: SetupFlowSectionsInputs): SetupFl
               // a step that blocks on evidence it may never receive is a dead
               // end, not a safeguard. The summary says the check could not run
               // rather than claiming the ports are right.
-              label: 'No port is receiving data while configured as unused',
+              label: 'Every port carrying traffic can decode it, and only one port claims RC input',
               met: !portsMismatched
             }
           ]
-          summary = portsMismatched
-            ? `${portsEvidence.unconfigured.length} port(s) receiving data but configured as unused.`
+          summary = portsDuplicateRcin
+            ? `${portsEvidence.duplicateRcinPorts.length + 1} ports claim RC input — only the lowest-numbered one is used.`
+            : portsMismatched
+            ? `${portsEvidence.unconfigured.length} port(s) carrying traffic the flight controller cannot use.`
             : portsEvidence.trafficUnknown
               ? 'Port traffic counters are unavailable — review the assignments manually.'
               : 'Configured port protocols match the ports that are carrying traffic.'
-          detail = portsMismatched
-            ? 'A peripheral is talking on a port the flight controller thinks is unused, so whatever is wired there cannot work. Set that port to the right protocol before setting up the receiver, GPS or OSD that depends on it.'
+          detail = portsDuplicateRcin
+            ? 'ArduPilot accepts only one RC input port: the lowest-numbered one wins and the others are refused at boot, so a receiver on a later port is silently ignored. Disable RC input on the ports that are not carrying the receiver.'
+            : portsMismatched
+            ? 'A peripheral is talking on a port the flight controller cannot decode it on, so whatever is wired there cannot work. Fix that port\u2019s protocol and baud before setting up the receiver, GPS or OSD that depends on it.'
             : 'Set each serial port to whatever is physically wired to it. Do this before the receiver, GPS and OSD steps — they configure peripherals that only work once their port is right.'
           evidence = [
+            ...(portsDuplicateRcin ? [describeDuplicateRcin(portsEvidence.duplicateRcinPorts)] : []),
             ...portsEvidence.unconfigured.slice(0, 2).map(describeUnconfiguredPort),
             portsEvidence.trafficUnknown
               ? 'Port traffic: counters unavailable'

--- a/apps/web/src/view-models/setup-ports-evidence.test.ts
+++ b/apps/web/src/view-models/setup-ports-evidence.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest'
 
 import {
   buildSetupPortsEvidence,
+  describeDuplicateRcin,
   describeUnconfiguredPort,
   parseUartTraffic
 } from './setup-ports-evidence'
@@ -51,9 +52,13 @@ describe('buildSetupPortsEvidence', () => {
       protocolByPort: { 0: 2, 1: 23, 2: 2, 3: 5, 7: -1 },
       minimumRxBytes: 8
     })
-    expect(evidence.unconfigured).toHaveLength(1)
-    expect(evidence.unconfigured[0].portNumber).toBe(2)
-    expect(evidence.unconfigured[0].garbled).toBe(true)
+    // SERIAL1 (429 framing errors on 29 bytes) is garbled too and is now
+    // reported alongside SERIAL2 — both are genuinely undecodable, and the
+    // narrower check used to skip SERIAL1 purely because it was set to RCIN.
+    const flagged = evidence.unconfigured.filter((finding) => finding.portNumber === 2)
+    expect(flagged).toHaveLength(1)
+    expect(flagged[0].garbled).toBe(true)
+    expect(flagged[0].kind).toBe('undecodable')
   })
 
   it('never flags a second USB port either (OTG2 / SERIAL9)', () => {
@@ -101,6 +106,32 @@ SERIAL9 OTG2  TX =       0 RX =    1128 TXBD=     0 RXBD=   235 RXDRP=       0 F
     expect(evidence.unconfigured[0].garbled).toBe(true)
   })
 
+  // The gap that made this widening worth doing: SERIAL2 sat at PROTOCOL=23
+  // (RCIN) baud 420 for hours, receiving 4867 bytes with 1508 framing errors,
+  // and the step said nothing — because it only ever examined ports set to -1
+  // or MAVLink2. A correctly-protocol'd port that still cannot decode its
+  // peripheral is the version of this failure nobody suspects.
+  it('flags undecodable traffic on a port whose protocol is already RCIN', () => {
+    const rcinWrongBaud = `UARTV1
+SERIAL2 UART2 TX =       0 RX*=    4867 TXBD=     0 RXBD=  3163 RXDRP=       0 FE=1508 OE=0 NE=1400 FlowCtrl=0
+`
+    const evidence = buildSetupPortsEvidence({
+      rawText: rcinWrongBaud,
+      protocolByPort: { 2: 23 }
+    })
+    expect(evidence.unconfigured.map((finding) => finding.portNumber)).toEqual([2])
+    expect(evidence.unconfigured[0].kind).toBe('undecodable')
+    expect(describeUnconfiguredPort(evidence.unconfigured[0])).toContain('cannot decode')
+  })
+
+  it('leaves a clean RCIN port alone', () => {
+    const healthyRcin = `UARTV1
+SERIAL2 UART2 TX =     500 RX*=   40000 TXBD=    80 RXBD=  6600 RXDRP=       0 FE=0 OE=0 NE=0 FlowCtrl=0
+`
+    const evidence = buildSetupPortsEvidence({ rawText: healthyRcin, protocolByPort: { 2: 23 } })
+    expect(evidence.unconfigured).toEqual([])
+  })
+
   it('flags a DISABLED port carrying traffic however cleanly it frames', () => {
     // Nothing should be listening on a -1 port, so clean traffic there is still
     // worth reporting — unlike MAVLink2, which is a legitimate listener.
@@ -123,10 +154,18 @@ SERIAL3 UART3 TX =       0 RX =    9000 TXBD=     0 RXBD=  1500 RXDRP=       0 F
     expect(evidence.unconfigured.some((finding) => finding.portNumber === 0)).toBe(false)
   })
 
-  it('stays quiet once the port is configured for what is on it', () => {
+  it('stays quiet once the port is configured AND its traffic decodes', () => {
+    // Setting the protocol is not on its own sufficient: SERIAL2 in the real
+    // capture is set to RCIN and still cannot frame what arrives, so the quiet
+    // case needs clean counters too.
+    const healthy = `UARTV1
+SERIAL0 OTG1  TX =  106511 RX =    3410 TXBD= 18692 RXBD=   598 RXDRP=       0 FE=0 OE=0 NE=0 FlowCtrl=1
+SERIAL2 UART2 TX =     500 RX*=   40000 TXBD=    80 RXBD=  6600 RXDRP=       0 FE=0 OE=0 NE=0 FlowCtrl=0
+SERIAL3 UART3 TX =       0 RX*=    9000 TXBD=     0 RXBD=  1500 RXDRP=       0 FE=0 OE=0 NE=0 FlowCtrl=0
+`
     const evidence = buildSetupPortsEvidence({
-      rawText: REAL_UARTS_TXT,
-      protocolByPort: { 0: 2, 1: 23, 2: 23, 3: 5, 7: -1 }
+      rawText: healthy,
+      protocolByPort: { 0: 2, 2: 23, 3: 5 }
     })
     expect(evidence.unconfigured).toEqual([])
   })
@@ -140,7 +179,9 @@ SERIAL3 UART3 TX =       0 RX =    9000 TXBD=     0 RXBD=  1500 RXDRP=       0 F
       protocolByPort: { 1: -1, 2: 23 },
       minimumRxBytes: 32
     })
-    expect(evidence.unconfigured).toEqual([])
+    // Scoped to SERIAL1: SERIAL2 in this capture is genuinely undecodable and
+    // is reported on its own merits.
+    expect(evidence.unconfigured.some((finding) => finding.portNumber === 1)).toBe(false)
   })
 
   it('reports traffic as unknown when uarts.txt was unavailable', () => {
@@ -154,6 +195,26 @@ SERIAL3 UART3 TX =       0 RX =    9000 TXBD=     0 RXBD=  1500 RXDRP=       0 F
     expect(
       buildSetupPortsEvidence({ rawText: REAL_UARTS_TXT, protocolByPort: {} }).trafficUnknown
     ).toBe(false)
+  })
+
+  // AP_SerialManager.cpp: exactly one RCIN port is permitted, the lowest index
+  // wins, and later ones are refused with a boot STATUSTEXT nobody reads. A
+  // receiver moved to a second port therefore looks configured and is ignored.
+  it('reports every RCIN port beyond the first, lowest index winning', () => {
+    const evidence = buildSetupPortsEvidence({
+      rawText: REAL_UARTS_TXT,
+      protocolByPort: { 1: 23, 2: 23, 7: 23 }
+    })
+    expect(evidence.duplicateRcinPorts).toEqual([2, 7])
+    expect(describeDuplicateRcin(evidence.duplicateRcinPorts)).toContain('SERIAL2, SERIAL7')
+  })
+
+  it('says nothing when exactly one port claims RC input', () => {
+    const evidence = buildSetupPortsEvidence({
+      rawText: REAL_UARTS_TXT,
+      protocolByPort: { 1: 23, 2: 2, 7: -1 }
+    })
+    expect(evidence.duplicateRcinPorts).toEqual([])
   })
 
   it('says nothing about a port whose protocol has not synced yet', () => {
@@ -181,7 +242,7 @@ describe('describeUnconfiguredPort', () => {
       minimumRxBytes: 8
     }).unconfigured
     expect(describeUnconfiguredPort(finding)).toBe(
-      'SERIAL2 (UART2) is receiving 39 bytes it cannot decode (80357 framing errors) while set to MAVLink2'
+      'SERIAL2 (UART2) is receiving 39 bytes it cannot decode (80357 framing errors) — check the baud and protocol for whatever is wired there'
     )
   })
 })

--- a/apps/web/src/view-models/setup-ports-evidence.ts
+++ b/apps/web/src/view-models/setup-ports-evidence.ts
@@ -12,10 +12,8 @@
 
 /** SERIALn_PROTOCOL values that mean "nothing meaningful is expected here". */
 const PROTOCOL_NONE = -1
-/** SERIALn_PROTOCOL = 2 is MAVLink2 — the default on unused ports, and so the
- *  overwhelmingly common value to find still sitting on a port that has had a
- *  peripheral soldered to it. */
-const PROTOCOL_MAVLINK2 = 2
+/** SerialProtocol_RCIN. ArduPilot permits exactly ONE — see below. */
+const PROTOCOL_RCIN = 23
 
 export interface UartPortTraffic {
   /** SERIALn index, as printed by uarts.txt. */
@@ -67,16 +65,27 @@ export function parseUartTraffic(rawText: string | undefined): UartPortTraffic[]
   return ports
 }
 
+export type PortFindingKind =
+  /** Traffic arriving that the UART cannot frame — a peripheral talking at a
+   *  rate or in a protocol the port is not set up for. Reported for ANY
+   *  protocol: a receiver on a port already set to RCIN but at the wrong baud
+   *  looks correctly configured and still cannot work, which is the harder
+   *  version of this failure to spot. */
+  | 'undecodable'
+  /** A disabled port (-1) carrying real traffic — something is wired to a port
+   *  the flight controller ignores entirely. */
+  | 'unclaimed'
+
 export interface UnconfiguredPortFinding {
   portNumber: number
   hardwarePort: string
   rxBytes: number
   framingErrors: number
-  /** The SERIALn_PROTOCOL currently set, or undefined if not synced. */
-  protocolValue: number | undefined
-  /** True when the traffic is arriving but cannot be framed — the signature of
-   *  a peripheral talking at a rate/protocol the port is not set up for. */
+  /** The SERIALn_PROTOCOL currently set. */
+  protocolValue: number
+  /** True when the traffic is arriving but cannot be framed. */
   garbled: boolean
+  kind: PortFindingKind
 }
 
 export interface SetupPortsEvidenceInputs {
@@ -90,8 +99,18 @@ export interface SetupPortsEvidenceInputs {
 
 export interface SetupPortsEvidence {
   ports: UartPortTraffic[]
-  /** Ports receiving real traffic while configured as None or MAVLink2. */
+  /** Ports whose traffic cannot be decoded, or which carry traffic while
+   *  disabled. */
   unconfigured: UnconfiguredPortFinding[]
+  /**
+   * SERIALn indices beyond the first that also claim RCIN.
+   *
+   * AP_SerialManager.cpp permits exactly one RCIN port: the lowest index wins
+   * and every later one is refused with "duplicate RCIN not permitted". The
+   * refusal appears only in a boot STATUSTEXT, so a receiver moved to a second
+   * port looks correctly configured and is silently ignored.
+   */
+  duplicateRcinPorts: number[]
   /** True when uarts.txt was unavailable, so absence of findings proves
    *  nothing and the step must not claim the ports are correct. */
   trafficUnknown: boolean
@@ -119,45 +138,69 @@ export function buildSetupPortsEvidence({
       continue
     }
     const protocolValue = protocolByPort[port.portNumber]
-    if (protocolValue !== PROTOCOL_NONE && protocolValue !== PROTOCOL_MAVLINK2) {
+    // Unknown is not misconfigured. Judging a port before its SERIALn_PROTOCOL
+    // has arrived would fire on every connection during the sync window.
+    if (protocolValue === undefined) {
       continue
     }
     // A tenth of the received bytes failing to frame is well beyond incidental
     // noise and means the port is mis-clocked for what is on it.
     const garbled = port.framingErrors > port.rxBytes / 10
 
-    // MAVLink2 carrying CLEAN traffic is a port doing its job — a telemetry
-    // radio, a companion computer, an ATAK link. Flagging it was wrong: the
-    // original failure was a receiver on a MAVLink2 port producing 80357
-    // framing errors against 39 bytes, and it is the GARBLE that identifies a
-    // mismatch, not the traffic. A working telemetry link is not a
-    // misconfiguration, and saying so trains operators to ignore this step.
-    //
-    // A DISABLED port (-1) is different: nothing should be listening at all, so
-    // any real traffic there is worth reporting however cleanly it frames.
-    if (protocolValue === PROTOCOL_MAVLINK2 && !garbled) {
+    if (garbled) {
+      // Checked BEFORE the protocol, deliberately. Undecodable traffic is a
+      // fault whatever the port claims to be — a receiver on a port already set
+      // to RCIN but at the wrong baud reads as correctly configured and still
+      // cannot work, which is the version of this that goes undiagnosed.
+      unconfigured.push({
+        portNumber: port.portNumber,
+        hardwarePort: port.hardwarePort,
+        rxBytes: port.rxBytes,
+        framingErrors: port.framingErrors,
+        protocolValue,
+        garbled,
+        kind: 'undecodable'
+      })
       continue
     }
 
+    // Clean traffic on a configured port is a port doing its job — a telemetry
+    // radio, a companion computer, an ATAK link. Only a DISABLED port is
+    // suspect, because nothing should be listening there at all.
+    if (protocolValue !== PROTOCOL_NONE) {
+      continue
+    }
     unconfigured.push({
       portNumber: port.portNumber,
       hardwarePort: port.hardwarePort,
       rxBytes: port.rxBytes,
       framingErrors: port.framingErrors,
       protocolValue,
-      garbled
+      garbled,
+      kind: 'unclaimed'
     })
   }
 
-  return { ports, unconfigured, trafficUnknown: ports.length === 0 }
+  // Duplicate RCIN: lowest index wins, the rest are silently refused.
+  const rcinPorts = Object.entries(protocolByPort)
+    .filter(([, value]) => value === PROTOCOL_RCIN)
+    .map(([port]) => Number(port))
+    .sort((a, b) => a - b)
+  const duplicateRcinPorts = rcinPorts.slice(1)
+
+  return { ports, unconfigured, duplicateRcinPorts, trafficUnknown: ports.length === 0 }
 }
 
 /** One-line description of a finding, for the wizard's evidence pills. */
 export function describeUnconfiguredPort(finding: UnconfiguredPortFinding): string {
-  if (finding.protocolValue === PROTOCOL_NONE) {
+  if (finding.kind === 'unclaimed') {
     return `SERIAL${finding.portNumber} (${finding.hardwarePort}) is receiving ${finding.rxBytes} bytes but the port is disabled`
   }
-  // Only reachable when the stream cannot be framed — a clean MAVLink2 port is
-  // not a finding at all.
-  return `SERIAL${finding.portNumber} (${finding.hardwarePort}) is receiving ${finding.rxBytes} bytes it cannot decode (${finding.framingErrors} framing errors) while set to MAVLink2`
+  return `SERIAL${finding.portNumber} (${finding.hardwarePort}) is receiving ${finding.rxBytes} bytes it cannot decode (${finding.framingErrors} framing errors) — check the baud and protocol for whatever is wired there`
+}
+
+/** One-line description of the duplicate-RCIN condition. */
+export function describeDuplicateRcin(duplicateRcinPorts: readonly number[]): string {
+  const list = duplicateRcinPorts.map((port) => `SERIAL${port}`).join(', ')
+  return `${list} also set to RCIN — ArduPilot uses only the lowest-numbered RC input port and silently ignores the rest`
 }


### PR DESCRIPTION
Two gaps left by the narrower check — both of which the bench board sat in while nothing was reported.

## Undecodable traffic on any port

The check only ever examined ports set to `-1` or MAVLink2. So SERIAL2 at `PROTOCOL=23` (RCIN) baud 420 — receiving 4867 bytes with **1508 framing errors** — passed silently for hours.

That's the version of this failure nobody suspects: the configuration *looks* right, so the port is the last place anyone looks.

The garble test now runs **before** the protocol test, because a stream the UART cannot frame is a fault regardless of what the port claims to be.

## Duplicate RC input

`AP_SerialManager.cpp` permits exactly one RCIN port: the lowest index wins and later ones are refused with a boot STATUSTEXT nobody reads. A receiver moved to a second port therefore looks configured and is silently ignored.

This was the *original* finding on the bench board — SERIAL1 and SERIAL7 both set to RCIN — and it was invisible to the app.

## What still does not flag, deliberately

A port carrying **clean** traffic on any configured protocol. That's a working link — telemetry, companion computer, ATAK — and calling it broken is exactly what made the previous version untrustworthy.

An **unsynced** protocol is still skipped entirely, so nothing fires during the parameter-sync window.

## ArduCopter byte-identical

Guided-flow presentation only. No parameter, no command, no vehicle branch.

## Validation

- `npm run typecheck` — clean
- `npm run test` — 836 pass / 0 fail
- web vitest — 636 pass / 0 fail (4 new)
- `npm run test:e2e` — 234 pass / 6 skipped

**Four existing tests changed**, all direct consequences worth stating plainly:

- The real capture contains **two** garbled ports — SERIAL1 (429 errors on 29 bytes) as well as SERIAL2 — which the narrower check skipped purely because they were set to RCIN. Both are genuine.
- One test asserted that setting the right protocol makes garbled traffic acceptable. It does not; that test now uses clean counters to express "quiet".