### PR TITLE
fix(receiver): alphabetical AUX function list; make the motor-spin gate visible

### DIFF
--- a/apps/web/src/sections/CalibrationSection.tsx
+++ b/apps/web/src/sections/CalibrationSection.tsx
@@ -102,6 +102,15 @@ export function CalibrationSection(props: CalibrationSectionProps): ReactElement
   // signature change.
   void airframe
 
+  /**
+   * Both motor-spin acknowledgements, named once.
+   *
+   * The gate, the button's colour and the hint text must agree — they were
+   * three separate spellings of the same condition, which is how a button that
+   * could not run ended up looking exactly like one that could.
+   */
+  const motorSpinReady = propsRemovedAcknowledged && testAreaAcknowledged
+
   return (
 
         <section className="grid one-up">
@@ -449,15 +458,23 @@ export function CalibrationSection(props: CalibrationSectionProps): ReactElement
                                   data-testid="battery-current-load-throttle"
                                 />
                               </label>
+                              {/* Green once the safety checks are acknowledged.
+                                *  The button sat in the neutral style whether or
+                                *  not it was armed to run, so "have I done the
+                                *  thing that lets me press this?" was not
+                                *  answerable from the button — the operator had
+                                *  to look at a DIFFERENT card to find out. Same
+                                *  grammar as "Calibrate from measured current"
+                                *  below it, which is green when it can run. */}
                               <button
                                 type="button"
-                                style={buttonStyle()}
+                                style={buttonStyle(motorSpinReady ? 'primary' : 'secondary')}
                                 data-testid="battery-current-spin-motors"
                                 disabled={
                                   busyAction !== undefined ||
                                   snapshot.connection.kind !== 'connected' ||
                                   snapshot.vehicle?.armed === true ||
-                                  !(propsRemovedAcknowledged && testAreaAcknowledged) ||
+                                  !motorSpinReady ||
                                   snapshot.motorTest.status === 'requested' ||
                                   snapshot.motorTest.status === 'running'
                                 }
@@ -488,8 +505,11 @@ export function CalibrationSection(props: CalibrationSectionProps): ReactElement
                               >
                                 {snapshot.motorTest.status === 'running' ? 'Motors spinning…' : `Spin motors for ${BATTERY_CURRENT_LOAD_SECONDS} s`}
                               </button>
-                              {!(propsRemovedAcknowledged && testAreaAcknowledged) ? (
-                                <small>Acknowledge the motor-spin safety checks below before applying a load.</small>
+                              {!motorSpinReady ? (
+                                <small>
+                                  Tick both boxes in the <strong>Motor-spin safety</strong> card before applying a
+                                  load. This button turns green when it can run.
+                                </small>
                               ) : null}
                             </div>
                           ) : null}
@@ -680,7 +700,7 @@ export function CalibrationSection(props: CalibrationSectionProps): ReactElement
                 if (!isCopterVehicle) {
                   return null
                 }
-                const motorSafetyOk = propsRemovedAcknowledged && testAreaAcknowledged
+                const motorSafetyOk = motorSpinReady
                 const baseReady = snapshot.connection.kind === 'connected' && snapshot.vehicle?.armed !== true && busyAction === undefined
                 // ESC endpoint calibration is a PWM-era procedure — the ESCs learn
                 // min/max from the analog throttle-range pulses. It only applies to

--- a/packages/param-metadata/src/arducopter.ts
+++ b/packages/param-metadata/src/arducopter.ts
@@ -563,6 +563,30 @@ function buildSerialPortParameterDefinitions(maxPortNumber: number): FirmwareMet
 // The option list is generated from ArduPilot's own @Values annotations rather
 // than curated, because a hand-picked subset is exactly how an operator ends up
 // unable to find the function they need.
+/**
+ * RCn_OPTION options in ALPHABETICAL order rather than by value.
+ *
+ * The generated list is ~120 entries in firmware value order, which is an
+ * implementation detail of RC_Channel.cpp and means nothing to an operator:
+ * finding "Motor Emergency Stop" means scanning the whole list because there is
+ * no rule saying where it sits. Mission Planner sorts these by name and that is
+ * what people are used to.
+ *
+ * "Do Nothing" (0) is pinned first. It is the cleared state rather than a
+ * function, so it belongs where you look to unassign a channel — not filed
+ * under D.
+ */
+function rcOptionsAlphabetical(labelMap: Record<number, string>): ParameterValueOption[] {
+  const options = enumOptions(labelMap)
+  const none = options.filter((option) => option.value === 0)
+  const rest = options
+    .filter((option) => option.value !== 0)
+    // Numeric-aware so Relay2 sorts before Relay10, and case-insensitive so
+    // capitalisation in the firmware annotations does not split the list.
+    .sort((left, right) => left.label.localeCompare(right.label, 'en', { numeric: true, sensitivity: 'base' }))
+  return [...none, ...rest]
+}
+
 function buildRcOptionParameterDefinitions(
   minChannelNumber: number,
   maxChannelNumber: number
@@ -576,7 +600,7 @@ function buildRcOptionParameterDefinitions(
       description: `Auxiliary function assigned to RC channel ${channelNumber}. "Do Nothing" leaves the channel unused by the flight controller.`,
       category: 'receiver',
       notes: ['Assigning the same function to two channels is undefined — clear the old channel first.'],
-      options: enumOptions(ARDUCOPTER_RC_OPTION_LABELS)
+      options: rcOptionsAlphabetical(ARDUCOPTER_RC_OPTION_LABELS)
     }
   }
 


### PR DESCRIPTION
Two small field-reported UX fixes. Both presentation-only.

## 1. AUX function list is alphabetical (`1c65a07`)

> "I suspect these functions are in numerical order.... alphabetical was nice in MP"

`RCn_OPTION` listed ~120 functions in firmware **value** order — an implementation detail of `RC_Channel.cpp` that means nothing to an operator. Finding "Motor Emergency Stop" meant scanning the whole list, because nothing about the ordering says where it should be.

Sorted numeric-aware (so `Relay2` precedes `Relay10`) and case-insensitively (so capitalisation drift in the firmware annotations can't split the list). **"Do Nothing" is pinned first** rather than filed under D — it's the cleared state, not a function, so it belongs where you look to *unassign* a channel.

Scoped to `RCn_OPTION`. `SERVOn_FUNCTION` and the RCL_ mixer rows still use value order.

Only the **order** of an existing list changes — no option added, removed, or relabelled. Every selectable value, and anything written to the FC, is exactly as before.

**Not included:** the requested two-group split (common functions first, long tail after). That needs a decision about which functions are "useful" — a judgement about real workflows, where guessing would make the list worse than plain alphabetical.

## 2. The motor-spin gate is visible from the button (`78a1850`)

> "The Motor spin safety is in a separate box and it wasn't clear that I needed to check those boxes to start the battery current calibration."
> "The spin motors button should probably go green when the spin safety is acknowledged"

One cause behind both: you couldn't tell from the button whether it was armed to run.

- The safety checkboxes live in a **separate card beside** the battery-current card, but the hint said to acknowledge the checks *"below"* — so you'd scroll past the end of the card hunting for boxes that were never there. It now names the **Motor-spin safety** card.
- The button stayed neutral whether or not it could run. It's now green once acknowledged — the same grammar as "Calibrate from measured current" directly beneath it.
- The gate, the colour and the hint were three separate spellings of one condition; they're a single named flag now so they can't drift apart.

The gate itself is unchanged: same two acknowledgements, same disabled conditions. Nothing runnable now that wasn't before.

## ArduCopter byte-identical

Both changes are presentation-only. No parameter value, write path, or metadata semantics is touched.

## Validation

Rung 1. `npm run typecheck` clean; `npm run test` **846 pass / 0 fail**.

## Known, not fixed here

The same report noted that clicking Spin "just jerked the motors and didn't do anything… I heard a beep like the ESC reset," while arming via radio still works.

That reproduces from the code and is a **separate, real defect**. Copter's motor test is single-state — `motor_test_seq` / `motor_test_count` / `motor_test_start_ms` are file-static in `ArduCopter/motor_test.cpp`, and every `mavlink_motor_test_start` overwrites them. Our simultaneous path fires one `DO_MOTOR_TEST` per motor back-to-back on the premise that earlier motors keep spinning; that premise is false. Each command *replaces* the previous test, so only the last motor runs (the jerk), and `motor_test_start` setting `esc_calibration` / `ap.motor_test` re-initialises the outputs (the beep).

There is no `DO_MOTOR_TEST` that spins all motors simultaneously on Copter, so the "steady multi-motor load, read your meter" procedure can't be built on this command as designed. Fixing it changes what the operator is told to measure, so it needs a deliberate decision rather than a tweak — tracked separately.

Note this PR makes the button correctly signal "this will run" for something that then misbehaves.