### PR TITLE
fix(parameters): keep the edited row in place when staging a draft

### DIFF
--- a/apps/web/src/sections/ParametersSection.tsx
+++ b/apps/web/src/sections/ParametersSection.tsx
@@ -3,7 +3,7 @@
 // staged / invalid / reboot-required draft groups, the import-backup file
 // input + three export buttons, and the selected-parameter detail card.
 
-import { Fragment, useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { Fragment, useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react'
 import type { Dispatch, ReactElement, ReactNode, RefObject, SetStateAction } from 'react'
 import { parameterAlias } from '@arduconfig/ardupilot-core'
 import type { ConfiguratorSnapshot, ParameterDraftEntry, ParameterDraftGroup, ParameterDraftSummary, ParameterImportCategory, ParameterState } from '@arduconfig/ardupilot-core'
@@ -220,6 +220,56 @@ export function ParametersSection(props: ParametersSectionProps): ReactElement {
     if (scrollToChangesRequestId === 0) return
     scrollToReviewTarget(invalidDiffGridRef.current ?? stagedDiffGridRef.current)
   }, [scrollToChangesRequestId, scrollToReviewTarget])
+
+  // Editing a row must not move that row out from under the operator. Staging
+  // the first draft inserts the whole staged-review block (~200px, more once it
+  // carries several categories) ABOVE the parameter table, so every row below it
+  // moves that far down the DOCUMENT — measured on the demo copter: the edited
+  // row's document top went 3557 -> 3759 (+202) on a single AUTOTUNE_AXES bit
+  // toggle. Blink and Gecko hide that with native scroll anchoring (scrollY
+  // silently absorbs the +202 and the row's viewport position is unchanged), so
+  // the shift is invisible THERE and only there: WebKit implements no scroll
+  // anchoring at all, and Blink itself suppresses the adjustment in several
+  // documented cases. With anchoring off the same toggle slides the row 202px
+  // down the viewport mid-edit, which is the reported "changing a bitmask throws
+  // me up the page and I have to scroll back down to where I was" — an operator
+  // report whose browser was not captured, so the app must not depend on a
+  // browser feature to hold the row. Rather than disable or fight
+  // the browser's anchoring, measure what it did NOT absorb and make up only the
+  // difference: record the row's viewport top at the moment of the edit, then in
+  // the layout effect after React commits (before paint, so no flicker) scroll by
+  // the residual drift. Where the browser already anchored, the residual is 0 and
+  // this does nothing at all.
+  const pendingRowAnchorRef = useRef<{ paramId: string; top: number } | undefined>(undefined)
+  const parameterRowElement = (paramId: string): HTMLElement | null => {
+    if (typeof document === 'undefined') return null
+    return document.querySelector<HTMLElement>(`.parameter-row[data-param-row="${CSS.escape(paramId)}"]`)
+  }
+  const setDraftKeepingRowInPlace = useCallback(
+    (paramId: string, value: string) => {
+      const top = parameterRowElement(paramId)?.getBoundingClientRect().top
+      pendingRowAnchorRef.current = top === undefined ? undefined : { paramId, top }
+      setDraft(paramId, value)
+    },
+    [setDraft]
+  )
+  // Deliberately un-keyed: it has to run on the commit that follows the edit,
+  // and the pending anchor (cleared on every commit) is what gates the work, so
+  // an unrelated re-render costs one ref read.
+  useLayoutEffect(() => {
+    const pending = pendingRowAnchorRef.current
+    pendingRowAnchorRef.current = undefined
+    if (!pending) return
+    // The row can legitimately be gone (a search/category filter re-evaluated,
+    // or "show only changed" dropped it) — there is nothing to hold still then.
+    const top = parameterRowElement(pending.paramId)?.getBoundingClientRect().top
+    if (top === undefined) return
+    const drift = top - pending.top
+    // Sub-pixel drift is layout rounding, not a jump; scrolling for it would
+    // just add noise.
+    if (Math.abs(drift) < 1) return
+    window.scrollBy({ top: drift, left: 0, behavior: 'instant' as ScrollBehavior })
+  })
   // The search box filters the staged review too: filtering only the
   // table while the review list (where you look mid-import) ignores it
   // makes wildcard search appear broken. Selection, Select all, and Drop
@@ -1060,6 +1110,10 @@ export function ParametersSection(props: ParametersSectionProps): ReactElement {
               <Fragment key={parameter.id}>
               <div
                 className={`${rowClassName}${isExpanded ? ' parameter-row--selected parameter-row--expanded' : ''}`}
+                // Lets the edit-time scroll compensation above find this row
+                // again after the commit, without threading a ref per row
+                // through the (unbounded) parameter list.
+                data-param-row={parameter.id}
                 // Click the row to expand its detail; toggle to collapse. The
                 // Draft + Actions cells stop propagation so editing/clicking a
                 // control never collapses the row under the operator.
@@ -1129,7 +1183,7 @@ export function ParametersSection(props: ParametersSectionProps): ReactElement {
                       liveValue={parameter.value}
                       editedValues={editedValues}
                       draftStatusById={draftStatusMap}
-                      onChange={setDraft}
+                      onChange={setDraftKeepingRowInPlace}
                     />
                   ) : (
                     <input
@@ -1138,7 +1192,7 @@ export function ParametersSection(props: ParametersSectionProps): ReactElement {
                       aria-label={`${parameter.id} value`}
                       value={editedValues[parameter.id] ?? String(parameter.value)}
                       onChange={(event) =>
-                        setDraft(parameter.id, event.target.value)
+                        setDraftKeepingRowInPlace(parameter.id, event.target.value)
                       }
                     />
                   )}
@@ -1193,7 +1247,7 @@ export function ParametersSection(props: ParametersSectionProps): ReactElement {
                     definition={definition}
                     alias={parameterAlias(parameter.id)}
                     editedValues={editedValues}
-                    onChange={setDraft}
+                    onChange={setDraftKeepingRowInPlace}
                     draftStatusById={draftStatusMap}
                     defaultValue={parameterDefaults?.get(parameter.id)}
                   />

--- a/tests/e2e/views.spec.ts
+++ b/tests/e2e/views.spec.ts
@@ -319,6 +319,61 @@ test.describe('Parameters tab (expert-only)', () => {
     await expect(page.getByTestId('parameter-diff-grid')).toBeInViewport()
   })
 
+  test('editing a bitmask row keeps that row under the operator, with no scroll anchoring to lean on', async ({ page }) => {
+    // Reported by an operator ticking AUTOTUNE_AXES bits in the full param list:
+    // "when I make a change it takes me to the top of the page so I have to
+    // scroll back down to where I was". Root cause, measured on the demo copter:
+    // staging the first draft inserts the staged-review block ABOVE the table, so
+    // the edited row's DOCUMENT position moves down by that block's height
+    // (3557 -> 3759px, +202). Blink/Gecko hide it with native scroll anchoring;
+    // WebKit has no scroll anchoring at all, so there the row visibly slides
+    // ~202px down the viewport mid-edit.
+    //
+    // Chromium (what this suite runs) would therefore pass on the browser's
+    // anchoring alone and never see the regression, so `overflow-anchor: none`
+    // is injected HERE, in the test only, to model an engine without it — that
+    // is what makes this test exercise the app's own compensation rather than
+    // Blink's. Nothing in the app disables anchoring.
+    await page.setViewportSize({ width: 1496, height: 715 })
+    await page.goto('/')
+    await page.addStyleTag({ content: '* { overflow-anchor: none !important; }' })
+    await connectViaHeader(page)
+    await expectParameterSyncComplete(page)
+    await page.getByTestId('product-mode-expert').click()
+    await page.getByTestId('view-button-parameters').click()
+    await page.addStyleTag({ content: '* { overflow-anchor: none !important; }' })
+
+    const popover = page.locator('.parameter-row details[data-testid="scoped-bitmask-AUTOTUNE_AXES"]')
+    await expect(popover).toBeVisible()
+    await popover.locator('summary').click()
+
+    // Park the row 300px down the viewport: clear of the sticky header, so the
+    // bit button is a real unobstructed hit and Playwright's actionability check
+    // never scrolls the page itself (which would mask the measurement).
+    await popover.evaluate((el) => {
+      const row = el.closest('.parameter-row') as HTMLElement
+      window.scrollTo({ top: window.scrollY + row.getBoundingClientRect().top - 300, behavior: 'instant' as ScrollBehavior })
+    })
+    // Reach the row through the popover rather than by any attribute the fix
+    // itself adds, so this measures behaviour and would still run (and fail) if
+    // the compensation were reverted.
+    const rowTop = () => popover.evaluate((el) => el.closest('.parameter-row')!.getBoundingClientRect().top)
+    const rowClass = () => popover.evaluate((el) => el.closest('.parameter-row')!.className)
+    const before = await rowTop()
+
+    const bits = popover.locator('.scoped-bitmask-popover__panel .scoped-bitmask-bit')
+    // First toggle: stages a draft, which is what inserts the review block.
+    await bits.first().click()
+    await expect.poll(rowClass).toContain('parameter-row--staged')
+    expect(Math.abs((await rowTop()) - before)).toBeLessThanOrEqual(4)
+
+    // And back to the original value, which DROPS the draft and removes the
+    // review block again — the shrink direction has to hold the row too.
+    await bits.first().click()
+    await expect.poll(rowClass).not.toContain('parameter-row--staged')
+    expect(Math.abs((await rowTop()) - before)).toBeLessThanOrEqual(4)
+  })
+
   test('a staged review row edited back to the original stays put (no vanish mid-edit)', async ({ page }) => {
     // Bug: editing a staged value in the Show Changes review to equal the live
     // value dropped the row from under the operator's cursor — how a half-typed


### PR DESCRIPTION
> "When I'm in the full param list and I start selecting options to change a bitmask — specifically autotune axes — when I make a change it takes me to the top of the page so I have to scroll back down."

## Mechanism, proven by measurement

Staging the first draft inserts the staged-review block **above** the parameter table, moving the edited row **+202px down the document**.

| | rowTop (viewport) | scrollY | rowDocTop |
|---|---|---|---|
| scroll anchoring **on** | 300 → 300 (Δ0) | 3257 → 3459 (**Δ+202**) | Δ+202 |
| anchoring **off** | 300 → **502** (Δ+202) | Δ0 | Δ+202 |

Nothing in the app scrolls: `window.scrollTo`/`scrollBy`/`Element.scrollIntoView`/`HTMLElement.focus` were monkey-patched with stack capture across the edit — **zero calls**. `activeElement` moves to the clicked bit button and stays. Neither deliberate scroll effect fires. Row keys and expansion were already fine.

## Honest caveat

**In stock Chromium the row does not visibly move** — Blink's scroll anchoring absorbs the whole 202px, and the jump could not be reproduced at any fully-visible row offset. Two apparent repros were discarded as measurement artifacts: a `data-testid` collision with the review block's popover, and Playwright auto-scrolling an off-screen click target (which produced convincing 200-900px "jumps" that were entirely the harness).

So the reporter's browser is **not identified**. What *is* proven is the layout shift, and that the app was relying on a browser feature to hide it — WebKit ships no scroll anchoring at all, and Blink suppresses it in several documented cases.

## Fix

Table editors route through `setDraftKeepingRowInPlace`, which records the row's viewport top at edit time; a `useLayoutEffect` (post-commit, pre-paint) scrolls by the **residual** drift only. Where the browser already anchored, residual is 0 and nothing happens — no fighting the engine, and `overflow-anchor` is never disabled. Verified identical with anchoring on and off, including the shrink direction.

`setDraft` receives byte-identical `(paramId, value)` — no value, write-path, draft or metadata semantics touched.

## Test

Not observable off the DOM, so it's an e2e block that injects `overflow-anchor:none` **in the test only** to model an engine without anchoring — otherwise Chromium passes on Blink's anchoring and never sees the regression. **Red before the fix (202.3px drift), green after.**

## Validation

typecheck clean; `npm run test` 846 pass / 0 fail / 3 skipped; `npm run test:e2e` 235 passed / 6 skipped, no flakes.