### PR TITLE
refactor(config): split RC and Arming into their own tabs; RC protocol first

### DIFF
--- a/apps/web/src/hooks/use-config-sections.ts
+++ b/apps/web/src/hooks/use-config-sections.ts
@@ -22,9 +22,8 @@ const CATEGORY_BY_SECTION: Record<string, ConfigCategoryId> = {
   'system-rates': 'sensors',
   'fast-loop-rate': 'sensors',
   gps: 'gps',
-  'receiver-signal': 'rc-arming',
-  arming: 'rc-arming',
-  'pilot-rates': 'rc-arming',
+  'receiver-signal': 'rc',
+  arming: 'arming',
   identity: 'system',
   logging: 'system',
   beeper: 'system',
@@ -38,7 +37,7 @@ const CATEGORY_BY_SECTION: Record<string, ConfigCategoryId> = {
 // Field feedback: this was folding away far too much. The disclosure mechanism
 // is worth keeping — some of these genuinely are set-once-and-forget — but the
 // bar is now "an operator would have to go looking for this", not "it isn't one
-// of the first two knobs". Notably RC & Arming is fully visible (an operator
+// of the first two knobs". Notably RC and Arming are fully visible (an operator
 // tuning a radio needs the protocol and options in front of them), and the
 // logging + gyro-rate settings are visible because they are routinely changed
 // per-build rather than once at bring-up.
@@ -50,10 +49,9 @@ const ADVANCED_FIELDS: Record<string, readonly string[]> = {
   // field report asked for it directly under Sensors).
   'system-rates': ['INS_FAST_SAMPLE'],
   'fast-loop-rate': ['FSTRATE_DIV'],
-  'pilot-rates': [],
   'active-imu': [],
   gps: ['GPS_GNSS_MODE'],
-  // RC & Arming: everything visible, per the field report.
+  // RC + Arming: everything visible, per the field report.
   'receiver-signal': [],
   arming: [],
   identity: ['SYSID_MYGCS', 'BRD_BOOT_DELAY'],
@@ -87,10 +85,8 @@ export function useConfigSections(snapshot: ConfiguratorSnapshot) {
   // build-time option — plenty of Copter builds (e.g. the RADIX 2 HD) compile
   // without it and never stream FSTRATE_ENABLE. Gate the section on the param
   // actually being present so those FCs don't render an empty "(not reported)"
-  // Fast loop rate card. Pilot-rate params are always present on Copter, but
-  // gate on PILOT_Y_RATE too for symmetry / partial param tables.
+  // Fast loop rate card.
   const hasFastRate = configParametersById.has('FSTRATE_ENABLE')
-  const hasPilotRates = configParametersById.has('PILOT_Y_RATE')
   // Compass section — gate on COMPASS_USE (present whenever a compass subsystem
   // is compiled in). Extra compasses / the disable mask only render when the FC
   // actually reports them, so a single-compass board stays uncluttered.
@@ -98,12 +94,6 @@ export function useConfigSections(snapshot: ConfiguratorSnapshot) {
   // Frame class/type — present on Copter (and Heli); Plane/Rover use different
   // frame params, so gate on FRAME_CLASS actually being in the synced tree.
   const hasFrame = configParametersById.has('FRAME_CLASS')
-  // Max lean angle was renamed ANGLE_MAX (cdeg) -> ATC_ANGLE_MAX (deg) in
-  // ArduPilot 4.7. Bind the field to whichever the FC actually streams so it
-  // stops reading "(not reported)" on 4.7+.
-  const leanAngleParamId = configParametersById.has('ATC_ANGLE_MAX') ? 'ATC_ANGLE_MAX' : 'ANGLE_MAX'
-  const leanAngleUnit = leanAngleParamId === 'ATC_ANGLE_MAX' ? 'deg' : 'cdeg'
-  const leanAngleDigits = leanAngleParamId === 'ATC_ANGLE_MAX' ? 1 : 0
   // Pre-arm checks bitmask: ArduPilot 4.7 replaced ARMING_CHECK (checks to
   // PERFORM, with an "All" bit) with ARMING_SKIPCHK (checks to SKIP, inverted,
   // no "All"; default 0 = run everything). Can't be aliased — the meaning
@@ -210,29 +200,16 @@ export function useConfigSections(snapshot: ConfiguratorSnapshot) {
           }
         ]
       : []),
-    // Pilot rates — the same curated knobs the Tuning tab exposes
-    // (PILOT_Y_RATE/EXPO yaw stick shaping, ANGLE_MAX lean limit, ACRO_*
-    // acro rates/expo), mirrored here so they can be reviewed alongside the
-    // rest of the config. Copter-only; ACRO_*/PILOT_Y_* are not Plane/Rover
-    // params.
-    ...(activeVehicle === 'ArduCopter' && hasPilotRates
-      ? [
-          {
-            id: 'pilot-rates',
-            title: 'Pilot rates',
-            description: 'Stick-response shaping: yaw rate/expo, the max lean angle, and acro roll/pitch/yaw rates + expo. Mirrored from the Tuning tab for review alongside the rest of the config.',
-            fields: [
-              { paramId: 'PILOT_Y_RATE', label: 'Pilot yaw rate', unit: 'deg/s', digits: 0 },
-              { paramId: 'PILOT_Y_EXPO', label: 'Pilot yaw expo', digits: 2 },
-              { paramId: leanAngleParamId, label: 'Max lean angle', unit: leanAngleUnit, digits: leanAngleDigits },
-              { paramId: 'ACRO_RP_RATE', label: 'Acro roll/pitch rate', unit: 'deg/s', digits: 0 },
-              { paramId: 'ACRO_Y_RATE', label: 'Acro yaw rate', unit: 'deg/s', digits: 0 },
-              { paramId: 'ACRO_RP_EXPO', label: 'Acro roll/pitch expo', digits: 2 },
-              { paramId: 'ACRO_Y_EXPO', label: 'Acro yaw expo', digits: 2 }
-            ]
-          }
-        ]
-      : []),
+    // Pilot rates (PILOT_Y_RATE/EXPO, the lean-angle limit, ACRO_* rates/expo)
+    // used to be mirrored here as a third card on the RC tab. Field report:
+    // they read as the FIRST thing on a tab whose job is getting a radio
+    // talking, which is the wrong order — and they were only ever a mirror of
+    // the Tuning tab, which already renders every one of those params
+    // (TUNING_FLIGHT_FEEL_PARAM_IDS + TUNING_ACRO_PARAM_IDS) with sliders,
+    // unit handling and the 4.5+/4.7 ANGLE_MAX -> ATC_ANGLE_MAX rename already
+    // covered. Stick shaping is a tuning job, so Tuning is the home; the mirror
+    // is dropped rather than moved to another Config tab so there is exactly one
+    // place these are edited. Nothing became unreachable.
     {
       id: 'active-imu',
       title: 'Active IMU',
@@ -259,21 +236,25 @@ export function useConfigSections(snapshot: ConfiguratorSnapshot) {
     {
       id: 'receiver-signal',
       title: 'Receiver & signal',
-      description: 'RC link and signal settings, mirrored from the Receiver tab so they can be reviewed alongside the rest of the config. Use the Receiver tab for the guided stage/review signal-setup flow; RSSI source, mode channel, RC options, and accepted RC protocols are all here too.',
+      description: 'RC link and signal settings, mirrored from the Receiver tab so they can be reviewed alongside the rest of the config. Set the accepted RC protocols and RC options first — radio calibration cannot run until the link is actually decoding. Use the Receiver tab for the guided stage/review signal-setup flow; RSSI source and mode channel are here too.',
       fields: [
+        // Protocol + options lead the card. Earlier ordering put RC_PROTOCOLS at
+        // the BOTTOM on the theory that it is set once at install — but the
+        // field report is that radio calibration is impossible until the
+        // protocol is right, so the operator who most needs this knob is
+        // exactly the one who cannot yet see any RC values on screen. Reading
+        // order now matches setup order: make the link decode, then shape it.
+        // (Display order only — writes are staged/applied from the draft pool,
+        // which is keyed by parameter id and unaffected by card layout.)
+        { paramId: 'RC_PROTOCOLS', label: 'RC protocols (type)', digits: 0 },
+        { paramId: 'RC_OPTIONS', label: 'RC options', digits: 0 },
         { paramId: 'RSSI_TYPE', label: 'RSSI source', digits: 0 },
         { paramId: 'RSSI_CHANNEL', label: 'RSSI channel', digits: 0 },
         // Mode channel param is vehicle-specific: Rover uses MODE_CH, Copter/
         // Plane use FLTMODE_CH, and Sub has no RC mode channel (button modes).
         ...(activeVehicle === 'ArduSub'
           ? []
-          : [{ paramId: activeVehicle === 'ArduRover' ? 'MODE_CH' : 'FLTMODE_CH', label: 'Flight-mode channel', digits: 0 }]),
-        { paramId: 'RC_OPTIONS', label: 'RC options', digits: 0 },
-        // RC protocol bitmask moves to the BOTTOM of the section so the
-        // higher-frequency knobs (RSSI / mode channel / RC options) stay
-        // above the fold — RC_PROTOCOLS is set once at install and rarely
-        // touched afterwards.
-        { paramId: 'RC_PROTOCOLS', label: 'RC protocols (type)', digits: 0 }
+          : [{ paramId: activeVehicle === 'ArduRover' ? 'MODE_CH' : 'FLTMODE_CH', label: 'Flight-mode channel', digits: 0 }])
       ]
     },
     {
@@ -335,11 +316,7 @@ export function useConfigSections(snapshot: ConfiguratorSnapshot) {
   ] as readonly ConfigSection[]).map(categorize), [
     activeVehicle,
     hasFastRate,
-    hasPilotRates,
     hasFrame,
-    leanAngleParamId,
-    leanAngleUnit,
-    leanAngleDigits,
     armingChecksParamId,
     armingChecksLabel,
     armingDescription

--- a/apps/web/src/views/Config.tsx
+++ b/apps/web/src/views/Config.tsx
@@ -33,7 +33,7 @@ export interface ConfigSectionField {
 }
 
 /** Config category ids — the top tab groups. */
-export type ConfigCategoryId = 'airframe' | 'sensors' | 'gps' | 'rc-arming' | 'system'
+export type ConfigCategoryId = 'airframe' | 'sensors' | 'gps' | 'rc' | 'arming' | 'system'
 
 export interface ConfigCategory {
   id: ConfigCategoryId
@@ -42,11 +42,19 @@ export interface ConfigCategory {
 
 // Tab order across the top of the Config surface. One calm group at a time
 // instead of 14 stacked cards.
+//
+// RC and Arming used to share one "RC & Arming" tab. Field report: they are
+// unrelated jobs that happen to both involve the pilot — an operator wiring a
+// receiver is not thinking about pre-arm checks, and an operator debugging a
+// refused arm is not thinking about RSSI. Splitting them means the RC tab can
+// lead with the two knobs that are prerequisites for the radio working at all
+// (protocol + options) instead of burying them under someone else's card.
 export const CONFIG_CATEGORIES: readonly ConfigCategory[] = [
   { id: 'airframe', label: 'Airframe' },
   { id: 'sensors', label: 'Sensors' },
   { id: 'gps', label: 'GPS' },
-  { id: 'rc-arming', label: 'RC & Arming' },
+  { id: 'rc', label: 'RC' },
+  { id: 'arming', label: 'Arming' },
   { id: 'system', label: 'System' }
 ]
 
@@ -224,7 +232,7 @@ export function ConfigView(props: ConfigViewProps) {
     <div id="setup-panel-config">
       <Panel
         title="Config"
-        subtitle="Airframe, sensors, GPS, RC & arming, and system settings — grouped so you only see one area at a time."
+        subtitle="Airframe, sensors, GPS, RC, arming, and system settings — grouped so you only see one area at a time."
       >
         {presentCategories.length > 1 ? (
           <div className="tab-strip config-category-nav" data-testid="config-category-nav" role="tablist">

--- a/tests/e2e/app.spec.ts
+++ b/tests/e2e/app.spec.ts
@@ -671,8 +671,8 @@ test.describe('browser configurator regression flows', () => {
   test('Config arming checks render as a bitmask chip grid', async ({ page }) => {
     await connectToVehicle(page, 'demo')
     await openView(page, 'config')
-    // Arming lives under the "RC & Arming" category tab now.
-    await page.getByTestId('config-category-rc-arming').click()
+    // Arming has its own category tab now (split out of "RC & Arming").
+    await page.getByTestId('config-category-arming').click()
 
     // ARMING_CHECK is flagged bitmask, so the Config arming section shows
     // per-bit chips. Demo seeds ARMING_CHECK=1 (bit 0 = "All checks").

--- a/tests/e2e/views.spec.ts
+++ b/tests/e2e/views.spec.ts
@@ -188,9 +188,8 @@ const CONFIG_SECTION_CATEGORY: Record<string, string> = {
   'system-rates': 'sensors',
   'fast-loop-rate': 'sensors',
   gps: 'gps',
-  'receiver-signal': 'rc-arming',
-  arming: 'rc-arming',
-  'pilot-rates': 'rc-arming',
+  'receiver-signal': 'rc',
+  arming: 'arming',
   identity: 'system',
   logging: 'system',
   beeper: 'system',
@@ -1228,6 +1227,28 @@ test.describe('Tuning tab', () => {
     await expect(input).toHaveValue('0.15')
   })
 
+  test('pilot rates (lean angle, yaw rate, acro rates) are reachable here', async ({ page }) => {
+    // Coverage moved from the Config "pilot rates" mirror card, which was
+    // dropped when Arming and RC split into their own Config tabs: Tuning is
+    // the single home for stick shaping now, so every param that card carried
+    // has to be reachable here or the split lost a surface.
+    await page.goto('/')
+    await connectViaHeader(page)
+    await openView(page, 'tuning')
+
+    await page.locator('details.bf-gui-box > summary').filter({ hasText: 'Angle' }).click()
+    // Lean angle resolves to whichever param the FC streams (ANGLE_MAX <= 4.6,
+    // ATC_ANGLE_MAX 4.7+); the demo Copter streams ANGLE_MAX.
+    await expect(page.getByTestId('tuning-input-ANGLE_MAX')).toBeVisible({ timeout: 10000 })
+    await expect(page.getByTestId('tuning-input-PILOT_Y_RATE')).toBeVisible()
+    await expect(page.getByTestId('tuning-input-PILOT_Y_EXPO')).toBeVisible()
+    await page.locator('details.bf-gui-box > summary').filter({ hasText: 'Acro' }).click()
+    await expect(page.getByTestId('tuning-input-ACRO_RP_RATE')).toBeVisible()
+    await expect(page.getByTestId('tuning-input-ACRO_Y_RATE')).toBeVisible()
+    await expect(page.getByTestId('tuning-input-ACRO_RP_EXPO')).toBeVisible()
+    await expect(page.getByTestId('tuning-input-ACRO_Y_EXPO')).toBeVisible()
+  })
+
   test('the slider tracks live while dragging and only stages on release', async ({ page }) => {
     await page.goto('/')
     await connectViaHeader(page)
@@ -1667,13 +1688,13 @@ test.describe('Config view', () => {
 
     await expect(page.getByTestId('config-section-grid')).toBeVisible()
     // Sections live under top-tab categories now — the category strip shows the
-    // five groups, and each holds its sections.
+    // six groups, and each holds its sections.
     await expect(page.getByTestId('config-category-nav')).toBeVisible()
     for (const [sectionId, category] of [
       ['board-orientation', 'airframe'],
       ['gps', 'gps'],
-      ['arming', 'rc-arming'],
-      ['pilot-rates', 'rc-arming'],
+      ['receiver-signal', 'rc'],
+      ['arming', 'arming'],
       ['identity', 'system'],
       ['beeper', 'system'],
       ['camera-trigger', 'system'],
@@ -1899,12 +1920,43 @@ test.describe('Config view', () => {
     await openConfigSection(page, 'receiver-signal')
     const section = page.getByTestId('config-section-receiver-signal')
     await expect(section).toBeVisible()
-    // RC_OPTIONS is visible without opening anything: RC & Arming no longer
-    // folds fields under Advanced (an operator setting up a radio needs the
-    // protocol and options in front of them).
+    // RC_OPTIONS is visible without opening anything: the RC tab does not fold
+    // fields under Advanced (an operator setting up a radio needs the protocol
+    // and options in front of them).
     await expect(section.getByTestId('config-advanced-receiver-signal')).toHaveCount(0)
     // RC_OPTIONS renders as a chip grid here too (shared bitmask field).
     await expect(page.getByTestId('scoped-bitmask-RC_OPTIONS')).toBeVisible()
+    // Protocol + options lead the card. Radio calibration is impossible until
+    // the link decodes, so the prerequisite knobs must read first — assert on
+    // DOM order rather than mere presence, which is what regressed before.
+    const fieldOrder = await section
+      .locator('[data-testid^="scoped-"], [data-testid^="config-field-missing-"]')
+      .evaluateAll((nodes) => nodes.map((node) => node.getAttribute('data-testid') ?? ''))
+    const indexOfParam = (paramId: string): number =>
+      fieldOrder.findIndex((testId) => testId.endsWith(`-${paramId}`))
+    expect(indexOfParam('RC_PROTOCOLS')).toBeGreaterThanOrEqual(0)
+    expect(indexOfParam('RC_PROTOCOLS')).toBeLessThan(indexOfParam('RC_OPTIONS'))
+    expect(indexOfParam('RC_OPTIONS')).toBeLessThan(indexOfParam('RSSI_TYPE'))
+  })
+
+  test('Arming has its own category tab, separate from RC', async ({ page }) => {
+    await page.goto('/')
+    await page.getByTestId('transport-mode-select').selectOption('demo')
+    await page.getByTestId('connect-button').click()
+    await page.getByTestId('view-button-config').click()
+
+    // Arming is its own group now: its tab exists, holds the arming card, and
+    // the RC tab must NOT also carry it (the old shared "RC & Arming" tab).
+    await page.getByTestId('config-category-arming').click()
+    await expect(page.getByTestId('config-section-arming')).toBeVisible()
+    await expect(page.getByTestId('config-section-receiver-signal')).toHaveCount(0)
+
+    await page.getByTestId('config-category-rc').click()
+    await expect(page.getByTestId('config-section-receiver-signal')).toBeVisible()
+    await expect(page.getByTestId('config-section-arming')).toHaveCount(0)
+    // Pilot rates left Config entirely — Tuning is the single home for stick
+    // shaping now, so no Config tab may resurrect the mirror.
+    await expect(page.getByTestId('config-section-pilot-rates')).toHaveCount(0)
   })
 
   test('ESC & DShot section exposes protocol + reverse/bdshot masks as chips', async ({ page }) => {
@@ -1967,14 +2019,6 @@ test.describe('Config view', () => {
     // Main loop rate renders as a dropdown (enum), defaulting to 400 Hz.
     const rates = page.getByTestId('config-section-system-rates')
     await expect(rates.getByText('Main loop rate')).toBeVisible()
-
-    // Max lean angle (pilot-rates, RC & Arming tab). Resolves to the param the
-    // FC actually streams (ANGLE_MAX <=4.6, ATC_ANGLE_MAX 4.7+) — demo streams
-    // ANGLE_MAX, so it reports a value rather than "(not reported)".
-    await openConfigSection(page, 'pilot-rates')
-    const pilotRates = page.getByTestId('config-section-pilot-rates')
-    await expect(pilotRates.getByText('Max lean angle')).toBeVisible()
-    await expect(pilotRates).not.toContainText('not reported')
 
     // GPS behavior — the multi-GPS knobs (Auto switch / Primary select) are
     // set-once, folded under Advanced.


### PR DESCRIPTION
Field feedback on the Config **RC & Arming** tab:

> "Right now has pilot rates first — those could go under a different tab. Should pull the RC protocol and options to the top. Move the Arming stuff to a new tab."

And, relatedly:

> "radio calibration isn't possible without setting up the params first. Depending on the type of radio that means digging in."

## What changed

**RC and Arming are separate tabs.** Category strip is now Airframe / Sensors / GPS / RC / Arming / System. The arming card itself is untouched — it just has its own home instead of sharing one.

**RC protocol and options lead the Receiver & signal card.** Order is now `RC_PROTOCOLS`, `RC_OPTIONS`, `RSSI_TYPE`, `RSSI_CHANNEL`, flight-mode channel — previously RSSI came first and `RC_PROTOCOLS` was deliberately *last*. That inversion is the point: the protocol has to be right before calibration can run at all, so it belongs where you start reading rather than where you finish. The card copy now says so.

Display order only. The apply batch is built from the draft pool keyed by param id, not from card layout.

**Pilot rates are removed from Config rather than moved to another Config tab.** That card was a mirror of Tuning, and Tuning already renders all seven params (`TUNING_FLIGHT_FEEL_PARAM_IDS` + `TUNING_ACRO_PARAM_IDS`) with sliders, cdeg/deg handling, and both `ANGLE_MAX` / `ATC_ANGLE_MAX` forms for the 4.7 rename. Two editors for the same parameter is how they drift apart, so Tuning is the single home.

The e2e coverage that lived on the Config mirror (lean angle resolving to whichever param the FC actually streams) moved to a Tuning-tab test asserting all seven controls render.

### Consequence worth stating plainly

Dropping that card removes those seven ids from `isConfigParamId`, so a staged `PILOT_Y_RATE` / `ACRO_*` draft is now flushed by **Tuning's Apply** rather than **Apply Config**. Same runtime `setParameters` path, same values, same verified per-param write — but a different button flushes them. Confirmed as intended.

## Guided-setup coupling

This repo has bitten itself here before: guided steps gate on state that specific UI sets, and moving that UI silently breaks the step (the old "power step" report). So this was audited rather than assumed — `setup-flow-sections.ts`, `setup-flow-helpers.ts`, and every reference to `configSections`, `ConfigCategoryId`, `isConfigParamId`, `pilot-rates`, `rc-arming`, `PILOT_*`, `ACRO_*`, `ARMING_*`.

**No guided step gates on, anchors into, or scrolls to a Config category or section id.** Panel anchors resolve to panel DOM ids, and `setup-panel-config` is the Config view's outer wrapper, which is untouched. Every criterion reads the snapshot, never Config card state. The `radio` step gates on `rcMappingSession` / `rcRangeExercise` / `rcCalibrationSession` — all set by the **Receiver** view, not the Config RC card — and its RCIN detour points at `setup-panel-ports`. There is no arming step. Nothing required updating.

## ArduCopter byte-identical

Layout and navigation only, `apps/web` only. No parameter value, PARAM_SET path, write ordering, tolerance, or metadata semantics changed. Blast radius is the apply-button change stated above.

## Validation

Rungs 1–3.

- `npm run typecheck` — clean
- `npm run test` — **846 pass / 0 fail / 3 skipped**
- `apps/web` vitest — 72 files, **634 pass**
- `npm run test:e2e` — **236 passed, 6 skipped (visual baselines), 0 failed**, first run, no flakes
- **390px** — the phone-layout gate navigates to Config and asserts no horizontal overflow; passes, since `.tab-strip` wraps rather than overflowing with a sixth tab

No rung 4/5: there is no runtime or write-path change to exercise.

New e2e asserts the Arming tab holds only arming, the RC tab holds only receiver-signal, pilot-rates is gone, and `RC_PROTOCOLS` precedes `RC_OPTIONS` precedes `RSSI_TYPE` in DOM order.

Independently verified before opening: the 8 removed ids (7 params — `ANGLE_MAX`/`ATC_ANGLE_MAX` are the two forms of the 4.7 rename) are all present in `tuning-params.ts`, so nothing became unreachable.