### PR TITLE
feat(mavftp): hand back the bytes a failed burst already read

### DIFF
--- a/packages/ardupilot-core/src/index.ts
+++ b/packages/ardupilot-core/src/index.ts
@@ -14,8 +14,8 @@ export * from './provisioning-library.js'
 export * from './runtime.js'
 export { GuidedActionService } from './runtime-guided-action-service.js'
 export type { GuidedActionServiceOptions } from './runtime-guided-action-service.js'
-export { MavftpService, MavftpAbortError } from './runtime-mavftp-service.js'
-export type { MavftpServiceOptions } from './runtime-mavftp-service.js'
+export { MavftpService, MavftpAbortError, partialTransferOf } from './runtime-mavftp-service.js'
+export type { MavftpServiceOptions, PartialTransfer } from './runtime-mavftp-service.js'
 export { LogDownloadService } from './runtime-log-download-service.js'
 export type {
   LogDownloadServiceOptions,

--- a/packages/ardupilot-core/src/runtime-mavftp-service.ts
+++ b/packages/ardupilot-core/src/runtime-mavftp-service.ts
@@ -67,6 +67,45 @@ export class MavftpAbortError extends Error {
   }
 }
 
+/**
+ * Bytes recovered from a transfer that did not finish.
+ *
+ * A failed burst is not necessarily a worthless one. The reader tracks a
+ * CONTIGUOUS frontier, so everything below it is known-good, and a dataflash
+ * log carries its FMT definitions at the front — which makes a prefix a
+ * genuinely parseable log that simply ends early. Throwing that away because
+ * the last packet never arrived discards a whole flight to save nothing.
+ */
+export interface PartialTransfer {
+  /** The contiguous prefix actually received. Never has holes. */
+  bytes: Uint8Array
+  /** Size the vehicle said the file was, for judging how much is missing. */
+  declaredSize: number
+}
+
+/**
+ * Carried on the rejected error rather than as a distinct error type, because
+ * callers already discriminate on MavftpAbortError / MavftpRequestError and a
+ * new type would silently change which branch they take. A symbol keeps it off
+ * the error's own enumerable surface.
+ */
+const PARTIAL_TRANSFER = Symbol.for('arduconfig.mavftp.partialTransfer')
+
+/** The bytes salvaged from a failed transfer, when there were any. */
+export function partialTransferOf(error: unknown): PartialTransfer | undefined {
+  if (typeof error !== 'object' || error === null) return undefined
+  const value = (error as Record<symbol, unknown>)[PARTIAL_TRANSFER]
+  return value as PartialTransfer | undefined
+}
+
+function attachPartialTransfer(error: Error, partial: PartialTransfer): void {
+  Object.defineProperty(error, PARTIAL_TRANSFER, {
+    value: partial,
+    enumerable: false,
+    configurable: true
+  })
+}
+
 interface BurstOperation {
   /** Detaches the abort listener, if one was attached. Called on every exit. */
   cleanup?: () => void
@@ -624,6 +663,15 @@ export class MavftpService {
     clearTimeout(op.timer)
     op.cleanup?.()
     this.activeBurst = undefined
+    // Hand back whatever arrived. `received` is the contiguous frontier, so the
+    // prefix is hole-free; the caller decides whether a partial file is worth
+    // anything, but it cannot decide that if we drop it here.
+    if (op.received > 0) {
+      attachPartialTransfer(error, {
+        bytes: op.buffer.slice(0, op.received),
+        declaredSize: op.declaredSize
+      })
+    }
     op.reject(error)
   }
 

--- a/tests/mavftp-partial-recovery.test.mjs
+++ b/tests/mavftp-partial-recovery.test.mjs
@@ -1,0 +1,129 @@
+// A failed burst must hand back what it managed to read.
+//
+// The reader tracks a CONTIGUOUS frontier, so bytes below it are known-good,
+// and a dataflash log carries its FMT definitions at the front — a prefix is a
+// real log that ends early. Discarding it because the last packet never
+// arrived throws away a whole flight to save nothing.
+//
+// The load-bearing property is that the salvaged prefix has NO HOLES. A buffer
+// with a gap in the middle would parse into confident nonsense, which is worse
+// than returning nothing at all.
+
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { MavftpService, MavftpAbortError, partialTransferOf } from '../packages/ardupilot-core/dist/index.js'
+
+/**
+ * A service whose burst never completes on its own, so the test decides when it
+ * ends. Only the transport is faked; the real op lifecycle, contiguity
+ * bookkeeping and failure path run. Same harness as mavftp-burst-abort.
+ */
+function createService() {
+  const service = new MavftpService({
+    send: async () => {},
+    getVehicle: () => ({ systemId: 1, componentId: 1 }),
+    appendStatusEntry: () => {},
+    emit: () => {}
+  })
+  service.ensureSupport = async () => {}
+  service.clearStaleSessionsOnce = async () => {}
+  service.terminateSession = async () => {}
+  service.sendBurstReadRequest = () => {}
+  return service
+}
+
+// A short timeout so the real failure path runs promptly. An earlier version
+// of this harness used the production 60 s and every test "passed" only after
+// waiting out the genuine timer — exercising the retry ladder by accident.
+const BURST_TIMEOUT_MS = 15
+/**
+ * Start a burst and return a promise of how it ENDED. The rejection handler is
+ * attached immediately and on purpose: the burst rejects while the test is
+ * still stalling the link, and a handler attached afterwards makes it an
+ * unhandled rejection.
+ */
+const startBurst = (service, declaredSize, signal) =>
+  service.runBurst(1, declaredSize, BURST_TIMEOUT_MS, undefined, signal).then(
+    () => new Error('the burst resolved; it was supposed to fail'),
+    (error) => error
+  )
+
+/** Feed one burst data packet of `length` bytes filled with `fill` at `offset`. */
+function burstPacket(service, { offset, length, fill }) {
+  service.handleBurstPacket({
+    opcode: 128,
+    session: 1,
+    size: length,
+    offset,
+    data: new Uint8Array(length).fill(fill)
+  })
+}
+
+/**
+ * Stop the burst the way a broken link does: stall until the retry budget is
+ * spent. Goes through the real timeout path rather than calling failBurst, so
+ * the salvage has to survive the retry ladder.
+ */
+const breakLink = () => new Promise((resolve) => setTimeout(resolve, BURST_TIMEOUT_MS * 12))
+
+test('a burst that dies partway attaches what it received to the error', async () => {
+  const service = createService()
+  const pending = startBurst(service, 4096)
+  burstPacket(service, { offset: 0, length: 1024, fill: 7 })
+  await breakLink()
+
+  const error = await pending
+  const partial = partialTransferOf(error)
+  assert.ok(partial, 'the failure discarded every byte it had already read')
+  assert.equal(partial.bytes.length, 1024)
+  assert.equal(partial.declaredSize, 4096)
+  assert.ok(partial.bytes.every((byte) => byte === 7), 'salvaged bytes should be the ones received')
+})
+
+test('the salvaged prefix stops at a HOLE rather than spanning it', async () => {
+  // The whole point. A packet at 2048 arriving after one at 0 leaves bytes
+  // 1024..2047 unwritten; returning 3072 bytes would hand back a buffer with a
+  // zero-filled gap, which parses into confident nonsense.
+  const service = createService()
+  const pending = startBurst(service, 8192)
+  burstPacket(service, { offset: 0, length: 1024, fill: 7 })
+  burstPacket(service, { offset: 2048, length: 1024, fill: 9 })
+  await breakLink()
+
+  const error = await pending
+  const partial = partialTransferOf(error)
+  assert.ok(partial)
+  assert.equal(partial.bytes.length, 1024, 'the prefix must not span the gap')
+  assert.ok(partial.bytes.every((byte) => byte === 7))
+})
+
+test('a burst that received nothing attaches nothing', async () => {
+  // An empty partial is not a zero-length file; there is simply nothing to say.
+  const service = createService()
+  const pending = startBurst(service, 4096)
+  await breakLink()
+  const error = await pending
+  assert.equal(partialTransferOf(error), undefined)
+})
+
+test('an aborted burst also carries its partial — the caller decides', async () => {
+  // Abort and failure are still distinguishable by error type; salvage is
+  // orthogonal to why the transfer stopped.
+  const controller = new AbortController()
+  const service = createService()
+  const pending = startBurst(service, 4096, controller.signal)
+  burstPacket(service, { offset: 0, length: 512, fill: 3 })
+  controller.abort()
+
+  const error = await pending
+  assert.ok(error instanceof MavftpAbortError, 'abort must stay distinguishable from failure')
+  assert.equal(partialTransferOf(error)?.bytes.length, 512)
+})
+
+test('partialTransferOf is safe on things that are not errors', () => {
+  assert.equal(partialTransferOf(undefined), undefined)
+  assert.equal(partialTransferOf(null), undefined)
+  assert.equal(partialTransferOf('nope'), undefined)
+  assert.equal(partialTransferOf(new Error('plain')), undefined)
+})


### PR DESCRIPTION
A MAVFTP burst that dies partway currently discards everything it read. The bytes are in the op's buffer when it rejects; the caller just never sees them.

They're worth having. The reader tracks a **contiguous frontier**, so everything below `received` is known-good with no holes, and a dataflash log carries its FMT definitions at the front — a prefix is a real log that ends early, not a corrupt one.

### Shape

Salvage rides on the rejected error, read via `partialTransferOf(error)`:

```ts
const partial = partialTransferOf(error)   // { bytes, declaredSize } | undefined
```

Not a new error type, deliberately: callers already discriminate on `MavftpAbortError` / `MavftpRequestError`, and introducing a type would silently change which branch they take. A symbol keeps it off the error's enumerable surface. Ignoring it leaves every existing caller behaving identically.

### The property that matters

The prefix **stops at a hole rather than spanning it**. A packet at 2048 arriving after one at 0 salvages 1024 bytes, not 3072 — a buffer with a zero-filled gap would parse into confident nonsense, which is worse than returning nothing. There's a test for exactly this.

Aborts carry their partial too; the error type still says why the transfer stopped, and the caller decides.

### ArduCopter byte-identical

Purely additive at the transport layer. No existing caller reads the new property, no thrown type changed, the resolve path is untouched.

### Validation

Rung 1. `npm run typecheck` clean, `npm run test` **851 pass / 0 fail** (5 new).

The new tests were mutation-checked — reverting the attach fails 3 of 5. Worth noting because an earlier draft of this test file passed for the wrong reason: it used the production 60 s timeout and each test only "passed" after waiting out the genuine timer.