### PR TITLE
feat(status): live rangefinder and optical-flow cards

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -332,6 +332,9 @@ import { SetupWizardHeader } from './sections/SetupWizardHeader'
 import { SetupWizardDetail } from './sections/SetupWizardDetail'
 import { SetupBenchActions } from './sections/SetupBenchActions'
 import { StatusDfuCard } from './sections/StatusDfuCard'
+import { AdvancedSensorCard } from './views/AdvancedSensorCard'
+import { buildAdvancedSensorCards } from './view-models/advanced-sensor-cards'
+import { useStatusClock } from './hooks/use-status-clock'
 import { ResetToDefaultsButton } from './views/ResetToDefaultsButton'
 import { CalibrationLocationButton } from './sections/CalibrationLocationCard'
 import { resolveSetupConfirmationRecord } from './view-models/setup-confirmation-resolve'
@@ -1632,6 +1635,11 @@ export function App() {
     setupConfirmations,
     setupProgressKey
   ])
+
+  // Drives the "last data / no data for N s" freshness readouts on the
+  // Status & Info sensor cards. Only runs while that tab is open and a
+  // vehicle is connected — nothing else in the app needs a wall clock.
+  const statusClockMs = useStatusClock(activeViewId === 'setup' && snapshot.connection.kind === 'connected')
 
   useEffect(() => {
     trackViewPageview(activeViewId)
@@ -6527,9 +6535,14 @@ export function App() {
   const headerMagActive =
     snapshot.connection.kind === 'connected' &&
     (compassSetupAvailability.enabledCompassCount > 0 || snapshot.liveVerification.magSensor.verified)
+  // RNGFND1_TYPE, falling back to the pre-4.5 unnumbered RNGFND_TYPE. Kept as
+  // `undefined` when neither is in the table: "not synced yet" is not the same
+  // claim as "the sensor is switched off", and the Status card must not make
+  // the second claim while only the first is true.
+  const rangefinderTypeValue = (selectParameterById(snapshot, 'RNGFND1_TYPE') ?? selectParameterById(snapshot, 'RNGFND_TYPE'))
+    ?.value
   const headerRangefinderActive =
-    snapshot.connection.kind === 'connected' &&
-    ((selectParameterById(snapshot, 'RNGFND1_TYPE') ?? selectParameterById(snapshot, 'RNGFND_TYPE'))?.value ?? 0) !== 0
+    snapshot.connection.kind === 'connected' && (rangefinderTypeValue ?? 0) !== 0
   // Flow chip: lit if OPTICAL_FLOW (msgid 100) is heartbeating. ArduCopter
   // streams it at 10 Hz when an optical-flow sensor is wired, so a 2s
   // freshness window comfortably covers ~20 expected messages — a single
@@ -6555,14 +6568,36 @@ export function App() {
     }
     if (!flowTypeConfigured) {
       return flowTypeValue === undefined
-        ? 'FLOW_TYPE is not in the parameter table yet — finish parameter sync, then set FLOW_TYPE to your sensor (e.g. 10 HereFlow, 8 PMW3901) to enable the optical flow stream.'
-        : 'FLOW_TYPE is 0 (disabled). Set FLOW_TYPE to your sensor (e.g. 10 HereFlow, 8 PMW3901) and reboot to enable the optical flow stream.'
+        // Driver numbers per AP_OpticalFlow.h `Type` / the FLOW_TYPE @Values
+        // block in AP_OpticalFlow.cpp — 6 is DroneCAN (HereFlow) and 8 is
+        // UPFLOW. The previous copy here said "10 HereFlow, 8 PMW3901"; 10 is
+        // SITL and PMW3901 is not a FLOW_TYPE option at all, so it pointed
+        // operators at a value that would never work.
+        ? 'FLOW_TYPE is not in the parameter table yet — finish parameter sync, then set FLOW_TYPE to your sensor (e.g. 6 DroneCAN/HereFlow, 4 CXOF, 1 PX4Flow) to enable the optical flow stream.'
+        : 'FLOW_TYPE is 0 (disabled). Set FLOW_TYPE to your sensor (e.g. 6 DroneCAN/HereFlow, 4 CXOF, 1 PX4Flow) and reboot to enable the optical flow stream.'
     }
     if (snapshot.liveVerification.opticalFlow.lastSeenAtMs !== undefined) {
       return `FLOW_TYPE=${flowTypeValue} is configured and the sensor was reporting, but the OPTICAL_FLOW stream has gone silent. Check the sensor wiring or the driver-specific bus.`
     }
     return `FLOW_TYPE=${flowTypeValue} is configured but no OPTICAL_FLOW messages have arrived yet. Verify the sensor wiring; some drivers need a reboot after FLOW_TYPE changes.`
   })()
+  // Status & Info advanced sensor cards (rangefinder + optical flow). The
+  // builder decides both the state and whether a card exists at all, so an
+  // unconfigured sensor simply produces nothing to render here — GPS and
+  // compass stay unconditional, everything above them is opt-in.
+  //
+  // `nowMs` is `statusClockMs`, a ~1 Hz ticking clock rather than Date.now():
+  // the card has to be able to age from "reporting" into "data stopped"
+  // without a snapshot arriving, and a snapshot is exactly what stops arriving
+  // when the sensor dies. Reading Date.now() during render would freeze the
+  // age at the last snapshot and the card would sit on a stale number forever.
+  const advancedSensorCards = buildAdvancedSensorCards({
+    connected: snapshot.connection.kind === 'connected',
+    liveVerification: snapshot.liveVerification,
+    rangefinderType: rangefinderTypeValue,
+    flowType: flowTypeValue,
+    nowMs: statusClockMs
+  })
   const headerWarningActive =
     !snapshot.preArmStatus.healthy || snapshot.statusTexts.some((entry) => entry.severity === 'warning' || entry.severity === 'error')
   const headerBatteryLabel = snapshot.liveVerification.batteryTelemetry.verified
@@ -7200,6 +7235,15 @@ export function App() {
                             ) : null}
                           </div>
                         </article>
+
+                        {/* Advanced sensors, below GPS. Each card only exists
+                         *  when the operator has actually configured that
+                         *  sensor — GPS and compass are the baseline, anything
+                         *  past them is opt-in, so an FPV quad with no lidar
+                         *  and no flow sees this space unchanged. */}
+                        {advancedSensorCards.map((card) => (
+                          <AdvancedSensorCard key={card.id} card={card} />
+                        ))}
 
                       </div>
                     </div>

--- a/apps/web/src/hooks/use-status-clock.ts
+++ b/apps/web/src/hooks/use-status-clock.ts
@@ -1,0 +1,38 @@
+import { useEffect, useState } from 'react'
+
+/**
+ * A coarse 1 Hz "what time is it now" clock for freshness readouts.
+ *
+ * The Status & Info sensor cards have to be able to age from "reporting" into
+ * "no data for 12 s" on their own. Everything else in the app re-renders when
+ * a snapshot arrives — but a snapshot arriving is exactly what STOPS happening
+ * when the sensor being watched dies, so a card that read `Date.now()` during
+ * render would freeze at the moment of the last message and keep displaying a
+ * stale distance as though the sensor were healthy. That is the single worst
+ * failure mode for this feature, so the clock is explicit.
+ *
+ * 1 Hz because the smallest unit any of these readouts prints is one second;
+ * ticking faster would only cost renders. `enabled` keeps it switched off
+ * entirely when nothing is displaying a freshness value, so the rest of the
+ * app pays nothing for it.
+ */
+export function useStatusClock(enabled: boolean): number {
+  const [nowMs, setNowMs] = useState(() => Date.now())
+
+  useEffect(() => {
+    if (!enabled) {
+      return
+    }
+    // Re-sync immediately on enable so a tab switch shows a current age
+    // rather than whatever the clock read when the app started.
+    setNowMs(Date.now())
+    const interval = window.setInterval(() => {
+      setNowMs(Date.now())
+    }, 1000)
+    return () => {
+      window.clearInterval(interval)
+    }
+  }, [enabled])
+
+  return nowMs
+}

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -2908,6 +2908,65 @@ textarea:focus {
   box-shadow: inset 0 0 0 1px rgba(150, 226, 18, 0.08);
 }
 
+/* Advanced sensor boxes (rangefinder / optical flow).
+ *
+ * "More colours might be good" — the operator wants the state readable at a
+ * glance, so the whole card border and a left rail carry the tone rather than
+ * just the badge. Colour is never the ONLY signal: the badge text and the
+ * headline copy say the same thing in words, and the state also lands on a
+ * `data-sensor-state` attribute for tests and assistive tooling.
+ *
+ * Tokens are the same --success / --warning / --danger the StatusBadge uses,
+ * so these cards stay in step with the rest of the app under any theme. */
+.setup-gui-box--sensor-reporting {
+  border-color: color-mix(in srgb, var(--success, #7fb966) 45%, transparent);
+  box-shadow: inset 3px 0 0 0 var(--success, #7fb966);
+}
+
+.setup-gui-box--sensor-degraded {
+  border-color: color-mix(in srgb, var(--warning, #ff6600) 55%, transparent);
+  box-shadow: inset 3px 0 0 0 var(--warning, #ff6600);
+}
+
+/* `silent` and `stalled` are both hard faults and share the danger treatment;
+ * the words distinguish them ("never reported" vs "was reporting, then
+ * stopped"), because a fourth colour would be noise, not information. */
+.setup-gui-box--sensor-silent,
+.setup-gui-box--sensor-stalled {
+  border-color: color-mix(in srgb, var(--danger, #e2123f) 55%, transparent);
+  box-shadow: inset 3px 0 0 0 var(--danger, #e2123f);
+}
+
+/* The fault/OK headline, on the face of the card. This is deliberately NOT a
+ * tooltip: in the field the hover-only version made an operator go looking
+ * for the one line that diagnosed their problem. */
+.setup-gui-box__sensor-headline {
+  margin: 0;
+  font-size: 0.82rem;
+  font-weight: 600;
+  line-height: 1.35;
+}
+
+.setup-gui-box__sensor-headline--success {
+  color: var(--success, #7fb966);
+}
+
+.setup-gui-box__sensor-headline--warning {
+  color: var(--warning, #ff6600);
+}
+
+.setup-gui-box__sensor-headline--danger {
+  color: var(--danger, #e2123f);
+}
+
+/* The headline measurement row — the number the operator actually came for.
+ * Slightly larger and tabular so a changing distance doesn't jitter the
+ * layout as digits change width. */
+.setup-gui-box__kv-row--measurement strong {
+  font-size: 1.02rem;
+  font-variant-numeric: tabular-nums;
+}
+
 .setup-gui-box__titlebar {
   position: absolute;
   top: -10px;

--- a/apps/web/src/view-models/advanced-sensor-cards.test.ts
+++ b/apps/web/src/view-models/advanced-sensor-cards.test.ts
@@ -1,0 +1,212 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  ADVANCED_SENSOR_FRESHNESS_MS,
+  buildAdvancedSensorCards,
+  buildOpticalFlowCard,
+  buildRangefinderCard,
+  type AdvancedSensorCardsInput
+} from './advanced-sensor-cards'
+
+const NOW = 1_700_000_000_000
+
+function input(overrides: {
+  connected?: boolean
+  rangefinderType?: number | undefined
+  flowType?: number | undefined
+  rangefinder?: Record<string, unknown>
+  opticalFlow?: Record<string, unknown>
+}): AdvancedSensorCardsInput {
+  return {
+    connected: overrides.connected ?? true,
+    rangefinderType: 'rangefinderType' in overrides ? overrides.rangefinderType : undefined,
+    flowType: 'flowType' in overrides ? overrides.flowType : undefined,
+    nowMs: NOW,
+    liveVerification: {
+      rangefinder: { verified: false, ...(overrides.rangefinder ?? {}) },
+      opticalFlow: { verified: false, ...(overrides.opticalFlow ?? {}) }
+    } as unknown as AdvancedSensorCardsInput['liveVerification']
+  }
+}
+
+/** A rangefinder that is configured and streaming a good reading. */
+const reportingRangefinder = {
+  verified: true,
+  lastSeenAtMs: NOW - 200,
+  sensorId: 0,
+  distanceM: 1.42,
+  minDistanceM: 0.2,
+  maxDistanceM: 7,
+  orientation: 25,
+  sensorType: 0,
+  signalQuality: 87
+}
+
+describe('advanced sensor cards — the absent case', () => {
+  // "Only show those boxes if setup. Anything above GPS and compass I'm
+  // calling advanced." An unconfigured sensor gets NO card, not a card of
+  // zeroes — a zeroed card is the dead end the operator was already stuck in.
+  it('drops the rangefinder card when RNGFND1_TYPE is 0', () => {
+    expect(buildRangefinderCard(input({ rangefinderType: 0 }))).toBeUndefined()
+  })
+
+  it('drops the flow card when FLOW_TYPE is 0', () => {
+    expect(buildOpticalFlowCard(input({ flowType: 0 }))).toBeUndefined()
+  })
+
+  // undefined is "the parameter has not synced yet", which is NOT the same as
+  // "the sensor is off" — claiming either way before the table lands would be
+  // a guess shown as a fact.
+  it('drops both cards while the parameters have not synced', () => {
+    expect(buildAdvancedSensorCards(input({}))).toEqual([])
+  })
+
+  it('drops both cards while disconnected even if the params say configured', () => {
+    expect(
+      buildAdvancedSensorCards(input({ connected: false, rangefinderType: 100, flowType: 6 }))
+    ).toEqual([])
+  })
+})
+
+describe('rangefinder card', () => {
+  it('shows the live distance as the emphasised headline row when reporting', () => {
+    const card = buildRangefinderCard(input({ rangefinderType: 100, rangefinder: reportingRangefinder }))
+    expect(card?.state).toBe('reporting')
+    expect(card?.tone).toBe('success')
+    const distance = card?.rows.find((row) => row.label === 'Distance')
+    expect(distance?.value).toBe('1.42 m')
+    expect(distance?.emphasis).toBe(true)
+    expect(card?.rows.find((row) => row.label === 'Signal')?.value).toBe('87%')
+    expect(card?.rows.find((row) => row.label === 'Range')?.value).toBe('0.20 – 7.00 m')
+    expect(card?.rows.find((row) => row.label === 'Facing')?.value).toBe('Down')
+  })
+
+  // The load-bearing state: configured, nothing ever arrived. This is the one
+  // that told a real operator their hand-soldered wires were crossed.
+  it('reports configured-but-silent on the face of the card, not just in the detail', () => {
+    const card = buildRangefinderCard(input({ rangefinderType: 100 }))
+    expect(card?.state).toBe('silent')
+    expect(card?.tone).toBe('danger')
+    expect(card?.badge).toBe('no data')
+    expect(card?.headline).toContain('No data received')
+    expect(card?.rows.find((row) => row.label === 'Distance')?.value).toBe('No data')
+    expect(card?.rows.find((row) => row.label === 'Last data')?.value).toBe('never')
+  })
+
+  // A sensor that reported and then stopped is a different fault from one that
+  // never reported — both are plausible with a marginal solder joint.
+  it('distinguishes "stopped reporting" from "never reported"', () => {
+    const card = buildRangefinderCard(
+      input({
+        rangefinderType: 100,
+        rangefinder: { ...reportingRangefinder, lastSeenAtMs: NOW - (ADVANCED_SENSOR_FRESHNESS_MS + 9000) }
+      })
+    )
+    expect(card?.state).toBe('stalled')
+    expect(card?.tone).toBe('danger')
+    expect(card?.badge).toBe('data stopped')
+    expect(card?.headline).toContain('was reporting, then stopped')
+    expect(card?.rows.find((row) => row.label === 'Last data')?.value).toBe('12 s ago')
+  })
+
+  // A stale distance left on screen looks exactly like a working sensor,
+  // which is the single worst outcome for this feature.
+  it('never shows a stale distance once the stream goes quiet', () => {
+    const card = buildRangefinderCard(
+      input({
+        rangefinderType: 100,
+        rangefinder: { ...reportingRangefinder, lastSeenAtMs: NOW - (ADVANCED_SENSOR_FRESHNESS_MS + 1) }
+      })
+    )
+    expect(card?.rows.find((row) => row.label === 'Distance')?.value).toBe('No data')
+  })
+
+  // ArduPilot's signal_quality sentinels: 0 = driver does not report quality,
+  // 1 = invalid signal. Rendering 0 as "0%" would libel a working lidar.
+  it('treats signal_quality 0 as "not reported", not as 0%', () => {
+    const card = buildRangefinderCard(
+      input({ rangefinderType: 100, rangefinder: { ...reportingRangefinder, signalQuality: 0 } })
+    )
+    expect(card?.state).toBe('reporting')
+    expect(card?.rows.find((row) => row.label === 'Signal')?.value).toBe('Not reported by driver')
+  })
+
+  it('flags signal_quality 1 as an invalid signal while still showing the distance', () => {
+    const card = buildRangefinderCard(
+      input({ rangefinderType: 100, rangefinder: { ...reportingRangefinder, signalQuality: 1 } })
+    )
+    expect(card?.state).toBe('degraded')
+    expect(card?.tone).toBe('warning')
+    expect(card?.rows.find((row) => row.label === 'Signal')?.value).toBe('Invalid signal')
+    expect(card?.rows.find((row) => row.label === 'Distance')?.value).toBe('1.42 m')
+  })
+})
+
+describe('optical flow card', () => {
+  it('shows quality and flow rates when reporting', () => {
+    const card = buildOpticalFlowCard(
+      input({
+        flowType: 6,
+        opticalFlow: {
+          verified: true,
+          lastSeenAtMs: NOW - 100,
+          sensorId: 0,
+          quality: 184,
+          flowRateX: 0.021,
+          flowRateY: -0.014,
+          groundDistanceM: 1.35
+        }
+      })
+    )
+    expect(card?.state).toBe('reporting')
+    expect(card?.rows.find((row) => row.label === 'Quality')?.value).toBe('184 / 255')
+    expect(card?.rows.find((row) => row.label === 'Flow rate X/Y')?.value).toBe('0.021 / -0.014 rad/s')
+    expect(card?.rows.find((row) => row.label === 'Height (HAGL)')?.value).toBe('1.35 m')
+  })
+
+  // The reported field case: a DroneCAN sensor, configured, wires crossed.
+  // FLOW_TYPE 6 must be recognised as configured — a card that only knew the
+  // directly-wired variants would have hidden this exact fault.
+  it('renders for a CAN-attached sensor and names the driver', () => {
+    const card = buildOpticalFlowCard(input({ flowType: 6 }))
+    expect(card?.state).toBe('silent')
+    expect(card?.headline).toContain('No data received')
+    expect(card?.rows.find((row) => row.label === 'Driver')?.value).toBe('FLOW_TYPE 6 · DroneCAN')
+    expect(card?.detail).toContain('CAN')
+  })
+
+  // Quality 0 with a live stream means the wiring is GOOD and the sensor
+  // cannot see. Opposite diagnosis to silence, so it must not share a state.
+  it('separates "alive but tracking nothing" from "no data at all"', () => {
+    const card = buildOpticalFlowCard(
+      input({ flowType: 8, opticalFlow: { verified: true, lastSeenAtMs: NOW - 100, quality: 0 } })
+    )
+    expect(card?.state).toBe('degraded')
+    expect(card?.tone).toBe('warning')
+    expect(card?.rows.find((row) => row.label === 'Quality')?.value).toBe('0 / 255')
+    expect(card?.detail).toContain('wiring is proven good')
+  })
+
+  it('says the height is not estimated rather than printing a fake 0 m', () => {
+    const card = buildOpticalFlowCard(
+      input({ flowType: 6, opticalFlow: { verified: true, lastSeenAtMs: NOW - 100, quality: 12 } })
+    )
+    expect(card?.rows.find((row) => row.label === 'Height (HAGL)')?.value).toBe('Not estimated')
+  })
+})
+
+describe('buildAdvancedSensorCards', () => {
+  it('returns only the configured sensors, rangefinder first', () => {
+    const cards = buildAdvancedSensorCards(
+      input({ rangefinderType: 100, flowType: 6, rangefinder: reportingRangefinder })
+    )
+    expect(cards.map((card) => card.id)).toEqual(['rangefinder', 'optical-flow'])
+    expect(cards[0]?.state).toBe('reporting')
+    expect(cards[1]?.state).toBe('silent')
+  })
+
+  it('drops just the unconfigured one', () => {
+    const cards = buildAdvancedSensorCards(input({ rangefinderType: 100, flowType: 0 }))
+    expect(cards.map((card) => card.id)).toEqual(['rangefinder'])
+  })
+})

--- a/apps/web/src/view-models/advanced-sensor-cards.ts
+++ b/apps/web/src/view-models/advanced-sensor-cards.ts
@@ -1,0 +1,381 @@
+import type { ConfiguratorSnapshot } from '@arduconfig/ardupilot-core'
+
+/**
+ * Status & Info "advanced sensor" cards: rangefinder and optical flow.
+ *
+ * WHY THIS EXISTS
+ * ---------------
+ * The operator ask was blunt: "I'd like to see rangefinder and optical flow so
+ * as a user I know they are working and reporting data. Right now I'm not sure
+ * how to do that besides look at logs or go back to MP." Two follow-ups
+ * sharpened it:
+ *
+ *   1. Real measurements, not adjectives. "Configured" and "healthy" are what
+ *      the app already said, and they are exactly what did NOT answer the
+ *      question. Each card's primary content is the live number.
+ *   2. Only show the card if the sensor is set up. GPS and compass are the
+ *      baseline and stay unconditional; rangefinder and flow are advanced, so
+ *      an unconfigured sensor gets no card at all rather than a card full of
+ *      zeroes.
+ *
+ * And a field report pinned down which state actually earns its keep: an
+ * operator with a DroneCAN flow sensor, hand-soldered because the connector
+ * would not fit, had the wires crossed. The sensor was configured; no data
+ * arrived; the card said so; that told them the solder job was wrong. So
+ * "configured but no data" is load-bearing and must never be able to render
+ * as anything resembling a working sensor — and it must be legible on the
+ * face of the card, because in that report it was only discoverable on hover.
+ *
+ * THE STATES
+ * ----------
+ * `absent`    — not configured. The caller drops the card entirely.
+ * `silent`    — configured, nothing has EVER arrived. Wiring/bus/driver fault.
+ * `stalled`   — configured, data arrived and then stopped. A different fault
+ *               from `silent` (an intermittent joint, a sensor browning out),
+ *               and one the operator explicitly wanted distinguished.
+ * `degraded`  — data IS arriving, but the sensor says its own reading is not
+ *               usable (flow quality 0, rangefinder signal_quality 1). The
+ *               wiring is proven good; the sensor cannot see. Showing the
+ *               number is the point: quality 0 is a diagnosis, not a blank.
+ * `reporting` — data arriving and usable.
+ *
+ * Everything here is pure: values in, view model out, no snapshot mutation and
+ * no clock of its own (`nowMs` is injected), so the state machine above is
+ * unit-tested directly rather than through the runtime.
+ */
+
+/** Tone vocabulary shared with `StatusBadge` in ui-kit. */
+export type AdvancedSensorTone = 'success' | 'warning' | 'danger'
+
+export type AdvancedSensorState = 'silent' | 'stalled' | 'degraded' | 'reporting'
+
+export interface AdvancedSensorReadout {
+  label: string
+  /** Already-formatted display value. Never a bare "0" standing in for
+   * "no reading" — callers get the literal string "No data" instead. */
+  value: string
+  /** Optional per-row emphasis; the headline measurement row sets this so the
+   * number the operator came for is visually first among equals. */
+  emphasis?: boolean
+}
+
+export interface AdvancedSensorCardViewModel {
+  id: 'rangefinder' | 'optical-flow'
+  title: string
+  state: AdvancedSensorState
+  tone: AdvancedSensorTone
+  /** Short badge text. Colour carries the state at a glance; this carries it
+   * for everyone else, because colour is never the only signal. */
+  badge: string
+  /** The at-a-glance headline printed on the FACE of the card. For a fault
+   * state this is the fault, in plain words — not a tooltip. */
+  headline: string
+  /** Longer diagnostic detail. Safe to put in a title/tooltip because the
+   * headline above already carries the actionable part. */
+  detail: string
+  rows: AdvancedSensorReadout[]
+  testId: string
+}
+
+/**
+ * How long a sensor may go quiet before the card stops trusting the last
+ * reading. Both streams are requested at 5 Hz (LIVE_TELEMETRY_REQUESTS), so
+ * 3 s is ~15 missed messages: far past a dropped frame or a busy link, well
+ * short of leaving a stale number on screen while an operator stares at it.
+ */
+export const ADVANCED_SENSOR_FRESHNESS_MS = 3000
+
+/**
+ * AP_OpticalFlow.h `Type` / the FLOW_TYPE @Values block in
+ * AP_OpticalFlow.cpp. Transcribed from source rather than memory — note 6 is
+ * DroneCAN (HereFlow) and 10 is SITL, which is easy to get backwards.
+ */
+const FLOW_TYPE_LABELS: Record<number, string> = {
+  1: 'PX4Flow',
+  2: 'Pixart',
+  3: 'Bebop',
+  4: 'CXOF',
+  5: 'MAVLink',
+  6: 'DroneCAN',
+  7: 'MSP',
+  8: 'UPFLOW',
+  10: 'SITL'
+}
+
+/** MAV_SENSOR_ORIENTATION values ArduPilot actually uses for rangefinders. */
+const RANGEFINDER_ORIENTATION_LABELS: Record<number, string> = {
+  0: 'Forward',
+  2: 'Right',
+  4: 'Back',
+  6: 'Left',
+  24: 'Up',
+  25: 'Down'
+}
+
+/** MAV_DISTANCE_SENSOR. */
+const DISTANCE_SENSOR_TYPE_LABELS: Record<number, string> = {
+  0: 'Laser',
+  1: 'Ultrasound',
+  2: 'Infrared',
+  3: 'Radar'
+}
+
+export interface AdvancedSensorCardsInput {
+  connected: boolean
+  liveVerification: ConfiguratorSnapshot['liveVerification']
+  /**
+   * RNGFND1_TYPE, falling back to the pre-4.5 unnumbered RNGFND_TYPE.
+   * `undefined` means the parameter is not in the synced table yet — which is
+   * NOT the same as 0, and must not render a card claiming the sensor is off.
+   */
+  rangefinderType: number | undefined
+  /** FLOW_TYPE. Any non-zero value counts, including the CAN-attached
+   * variants — a card that only recognised directly-wired sensors would have
+   * hidden the exact DroneCAN fault this feature was built to catch. */
+  flowType: number | undefined
+  nowMs: number
+}
+
+function formatAge(lastSeenAtMs: number | undefined, nowMs: number): string {
+  if (lastSeenAtMs === undefined) {
+    return 'never'
+  }
+  const ageMs = Math.max(0, nowMs - lastSeenAtMs)
+  if (ageMs < 1000) {
+    return 'just now'
+  }
+  if (ageMs < 60000) {
+    return `${Math.round(ageMs / 1000)} s ago`
+  }
+  return `${Math.round(ageMs / 60000)} min ago`
+}
+
+/**
+ * Resolves `silent` vs `stalled` vs "data is live". Shared by both cards so
+ * the two can never drift into disagreeing about what silence means.
+ */
+function resolveLiveness(
+  lastSeenAtMs: number | undefined,
+  nowMs: number
+): { fresh: boolean; state: 'silent' | 'stalled' | undefined } {
+  if (lastSeenAtMs === undefined) {
+    return { fresh: false, state: 'silent' }
+  }
+  if (nowMs - lastSeenAtMs > ADVANCED_SENSOR_FRESHNESS_MS) {
+    return { fresh: false, state: 'stalled' }
+  }
+  return { fresh: true, state: undefined }
+}
+
+function formatMetres(value: number | undefined): string {
+  return value === undefined ? 'No data' : `${value.toFixed(2)} m`
+}
+
+export function buildRangefinderCard(
+  input: AdvancedSensorCardsInput
+): AdvancedSensorCardViewModel | undefined {
+  const { rangefinderType, liveVerification, nowMs } = input
+  // Absent: no card. An unconfigured rangefinder is not a fault to report,
+  // it is a feature the operator has not opted into — and "advanced" boxes
+  // only earn their space once they have something to say.
+  if (!input.connected || rangefinderType === undefined || rangefinderType === 0) {
+    return undefined
+  }
+
+  const rangefinder = liveVerification.rangefinder
+  const { fresh, state: livenessState } = resolveLiveness(rangefinder.lastSeenAtMs, nowMs)
+  const age = formatAge(rangefinder.lastSeenAtMs, nowMs)
+
+  // ArduPilot's signal_quality sentinels (GCS_Common.cpp): 0 = the driver
+  // does not report quality at all, 1 = it reports the signal as invalid,
+  // 2..100 = a real percentage. Printing "0%" for the first case would
+  // libel a perfectly good lidar, so all three branch separately.
+  const quality = rangefinder.signalQuality
+  const qualityText =
+    !fresh || quality === undefined
+      ? 'No data'
+      : quality === 0
+        ? 'Not reported by driver'
+        : quality === 1
+          ? 'Invalid signal'
+          : `${quality}%`
+
+  const state: AdvancedSensorState = livenessState
+    ? livenessState
+    : quality === 1
+      ? 'degraded'
+      : 'reporting'
+
+  const rows: AdvancedSensorReadout[] = [
+    {
+      label: 'Distance',
+      // The headline measurement. Suppressed the moment the stream goes
+      // quiet: a distance left on screen from four seconds ago is worse than
+      // no distance, because it looks like a working sensor.
+      value: fresh ? formatMetres(rangefinder.distanceM) : 'No data',
+      emphasis: true
+    },
+    { label: 'Signal', value: qualityText },
+    {
+      label: 'Range',
+      value:
+        rangefinder.minDistanceM !== undefined && rangefinder.maxDistanceM !== undefined
+          ? `${rangefinder.minDistanceM.toFixed(2)} – ${rangefinder.maxDistanceM.toFixed(2)} m`
+          : 'Unknown'
+    },
+    {
+      label: 'Facing',
+      value:
+        rangefinder.orientation === undefined
+          ? 'Unknown'
+          : (RANGEFINDER_ORIENTATION_LABELS[rangefinder.orientation] ?? `Orientation ${rangefinder.orientation}`)
+    },
+    {
+      label: 'Driver',
+      value:
+        rangefinder.sensorType !== undefined && DISTANCE_SENSOR_TYPE_LABELS[rangefinder.sensorType]
+          ? `RNGFND1_TYPE ${rangefinderType} · ${DISTANCE_SENSOR_TYPE_LABELS[rangefinder.sensorType]}`
+          : `RNGFND1_TYPE ${rangefinderType}`
+    },
+    { label: 'Last data', value: age }
+  ]
+
+  const headline =
+    state === 'silent'
+      ? 'No data received. The rangefinder is configured but has never reported.'
+      : state === 'stalled'
+        ? `No data for ${age.replace(' ago', '')} — it was reporting, then stopped.`
+        : state === 'degraded'
+          ? 'Reporting, but the sensor flags its own signal as invalid.'
+          : 'Reporting live distance.'
+
+  const detail =
+    state === 'silent'
+      ? `RNGFND1_TYPE is ${rangefinderType}, but no DISTANCE_SENSOR (msgid 132) message has ever arrived. ArduPilot suppresses this message entirely while the driver has no data, so this points at wiring, bus address, or a driver that needs a reboot after the type change.`
+      : state === 'stalled'
+        ? `DISTANCE_SENSOR (msgid 132) last arrived ${age}. An intermittent connection or a sensor dropping out mid-session looks like this; a never-connected one would read "never".`
+        : state === 'degraded'
+          ? 'DISTANCE_SENSOR reports signal_quality 1, ArduPilot\'s "invalid signal" sentinel — the link is fine, the return is not. Check the surface, sunlight, or the lens.'
+          : `DISTANCE_SENSOR (msgid 132) is arriving from sensor id ${rangefinder.sensorId ?? 0}.`
+
+  return {
+    id: 'rangefinder',
+    title: 'Rangefinder',
+    state,
+    tone: state === 'reporting' ? 'success' : state === 'degraded' ? 'warning' : 'danger',
+    badge:
+      state === 'reporting'
+        ? 'reporting'
+        : state === 'degraded'
+          ? 'bad signal'
+          : state === 'stalled'
+            ? 'data stopped'
+            : 'no data',
+    headline,
+    detail,
+    rows,
+    testId: 'setup-rangefinder-card'
+  }
+}
+
+export function buildOpticalFlowCard(
+  input: AdvancedSensorCardsInput
+): AdvancedSensorCardViewModel | undefined {
+  const { flowType, liveVerification, nowMs } = input
+  if (!input.connected || flowType === undefined || flowType === 0) {
+    return undefined
+  }
+
+  const flow = liveVerification.opticalFlow
+  const { fresh, state: livenessState } = resolveLiveness(flow.lastSeenAtMs, nowMs)
+  const age = formatAge(flow.lastSeenAtMs, nowMs)
+
+  // OPTICAL_FLOW quality is a plain 0..255 with no sentinels: ArduPilot only
+  // sends the message at all when the driver is healthy, so quality 0 means
+  // "sensor is alive and cannot find anything to track" — dark room, blank
+  // floor, out of focus. That is a genuinely useful answer, so it is shown as
+  // a number and called out, never hidden behind a blank.
+  const quality = flow.quality
+  const qualityUsable = quality !== undefined && quality > 0
+  const state: AdvancedSensorState = livenessState ? livenessState : qualityUsable ? 'reporting' : 'degraded'
+
+  const rows: AdvancedSensorReadout[] = [
+    {
+      label: 'Quality',
+      value: !fresh || quality === undefined ? 'No data' : `${quality} / 255`,
+      emphasis: true
+    },
+    {
+      label: 'Flow rate X/Y',
+      value:
+        fresh && flow.flowRateX !== undefined && flow.flowRateY !== undefined
+          ? `${flow.flowRateX.toFixed(3)} / ${flow.flowRateY.toFixed(3)} rad/s`
+          : 'No data'
+    },
+    {
+      label: 'Height (HAGL)',
+      // ArduPilot sends 0 when AHRS has no height estimate and the runtime
+      // normalises that to undefined, so this says "Not estimated" rather
+      // than parking the craft on the ground.
+      value: fresh ? (flow.groundDistanceM !== undefined ? formatMetres(flow.groundDistanceM) : 'Not estimated') : 'No data'
+    },
+    {
+      label: 'Driver',
+      value: FLOW_TYPE_LABELS[flowType]
+        ? `FLOW_TYPE ${flowType} · ${FLOW_TYPE_LABELS[flowType]}`
+        : `FLOW_TYPE ${flowType}`
+    },
+    { label: 'Last data', value: age }
+  ]
+
+  const headline =
+    state === 'silent'
+      ? 'No data received. The flow sensor is configured but has never reported.'
+      : state === 'stalled'
+        ? `No data for ${age.replace(' ago', '')} — it was reporting, then stopped.`
+        : state === 'degraded'
+          ? 'Reporting, but quality is 0 — the sensor cannot track anything.'
+          : 'Reporting live flow.'
+
+  const detail =
+    state === 'silent'
+      ? `FLOW_TYPE is ${flowType}${FLOW_TYPE_LABELS[flowType] ? ` (${FLOW_TYPE_LABELS[flowType]})` : ''}, but no OPTICAL_FLOW (msgid 100) message has ever arrived. ArduPilot only sends this message while the driver reports healthy, so this points at wiring — on a CAN sensor, the CAN pair or the node itself — or a driver that needs a reboot after the type change.`
+      : state === 'stalled'
+        ? `OPTICAL_FLOW (msgid 100) last arrived ${age}. A sensor that reported and then stopped is a different fault from one that never reported: suspect an intermittent joint or a node dropping off the bus.`
+        : state === 'degraded'
+          ? 'OPTICAL_FLOW is arriving with quality 0, so the wiring is proven good — the sensor simply has no usable texture to track. Try more light, more surface detail, or check the focus.'
+          : `OPTICAL_FLOW (msgid 100) is arriving from sensor id ${flow.sensorId ?? 0}.`
+
+  return {
+    id: 'optical-flow',
+    title: 'Optical Flow',
+    state,
+    tone: state === 'reporting' ? 'success' : state === 'degraded' ? 'warning' : 'danger',
+    badge:
+      state === 'reporting'
+        ? 'reporting'
+        : state === 'degraded'
+          ? 'no track'
+          : state === 'stalled'
+            ? 'data stopped'
+            : 'no data',
+    headline,
+    detail,
+    rows,
+    testId: 'setup-optical-flow-card'
+  }
+}
+
+/** Both advanced sensor cards, in display order, with unconfigured ones dropped. */
+export function buildAdvancedSensorCards(input: AdvancedSensorCardsInput): AdvancedSensorCardViewModel[] {
+  const cards: AdvancedSensorCardViewModel[] = []
+  const rangefinder = buildRangefinderCard(input)
+  if (rangefinder) {
+    cards.push(rangefinder)
+  }
+  const flow = buildOpticalFlowCard(input)
+  if (flow) {
+    cards.push(flow)
+  }
+  return cards
+}

--- a/apps/web/src/views/AdvancedSensorCard.tsx
+++ b/apps/web/src/views/AdvancedSensorCard.tsx
@@ -1,0 +1,65 @@
+import { StatusBadge } from '@arduconfig/ui-kit'
+
+import type { AdvancedSensorCardViewModel } from '../view-models/advanced-sensor-cards'
+
+/**
+ * One advanced-sensor box (rangefinder / optical flow) for the Status & Info
+ * tab, styled as a sibling of the existing GPS box.
+ *
+ * Dumb by design: every decision about which state the sensor is in, what the
+ * measurement reads, and whether the card should exist at all is made by
+ * `buildAdvancedSensorCards` and unit-tested there. This file only paints.
+ *
+ * Two rules it exists to enforce:
+ *   - The fault text is rendered as visible copy, never only as a `title`.
+ *     The first version of this idea put "no data received" behind a hover
+ *     and an operator had to go looking for it; by the time they found it,
+ *     it had already diagnosed a mis-soldered sensor — so it earns a place
+ *     on the face of the card.
+ *   - Colour is carried by the state class AND repeated in the badge text,
+ *     so the card is readable without relying on colour alone.
+ */
+export function AdvancedSensorCard({ card }: { card: AdvancedSensorCardViewModel }) {
+  return (
+    <article
+      className={`setup-gui-box setup-gui-box--sensor setup-gui-box--sensor-${card.state}`}
+      data-testid={card.testId}
+      data-sensor-state={card.state}
+    >
+      <div className="setup-gui-box__titlebar">
+        <strong>{card.title}</strong>
+        <StatusBadge tone={card.tone}>{card.badge}</StatusBadge>
+      </div>
+      <div className="setup-gui-box__body">
+        {/* The headline sits ABOVE the readings: in a fault state the first
+         *  thing the eye lands on must be the fault, not a column of
+         *  "No data" rows the operator has to interpret. */}
+        <p
+          className={`setup-gui-box__sensor-headline setup-gui-box__sensor-headline--${card.tone}`}
+          data-testid={`${card.testId}-headline`}
+          title={card.detail}
+        >
+          {card.headline}
+        </p>
+        <div className="setup-gui-box__kv-list">
+          {card.rows.map((row) => (
+            <div
+              key={row.label}
+              className={`setup-gui-box__kv-row${row.emphasis ? ' setup-gui-box__kv-row--measurement' : ''}`}
+            >
+              <span>{row.label}</span>
+              <strong data-testid={`${card.testId}-${row.label.toLowerCase().replace(/[^a-z0-9]+/g, '-')}`}>
+                {row.value}
+              </strong>
+            </div>
+          ))}
+        </div>
+        {/* Detail is duplicated as body copy, not left to the tooltip alone —
+         *  it is the "what do I do about it" half of the diagnosis. */}
+        <p className="setup-gui-box__note" data-testid={`${card.testId}-detail`}>
+          {card.detail}
+        </p>
+      </div>
+    </article>
+  )
+}

--- a/packages/ardupilot-core/src/runtime-helpers.ts
+++ b/packages/ardupilot-core/src/runtime-helpers.ts
@@ -230,6 +230,9 @@ export function createIdleLiveVerification(): LiveVerificationState {
     },
     opticalFlow: {
       verified: false
+    },
+    rangefinder: {
+      verified: false
     }
   }
 }
@@ -343,6 +346,13 @@ export function cloneLiveVerification(liveVerification: LiveVerificationState): 
     },
     opticalFlow: {
       ...liveVerification.opticalFlow
+    },
+    // Spread, not a field-by-field copy: the TCAL regression (#88) was
+    // caused by cloneLiveVerification silently dropping a newly added
+    // field, so every new sensor block goes in as a whole-object spread
+    // and any new field is carried by construction.
+    rangefinder: {
+      ...liveVerification.rangefinder
     },
     // Scalar carried straight through — omitting it here silently dropped the
     // live IMU temperature (from SCALED_IMU) out of every emitted snapshot, so

--- a/packages/ardupilot-core/src/runtime.ts
+++ b/packages/ardupilot-core/src/runtime.ts
@@ -17,6 +17,7 @@ import type {
   ParamValueMessage,
   RcChannelsMessage,
   OpticalFlowMessage,
+  DistanceSensorMessage,
   StatusTextMessage,
   SysStatusMessage,
   UavcanNodeInfoMessage,
@@ -284,6 +285,13 @@ const CAN_NODE_INFO_REFRESH_DEBOUNCE_MS = 5000
 const CAN_NODE_OFFLINE_AFTER_MS = 3000
 const CAN_NODE_REMOVE_AFTER_MS = 30000
 const CAN_NODE_STALE_SWEEP_INTERVAL_MS = 1000
+
+// AP_Proximity.h: PROXIMITY_SENSOR_ID_START. AP_Proximity publishes its
+// 360-degree sectors as DISTANCE_SENSOR messages with ids from this value
+// upwards, sharing the message with real rangefinder instances (ids 0..9,
+// where the id IS the backend instance). Anything at or above this is an
+// avoidance sector, not the downward lidar the Status card reports.
+const PROXIMITY_SENSOR_ID_START = 10
 const LIVE_TELEMETRY_REQUESTS = [
   {
     // The RAW receiver report. Distinct from GLOBAL_POSITION_INT, which only
@@ -352,6 +360,36 @@ const LIVE_TELEMETRY_REQUESTS = [
     messageId: MAVLINK_MESSAGE_IDS.MAG_CAL_REPORT,
     label: 'MAG_CAL_REPORT',
     intervalUs: 1000000
+  },
+  // Rangefinder + optical flow both live in STREAM_EXTRA3
+  // (libraries/GCS_MAVLink/GCS_MAVLink_Parameters.cpp), which ArduPilot does
+  // NOT stream unless a GCS asks for it. Without these two entries the
+  // Status & Info sensor cards render perfectly in demo mode — the mock
+  // scenario emits whatever it likes — and are stone dead on a real FC.
+  // That is the exact failure this feature must not ship: an operator
+  // checking a sensor would read our silence as "sensor broken".
+  {
+    // The per-instance rangefinder report. Chosen over RANGEFINDER (msgid
+    // 173) because send_distance_sensor() skips a backend whose has_data()
+    // is false, so no-message genuinely means no-data — see
+    // RangefinderSensorState in types.ts for the full justification.
+    // 5 Hz: fast enough that an operator waving a hand under the craft sees
+    // the number track their hand, slow enough to be free on a 57k6 link
+    // (39-byte payload × a handful of instances).
+    messageId: MAVLINK_MESSAGE_IDS.DISTANCE_SENSOR,
+    label: 'DISTANCE_SENSOR',
+    intervalUs: 200000
+  },
+  {
+    // OPTICAL_FLOW was already decoded and already drove the header Flow
+    // chip, but was never requested — so on real hardware that chip could
+    // only ever be grey. Requesting it here is what makes both the chip and
+    // the new flow card work off a flight controller instead of the mock.
+    // 5 Hz matches the rangefinder cadence; flow quality is the number an
+    // operator watches while they change lighting or height.
+    messageId: MAVLINK_MESSAGE_IDS.OPTICAL_FLOW,
+    label: 'OPTICAL_FLOW',
+    intervalUs: 200000
   }
 ] as const
 /**
@@ -2081,6 +2119,9 @@ export class ArduPilotConfiguratorRuntime {
       case 'OPTICAL_FLOW':
         this.processOpticalFlow(envelope.message)
         break
+      case 'DISTANCE_SENSOR':
+        this.processDistanceSensor(envelope.message)
+        break
       default:
         break
     }
@@ -2658,15 +2699,61 @@ export class ArduPilotConfiguratorRuntime {
     })
   }
 
-  // OPTICAL_FLOW (msgid 100) is the "pulse on the flow sensor" signal. This
-  // only records whether the sensor is producing telemetry (no EKF
-  // innovations); the UI computes the freshness window against lastSeenAtMs.
+  // OPTICAL_FLOW (msgid 100) is both the "pulse on the flow sensor" signal
+  // and the sensor's actual reading. ArduPilot's send_opticalflow()
+  // (GCS_Common.cpp) returns early unless `optflow->healthy()`, so receiving
+  // this message at all already means the driver is enumerating and updating
+  // the sensor; `quality` then says whether the image it sees is usable.
+  // Those are different failures — a live message with quality 0 is a sensor
+  // that is wired correctly and staring at a featureless surface — so both
+  // are recorded and the UI reports them separately.
+  //
+  // Still no EKF-innovation processing; the UI computes its own freshness
+  // window against lastSeenAtMs.
   private processOpticalFlow(message: OpticalFlowMessage): void {
     this.liveVerification.opticalFlow = {
       verified: true,
       lastSeenAtMs: Date.now(),
       sensorId: message.sensorId,
-      quality: message.quality
+      quality: message.quality,
+      flowRateX: message.flowRateX,
+      flowRateY: message.flowRateY,
+      // MAVLink reserves negative ground_distance for "unknown", and
+      // ArduPilot substitutes 0 when AHRS has no HAGL estimate. Normalise
+      // both to undefined so the UI never prints a fake altitude.
+      groundDistanceM: message.groundDistance > 0 ? message.groundDistance : undefined
+    }
+  }
+
+  // DISTANCE_SENSOR (msgid 132). ArduPilot multiplexes rangefinder instances
+  // AND AP_Proximity sectors onto this message; proximity uses
+  // PROXIMITY_SENSOR_ID_START (10, AP_Proximity.h) as its id base, so ids at
+  // or above that are 360° avoidance sectors and must not be mistaken for the
+  // downward rangefinder the Status card is about.
+  //
+  // Among genuine rangefinder instances we keep the LOWEST id. RNGFND1 is
+  // instance 0 and is what a Copter build uses for terrain/altitude, so a
+  // second forward-facing lidar on RNGFND2 cannot displace the reading the
+  // operator is checking. Same-instance updates always win, so the value
+  // stays live.
+  private processDistanceSensor(message: DistanceSensorMessage): void {
+    if (message.id >= PROXIMITY_SENSOR_ID_START) {
+      return
+    }
+    const current = this.liveVerification.rangefinder
+    if (current.sensorId !== undefined && message.id > current.sensorId) {
+      return
+    }
+    this.liveVerification.rangefinder = {
+      verified: true,
+      lastSeenAtMs: Date.now(),
+      sensorId: message.id,
+      distanceM: message.currentDistanceCm / 100,
+      minDistanceM: message.minDistanceCm / 100,
+      maxDistanceM: message.maxDistanceCm / 100,
+      orientation: message.orientation,
+      sensorType: message.sensorType,
+      signalQuality: message.signalQuality
     }
   }
 

--- a/packages/ardupilot-core/src/types.ts
+++ b/packages/ardupilot-core/src/types.ts
@@ -344,18 +344,31 @@ export interface LiveVerificationState {
    */
   gpsSensor: SensorBitState
   /**
-   * Optical flow sensor liveness, derived from OPTICAL_FLOW (msgid 100).
-   * Phase 1 surfaces only a "pulse on the sensor" check — was a flow
-   * message recently received — plus the most recent quality / sensor ID.
-   * No flow-rate processing; that lives in the EKF on the autopilot side
-   * and the GCS does not need to recompute it.
+   * Optical flow sensor liveness AND its last reading, derived from
+   * OPTICAL_FLOW (msgid 100). The "pulse on the sensor" check drives the
+   * header Flow chip; the flow rates / ground distance are what the
+   * Status & Info card actually prints, because "configured" and "healthy"
+   * are adjectives an operator cannot act on — a number they can watch
+   * change while they wave a hand under the craft is.
+   *
+   * Still no EKF-innovation processing: that lives on the autopilot and
+   * the GCS has no business recomputing it.
    */
   opticalFlow: OpticalFlowSensorState
+  /**
+   * Downward rangefinder liveness AND its last reading, derived from
+   * DISTANCE_SENSOR (msgid 132). See RangefinderSensorState for why that
+   * message and not RANGEFINDER (msgid 173).
+   */
+  rangefinder: RangefinderSensorState
 }
 
 export interface OpticalFlowSensorState {
-  /** True iff an OPTICAL_FLOW message has arrived within the freshness
-   * window (Phase 1: 2s). Drives the header "Flow" chip. */
+  /** True once an OPTICAL_FLOW message has ever arrived. Deliberately NOT
+   * self-expiring: consumers compare `lastSeenAtMs` against their own
+   * freshness window, and the sticky flag is what lets the UI tell
+   * "reported, then went silent" apart from "never reported at all" —
+   * two different faults with the same live symptom. */
   verified: boolean
   lastSeenAtMs?: number
   /** Sensor ID from the most recent OPTICAL_FLOW message; FCs with a
@@ -364,6 +377,57 @@ export interface OpticalFlowSensorState {
   /** Quality 0..255 from the most recent OPTICAL_FLOW message. 0 = bad
    * track (sensor present but no usable optical features), 255 = max. */
   quality?: number
+  /** Flow rate about the sensor X axis, rad/s (OPTICAL_FLOW extension). */
+  flowRateX?: number
+  /** Flow rate about the sensor Y axis, rad/s (OPTICAL_FLOW extension). */
+  flowRateY?: number
+  /** Ground distance (HAGL) the FC attached to the flow report, metres.
+   * ArduPilot sends 0 when AHRS has no HAGL estimate, and the MAVLink spec
+   * reserves negative for "unknown" — so this is context, never a
+   * substitute for the rangefinder card's own reading. */
+  groundDistanceM?: number
+}
+
+/**
+ * Latest DISTANCE_SENSOR (msgid 132) reading for the primary rangefinder.
+ *
+ * Why DISTANCE_SENSOR and not RANGEFINDER (msgid 173), from
+ * libraries/GCS_MAVLink/GCS_Common.cpp:
+ *   - `send_distance_sensor()` walks every rangefinder backend and returns
+ *     early on `!sensor->has_data()`. So a lidar that is configured but not
+ *     actually talking emits NOTHING, which makes silence a truthful fault
+ *     signal. `send_rangefinder()` has no such guard and will happily keep
+ *     publishing a stale distance for a dead sensor.
+ *   - DISTANCE_SENSOR carries signal_quality, min/max range, orientation and
+ *     an instance id. RANGEFINDER carries distance + voltage only.
+ *   - DISTANCE_SENSOR is a member of STREAM_EXTRA3
+ *     (GCS_MAVLink_Parameters.cpp); RANGEFINDER is in no stream group at all
+ *     and is additionally compiled out unless
+ *     AP_MAVLINK_MSG_RANGEFINDER_SENDING_ENABLED.
+ * Both still require an explicit SET_MESSAGE_INTERVAL from us — see
+ * LIVE_TELEMETRY_REQUESTS in runtime.ts.
+ */
+export interface RangefinderSensorState {
+  /** True once a DISTANCE_SENSOR for a rangefinder instance has ever
+   * arrived. Sticky for the same reason as OpticalFlowSensorState.verified. */
+  verified: boolean
+  lastSeenAtMs?: number
+  /** Onboard sensor id (== backend instance; 0 is RNGFND1). */
+  sensorId?: number
+  /** The live reading in metres — the headline number on the card. */
+  distanceM?: number
+  /** Configured measurable range in metres (RNGFNDn_MIN / _MAX), so the UI
+   * can say "1.42 m of 0.20–7.00 m" instead of an unanchored figure. */
+  minDistanceM?: number
+  maxDistanceM?: number
+  /** MAV_SENSOR_ORIENTATION; 25 = ROTATION_PITCH_270 = downward. */
+  orientation?: number
+  /** MAV_DISTANCE_SENSOR type (0 laser, 1 ultrasound, 2 infrared, 3 radar). */
+  sensorType?: number
+  /** Raw signal_quality with ArduPilot's sentinels intact: 0 = the driver
+   * does not report quality, 1 = invalid signal, 2..100 = percent. The UI
+   * must branch on these rather than printing "0%". */
+  signalQuality?: number
 }
 
 export interface MotorTestState {

--- a/packages/protocol-mavlink/src/constants.ts
+++ b/packages/protocol-mavlink/src/constants.ts
@@ -8,6 +8,7 @@ export const MAVLINK_MESSAGE_IDS = {
   HEARTBEAT: 0,
   SYS_STATUS: 1,
   OPTICAL_FLOW: 100,
+  DISTANCE_SENSOR: 132,
   CAN_FRAME: 386,
   CANFD_FRAME: 387,
   GPS_RAW_INT: 24,
@@ -42,6 +43,11 @@ export const MAVLINK_MESSAGE_CRCS: Record<number, number> = {
   [MAVLINK_MESSAGE_IDS.HEARTBEAT]: 50,
   [MAVLINK_MESSAGE_IDS.SYS_STATUS]: 124,
   [MAVLINK_MESSAGE_IDS.OPTICAL_FLOW]: 175,
+  // crc_extra 85 (c_library_v2 mavlink_msg_distance_sensor.h:
+  // MAVLINK_MSG_ID_DISTANCE_SENSOR_CRC 85). Decode-only — nothing in the
+  // configurator ever sends a DISTANCE_SENSOR to the vehicle; the encoder
+  // exists purely so the mock scenario can play one back.
+  [MAVLINK_MESSAGE_IDS.DISTANCE_SENSOR]: 85,
   [MAVLINK_MESSAGE_IDS.CAN_FRAME]: 132,
   [MAVLINK_MESSAGE_IDS.CANFD_FRAME]: 4,
   [MAVLINK_MESSAGE_IDS.GPS_RAW_INT]: 24,
@@ -82,6 +88,10 @@ export const MAVLINK_PAYLOAD_LENGTHS: Record<number, number> = {
   [MAVLINK_MESSAGE_IDS.HEARTBEAT]: 9,
   [MAVLINK_MESSAGE_IDS.SYS_STATUS]: 43,
   [MAVLINK_MESSAGE_IDS.OPTICAL_FLOW]: 34,
+  // time_boot_ms(4) + min/max/current_distance(3×2=6) + type(1) + id(1) +
+  // orientation(1) + covariance(1) + horizontal_fov(4) + vertical_fov(4) +
+  // quaternion[4](16) + signal_quality(1) = 39 (MAVLINK_MSG_ID_DISTANCE_SENSOR_LEN).
+  [MAVLINK_MESSAGE_IDS.DISTANCE_SENSOR]: 39,
   [MAVLINK_MESSAGE_IDS.CAN_FRAME]: 16,
   [MAVLINK_MESSAGE_IDS.CANFD_FRAME]: 72,
   [MAVLINK_MESSAGE_IDS.GPS_RAW_INT]: 30,
@@ -121,6 +131,12 @@ export const MAVLINK_MIN_PAYLOAD_LENGTHS: Record<number, number> = {
   [MAVLINK_MESSAGE_IDS.HEARTBEAT]: 9,
   [MAVLINK_MESSAGE_IDS.SYS_STATUS]: 31,
   [MAVLINK_MESSAGE_IDS.OPTICAL_FLOW]: 26,
+  // MAVLINK_MSG_ID_DISTANCE_SENSOR_MIN_LEN = 14: everything from
+  // horizontal_fov onwards (incl. signal_quality) is a v2 extension field.
+  // ArduPilot's own send truncates trailing zeros, so a downward lidar with
+  // no FOV, no quaternion and signal_quality 0 arrives as a 14-byte payload —
+  // requiring more here would drop exactly the frames we care about.
+  [MAVLINK_MESSAGE_IDS.DISTANCE_SENSOR]: 14,
   [MAVLINK_MESSAGE_IDS.CAN_FRAME]: 16,
   [MAVLINK_MESSAGE_IDS.CANFD_FRAME]: 72,
   [MAVLINK_MESSAGE_IDS.GLOBAL_POSITION_INT]: 28,

--- a/packages/protocol-mavlink/src/mavlink-v2-codec.ts
+++ b/packages/protocol-mavlink/src/mavlink-v2-codec.ts
@@ -39,6 +39,7 @@ import type {
   ParamValueMessage,
   CanFrameMessage,
   OpticalFlowMessage,
+  DistanceSensorMessage,
   RcChannelsMessage,
   SetupSigningMessage,
   StatusTextMessage,
@@ -674,6 +675,8 @@ function encodePayload(message: MavlinkMessage): Uint8Array {
       return encodeUavcanNodeInfoPayload(message)
     case 'OPTICAL_FLOW':
       return encodeOpticalFlowPayload(message)
+    case 'DISTANCE_SENSOR':
+      return encodeDistanceSensorPayload(message)
     case 'CAN_FRAME':
       return encodeCanFramePayload(message)
     case 'SETUP_SIGNING':
@@ -739,6 +742,8 @@ function decodePayload(messageId: number, payload: Uint8Array): MavlinkMessage |
       return decodeUavcanNodeInfoPayload(payload)
     case MAVLINK_MESSAGE_IDS.OPTICAL_FLOW:
       return decodeOpticalFlowPayload(payload)
+    case MAVLINK_MESSAGE_IDS.DISTANCE_SENSOR:
+      return decodeDistanceSensorPayload(payload)
     case MAVLINK_MESSAGE_IDS.CAN_FRAME:
       return decodeCanFramePayload(payload)
     default:
@@ -800,6 +805,8 @@ function messageIdFor(message: MavlinkMessage): number {
       return MAVLINK_MESSAGE_IDS.UAVCAN_NODE_INFO
     case 'OPTICAL_FLOW':
       return MAVLINK_MESSAGE_IDS.OPTICAL_FLOW
+    case 'DISTANCE_SENSOR':
+      return MAVLINK_MESSAGE_IDS.DISTANCE_SENSOR
     case 'CAN_FRAME':
       return MAVLINK_MESSAGE_IDS.CAN_FRAME
     case 'SETUP_SIGNING':
@@ -1551,6 +1558,55 @@ function decodeOpticalFlowPayload(payload: Uint8Array): OpticalFlowMessage {
     quality: view.getUint8(25),
     flowRateX: payload.byteLength >= 30 ? view.getFloat32(26, true) : 0,
     flowRateY: payload.byteLength >= 34 ? view.getFloat32(30, true) : 0
+  }
+}
+
+// DISTANCE_SENSOR (msgid 132). Wire layout per c_library_v2's
+// mavlink_msg_distance_sensor.h — MAVLink v2 orders fields by descending
+// type size, NOT by XML declaration order, so the offsets below are the
+// generated ones: time_boot_ms(0), min_distance(4), max_distance(6),
+// current_distance(8), type(10), id(11), orientation(12), covariance(13),
+// then the extension block horizontal_fov(14), vertical_fov(18),
+// quaternion[4](22..37), signal_quality(38). LEN 39, MIN_LEN 14.
+//
+// Every extension read is length-guarded: ArduPilot trims trailing zero
+// bytes before transmitting, so a plain downward lidar with no FOV, no
+// custom quaternion and quality 0 arrives as a 14-byte payload. Decoding
+// that as "short frame, ignore" would blind us to the most common setup.
+function encodeDistanceSensorPayload(message: DistanceSensorMessage): Uint8Array {
+  const payload = new Uint8Array(39)
+  const view = new DataView(payload.buffer)
+  view.setUint32(0, message.timeBootMs, true)
+  view.setUint16(4, message.minDistanceCm, true)
+  view.setUint16(6, message.maxDistanceCm, true)
+  view.setUint16(8, message.currentDistanceCm, true)
+  view.setUint8(10, message.sensorType)
+  view.setUint8(11, message.id)
+  view.setUint8(12, message.orientation)
+  view.setUint8(13, message.covariance)
+  view.setFloat32(14, message.horizontalFov, true)
+  view.setFloat32(18, message.verticalFov, true)
+  // quaternion[4] at 22..37 stays zero — ArduPilot only fills it for
+  // MAV_SENSOR_ROTATION_CUSTOM, which no rangefinder backend uses.
+  view.setUint8(38, message.signalQuality)
+  return payload
+}
+
+function decodeDistanceSensorPayload(payload: Uint8Array): DistanceSensorMessage {
+  const view = new DataView(payload.buffer, payload.byteOffset, payload.byteLength)
+  return {
+    type: 'DISTANCE_SENSOR',
+    timeBootMs: view.getUint32(0, true),
+    minDistanceCm: view.getUint16(4, true),
+    maxDistanceCm: view.getUint16(6, true),
+    currentDistanceCm: view.getUint16(8, true),
+    sensorType: view.getUint8(10),
+    id: view.getUint8(11),
+    orientation: view.getUint8(12),
+    covariance: view.getUint8(13),
+    horizontalFov: payload.byteLength >= 18 ? view.getFloat32(14, true) : 0,
+    verticalFov: payload.byteLength >= 22 ? view.getFloat32(18, true) : 0,
+    signalQuality: payload.byteLength >= 39 ? view.getUint8(38) : 0
   }
 }
 

--- a/packages/protocol-mavlink/src/messages.ts
+++ b/packages/protocol-mavlink/src/messages.ts
@@ -357,6 +357,56 @@ export interface OpticalFlowMessage {
   flowRateY: number
 }
 
+/**
+ * DISTANCE_SENSOR (msgid 132) — one message per rangefinder instance.
+ *
+ * ArduPilot emits this from `GCS_MAVLINK::send_distance_sensor()`
+ * (libraries/GCS_MAVLink/GCS_Common.cpp), which iterates every rangefinder
+ * backend and skips any whose `has_data()` is false. That skip is the whole
+ * reason this message — rather than RANGEFINDER (msgid 173) — is the one we
+ * decode: a configured-but-not-talking lidar produces NO DISTANCE_SENSOR at
+ * all, so silence is a truthful "wired wrong / broken" signal. RANGEFINDER
+ * has no such guard, carries no signal-quality field, and only ever covers
+ * the single ROTATION_PITCH_270 instance.
+ *
+ * Proximity backends share the message: AP_Proximity sends its sectors with
+ * `id >= PROXIMITY_SENSOR_ID_START` (10, AP_Proximity.h), which is how a
+ * consumer separates real rangefinder instances (id == instance, 0..9) from
+ * 360° proximity sectors.
+ */
+export interface DistanceSensorMessage {
+  type: 'DISTANCE_SENSOR'
+  /** Milliseconds since vehicle boot. */
+  timeBootMs: number
+  /** Minimum measurable distance, centimetres (RNGFNDn_MIN × 100). */
+  minDistanceCm: number
+  /** Maximum measurable distance, centimetres (RNGFNDn_MAX × 100). */
+  maxDistanceCm: number
+  /** The live reading, centimetres. This is the number the operator wants. */
+  currentDistanceCm: number
+  /** MAV_DISTANCE_SENSOR enum (0 laser, 1 ultrasound, 2 infrared, 3 radar). */
+  sensorType: number
+  /** Onboard sensor ID. For rangefinders this equals the backend instance
+   * (0 = RNGFND1); values >= 10 are AP_Proximity sectors, not rangefinders. */
+  id: number
+  /** MAV_SENSOR_ORIENTATION; 25 = ROTATION_PITCH_270 = downward-facing. */
+  orientation: number
+  /** Measurement variance in cm²; 0 = unknown. */
+  covariance: number
+  /** Horizontal field of view (rad); 0 when unknown. Extension field. */
+  horizontalFov: number
+  /** Vertical field of view (rad); 0 when unknown. Extension field. */
+  verticalFov: number
+  /**
+   * Signal quality as a percentage, with two reserved sentinels that
+   * ArduPilot sets deliberately (GCS_Common.cpp): 0 = unknown/unset (the
+   * driver does not report quality at all), 1 = invalid signal, 2..100 =
+   * a real quality percentage. Extension field, so it is 0 on a truncated
+   * payload too — which is why "0" must never be rendered as "0% quality".
+   */
+  signalQuality: number
+}
+
 export interface UavcanNodeStatusMessage {
   type: 'UAVCAN_NODE_STATUS'
   /** Timestamp (UNIX epoch microseconds or microseconds since system boot). */
@@ -440,6 +490,7 @@ export type MavlinkMessage =
   | RcChannelsMessage
   | SysStatusMessage
   | OpticalFlowMessage
+  | DistanceSensorMessage
   | CanFrameMessage
   | GpsRawIntMessage
   | GlobalPositionIntMessage

--- a/packages/protocol-mavlink/src/mock-scenario.ts
+++ b/packages/protocol-mavlink/src/mock-scenario.ts
@@ -19,6 +19,7 @@ import type {
   CommandLongMessage,
   FileTransferProtocolMessage,
   GpsRawIntMessage,
+  DistanceSensorMessage,
   GlobalPositionIntMessage,
   LogRequestDataMessage,
   MavlinkEnvelope,
@@ -143,6 +144,21 @@ const mockParameters: ParameterState = {
   RNGFND1_RMETRIC: 1,
   RNGFND1_STOP_PIN: -1,
   RNGFND1_PWRRNG: 0,
+  // Optical flow, seeded CONFIGURED BUT DELIBERATELY SILENT: FLOW_TYPE is
+  // non-zero so the Status & Info flow card renders, but the mock never emits
+  // an OPTICAL_FLOW message, so the card sits in the "no data received" state.
+  //
+  // That state is the load-bearing one. A field report on this feature was an
+  // operator with a DroneCAN flow sensor they had hand-soldered (no room for
+  // the connector) with the wires crossed: the sensor was configured, no data
+  // arrived, and the card saying so is what told them the solder job was wrong
+  // instead of sending them to Mission Planner or the logs. The happy path is
+  // covered by the rangefinder card, which the mock does stream.
+  //
+  // 6 = DroneCAN (AP_OpticalFlow.h Type::UAVCAN, i.e. HereFlow) — matching
+  // that report, and specifically exercising the CAN-attached variant rather
+  // than a directly-wired one.
+  FLOW_TYPE: 6,
   // Relays (RELAY1/RELAY2) — seeded so the demo surfaces the Relays tab
   // populated: relay 1 is a plain operator relay on an AUX pin (default off),
   // relay 2 is mapped to the camera shutter. Metadata ships RELAY1..RELAY6.
@@ -800,6 +816,49 @@ function globalPositionMessage(timeBootMs: number): GlobalPositionIntMessage {
     velocityZcms: 0,
     headingCdeg: 27450
   }
+}
+
+/**
+ * A downward lidar that IS reporting — the demo's rangefinder happy path,
+ * and the counterweight to the deliberately-silent optical flow above.
+ *
+ * Mirrors what ArduPilot's send_distance_sensor() would emit for RNGFND1 as
+ * seeded in mockParameters: instance/id 0, MAV_DISTANCE_SENSOR_LASER (0),
+ * orientation 25 (ROTATION_PITCH_270, downward), and min/max taken straight
+ * from RNGFND1_MIN 0.2 m / RNGFND1_MAX 7 m. signal_quality 87 exercises the
+ * "real percentage" branch rather than either sentinel (0 unknown, 1 invalid).
+ *
+ * `distanceCm` is walked by the caller so the card visibly updates instead of
+ * showing one frozen number that could just as easily be a stale render.
+ */
+function distanceSensorMessage(timeBootMs: number, distanceCm: number): DistanceSensorMessage {
+  return {
+    type: 'DISTANCE_SENSOR',
+    timeBootMs,
+    minDistanceCm: 20,
+    maxDistanceCm: 700,
+    currentDistanceCm: distanceCm,
+    sensorType: 0,
+    id: 0,
+    orientation: 25,
+    covariance: 0,
+    horizontalFov: 0,
+    verticalFov: 0,
+    signalQuality: 87
+  }
+}
+
+/**
+ * A deterministic sawtooth between 0.62 m and 2.42 m, stepping 0.20 m per
+ * tick. Pure function of the tick index — no wall clock, no RNG — so a test
+ * that pumps N ticks always sees the same distance, matching how the
+ * attitude/stick choreography is built.
+ */
+function mockRangefinderDistanceCmForTick(tick: number): number {
+  const steps = 10
+  const phase = ((tick % (steps * 2)) + steps * 2) % (steps * 2)
+  const rising = phase < steps ? phase : steps * 2 - phase
+  return 62 + rising * 20
 }
 
 /** A healthy GPS with a 3D fix — the demo's happy path. */
@@ -1660,6 +1719,20 @@ function buildMockScenario(profile: MockVehicleProfile, options: MockScenarioOpt
             if (requestedMessageId === MAVLINK_MESSAGE_IDS.GPS_RAW_INT) {
               responses.push(codec.encode(envelope(96, gpsRawIntMessage())))
             }
+            // Answered ONLY on request, and absent from initialFrames. That is
+            // deliberate: it makes the demo prove the same thing hardware does
+            // — DISTANCE_SENSOR rides STREAM_EXTRA3 and arrives only because
+            // the runtime asked for it. If the LIVE_TELEMETRY_REQUESTS entry
+            // is ever dropped, the demo card goes dark too instead of quietly
+            // passing while real hardware fails.
+            if (requestedMessageId === MAVLINK_MESSAGE_IDS.DISTANCE_SENSOR) {
+              responses.push(
+                codec.encode(envelope(97, distanceSensorMessage(1600, mockRangefinderDistanceCmForTick(0))))
+              )
+            }
+            // No OPTICAL_FLOW response, on purpose. FLOW_TYPE is seeded
+            // non-zero so the flow card renders, but nothing ever answers —
+            // the demo's standing rehearsal of "configured but no data".
           } else if (
             outbound.message.command === MAV_CMD.REQUEST_MESSAGE &&
             Math.round(outbound.message.params[0] ?? 0) === MAVLINK_MESSAGE_IDS.AUTOPILOT_VERSION
@@ -2391,6 +2464,26 @@ function tickDynamicState(
         nextSequence,
         MAV_SEVERITY.INFO,
         'EKF variance cleared.'
+      )
+    )
+  }
+
+  // --- Rangefinder ---------------------------------------------------------
+  // Keep the downward lidar alive for as long as the demo runs, walking the
+  // distance so the Status & Info card reads as a live measurement rather
+  // than a value frozen at connect. Gated on RNGFND1_TYPE so a test using
+  // ?demoParamOverrides=RNGFND1_TYPE:0 gets a genuinely unconfigured
+  // rangefinder — no card, and no stray frames contradicting that.
+  if ((parameters.RNGFND1_TYPE ?? 0) !== 0) {
+    frames.push(
+      codec.encode(
+        envelope(
+          nextSequence(),
+          distanceSensorMessage(
+            Math.max(0, nowMs - (state.startedAtMs || nowMs)),
+            mockRangefinderDistanceCmForTick(state.tickCount)
+          )
+        )
       )
     )
   }

--- a/tests/e2e/views.spec.ts
+++ b/tests/e2e/views.spec.ts
@@ -4571,3 +4571,97 @@ test.describe('OSD message shorthand editor (@OSD/shorthand.dat)', () => {
     await expect(page.getByTestId('osd-shorthand-to-0')).toHaveValue('PRE')
   })
 })
+
+test.describe('Status & Info advanced sensor cards', () => {
+  // The ask: "I'd like to see rangefinder and optical flow so as a user I know
+  // they are working and reporting data. Right now I'm not sure how to do that
+  // besides look at logs or go back to MP."
+  //
+  // The Copter demo is seeded to hold the two states that matter at once:
+  // RNGFND1_TYPE=100 with the mock streaming DISTANCE_SENSOR (reporting), and
+  // FLOW_TYPE=6 with nothing ever answering (configured but silent). The third
+  // state — not configured — is asserted separately via ?demoParamOverrides,
+  // because "no card at all" is only provable against a build where the params
+  // say the sensor is off.
+
+  test('rangefinder card shows a live distance, not just a health adjective', async ({ page }) => {
+    await page.goto('/')
+    await page.getByTestId('transport-mode-select').selectOption('demo')
+    await page.getByTestId('connect-button').click()
+    await expect(page.getByTestId('session-vehicle-name')).toHaveText('ArduCopter', { timeout: VEHICLE_CONNECT_TIMEOUT })
+
+    const card = page.getByTestId('setup-rangefinder-card')
+    await expect(card).toBeVisible({ timeout: VEHICLE_CONNECT_TIMEOUT })
+
+    // A real measurement in metres is the primary content. The regex refuses a
+    // bare "0" or a dash: an unexplained zero is the same dead end the operator
+    // was already stuck in.
+    await expect(page.getByTestId('setup-rangefinder-card-distance')).toHaveText(/^\d+\.\d{2} m$/, {
+      timeout: VEHICLE_CONNECT_TIMEOUT
+    })
+    // Signal quality comes off the DISTANCE_SENSOR extension field.
+    await expect(page.getByTestId('setup-rangefinder-card-signal')).toHaveText('87%')
+    // Colour carries the state, but never alone — the state also lands on an
+    // attribute and in the headline copy.
+    await expect(card).toHaveAttribute('data-sensor-state', 'reporting')
+    await expect(page.getByTestId('setup-rangefinder-card-headline')).toContainText('Reporting live distance')
+  })
+
+  test('optical flow card says "no data received" on its face when the sensor is silent', async ({ page }) => {
+    // The load-bearing state. A field report closed the loop on exactly this:
+    // a DroneCAN flow sensor, hand-soldered with the wires crossed, configured
+    // but silent — and this message is what told the operator the solder job
+    // was wrong instead of sending them back to Mission Planner.
+    await page.goto('/')
+    await page.getByTestId('transport-mode-select').selectOption('demo')
+    await page.getByTestId('connect-button').click()
+    await expect(page.getByTestId('session-vehicle-name')).toHaveText('ArduCopter', { timeout: VEHICLE_CONNECT_TIMEOUT })
+
+    const card = page.getByTestId('setup-optical-flow-card')
+    await expect(card).toBeVisible({ timeout: VEHICLE_CONNECT_TIMEOUT })
+    await expect(card).toHaveAttribute('data-sensor-state', 'silent')
+
+    // Visible copy, NOT a tooltip. The first cut of this idea hid the diagnosis
+    // behind a hover and the operator had to go looking for it.
+    const headline = page.getByTestId('setup-optical-flow-card-headline')
+    await expect(headline).toBeVisible()
+    await expect(headline).toContainText('No data received')
+
+    // No fake reading stands in for the missing one.
+    await expect(page.getByTestId('setup-optical-flow-card-quality')).toHaveText('No data')
+    await expect(page.getByTestId('setup-optical-flow-card-last-data')).toHaveText('never')
+
+    // The CAN-attached driver is recognised as configured — a card that only
+    // knew the directly-wired variants would have hidden this exact fault.
+    await expect(page.getByTestId('setup-optical-flow-card-driver')).toHaveText('FLOW_TYPE 6 · DroneCAN')
+  })
+
+  test('an unconfigured sensor gets no card at all', async ({ page }) => {
+    // "Only show those boxes if setup. Anything above GPS and compass I'm
+    // calling advanced." GPS stays unconditional; these two disappear.
+    await page.goto('/?demoParamOverrides=RNGFND1_TYPE:0,FLOW_TYPE:0')
+    await page.getByTestId('transport-mode-select').selectOption('demo')
+    await page.getByTestId('connect-button').click()
+    await expect(page.getByTestId('session-vehicle-name')).toHaveText('ArduCopter', { timeout: VEHICLE_CONNECT_TIMEOUT })
+
+    // GPS is the baseline sensor and is still there...
+    await expect(page.getByTestId('setup-gps-format-select')).toBeVisible({ timeout: VEHICLE_CONNECT_TIMEOUT })
+    // ...while the advanced boxes are genuinely absent, not zeroed out.
+    await expect(page.getByTestId('setup-rangefinder-card')).toHaveCount(0)
+    await expect(page.getByTestId('setup-optical-flow-card')).toHaveCount(0)
+  })
+
+  test('the sensor cards do not overflow the phone layout', async ({ page }) => {
+    await page.setViewportSize({ width: 390, height: 844 })
+    await page.goto('/')
+    await page.getByTestId('transport-mode-select').selectOption('demo')
+    await page.getByTestId('connect-button').click()
+    await expect(page.getByTestId('session-vehicle-name')).toHaveText('ArduCopter', { timeout: VEHICLE_CONNECT_TIMEOUT })
+    await expect(page.getByTestId('setup-optical-flow-card')).toBeVisible({ timeout: VEHICLE_CONNECT_TIMEOUT })
+
+    const overflow = await page.evaluate(
+      () => document.documentElement.scrollWidth - document.documentElement.clientWidth
+    )
+    expect(overflow).toBeLessThanOrEqual(2)
+  })
+})

--- a/tests/runtime.integration.test.mjs
+++ b/tests/runtime.integration.test.mjs
@@ -1524,7 +1524,16 @@ test('live telemetry requests use responsive attitude rates and slower support s
         // timeout falsely fails the guided action. Idle cost is zero —
         // ArduPilot only fills these while a calibrator is running.
         [MAVLINK_MESSAGE_IDS.MAG_CAL_PROGRESS, 500000],
-        [MAVLINK_MESSAGE_IDS.MAG_CAL_REPORT, 1000000]
+        [MAVLINK_MESSAGE_IDS.MAG_CAL_REPORT, 1000000],
+        // 5 Hz DISTANCE_SENSOR + OPTICAL_FLOW for the Status & Info sensor
+        // cards. Both live in STREAM_EXTRA3, which ArduPilot does not stream
+        // unless a GCS asks — so without these two entries the cards render
+        // beautifully against the mock and are stone dead on real hardware.
+        // This assertion is the guard: it is the only automated place that
+        // notices if someone deletes the requests, because the mock scenario
+        // will happily emit whichever messages it likes regardless.
+        [MAVLINK_MESSAGE_IDS.DISTANCE_SENSOR, 200000],
+        [MAVLINK_MESSAGE_IDS.OPTICAL_FLOW, 200000]
       ]
     )
   } finally {

--- a/tests/runtime.sitl.test.mjs
+++ b/tests/runtime.sitl.test.mjs
@@ -165,3 +165,107 @@ test('true SITL: an ArduPlane vehicle is detected and swaps to the Plane catalog
     await sitl?.stop().catch(() => {})
   }
 })
+
+/**
+ * The rangefinder / optical-flow Status cards depend on two messages that live
+ * in STREAM_EXTRA3 and therefore only ever arrive because the runtime issues a
+ * SET_MESSAGE_INTERVAL for them. NOTHING below rung 4 can prove that: the mock
+ * scenario emits whatever it is told to, so the cards look perfect in demo mode
+ * and in every unit test even if the requests were deleted. Only a real
+ * autopilot can answer, which is why this test exists.
+ *
+ * Two levels of assertion:
+ *   1. Always — a real ArduPilot ACCEPTS both requests. A rejected stream makes
+ *      the runtime append a warning status entry naming the stream, so the
+ *      absence of those entries is the proof. This runs on any SITL, with or
+ *      without sensors configured.
+ *   2. When the attached SITL actually has the sensors configured (set
+ *      RNGFND1_TYPE=100 / FLOW_TYPE=10 / SIM_FLOW_ENABLE=1 and reboot it), the
+ *      readings themselves are asserted.
+ *
+ * Level 2 was walked by hand against ArduCopter SITL while building this and
+ * both streams arrived — rangefinder orientation 25 (down), min/max mirroring
+ * RNGFND1_MIN/_MAX, signal_quality 0 (the SIM backend does not report quality);
+ * optical flow quality 51 with live flowRateX/Y. It is kept conditional here so
+ * the test does not require reconfiguring and rebooting the SITL mid-run.
+ */
+test('true SITL: the rangefinder + optical-flow streams are accepted and arrive', { timeout: 240000 }, async (t) => {
+  const repoPath = process.env.ARDUPILOT_REPO_PATH
+  const attachHost = process.env.ARDUPILOT_SITL_HOST
+  const attachPort = Number(process.env.ARDUPILOT_SITL_PORT ?? '5760')
+  const launchWaitPort = Number(process.env.ARDUPILOT_SITL_LAUNCH_WAIT_PORT ?? '5760')
+
+  if (!repoPath && !attachHost) {
+    t.skip('Set ARDUPILOT_REPO_PATH to launch SITL, or ARDUPILOT_SITL_HOST/PORT to attach to an existing endpoint.')
+    return
+  }
+
+  let sitl
+  if (repoPath) {
+    sitl = await launchArduPilotDirectBinary({
+      repoPath,
+      vehicle: process.env.ARDUPILOT_SITL_VEHICLE ?? 'ArduCopter',
+      frame: process.env.ARDUPILOT_SITL_FRAME ?? 'quad',
+      port: launchWaitPort,
+      launchTimeoutMs: Number(process.env.ARDUPILOT_SITL_LAUNCH_TIMEOUT_MS ?? '120000')
+    })
+  }
+
+  const transport = new TcpTransport('sitl-sensor-streams-tcp', {
+    host: attachHost ?? '127.0.0.1',
+    port: attachPort,
+    connectTimeoutMs: 10000
+  })
+  const session = new MavlinkSession(transport, new MavlinkV2Codec())
+  const runtime = new ArduPilotConfiguratorRuntime(session, arducopterMetadata, {})
+
+  try {
+    await runtime.connect()
+    await runtime.waitForVehicle({ timeoutMs: 20000 })
+    await runtime.requestParameterList({ timeoutMs: 20000 })
+    await runtime.waitForParameterSync({ timeoutMs: 60000 })
+
+    // Let the SET_MESSAGE_INTERVAL ACKs land and give the streams a few
+    // seconds of runway at their requested 5 Hz.
+    await new Promise((resolve) => setTimeout(resolve, 8000))
+
+    const snapshot = runtime.getSnapshot()
+
+    // Level 1: a real autopilot took both requests. The runtime only files a
+    // warning here when the FC actively refuses a stream, so a clean log means
+    // DISTANCE_SENSOR and OPTICAL_FLOW were accepted as sent.
+    const rejections = snapshot.statusTexts.filter(
+      (entry) =>
+        entry.severity !== 'info' &&
+        /DISTANCE_SENSOR|OPTICAL_FLOW/.test(entry.text) &&
+        /stream/i.test(entry.text)
+    )
+    assert.deepEqual(rejections, [], 'SITL refused one of the sensor telemetry streams.')
+
+    // Level 2: if this SITL has the sensors configured, the readings must be
+    // real — not merely "a message arrived".
+    const rangefinderType = snapshot.parameters.find((entry) => entry.id === 'RNGFND1_TYPE')?.value ?? 0
+    if (rangefinderType !== 0) {
+      const rangefinder = snapshot.liveVerification.rangefinder
+      assert.equal(rangefinder.verified, true, 'RNGFND1_TYPE is set but no DISTANCE_SENSOR arrived.')
+      assert.equal(typeof rangefinder.distanceM, 'number')
+      // Instance 0 == RNGFND1, and never an AP_Proximity sector (id >= 10).
+      assert.ok(rangefinder.sensorId !== undefined && rangefinder.sensorId < 10)
+    } else {
+      t.diagnostic('RNGFND1_TYPE is 0 on this SITL — stream acceptance asserted, reading not exercised.')
+    }
+
+    const flowType = snapshot.parameters.find((entry) => entry.id === 'FLOW_TYPE')?.value ?? 0
+    if (flowType !== 0) {
+      const flow = snapshot.liveVerification.opticalFlow
+      assert.equal(flow.verified, true, 'FLOW_TYPE is set but no OPTICAL_FLOW arrived.')
+      assert.equal(typeof flow.quality, 'number')
+    } else {
+      t.diagnostic('FLOW_TYPE is 0 on this SITL — stream acceptance asserted, reading not exercised.')
+    }
+  } finally {
+    await runtime.disconnect().catch(() => {})
+    runtime.destroy()
+    await sitl?.stop().catch(() => {})
+  }
+})

--- a/tests/transport.test.mjs
+++ b/tests/transport.test.mjs
@@ -714,8 +714,8 @@ test('MockTransport serializes chunked inbound frames so demo parameter sync com
     const stats = await runtime.waitForParameterSync({ timeoutMs: 120000 })
 
     assert.equal(stats.status, 'complete')
-    assert.equal(stats.downloaded, 1173)
-    assert.equal(stats.total, 1173)
+    assert.equal(stats.downloaded, 1174)
+    assert.equal(stats.total, 1174)
     assert.equal(runtime.getSnapshot().parameters.find((parameter) => parameter.id === 'FRAME_CLASS')?.value, 1)
     assert.equal(runtime.getSnapshot().parameters.find((parameter) => parameter.id === 'FRAME_TYPE')?.value, 1)
   } finally {
@@ -846,7 +846,7 @@ test('Bundled WebSocket bridge can drive runtime heartbeat and parameter sync fr
     assert.equal(runtime.getSnapshot().connection.kind, 'connected')
     assert.equal(runtime.getSnapshot().vehicle?.vehicle, 'ArduCopter')
     assert.equal(stats.status, 'complete')
-    assert.equal(stats.downloaded, 1173)
+    assert.equal(stats.downloaded, 1174)
     assert.equal(runtime.getSnapshot().parameters.find((parameter) => parameter.id === 'FRAME_CLASS')?.value, 1)
   } finally {
     await runtime.disconnect().catch(() => {})


### PR DESCRIPTION
> "I'd like to see rangefinder and optical flow so as a user I know they are working and reporting data. Right now I'm not sure how to do that besides look at logs or go back to MP."

Adds live rangefinder and optical-flow readouts to Status & Info.

## Real measurements, not adjectives

- **Rangefinder** — measured distance in metres from `DISTANCE_SENSOR.current_distance`, plus signal quality, configured range, facing, driver, last-data age.
- **Optical flow** — `quality` 0-255 as the headline (the number that says whether it actually works), plus flow rates, HAGL, driver, last-data age.

States: **absent** (no card at all — GPS/compass stay unconditional), **silent** (configured, never reported), **stalled** (reported then stopped, with how long it's been quiet), **degraded** (data arriving but unusable — value still shown, because that's the diagnosis), **reporting**. Fault text is body copy, never tooltip-only. Colour uses existing `--success/--warning/--danger` tokens and is never the sole signal.

ArduPilot's `signal_quality` sentinels are honoured (0 = driver doesn't report, 1 = invalid) so neither renders as a misleading "0%". A reading is suppressed the instant the stream goes quiet — a four-second-old distance looks exactly like a working sensor.

## `DISTANCE_SENSOR` over `RANGEFINDER`, on evidence

`send_distance_sensor()` returns early on `!sensor->has_data()`, so a dead lidar emits nothing and silence is truthful. `send_rangefinder()` has no such guard and would keep publishing a stale distance for a dead sensor — precisely the failure this feature exists to expose. `DISTANCE_SENSOR` also carries signal_quality/min/max/orientation/instance; `RANGEFINDER` is in no stream group and is compiled out unless `AP_MAVLINK_MSG_RANGEFINDER_SENDING_ENABLED`.

## Fixes a latent bug

Both messages are now in `LIVE_TELEMETRY_REQUESTS` at 5 Hz. They live in `STREAM_EXTRA3`, which ArduPilot **never streams unsolicited** — so the existing header "Flow" chip, which has read `OPTICAL_FLOW` since it was added, could only ever have been grey on real hardware. Nobody had requested the message.

Also corrects the Flow tooltip, which advised "10 HereFlow, 8 PMW3901". Per `AP_OpticalFlow.cpp:30` the values are `6:DroneCAN, 8:UPFLOW, 10:SITL` — it was pointing operators at a value that could never work.

## Byte-identical: **no**

Stated honestly. This adds two `SET_MESSAGE_INTERVAL` requests to what every vehicle, including ArduCopter, asks for at connect, and adds `FLOW_TYPE=6` to the demo param set (1173→1174). No parameter value, write path, or guided action is touched.

## Validation

Rungs 1-4. typecheck clean; `npm run test` 846 pass / 0 fail / 3 skipped; web vitest 73 files / 650 pass (16 new); `npm run test:e2e` 238 passed / 6 skipped / 0 failed (4 new blocks incl. 390px); `npm run test:sitl` 2 pass / 0 fail.

**SITL confirmed the streams actually arrive** — with sensors enabled (`RNGFND1_TYPE=100`, `FLOW_TYPE=10`, `SIM_FLOW_ENABLE=1`), `DISTANCE_SENSOR` arrived at orientation 25 (down) with min/max mirroring `RNGFND1_MIN/_MAX`, and `OPTICAL_FLOW` at quality 51 with live flow rates. This is the only rung that can prove it; the mock cannot.

**Rung 5 outstanding** — no live FC. The hardware-facing behaviour is SITL-proven, not FC-proven. Worth a bench check on a real aircraft, ideally one with a CAN flow sensor.