### PR TITLE
fix(runtime): re-stream a mostly-absent parameter table instead of gap-filling

### DIFF
--- a/packages/ardupilot-core/src/runtime.ts
+++ b/packages/ardupilot-core/src/runtime.ts
@@ -224,6 +224,14 @@ const PARAMETER_CARRY_OVER_TTL_MS = 10 * 60 * 1000
 // real-world gap is a handful of dropped frames; any remainder rolls to the
 // next stall-retry pass.
 const MAX_PARAMETER_GAP_FILL_PER_PASS = 256
+// Above this share of the table missing, a full re-stream beats by-index
+// refetch. See the reasoning at the canGapFill decision — bulk measured 13x
+// faster than gap-fill on the same link when most of the table was absent.
+const PARAMETER_GAP_FILL_MAX_FRACTION = 0.2
+// Below this many missing parameters the fraction rule does not apply at all —
+// a small table with a couple of holes is the case by-index refetch is FOR, and
+// re-streaming it would be slower, not faster.
+const MIN_MISSING_FOR_FRACTION_RESTREAM = 64
 // Hard upper bound on emit() coalescing. requestAnimationFrame is suspended
 // in a backgrounded tab, so a setTimeout fallback at this bound guarantees a
 // coalesced terminal snapshot still reaches the UI.
@@ -473,6 +481,9 @@ export class ArduPilotConfiguratorRuntime {
   private fakeGpsOriginalType: number | undefined
   private liveVerification = createIdleLiveVerification()
   private totalParameters = 0
+  /** Set when the FC's reported parameter count grew mid-sync — a board that
+   *  was still registering parameters when it answered. */
+  private parameterTableGrewDuringSync = false
   private liveTelemetryRequestsIssued = false
   // FIFO of un-ACKed SET_MESSAGE_INTERVAL requests, dequeued in arrival order
   // so processCommandAck can name which stream the autopilot rejected.
@@ -2151,6 +2162,7 @@ export class ArduPilotConfiguratorRuntime {
     this.realParameterIdsReceived.clear()
     this.receivedParameterIndices.clear()
     this.totalParameters = 0
+    this.parameterTableGrewDuringSync = false
     this.parameterSyncLastRetryDownloaded = 0
     this.parameterSyncGapFillActive = false
     this.parameterSync = {
@@ -2176,6 +2188,17 @@ export class ArduPilotConfiguratorRuntime {
     // an earlier real arrival under the other id as a duplicate.
     const known = this.realParameterIdsReceived.has(message.paramId)
     this.realParameterIdsReceived.add(message.paramId)
+    // A board still booting answers PARAM_REQUEST_LIST from a table its
+    // libraries have not finished registering, so the count it reports GROWS
+    // mid-stream (measured: 953, then 1125 on the same board seconds later).
+    // Every index recorded against the smaller table is suspect — the FC
+    // renumbers as entries appear — so the coverage map is dropped and the
+    // stream re-requested against the real table rather than gap-filling
+    // against indices that no longer mean anything.
+    if (this.totalParameters > 0 && message.paramCount > this.totalParameters) {
+      this.receivedParameterIndices.clear()
+      this.parameterTableGrewDuringSync = true
+    }
     this.totalParameters = message.paramCount
     // Record the streamed index so a stalled sync can target the gaps. A
     // by-name write echo carries paramIndex 0xffff (no valid index) — ignore it
@@ -2972,6 +2995,7 @@ export class ArduPilotConfiguratorRuntime {
     this.realParameterIdsReceived.clear()
     this.receivedParameterIndices.clear()
     this.totalParameters = 0
+    this.parameterTableGrewDuringSync = false
   }
 
   /**
@@ -3198,7 +3222,30 @@ export class ArduPilotConfiguratorRuntime {
     // dropping the by-index responses too), restoring the pre-gap-fill recovery.
     const missingIndices = this.missingParameterIndices()
     const gapFillStalled = this.parameterSyncGapFillActive && !madeProgressSinceLastRetry
-    const canGapFill = total > 0 && downloaded > 0 && missingIndices.length > 0 && !gapFillStalled
+    // Gap-fill is right for a HANDFUL of dropped frames and badly wrong for a
+    // table that never arrived. Measured on a real board: a bulk stream lands
+    // 146 params/s, while by-index refetch of a near-empty table crawls at 11 —
+    // it asks for up to MAX_PARAMETER_GAP_FILL_PER_PASS by index and gets a few
+    // dozen answers back, then waits out the stall timer and asks again. A
+    // reconnect made while the FC is still booting drops into exactly that
+    // state and took 96 s where a cold sync took 8 s.
+    //
+    // So a large gap re-streams instead. The threshold is deliberately
+    // generous toward re-streaming: the cost of a needless re-stream is one
+    // fast bulk transfer, and the cost of gap-filling a mostly-missing table is
+    // minutes.
+    // The FRACTION rule is gated on an absolute count as well: two dropped
+    // frames out of a six-parameter table is 33% and is precisely the case
+    // gap-fill exists for. Only a table that is substantially absent — many
+    // parameters AND most of them — is better served by re-streaming.
+    const gapTooLargeToFill =
+      this.parameterTableGrewDuringSync ||
+      missingIndices.length > MAX_PARAMETER_GAP_FILL_PER_PASS ||
+      (total > 0 &&
+        missingIndices.length >= MIN_MISSING_FOR_FRACTION_RESTREAM &&
+        missingIndices.length / total > PARAMETER_GAP_FILL_MAX_FRACTION)
+    const canGapFill =
+      total > 0 && downloaded > 0 && missingIndices.length > 0 && !gapFillStalled && !gapTooLargeToFill
     this.parameterSyncGapFillActive = canGapFill
 
     // Retries are unbounded, so every pass must NOT write a notice — a board

--- a/tests/parameter-sync-gap-fill.test.mjs
+++ b/tests/parameter-sync-gap-fill.test.mjs
@@ -209,11 +209,18 @@ function createIndexedSession(sentMessages, { total, initialCount, answerReads =
   }
 }
 
-test('a gap larger than one gap-fill budget still converges (retry budget refunds on progress)', async () => {
-  // 1200 params, only 300 in the first burst → 900 missing, far beyond
-  // MAX_PARAMETER_GAP_FILL_PER_PASS (256) × MAX_PARAMETER_SYNC_RETRIES (3) = 768.
-  // Before the refund fix this stranded at ~1068/1200; now each pass that
-  // recovers params refunds the budget, so it converges.
+test('a mostly-absent table converges by RE-STREAMING, not by-index refetch', async () => {
+  // 1200 params, only 300 in the first burst → 900 missing (75%).
+  //
+  // This used to gap-fill all 900 by index, and did converge — but measured on
+  // a real board that path runs at ~11 params/s against ~146 for a bulk
+  // stream, because the FC answers only a few dozen of each pass's by-index
+  // reads and the rest waits out the stall timer. A reconnect made while the
+  // board was still booting therefore took 96 s where a cold sync took 8 s.
+  //
+  // A table this empty now re-streams instead. The guarantee under test is
+  // unchanged — a large gap must still CONVERGE — but the mechanism that gets
+  // there is deliberately different.
   const sentMessages = []
   const session = createIndexedSession(sentMessages, { total: 1200, initialCount: 300 })
   const runtime = new ArduPilotConfiguratorRuntime(session, arducopterMetadata, { parameterSyncStallRetryMs: 5 })
@@ -222,9 +229,16 @@ test('a gap larger than one gap-fill budget still converges (retry budget refund
     await runtime.requestParameterList({ timeoutMs: 2000 })
     const stats = await runtime.waitForParameterSync({ timeoutMs: 5000 })
     assert.equal(stats.status, 'complete', 'large gap converged')
-    assert.equal(stats.downloaded, 1200, 'all 1200 recovered (past the old 768 cap)')
+    assert.equal(stats.downloaded, 1200, 'all 1200 recovered')
+    // More than one PARAM_REQUEST_LIST means it re-streamed rather than
+    // grinding through by-index reads.
+    const lists = sentMessages.filter((m) => m.type === 'PARAM_REQUEST_LIST')
+    assert.ok(lists.length >= 2, `expected a re-stream, saw ${lists.length} PARAM_REQUEST_LIST`)
     const reads = sentMessages.filter((m) => m.type === 'PARAM_REQUEST_READ')
-    assert.ok(reads.length >= 900, `refetched all missing indices by gap-fill (${reads.length} reads)`)
+    assert.ok(
+      reads.length < 900,
+      `should not grind 900 by-index reads for a 75% gap (${reads.length} reads)`
+    )
   } finally {
     await runtime.disconnect().catch(() => {})
     runtime.destroy()


### PR DESCRIPTION
Measured on a real board, not inferred — the evidence #116 lacked.

## Reproduced

Reconnecting the *instant* the port reappears after a reboot — what an operator actually does, rather than waiting politely — on a live BROTHERHOBBYH743:

```
cold        :   8.4 s, 134 params/s,  0 stall-retry passes
post-reboot : 105.1 s,  11 params/s, 46 stall-retry passes
```

Same board, same link, same session. A 14-second pause before reconnecting hides it completely (7.7 s vs 8.0 s), which is why it never showed up in testing.

## Cause

A board still booting answers `PARAM_REQUEST_LIST` from a table its libraries haven't finished registering. It reported a count of **953**, then **1125** seconds later, and sat stuck at **one parameter for ~4 s**.

That partial start drops the sync into by-index gap-fill — and gap-fill never returns to bulk streaming. It asks for up to 256 parameters by index per pass, the FC answers a few dozen, and the remainder waits out the stall timer. The status entries show it recovering **~21 per pass**, forty-odd times.

So gap-fill is right for a *handful* of dropped frames and badly wrong for a table that never arrived.

## Fix

**A mostly-absent table re-streams.** Thresholds lean toward re-streaming: a needless re-stream costs one fast bulk transfer, while gap-filling a mostly-missing table costs minutes. The fraction rule is gated on an absolute count (≥64 missing) too — two dropped frames out of a six-parameter table is 33% and is exactly what by-index refetch is *for*.

**A table that grew mid-sync forces a re-stream** and clears the coverage map. Every index recorded against the smaller table is suspect once the FC renumbers as entries appear.

## Result, same board, same condition

```
post-reboot : 13.4 s, 84 params/s, 3 stall-retry passes   (12.2x -> 1.7x)
```

**7× faster.** Re-verified after the threshold was tuned.

## A test that asserted the old mechanism

`a gap larger than one gap-fill budget still converges` constructed a 900-of-1200 gap and required **900 by-index reads** — it was pinning the slow path. Rewritten to assert the guarantee that actually matters (a large gap still *converges*) while requiring the faster mechanism. Its original point was convergence, not the means.

## ArduCopter byte-identical

Transport-layer recovery strategy only. The same parameters arrive with the same values; only the request pattern used to recover a degraded stream changes.

## Validation

- `npm run typecheck` — clean
- `npm run test` — 836 pass / 0 fail
- web vitest — 657 pass / 0 fail
- **Rung 5** — measured on live hardware before and after