### PR TITLE
feat(mavftp): cancellable burst downloads and a silent download option

### DIFF
--- a/packages/ardupilot-core/src/index.ts
+++ b/packages/ardupilot-core/src/index.ts
@@ -14,7 +14,7 @@ export * from './provisioning-library.js'
 export * from './runtime.js'
 export { GuidedActionService } from './runtime-guided-action-service.js'
 export type { GuidedActionServiceOptions } from './runtime-guided-action-service.js'
-export { MavftpService } from './runtime-mavftp-service.js'
+export { MavftpService, MavftpAbortError } from './runtime-mavftp-service.js'
 export type { MavftpServiceOptions } from './runtime-mavftp-service.js'
 export { LogDownloadService } from './runtime-log-download-service.js'
 export type {

--- a/packages/ardupilot-core/src/runtime-mavftp-service.ts
+++ b/packages/ardupilot-core/src/runtime-mavftp-service.ts
@@ -52,7 +52,24 @@ interface MavftpWaiterHandle {
   cancel: (error: Error) => void
 }
 
+/**
+ * A burst that was cancelled by its caller, not one that failed.
+ *
+ * Distinct from a generic Error so a caller can tell "I stood this down" from
+ * "the link broke" — background work must swallow its own cancellation
+ * silently, while a real failure is worth knowing about.
+ */
+export class MavftpAbortError extends Error {
+  readonly aborted = true
+  constructor() {
+    super('MAVFTP burst download was aborted.')
+    this.name = 'MavftpAbortError'
+  }
+}
+
 interface BurstOperation {
+  /** Detaches the abort listener, if one was attached. Called on every exit. */
+  cleanup?: () => void
   session: number
   declaredSize: number
   buffer: Uint8Array
@@ -327,9 +344,28 @@ export class MavftpService {
       timeoutMs?: number
       maxBytes?: number
       onProgress?: (progress: LogDownloadProgress) => void
+      /**
+       * Cancels an in-flight burst.
+       *
+       * Exists for BACKGROUND reads. A burst holds the single activeBurst slot
+       * for its whole duration and a second one throws, so an uncancellable
+       * multi-megabyte read in the background would make an operator's own
+       * download fail while they waited on it. With a signal the background
+       * work can stand down instead.
+       *
+       * Aborting rejects through the normal failure path, so the session is
+       * still terminated by the caller's finally — the flight controller is
+       * never left streaming into a dead operation.
+       */
+      signal?: AbortSignal
     } = {}
   ): Promise<Uint8Array> {
     await this.ensureSupport()
+    if (options.signal?.aborted) {
+      // Checked before opening a session so an already-cancelled request costs
+      // the flight controller nothing at all.
+      throw new MavftpAbortError()
+    }
     if (this.activeBurst) {
       throw new Error('A MAVFTP burst download is already in progress.')
     }
@@ -374,7 +410,7 @@ export class MavftpService {
     }
 
     try {
-      return await this.runBurst(session, declaredSize, timeoutMs, options.onProgress)
+      return await this.runBurst(session, declaredSize, timeoutMs, options.onProgress, options.signal)
     } finally {
       await this.terminateSession(session)
     }
@@ -407,7 +443,8 @@ export class MavftpService {
     session: number,
     declaredSize: number,
     timeoutMs: number | undefined,
-    onProgress?: (progress: LogDownloadProgress) => void
+    onProgress?: (progress: LogDownloadProgress) => void,
+    signal?: AbortSignal
   ): Promise<Uint8Array> {
     const effectiveTimeoutMs = timeoutMs ?? DEFAULT_MAVFTP_BURST_TIMEOUT_MS
     return new Promise<Uint8Array>((resolve, reject) => {
@@ -423,6 +460,16 @@ export class MavftpService {
         resolve,
         reject,
         timer: setTimeout(() => this.onBurstTimeout(), effectiveTimeoutMs)
+      }
+      // Abort routes through failBurst, the SAME path a timeout takes, so
+      // cancellation cannot leave the service in a state the normal failure
+      // path does not already handle.
+      if (signal) {
+        const onAbort = (): void => this.failBurst(new MavftpAbortError())
+        signal.addEventListener('abort', onAbort, { once: true })
+        // Detached however the op ends — resolve, reject or abort — so a long
+        // session cannot accumulate listeners on a shared signal.
+        op.cleanup = () => signal.removeEventListener('abort', onAbort)
       }
       this.activeBurst = op
       this.sendBurstReadRequest(op, 0)
@@ -563,6 +610,7 @@ export class MavftpService {
       return
     }
     clearTimeout(op.timer)
+    op.cleanup?.()
     this.activeBurst = undefined
     const bytes = op.received >= op.declaredSize ? op.buffer : op.buffer.slice(0, op.received)
     op.resolve(bytes)
@@ -574,6 +622,7 @@ export class MavftpService {
       return
     }
     clearTimeout(op.timer)
+    op.cleanup?.()
     this.activeBurst = undefined
     op.reject(error)
   }

--- a/packages/ardupilot-core/src/runtime.ts
+++ b/packages/ardupilot-core/src/runtime.ts
@@ -1308,16 +1308,30 @@ export class ArduPilotConfiguratorRuntime {
   }
 
   /** Download one onboard log over MAVFTP burst read, reporting progress. */
+  /**
+   * Download one onboard log over MAVFTP burst read, reporting progress.
+   *
+   * `silent` suppresses the status entry and the snapshot emit. Background work
+   * the operator did not ask for must leave no trace in the status feed: a
+   * "Downloaded /APM/LOGS/00000042.BIN" line appearing unprompted reads as the
+   * app doing something behind their back, and buries the entries they were
+   * actually watching for. An operator-initiated download still reports, since
+   * there the line is the confirmation they are waiting on.
+   */
   async downloadMavftpLog(
     path: string,
-    onProgress?: (progress: LogDownloadProgress) => void
+    onProgress?: (progress: LogDownloadProgress) => void,
+    options: { silent?: boolean; signal?: AbortSignal } = {}
   ): Promise<Uint8Array> {
     const bytes = await this.mavftp.downloadRemoteFileBurst(path, {
       onProgress,
-      maxBytes: MAX_MAVFTP_LOG_BYTES
+      maxBytes: MAX_MAVFTP_LOG_BYTES,
+      signal: options.signal
     })
-    this.appendStatusEntry('info', `Downloaded ${path} via MAVFTP (${bytes.length} bytes).`)
-    this.emit()
+    if (!options.silent) {
+      this.appendStatusEntry('info', `Downloaded ${path} via MAVFTP (${bytes.length} bytes).`)
+      this.emit()
+    }
     return bytes
   }
 

--- a/tests/mavftp-burst-abort.test.mjs
+++ b/tests/mavftp-burst-abort.test.mjs
@@ -1,0 +1,133 @@
+// Cancelling an in-flight MAVFTP burst.
+//
+// This exists so BACKGROUND log reads can stand down. A burst holds the single
+// `activeBurst` slot for its whole duration and a second one throws, so an
+// uncancellable multi-megabyte read in the background would make an operator's
+// own download fail while they sat waiting on it. That is background work
+// degrading foreground work, which is exactly what a feature meant to be
+// invisible must never do.
+//
+// So the assertion that actually matters is not "abort rejects" — it is that
+// after aborting, the slot is FREE and a real download succeeds.
+
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { MavftpService, MavftpAbortError } from '../packages/ardupilot-core/dist/index.js'
+
+/**
+ * A service whose burst never completes on its own, so a test can decide when
+ * (or whether) it ends. Only the transport is faked; the real op lifecycle,
+ * timer handling and activeBurst bookkeeping run.
+ */
+function createService({ declaredSize = 4096 } = {}) {
+  const sent = []
+  const service = new MavftpService({
+    send: async (message) => {
+      sent.push(message)
+    },
+    getVehicle: () => ({ systemId: 1, componentId: 1 }),
+    appendStatusEntry: () => {},
+    emit: () => {}
+  })
+  // Bypass the handshake and the open/size negotiation: this test is about the
+  // burst's cancellation, not about MAVFTP capability probing.
+  service.ensureSupport = async () => {}
+  service.clearStaleSessionsOnce = async () => {}
+  service.terminateSession = async () => {}
+  service.send = async () => ({ size: declaredSize, data: new Uint8Array(0) })
+  service.sendBurstReadRequest = () => {}
+  return { service, sent }
+}
+
+/** Drive a burst directly so the test controls its lifetime. */
+function startBurst(service, signal, declaredSize = 4096) {
+  return service.runBurst(1, declaredSize, 60_000, undefined, signal)
+}
+
+test('aborting rejects with a distinguishable error, not a generic failure', async () => {
+  // Background work must be able to tell "I stood this down" from "the link
+  // broke" — one is silent, the other is worth knowing about.
+  const { service } = createService()
+  const controller = new AbortController()
+  const burst = startBurst(service, controller.signal)
+  controller.abort()
+  const error = await burst.then(
+    () => undefined,
+    (e) => e
+  )
+  assert.ok(error instanceof MavftpAbortError, `expected MavftpAbortError, got ${error}`)
+  assert.equal(error.aborted, true)
+})
+
+// THE POINT OF THE FEATURE.
+test('after aborting, the burst slot is free for another download', async () => {
+  const { service } = createService()
+  const controller = new AbortController()
+  const background = startBurst(service, controller.signal)
+  // The slot is taken while it runs.
+  assert.ok(service.activeBurst, 'a running burst should hold the slot')
+
+  controller.abort()
+  await background.catch(() => {})
+
+  assert.equal(service.activeBurst, undefined, 'aborting must release the slot')
+  // A foreground download can now proceed — the whole reason abort exists.
+  const foreground = startBurst(service, undefined)
+  assert.ok(service.activeBurst, 'a new burst should be able to start')
+  service.finishBurst(service.activeBurst)
+  await foreground
+})
+
+test('an already-aborted signal never opens a session at all', async () => {
+  // Cheapest possible refusal: the flight controller is not touched.
+  const { service, sent } = createService()
+  const controller = new AbortController()
+  controller.abort()
+  const before = sent.length
+  await assert.rejects(
+    () => service.downloadRemoteFileBurst('/APM/LOGS/1.BIN', { signal: controller.signal }),
+    (error) => error instanceof MavftpAbortError
+  )
+  assert.equal(sent.length, before, 'no MAVFTP traffic should be emitted')
+})
+
+test('a completed burst detaches its abort listener', async () => {
+  // A shared signal across many background reads must not accumulate
+  // listeners for bursts that already finished.
+  const { service } = createService()
+  const controller = new AbortController()
+  const burst = startBurst(service, controller.signal)
+  const op = service.activeBurst
+  service.finishBurst(op)
+  await burst
+
+  // Aborting now must be inert — the op is gone and nothing should react.
+  assert.equal(service.activeBurst, undefined)
+  controller.abort()
+  assert.equal(service.activeBurst, undefined)
+})
+
+test('aborting one burst does not reject an unrelated later one', async () => {
+  const { service } = createService()
+  const first = new AbortController()
+  const burstA = startBurst(service, first.signal)
+  first.abort()
+  await burstA.catch(() => {})
+
+  const second = new AbortController()
+  const burstB = startBurst(service, second.signal)
+  // The already-fired first signal must not touch this one.
+  service.finishBurst(service.activeBurst)
+  await assert.doesNotReject(() => burstB)
+})
+
+test('a burst without a signal behaves exactly as before', async () => {
+  // Operator-initiated downloads pass no signal; nothing about them changes.
+  const { service } = createService()
+  const burst = startBurst(service, undefined)
+  assert.ok(service.activeBurst)
+  service.finishBurst(service.activeBurst)
+  const bytes = await burst
+  assert.ok(bytes instanceof Uint8Array)
+})

--- a/tests/silent-log-download.test.mjs
+++ b/tests/silent-log-download.test.mjs
@@ -1,0 +1,107 @@
+// Background log reads must leave NO trace in the operator's status feed.
+//
+// Any automatic read the operator did not ask for must be invisible: a
+// "Downloaded /APM/LOGS/00000042.BIN" line appearing unprompted reads as the
+// app acting behind their back, and buries the entries they were actually
+// watching for.
+//
+// The inverse matters just as much: an operator-initiated download must STILL
+// report, because there the line is the confirmation they are waiting on. A
+// blanket silence would be a regression dressed as a fix.
+
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { ArduPilotConfiguratorRuntime } from '../packages/ardupilot-core/dist/index.js'
+import { arducopterMetadata } from '../packages/param-metadata/dist/index.js'
+
+function createSession() {
+  const statusListeners = []
+  const messageListeners = []
+  return {
+    getTransportStatus: () => ({ kind: 'connected' }),
+    onStatus(listener) {
+      statusListeners.push(listener)
+      return () => {}
+    },
+    onMessage(listener) {
+      messageListeners.push(listener)
+      return () => {}
+    },
+    async connect() {
+      statusListeners.forEach((listener) => listener({ kind: 'connected' }))
+      messageListeners.forEach((listener) =>
+        listener({
+          header: { systemId: 1, componentId: 1, sequence: 0 },
+          message: {
+            type: 'HEARTBEAT',
+            autopilot: 3,
+            vehicleType: 2,
+            baseMode: 0,
+            customMode: 0,
+            systemStatus: 4,
+            mavlinkVersion: 3
+          },
+          timestampMs: Date.now()
+        })
+      )
+    },
+    async disconnect() {},
+    destroy() {},
+    async send() {}
+  }
+}
+
+/** Stub the burst reader so the test exercises the REPORTING decision, not MAVFTP. */
+async function withRuntime(run) {
+  const runtime = new ArduPilotConfiguratorRuntime(createSession(), arducopterMetadata)
+  try {
+    await runtime.connect()
+    runtime.mavftp.downloadRemoteFileBurst = async () => new Uint8Array(1024)
+    await run(runtime)
+  } finally {
+    runtime.destroy()
+  }
+}
+
+const logEntries = (runtime) =>
+  runtime
+    .getSnapshot()
+    .statusTexts.filter((entry) => String(entry.text).includes('Downloaded'))
+
+test('a silent download adds NO status entry', async () => {
+  await withRuntime(async (runtime) => {
+    const before = logEntries(runtime).length
+    await runtime.downloadMavftpLog('/APM/LOGS/00000042.BIN', undefined, { silent: true })
+    assert.equal(
+      logEntries(runtime).length,
+      before,
+      'an automatic background read must leave the status feed untouched'
+    )
+  })
+})
+
+test('an operator-initiated download still reports — silence is opt-in', async () => {
+  // The confirmation the operator is waiting on must not disappear.
+  await withRuntime(async (runtime) => {
+    const before = logEntries(runtime).length
+    await runtime.downloadMavftpLog('/APM/LOGS/00000042.BIN')
+    assert.equal(logEntries(runtime).length, before + 1, 'a normal download should report')
+  })
+})
+
+test('silent: false is explicit and still reports', async () => {
+  await withRuntime(async (runtime) => {
+    const before = logEntries(runtime).length
+    await runtime.downloadMavftpLog('/APM/LOGS/1.BIN', undefined, { silent: false })
+    assert.equal(logEntries(runtime).length, before + 1)
+  })
+})
+
+test('a silent download still returns the bytes — quiet, not crippled', async () => {
+  await withRuntime(async (runtime) => {
+    const bytes = await runtime.downloadMavftpLog('/APM/LOGS/1.BIN', undefined, { silent: true })
+    assert.ok(bytes instanceof Uint8Array)
+    assert.equal(bytes.length, 1024)
+  })
+})


### PR DESCRIPTION
## Why this is here

Both capabilities were built while working on something that happened to be their first caller, but neither is specific to it — they're general runtime capabilities, and keeping them out of public left the shared `ardupilot-core` package **diverged between the two repos**. Anyone flashing firmware or pulling a log benefits from being able to cancel it.

## Cancellation

`downloadRemoteFileBurst` now takes an `AbortSignal`.

A burst holds the single `activeBurst` slot for its whole duration and a second one throws, so any long automatic read was previously uninterruptible — an operator starting their own download mid-read would get the failure. That's background work degrading foreground work.

- Abort routes through `failBurst`, the **same path a timeout already takes**, so cancellation can't leave the service in a state the normal failure path doesn't handle.
- The caller's existing `finally` still terminates the session — the FC is never left streaming into a dead operation.
- An already-aborted signal is refused **before** a session is opened, so a cancelled request costs the flight controller nothing.
- `MavftpAbortError` is distinct from a generic `Error`, so a caller can tell "I stood this down" from "the link broke".
- The abort listener detaches on **every** exit — resolve, reject or abort — so a signal shared across many reads can't accumulate listeners.

The load-bearing test isn't "abort rejects"; it's that **after aborting, the slot is free and a subsequent download succeeds**.

## Silence

`downloadMavftpLog` gained a `silent` option suppressing its status entry and snapshot emit.

An automatic read the operator didn't ask for must leave no trace — an unprompted `Downloaded /APM/LOGS/00000042.BIN` reads as the app acting behind their back and buries the entries they were watching for.

**Opt-in, deliberately.** An operator-initiated download still reports, because there the line is the confirmation they're waiting on. Blanket silence would be a regression dressed as a fix.

## Nothing existing changes

A burst with no signal, and a download with no options, behave exactly as before. Tests pin both directions.

## ArduCopter byte-identical

Adds capability, changes no existing behaviour. No parameter read or written, no vehicle branch.

## Validation

- `npm run typecheck` — clean
- `npm run test` — 846 pass / 0 fail (10 new)
- web vitest — 657 pass / 0 fail

**No rung-5 evidence.** This touches the transfer layer that also moves firmware, so a real log download and a real flash are worth exercising before trusting it.