### PR TITLE
feat(ui): parameter "i" bubble names the raw param and links our own wiki

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -277,6 +277,7 @@ import { DronecanInspectorView, type DronecanFirmwareOnlineSource } from './view
 import { useDronecanBusStats } from './hooks/use-dronecan-bus-stats'
 import { dronecanNodeBoardId, parseApj, decodeApjImage } from '@arduconfig/firmware-flash'
 import { inflateZlib } from './firmware/web-serial-bootloader'
+import { ParamInfoBubble } from './views/ParamInfoBubble'
 import { ScopedField, ScopedSelectField } from './views/ScopedField'
 import { ModesView } from './views/Modes'
 import { FailsafeSection } from './sections/FailsafeSection'
@@ -5897,29 +5898,22 @@ export function App() {
   // ArduPilot description right next to the control, so the operator knows what
   // each NET_ param does without leaving the tab. Mirrors the Config "i".
   function withNetworkingFieldInfo(parameter: ParameterState, node: ReactNode): ReactNode {
-    const description = parameter.definition?.description
-    if (node === null || node === undefined || !description) {
+    if (node === null || node === undefined) {
       return node
     }
-    // Same per-field "i" affordance as the Config tab (config-section__info) —
-    // hover/focus reveals the styled description box — so it's consistent with
-    // the rest of the app.
+    // Same shared per-field "i" affordance as the Config tab — hover/focus
+    // reveals the raw parameter id, the ArduPilot description and a wiki deep
+    // link, so it's consistent with the rest of the app. No longer gated on
+    // there being a description: the id and the link are always worth having.
     return (
       <div key={parameter.id} className="config-section__field-row">
         {node}
-        <span className="config-section__info-wrap">
-          <button
-            type="button"
-            className="config-section__info"
-            data-testid={`networking-field-info-${parameter.id}`}
-            aria-label={`About ${parameter.definition?.label ?? parameter.id}`}
-          >
-            i
-          </button>
-          <span className="config-section__info-tip" role="tooltip">
-            {description}
-          </span>
-        </span>
+        <ParamInfoBubble
+          paramId={parameter.id}
+          label={parameter.definition?.label ?? parameter.id}
+          description={parameter.definition?.description}
+          testId={`networking-field-info-${parameter.id}`}
+        />
       </div>
     )
   }

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -6702,8 +6702,29 @@ textarea:focus {
   letter-spacing: normal;
   text-transform: none;
 }
+/* The header's blanket span styling (block/uppercase/muted/tracked) would also
+   claim the tip's inner spans, so restate those two here as well — the param id
+   keeps its data font, the description reads as prose. */
+.tuning-control__header .config-section__info-param {
+  display: block;
+  margin-bottom: 0;
+  color: var(--text);
+  font-size: 11px;
+  letter-spacing: 0.06em;
+}
+.tuning-control__header .config-section__info-text {
+  display: block;
+  margin: 6px 0 0;
+  color: var(--text-muted);
+  font-size: 12px;
+  font-family: inherit;
+  font-weight: 400;
+  letter-spacing: normal;
+  text-transform: none;
+}
 .tuning-control__header .config-section__info-wrap:hover .config-section__info-tip,
-.tuning-control__header .config-section__info:focus-visible + .config-section__info-tip {
+.tuning-control__header .config-section__info:focus-visible + .config-section__info-tip,
+.tuning-control__header .config-section__info-wrap:focus-within .config-section__info-tip {
   display: block;
 }
 
@@ -13442,7 +13463,10 @@ details.bf-gui-box:not([open]) > summary::after {
   top: 24px;
   z-index: 20;
   width: max-content;
-  max-width: 260px;
+  /* Clamp to the viewport as well as the 260px design width: the box is
+     right-anchored to an 18px icon, so on a 390px phone a fixed 260px box can
+     run past the left edge of the screen and clip its own text. */
+  max-width: min(260px, calc(100vw - 32px));
   padding: 8px 10px;
   border-radius: 6px;
   border: 1px solid var(--surface-400);
@@ -13459,9 +13483,54 @@ details.bf-gui-box:not([open]) > summary::after {
   box-shadow: 0 6px 20px rgba(0, 0, 0, 0.45);
 }
 
+/* The tip sits 24px down while the button is only 18px tall, so there is a 6px
+   dead band between them. Hover state follows the DOM (the tip is a descendant
+   of the wrap), not the visual box, so a pointer crossing that band leaves the
+   wrap and the tip disappears — which made the wiki link inside it impossible
+   to click. This invisible bridge covers the gap so the pointer never leaves. */
+.config-section__info-tip::before {
+  content: '';
+  position: absolute;
+  left: 0;
+  right: 0;
+  top: -8px;
+  height: 8px;
+}
+
 .config-section__info-wrap:hover .config-section__info-tip,
-.config-section__info:focus-visible + .config-section__info-tip {
+.config-section__info:focus-visible + .config-section__info-tip,
+/* focus-within, not just the button's own focus: tabbing from the "i" onto the
+   wiki link inside the tip would otherwise blur the button and close the tip
+   out from under the link, leaving it unreachable by keyboard. */
+.config-section__info-wrap:focus-within .config-section__info-tip {
   display: block;
+}
+
+/* Raw ArduPilot parameter name — the whole point of the bubble for an operator
+   who only ever sees the friendly label. Monospaced and select-all so it can be
+   copied straight into the Parameters tab search. */
+.config-section__info-param {
+  display: block;
+  font-family: var(--font-data);
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  color: var(--text);
+  user-select: all;
+}
+
+.config-section__info-text {
+  display: block;
+  margin-top: 6px;
+  color: var(--text-muted);
+}
+
+.config-section__info-wiki {
+  display: inline-block;
+  margin-top: 6px;
+  color: var(--accent-strong, var(--accent));
+  font-size: 11px;
+  text-decoration: underline;
 }
 
 .config-section__missing-row {

--- a/apps/web/src/tuning-control.tsx
+++ b/apps/web/src/tuning-control.tsx
@@ -9,6 +9,7 @@ import type { ParameterDraftStatus, ParameterState } from '@arduconfig/ardupilot
 import { StatusBadge } from '@arduconfig/ui-kit'
 
 import { formatNumericDisplayValue, formatParameterDisplayValue, formatAngleMaxDegrees } from './parameter-format'
+import { ParamInfoBubble } from './views/ParamInfoBubble'
 
 export function tuningInputValue(parameter: ParameterState, editedValues: Record<string, string>): string {
   const rawValue = editedValues[parameter.id]
@@ -180,24 +181,17 @@ export function TuningControl(props: TuningControlProps): ReactElement {
         </div>
         {draftStatus === 'staged' ? <StatusBadge tone="warning">staged</StatusBadge> : null}
         {draftStatus === 'invalid' ? <StatusBadge tone="danger">invalid</StatusBadge> : null}
-        {description ? (
-          // Same per-field "i" affordance as the Config / Networking tabs
-          // (config-section__info) — hover/focus reveals the styled description
-          // box — so it reads consistently across the app.
-          <span className="config-section__info-wrap">
-            <button
-              type="button"
-              className="config-section__info"
-              data-testid={`tuning-info-${parameter.id}`}
-              aria-label={`About ${label}`}
-            >
-              i
-            </button>
-            <span className="config-section__info-tip" role="tooltip">
-              {description}
-            </span>
-          </span>
-        ) : null}
+        {/* Shared per-field "i" affordance (Config / Networking use the same
+            component). Unconditional: a curated tuning card shows ONLY the
+            friendly label ("Stick Feel Smoothing"), so the bubble is the only
+            place the operator can learn the parameter is ATC_INPUT_TC — that
+            has to work whether or not the metadata carries a description. */}
+        <ParamInfoBubble
+          paramId={parameter.id}
+          label={label}
+          description={description}
+          testId={`tuning-info-${parameter.id}`}
+        />
       </div>
 
       <input

--- a/apps/web/src/view-models/param-docs.test.ts
+++ b/apps/web/src/view-models/param-docs.test.ts
@@ -1,32 +1,62 @@
 import { describe, expect, it } from 'vitest'
 
-import { ARDUPILOT_PARAMETER_DOCS_URL, parameterWikiUrl } from './param-docs'
+import {
+  WIKI_PARAMETER_FIRMWARE,
+  WIKI_PARAMETER_QUERY_KEY,
+  WIKI_PARAMETER_REFERENCE_URL,
+  parameterWikiUrl,
+} from './param-docs'
 
 describe('parameterWikiUrl', () => {
-  // These expectations were checked against the live parameters.html: each of
-  // these short anchors exists on the page. If ArduPilot ever changes the
-  // Sphinx anchor scheme, this is the test that should fail first.
-  it('derives the short Sphinx anchor for real parameter ids', () => {
-    expect(parameterWikiUrl('ATC_INPUT_TC')).toBe(`${ARDUPILOT_PARAMETER_DOCS_URL}#atc-input-tc`)
-    expect(parameterWikiUrl('BATT_MONITOR')).toBe(`${ARDUPILOT_PARAMETER_DOCS_URL}#batt-monitor`)
-    expect(parameterWikiUrl('COMPASS_DISBLMSK')).toBe(`${ARDUPILOT_PARAMETER_DOCS_URL}#compass-disblmsk`)
+  // The other half of this contract is asserted against the REAL generated
+  // reference in tests/wiki-parameter-reference.test.mjs: that
+  // parameters/index.html is a page the generator emits, that the search script
+  // reads this query key, and that an exact name resolves to a group page and
+  // an anchor that both exist. This file pins the app-side derivation only.
+  it('addresses a parameter by name against the reference', () => {
+    expect(parameterWikiUrl('ATC_INPUT_TC')).toBe(`${WIKI_PARAMETER_REFERENCE_URL}?param=ATC_INPUT_TC`)
+    expect(parameterWikiUrl('BATT_MONITOR')).toBe(`${WIKI_PARAMETER_REFERENCE_URL}?param=BATT_MONITOR`)
+    expect(parameterWikiUrl('COMPASS_DISBLMSK')).toBe(`${WIKI_PARAMETER_REFERENCE_URL}?param=COMPASS_DISBLMSK`)
   })
 
   it('keeps digits in place for indexed families', () => {
-    expect(parameterWikiUrl('SERVO1_FUNCTION')).toBe(`${ARDUPILOT_PARAMETER_DOCS_URL}#servo1-function`)
-    expect(parameterWikiUrl('INS_HNTC2_MODE')).toBe(`${ARDUPILOT_PARAMETER_DOCS_URL}#ins-hntc2-mode`)
+    expect(parameterWikiUrl('SERVO1_FUNCTION')).toBe(`${WIKI_PARAMETER_REFERENCE_URL}?param=SERVO1_FUNCTION`)
+    expect(parameterWikiUrl('INS_HNTC2_MODE')).toBe(`${WIKI_PARAMETER_REFERENCE_URL}?param=INS_HNTC2_MODE`)
   })
 
-  it('falls back to the bare docs page rather than inventing an anchor', () => {
-    // Composed / non-ArduPilot-shaped ids: no fragment is better than a wrong one.
-    expect(parameterWikiUrl('')).toBe(ARDUPILOT_PARAMETER_DOCS_URL)
-    expect(parameterWikiUrl('uavcan.node.id')).toBe(ARDUPILOT_PARAMETER_DOCS_URL)
-    expect(parameterWikiUrl('NET_IPADDR0 / NET_IPADDR1')).toBe(ARDUPILOT_PARAMETER_DOCS_URL)
+  it('names parameters whose family page is NOT derivable from the name', () => {
+    // The reason the link is name-addressed rather than page-addressed: Copter's
+    // top-level parameters all live on group-copter, and ARSPD_ lands on the
+    // suffixed group-arspd-2 because ARSPD took group-arspd first. Neither is
+    // recoverable from the id, so the app must not try.
+    expect(parameterWikiUrl('ACRO_RP_EXPO')).toBe(`${WIKI_PARAMETER_REFERENCE_URL}?param=ACRO_RP_EXPO`)
+    expect(parameterWikiUrl('ARSPD_TYPE')).toBe(`${WIKI_PARAMETER_REFERENCE_URL}?param=ARSPD_TYPE`)
   })
 
-  it('never emits a URL off the ArduPilot docs origin', () => {
-    for (const id of ['ATC_INPUT_TC', 'javascript:alert(1)', '../../evil']) {
-      expect(parameterWikiUrl(id).startsWith(ARDUPILOT_PARAMETER_DOCS_URL)).toBe(true)
+  it('falls back to the bare reference rather than inventing a lookup', () => {
+    // Composed / non-ArduPilot-shaped ids: landing on the reference is better
+    // than sending the search page after a name that cannot exist.
+    expect(parameterWikiUrl('')).toBe(WIKI_PARAMETER_REFERENCE_URL)
+    expect(parameterWikiUrl('uavcan.node.id')).toBe(WIKI_PARAMETER_REFERENCE_URL)
+    expect(parameterWikiUrl('NET_IPADDR0 / NET_IPADDR1')).toBe(WIKI_PARAMETER_REFERENCE_URL)
+    // A parameter the reference simply doesn't carry (fork-only) still gets a
+    // well-formed link — the reference itself reports the miss, and never a
+    // broken anchor.
+    expect(parameterWikiUrl('OSD_MSG_ABBR')).toBe(`${WIKI_PARAMETER_REFERENCE_URL}?param=OSD_MSG_ABBR`)
+  })
+
+  it('never emits a URL off the wiki reference page', () => {
+    for (const id of ['ATC_INPUT_TC', 'javascript:alert(1)', '../../evil', 'A?x=1#y']) {
+      expect(parameterWikiUrl(id).startsWith(WIKI_PARAMETER_REFERENCE_URL)).toBe(true)
     }
+    // Query-encoded, so a hostile id can neither add a parameter nor a fragment.
+    expect(parameterWikiUrl('A%26b')).toBe(WIKI_PARAMETER_REFERENCE_URL)
+  })
+
+  it('states the firmware the reference documents', () => {
+    // Surfaced in the link label so a 4.6 operator is told before the click, not
+    // after. tests/wiki-parameter-reference.test.mjs pins it to the generator.
+    expect(WIKI_PARAMETER_FIRMWARE).toBe('ArduCopter 4.7')
+    expect(WIKI_PARAMETER_QUERY_KEY).toBe('param')
   })
 })

--- a/apps/web/src/view-models/param-docs.test.ts
+++ b/apps/web/src/view-models/param-docs.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest'
+
+import { ARDUPILOT_PARAMETER_DOCS_URL, parameterWikiUrl } from './param-docs'
+
+describe('parameterWikiUrl', () => {
+  // These expectations were checked against the live parameters.html: each of
+  // these short anchors exists on the page. If ArduPilot ever changes the
+  // Sphinx anchor scheme, this is the test that should fail first.
+  it('derives the short Sphinx anchor for real parameter ids', () => {
+    expect(parameterWikiUrl('ATC_INPUT_TC')).toBe(`${ARDUPILOT_PARAMETER_DOCS_URL}#atc-input-tc`)
+    expect(parameterWikiUrl('BATT_MONITOR')).toBe(`${ARDUPILOT_PARAMETER_DOCS_URL}#batt-monitor`)
+    expect(parameterWikiUrl('COMPASS_DISBLMSK')).toBe(`${ARDUPILOT_PARAMETER_DOCS_URL}#compass-disblmsk`)
+  })
+
+  it('keeps digits in place for indexed families', () => {
+    expect(parameterWikiUrl('SERVO1_FUNCTION')).toBe(`${ARDUPILOT_PARAMETER_DOCS_URL}#servo1-function`)
+    expect(parameterWikiUrl('INS_HNTC2_MODE')).toBe(`${ARDUPILOT_PARAMETER_DOCS_URL}#ins-hntc2-mode`)
+  })
+
+  it('falls back to the bare docs page rather than inventing an anchor', () => {
+    // Composed / non-ArduPilot-shaped ids: no fragment is better than a wrong one.
+    expect(parameterWikiUrl('')).toBe(ARDUPILOT_PARAMETER_DOCS_URL)
+    expect(parameterWikiUrl('uavcan.node.id')).toBe(ARDUPILOT_PARAMETER_DOCS_URL)
+    expect(parameterWikiUrl('NET_IPADDR0 / NET_IPADDR1')).toBe(ARDUPILOT_PARAMETER_DOCS_URL)
+  })
+
+  it('never emits a URL off the ArduPilot docs origin', () => {
+    for (const id of ['ATC_INPUT_TC', 'javascript:alert(1)', '../../evil']) {
+      expect(parameterWikiUrl(id).startsWith(ARDUPILOT_PARAMETER_DOCS_URL)).toBe(true)
+    }
+  })
+})

--- a/apps/web/src/view-models/param-docs.ts
+++ b/apps/web/src/view-models/param-docs.ts
@@ -1,0 +1,52 @@
+// Deriving the ArduPilot wiki URL for a raw parameter id.
+//
+// Operators told us the friendly labels hide the thing they actually have to
+// search for: "Maybe I know this exists, but I don't know it as Stick Feel
+// Smoothing." Showing the raw id (ATC_INPUT_TC) next to a deep link into the
+// official parameter docs closes that gap, and makes the eventual step into
+// Expert mode / the raw Parameters tab far less of a cliff.
+//
+// The URL is DERIVED, never hand-maintained: a curated table of ~1500 anchors
+// would rot the moment ArduPilot renames or adds a parameter, and every stale
+// row would be a link to the wrong doc.
+
+/** Landing page for the full ArduCopter parameter reference. */
+export const ARDUPILOT_PARAMETER_DOCS_URL = 'https://ardupilot.org/copter/docs/parameters.html'
+
+/**
+ * Only ids that look like real ArduPilot parameter names get an anchor.
+ * Anything else (a synthetic/composed id, a DroneCAN node param with dots)
+ * falls back to the bare page rather than inventing a fragment that resolves
+ * to nothing meaningful.
+ */
+const ARDUPILOT_PARAM_ID = /^[A-Z][A-Z0-9_]*$/
+
+/**
+ * Deep link into the ArduPilot parameter reference for `paramId`.
+ *
+ * The anchor scheme was verified against the live page rather than assumed:
+ * parameters.html is Sphinx-generated and carries a short per-parameter id
+ * alongside the long "name + description" one — e.g. ATC_INPUT_TC is both
+ * `#atc-input-tc-attitude-control-input-time-constant` and `#atc-input-tc`.
+ * Only the short form is derivable from the id alone, so that is what we use:
+ * lowercase, underscores to hyphens.
+ *
+ * Two known limits, both of which degrade to "you land at the top of the
+ * parameter reference" (browsers ignore a fragment that matches nothing):
+ *  - Fork-only parameters (OSD_MSG_ABBR and friends) aren't in the upstream
+ *    docs at all.
+ *  - A handful of parameters are documented under a different name than the
+ *    firmware reports — ANGLE_MAX appears as ATC_ANGLE_MAX. Special-casing
+ *    those would reintroduce exactly the hand-maintained table this avoids.
+ *
+ * The docs are always the Copter set: this configurator is Copter-first, and
+ * the views that render the link are dumb components with no vehicle prop to
+ * key off. Most parameters here are shared library parameters, so the Copter
+ * page is right for them regardless of vehicle.
+ */
+export function parameterWikiUrl(paramId: string): string {
+  if (!ARDUPILOT_PARAM_ID.test(paramId)) {
+    return ARDUPILOT_PARAMETER_DOCS_URL
+  }
+  return `${ARDUPILOT_PARAMETER_DOCS_URL}#${paramId.toLowerCase().replace(/_/g, '-')}`
+}

--- a/apps/web/src/view-models/param-docs.ts
+++ b/apps/web/src/view-models/param-docs.ts
@@ -1,52 +1,86 @@
-// Deriving the ArduPilot wiki URL for a raw parameter id.
+// Deriving the parameter-reference URL for a raw parameter id.
 //
 // Operators told us the friendly labels hide the thing they actually have to
 // search for: "Maybe I know this exists, but I don't know it as Stick Feel
 // Smoothing." Showing the raw id (ATC_INPUT_TC) next to a deep link into the
-// official parameter docs closes that gap, and makes the eventual step into
-// Expert mode / the raw Parameters tab far less of a cliff.
+// parameter reference closes that gap, and makes the eventual step into Expert
+// mode / the raw Parameters tab far less of a cliff.
 //
-// The URL is DERIVED, never hand-maintained: a curated table of ~1500 anchors
-// would rot the moment ArduPilot renames or adds a parameter, and every stale
-// row would be a link to the wrong doc.
-
-/** Landing page for the full ArduCopter parameter reference. */
-export const ARDUPILOT_PARAMETER_DOCS_URL = 'https://ardupilot.org/copter/docs/parameters.html'
+// The link points at OUR wiki (arduconfigurator.com/wiki), not ardupilot.org.
+// We ship the same upstream metadata (wiki/data/apm.pdef.Copter-4.7.json, pinned
+// from ArduPilot/ParameterRepository) rendered as one page per parameter FAMILY
+// plus a search page, because upstream publishes all 5689 Copter parameters as a
+// single HTML document that is genuinely unloadable on a phone — which is the
+// device an operator has in the field. Same content, same source, usable.
 
 /**
- * Only ids that look like real ArduPilot parameter names get an anchor.
+ * The wiki's parameter reference. This page IS the search page (see
+ * wiki/tools/generate_parameter_reference.py — the index carries the search box
+ * itself), which is what lets us address a parameter by NAME rather than having
+ * to know which family page it lives on.
+ */
+export const WIKI_PARAMETER_REFERENCE_URL = 'https://arduconfigurator.com/wiki/parameters/index.html'
+
+/**
+ * Query key the reference's search page reads on load (wiki/_static/parameter-search.js).
+ * Kept here so the producer and consumer of the contract sit next to each other.
+ */
+export const WIKI_PARAMETER_QUERY_KEY = 'param'
+
+/**
+ * The firmware the reference documents, surfaced in the link label.
+ *
+ * VERSION CAVEAT, disclosed rather than ignored: the reference is generated from
+ * the pinned Copter-4.7 metadata, so on a 4.6 board a range or a value list can
+ * differ from what the aircraft actually implements. The repo's established
+ * version-gating (applyArducopter47CatalogOverrides) can't help here — it keys
+ * on the detected FLIGHT_SW_VERSION, but there is no 4.6 reference to fall back
+ * to, and ParamInfoBubble is a dumb view with no firmware prop. So the honest
+ * fix is to say which version you are about to read, before the click; every
+ * destination page also carries its own "ArduCopter 4.7 only" warning.
+ *
+ * tests/wiki-parameter-reference.test.mjs pins this string to the `firmware`
+ * field the generator writes into parameter-index.json, so regenerating the
+ * reference for a new release cannot silently leave this label stale.
+ */
+export const WIKI_PARAMETER_FIRMWARE = 'ArduCopter 4.7'
+
+/**
+ * Only ids that look like real ArduPilot parameter names get a lookup.
  * Anything else (a synthetic/composed id, a DroneCAN node param with dots)
- * falls back to the bare page rather than inventing a fragment that resolves
- * to nothing meaningful.
+ * falls back to the bare reference rather than sending the search page after a
+ * name that cannot exist.
  */
 const ARDUPILOT_PARAM_ID = /^[A-Z][A-Z0-9_]*$/
 
 /**
- * Deep link into the ArduPilot parameter reference for `paramId`.
+ * Deep link into the wiki's parameter reference for `paramId`.
  *
- * The anchor scheme was verified against the live page rather than assumed:
- * parameters.html is Sphinx-generated and carries a short per-parameter id
- * alongside the long "name + description" one — e.g. ATC_INPUT_TC is both
- * `#atc-input-tc-attitude-control-input-time-constant` and `#atc-input-tc`.
- * Only the short form is derivable from the id alone, so that is what we use:
- * lowercase, underscores to hyphens.
+ * The scheme is name-addressed on purpose. The reference is paginated by FAMILY
+ * (`parameters/group-<slug>.html#param-<id lowercased, _ → ->`, e.g.
+ * `group-atc.html#param-atc-input-tc`), and which family page a parameter lands
+ * on is NOT derivable from its name: 424 of 5688 parameters resolve to the wrong
+ * page under a longest-prefix rule — everything Copter defines at top level
+ * (ACRO_*, PILOT_*, …) lives on `group-copter.html`, and families that differ
+ * only by a trailing underscore get a numeric suffix (ARSPD_ → `group-arspd-2`).
+ * The alternatives were both worse than this one: shipping the generated
+ * name→page map is ~5700 rows of duplicated build output in the app bundle, and
+ * it goes silently WRONG (a link to a 404) the first time the wiki is
+ * regenerated for a new release without the app being rebuilt in lockstep.
  *
- * Two known limits, both of which degrade to "you land at the top of the
- * parameter reference" (browsers ignore a fragment that matches nothing):
- *  - Fork-only parameters (OSD_MSG_ABBR and friends) aren't in the upstream
- *    docs at all.
- *  - A handful of parameters are documented under a different name than the
- *    firmware reports — ANGLE_MAX appears as ATC_ANGLE_MAX. Special-casing
- *    those would reintroduce exactly the hand-maintained table this avoids.
+ * So the app names the parameter and the wiki resolves it against its own index
+ * at load time — the side that owns the page layout is the side that maps names
+ * to pages. An exact match jumps straight to that parameter's section; a name
+ * the reference doesn't carry (fork-only params like OSD_MSG_ABBR, or a newer
+ * firmware's additions) just stays on the reference and says so. Either way
+ * there is no invented fragment and no dead link.
  *
- * The docs are always the Copter set: this configurator is Copter-first, and
- * the views that render the link are dumb components with no vehicle prop to
- * key off. Most parameters here are shared library parameters, so the Copter
- * page is right for them regardless of vehicle.
+ * The reference is the Copter set: this configurator is Copter-first, and most
+ * of these are shared library parameters that read the same on any vehicle.
  */
 export function parameterWikiUrl(paramId: string): string {
   if (!ARDUPILOT_PARAM_ID.test(paramId)) {
-    return ARDUPILOT_PARAMETER_DOCS_URL
+    return WIKI_PARAMETER_REFERENCE_URL
   }
-  return `${ARDUPILOT_PARAMETER_DOCS_URL}#${paramId.toLowerCase().replace(/_/g, '-')}`
+  return `${WIKI_PARAMETER_REFERENCE_URL}?${WIKI_PARAMETER_QUERY_KEY}=${encodeURIComponent(paramId)}`
 }

--- a/apps/web/src/views/Config.tsx
+++ b/apps/web/src/views/Config.tsx
@@ -3,6 +3,7 @@ import { useMemo, useState, type ReactNode } from 'react'
 import type { ParameterState } from '@arduconfig/ardupilot-core'
 import { Panel, StatusBadge, buttonStyle } from '@arduconfig/ui-kit'
 
+import { ParamInfoBubble } from './ParamInfoBubble'
 import { ScopedField, ScopedSelectField, ScopedBitmaskField, type ScopedFieldDraftMap } from './ScopedField'
 
 // BF-style "Configuration" catch-all surface. Mission Planner and BF
@@ -201,21 +202,15 @@ export function ConfigView(props: ConfigViewProps) {
     return (
       <div key={field.paramId} className="config-section__field-row">
         {editor}
-        {description ? (
-          <span className="config-section__info-wrap">
-            <button
-              type="button"
-              className="config-section__info"
-              data-testid={`config-field-info-${field.paramId}`}
-              aria-label={`About ${parameter.definition?.label ?? field.label}`}
-            >
-              i
-            </button>
-            <span className="config-section__info-tip" role="tooltip">
-              {description}
-            </span>
-          </span>
-        ) : null}
+        {/* Unconditional now: the bubble also carries the raw parameter id and
+            the wiki deep link, both of which exist even for the params whose
+            metadata has no description. */}
+        <ParamInfoBubble
+          paramId={field.paramId}
+          label={parameter.definition?.label ?? field.label}
+          description={description}
+          testId={`config-field-info-${field.paramId}`}
+        />
       </div>
     )
   }

--- a/apps/web/src/views/ParamInfoBubble.tsx
+++ b/apps/web/src/views/ParamInfoBubble.tsx
@@ -1,6 +1,6 @@
 import type { ReactElement } from 'react'
 
-import { parameterWikiUrl } from '../view-models/param-docs'
+import { WIKI_PARAMETER_FIRMWARE, parameterWikiUrl } from '../view-models/param-docs'
 
 export interface ParamInfoBubbleProps {
   /** Raw ArduPilot parameter id, e.g. `ATC_INPUT_TC`. */
@@ -56,7 +56,11 @@ export function ParamInfoBubble({ paramId, label, description, testId }: ParamIn
           rel="noopener noreferrer"
           data-testid={`param-wiki-${paramId}`}
         >
-          ArduPilot wiki ↗
+          {/* Name the documented firmware in the label, not just on the far
+              side of the click: the reference is generated from the pinned
+              Copter-4.7 metadata, and on a 4.6 board a range or value list can
+              differ. Nothing here knows the connected firmware to gate on. */}
+          Parameter reference ({WIKI_PARAMETER_FIRMWARE}) ↗
         </a>
       </span>
     </span>

--- a/apps/web/src/views/ParamInfoBubble.tsx
+++ b/apps/web/src/views/ParamInfoBubble.tsx
@@ -1,0 +1,64 @@
+import type { ReactElement } from 'react'
+
+import { parameterWikiUrl } from '../view-models/param-docs'
+
+export interface ParamInfoBubbleProps {
+  /** Raw ArduPilot parameter id, e.g. `ATC_INPUT_TC`. */
+  paramId: string
+  /** Friendly label the surface shows instead of the id, for the button's accessible name. */
+  label: string
+  /** Plain-text ArduPilot description, when the metadata carries one. */
+  description?: string
+  /** Stable per-surface hook, e.g. `tuning-info-ATC_INPUT_TC`. */
+  testId: string
+}
+
+/**
+ * The per-parameter "i" affordance, shared by every surface that shows a
+ * friendly label in place of the raw parameter name (Config, Networking,
+ * curated Tuning). Hover or focus reveals the raw id, the ArduPilot
+ * description, and a deep link into the parameter reference.
+ *
+ * Previously each surface inlined this markup and rendered it ONLY when the
+ * metadata carried a description — so a curated card like Tuning ▸ Pilot ▸
+ * "Stick Feel Smoothing" could show a friendly name with no way at all to find
+ * out it means ATC_INPUT_TC. The id and the wiki link exist for every
+ * parameter, so the bubble now always renders and the description is the
+ * optional part.
+ *
+ * The wiki link is a plain external anchor and must stay one: an earlier
+ * version pulled wiki content in-app and it poisoned the PWA shell (a P1
+ * production bug). Never navigate the SPA to it, never fetch or embed it.
+ */
+export function ParamInfoBubble({ paramId, label, description, testId }: ParamInfoBubbleProps): ReactElement {
+  return (
+    <span className="config-section__info-wrap">
+      <button
+        type="button"
+        className="config-section__info"
+        data-testid={testId}
+        // Include the raw id in the accessible name: a screen-reader user gets
+        // the same "which parameter is this really?" answer sighted users get
+        // from opening the bubble.
+        aria-label={`About ${label} (${paramId})`}
+      >
+        i
+      </button>
+      {/* Kept as the button's next sibling — surfaces' e2e checks and the
+          `.config-section__info:focus-visible + …` CSS both rely on that. */}
+      <span className="config-section__info-tip" role="tooltip">
+        <span className="config-section__info-param">{paramId}</span>
+        {description ? <span className="config-section__info-text">{description}</span> : null}
+        <a
+          className="config-section__info-wiki"
+          href={parameterWikiUrl(paramId)}
+          target="_blank"
+          rel="noopener noreferrer"
+          data-testid={`param-wiki-${paramId}`}
+        >
+          ArduPilot wiki ↗
+        </a>
+      </span>
+    </span>
+  )
+}

--- a/tests/e2e/views.spec.ts
+++ b/tests/e2e/views.spec.ts
@@ -1265,6 +1265,58 @@ test.describe('Tuning tab', () => {
     await angleSummary.click()
     await expect(page.getByTestId('tuning-input-ATC_INPUT_TC')).toBeVisible()
   })
+
+  test('the curated control info bubble reveals the raw param name and a wiki link', async ({ page }) => {
+    await page.goto('/')
+    await connectViaHeader(page)
+    await openView(page, 'tuning')
+    await page.locator('details.bf-gui-box > summary').filter({ hasText: 'Angle' }).click()
+
+    // The card only ever shows the friendly label ("Stick feel smoothing"), so
+    // the bubble is the operator's ONLY route from that label to ATC_INPUT_TC.
+    const info = page.getByTestId('tuning-info-ATC_INPUT_TC')
+    await expect(info).toBeVisible({ timeout: 10000 })
+    const tip = info.locator('xpath=following-sibling::span[@role="tooltip"]')
+    await expect(tip).toBeHidden()
+    await info.hover()
+    await expect(tip).toBeVisible()
+    await expect(tip).toContainText('ATC_INPUT_TC')
+
+    const link = tip.getByTestId('param-wiki-ATC_INPUT_TC')
+    await expect(link).toHaveAttribute('href', 'https://ardupilot.org/copter/docs/parameters.html#atc-input-tc')
+    await expect(link).toHaveAttribute('target', '_blank')
+    await expect(link).toHaveAttribute('rel', 'noopener noreferrer')
+
+    // The tip hangs a few px below the "i", and hover state follows the DOM, so
+    // without the invisible bridge the pointer crossing that dead band closed
+    // the tip and the link was unclickable in practice. Park the mouse IN the
+    // gap and assert the tip survives, then click through to the link.
+    const iconBox = (await info.boundingBox())!
+    const tipBox = (await tip.boundingBox())!
+    await page.mouse.move(iconBox.x + iconBox.width / 2, (iconBox.y + iconBox.height + tipBox.y) / 2)
+    await expect(tip).toBeVisible()
+    await link.hover()
+    await expect(tip).toBeVisible()
+  })
+
+  test('the info bubble stays open while tabbing onto its wiki link', async ({ page }) => {
+    await page.goto('/')
+    await connectViaHeader(page)
+    await openView(page, 'tuning')
+    await page.locator('details.bf-gui-box > summary').filter({ hasText: 'Angle' }).click()
+
+    const info = page.getByTestId('tuning-info-ATC_INPUT_TC')
+    await expect(info).toBeVisible({ timeout: 10000 })
+    const tip = info.locator('xpath=following-sibling::span[@role="tooltip"]')
+    // Keyboard route: focusing the "i" opens the tip, and focus-within keeps it
+    // open when Tab moves on to the link inside it (button-only :focus-visible
+    // would close it and strand the link).
+    await info.focus()
+    await expect(tip).toBeVisible()
+    await page.keyboard.press('Tab')
+    await expect(page.getByTestId('param-wiki-ATC_INPUT_TC')).toBeFocused()
+    await expect(tip).toBeVisible()
+  })
 })
 
 test.describe('Failsafe view', () => {
@@ -1940,6 +1992,25 @@ test.describe('Config view', () => {
     await info.hover()
     await expect(tip).toBeVisible()
     await expect(tip).not.toHaveText('')
+  })
+
+  test('Config info bubble names the raw parameter and links the ArduPilot wiki', async ({ page }) => {
+    await page.goto('/')
+    await page.getByTestId('transport-mode-select').selectOption('demo')
+    await page.getByTestId('connect-button').click()
+    await page.getByTestId('view-button-config').click()
+    const info = page.getByTestId('config-field-info-FRAME_CLASS')
+    await info.scrollIntoViewIfNeeded()
+    await info.hover()
+    const tip = info.locator('xpath=following-sibling::span[@role="tooltip"]')
+    await expect(tip).toBeVisible()
+    await expect(tip).toContainText('FRAME_CLASS')
+    const link = tip.getByTestId('param-wiki-FRAME_CLASS')
+    await expect(link).toHaveAttribute('href', 'https://ardupilot.org/copter/docs/parameters.html#frame-class')
+    // Plain external link in a new tab — the wiki must never be pulled into the
+    // SPA (an earlier in-app wiki poisoned the PWA shell; that was a P1).
+    await expect(link).toHaveAttribute('target', '_blank')
+    await expect(link).toHaveAttribute('rel', 'noopener noreferrer')
   })
 
   test('Config exposes a Frame section to set FRAME_CLASS / FRAME_TYPE', async ({ page }) => {

--- a/tests/e2e/views.spec.ts
+++ b/tests/e2e/views.spec.ts
@@ -1283,7 +1283,16 @@ test.describe('Tuning tab', () => {
     await expect(tip).toContainText('ATC_INPUT_TC')
 
     const link = tip.getByTestId('param-wiki-ATC_INPUT_TC')
-    await expect(link).toHaveAttribute('href', 'https://ardupilot.org/copter/docs/parameters.html#atc-input-tc')
+    // Our own reference, addressed by parameter NAME — the wiki resolves the
+    // name to its family page (see wiki/_static/parameter-search.js), so the
+    // app never ships a copy of that map and can't point at a stale page.
+    await expect(link).toHaveAttribute(
+      'href',
+      'https://arduconfigurator.com/wiki/parameters/index.html?param=ATC_INPUT_TC'
+    )
+    // The reference is generated from the pinned Copter-4.7 metadata; say so
+    // before the click, since nothing here knows the connected firmware.
+    await expect(link).toContainText('ArduCopter 4.7')
     await expect(link).toHaveAttribute('target', '_blank')
     await expect(link).toHaveAttribute('rel', 'noopener noreferrer')
 
@@ -1994,7 +2003,7 @@ test.describe('Config view', () => {
     await expect(tip).not.toHaveText('')
   })
 
-  test('Config info bubble names the raw parameter and links the ArduPilot wiki', async ({ page }) => {
+  test('Config info bubble names the raw parameter and links our parameter reference', async ({ page }) => {
     await page.goto('/')
     await page.getByTestId('transport-mode-select').selectOption('demo')
     await page.getByTestId('connect-button').click()
@@ -2006,7 +2015,10 @@ test.describe('Config view', () => {
     await expect(tip).toBeVisible()
     await expect(tip).toContainText('FRAME_CLASS')
     const link = tip.getByTestId('param-wiki-FRAME_CLASS')
-    await expect(link).toHaveAttribute('href', 'https://ardupilot.org/copter/docs/parameters.html#frame-class')
+    await expect(link).toHaveAttribute(
+      'href',
+      'https://arduconfigurator.com/wiki/parameters/index.html?param=FRAME_CLASS'
+    )
     // Plain external link in a new tab — the wiki must never be pulled into the
     // SPA (an earlier in-app wiki poisoned the PWA shell; that was a P1).
     await expect(link).toHaveAttribute('target', '_blank')

--- a/tests/wiki-parameter-reference.test.mjs
+++ b/tests/wiki-parameter-reference.test.mjs
@@ -106,6 +106,58 @@ test('the index IS the search page, and generated pages stay out of the nav tree
   assert.match(letter, /^:orphan:/, 'letter pages must stay out of the nav tree')
 })
 
+test("the app's per-parameter link resolves against this reference", () => {
+  // The "i" bubble in the app links parameters by NAME
+  // (parameters/index.html?param=ATC_INPUT_TC) and this reference's search
+  // script resolves the name to a family page. That contract spans two
+  // packages, so neither side's own tests can catch it drifting: the app can't
+  // see the generated pages, and the generator doesn't know the app exists.
+  generate()
+  const docs = readFileSync(path.join(REPO, 'apps', 'web', 'src', 'view-models', 'param-docs.ts'), 'utf8')
+
+  // 1. The page the app links to is a page this generator emits.
+  const target = /WIKI_PARAMETER_REFERENCE_URL = '([^']+)'/.exec(docs)?.[1]
+  assert.ok(target?.endsWith('/wiki/parameters/index.html'), `unexpected link target: ${target}`)
+  assert.ok(existsSync(path.join(PARAMS_DIR, 'index.rst')), 'the app links a page the generator does not emit')
+
+  // 2. The query key the app writes is the one the search script reads.
+  const key = /WIKI_PARAMETER_QUERY_KEY = '([^']+)'/.exec(docs)?.[1]
+  const search = readFileSync(path.join(WIKI, '_static', 'parameter-search.js'), 'utf8')
+  assert.ok(key, 'the app must declare the query key it uses')
+  assert.match(search, new RegExp(`\\.get\\('${key}'\\)`), 'the search script does not read that query key')
+
+  // 3. A named parameter resolves to a page and an anchor that both exist —
+  //    including the two shapes whose page is NOT derivable from the name
+  //    (top-level Copter params, and the underscore-collision suffix), which is
+  //    the whole reason the link is name-addressed.
+  const byName = new Map(
+    JSON.parse(readFileSync(INDEX_JSON, 'utf8')).params.map((entry) => [entry.n, entry])
+  )
+  for (const [name, expectedPage] of [
+    ['ATC_INPUT_TC', 'group-atc.rst'],
+    ['BATT_MONITOR', 'group-batt.rst'],
+    ['SERVO1_FUNCTION', 'group-servo1.rst'],
+    ['ACRO_RP_EXPO', 'group-copter.rst'],
+    ['ARSPD_TYPE', 'group-arspd-2.rst'],
+  ]) {
+    const entry = byName.get(name)
+    assert.ok(entry, `${name} is not in the index the search resolves against`)
+    const page = path.join(PARAMS_DIR, `group-${entry.g}.rst`)
+    assert.equal(path.basename(page), expectedPage, `${name} moved family page`)
+    assert.match(
+      readFileSync(page, 'utf8'),
+      new RegExp(`^\\.\\. _param-${name.toLowerCase()}:$`, 'm'),
+      `${name}: no anchor to land on`
+    )
+  }
+
+  // 4. The firmware the app puts in the link label is the one this reference
+  //    documents — a regenerate for a new release must not leave it lying.
+  const labelled = /WIKI_PARAMETER_FIRMWARE = '([^']+)'/.exec(docs)?.[1]
+  const { vehicle, firmware } = JSON.parse(readFileSync(INDEX_JSON, 'utf8'))
+  assert.equal(labelled, `${vehicle} ${firmware}`, 'the app advertises a firmware the reference is not for')
+})
+
 test('page titles escape the trailing underscore every ArduPilot family name has', () => {
   // An unescaped trailing underscore is RST hyperlink-reference syntax: it
   // produced ~290 "Unknown target name" build errors and a mangled heading.

--- a/wiki/_static/parameter-search.js
+++ b/wiki/_static/parameter-search.js
@@ -22,12 +22,44 @@
   // path, or a local file build) rather than assuming a site root.
   var root = (window.DOCUMENTATION_OPTIONS && window.DOCUMENTATION_OPTIONS.URL_ROOT) || '../'
 
+  // ?param=<NAME> — the app's per-field "i" bubble links here by NAME rather
+  // than by page, because which family page a parameter lands on is not
+  // derivable from its name (top-level Copter params all live on group-copter,
+  // and ARSPD_ vs ARSPD collide onto suffixed slugs). Resolving the name here,
+  // against the index this page already loads, keeps the page layout owned by
+  // the side that generates it — the app never has to ship a copy of the map,
+  // and a regenerated reference can't leave the app pointing at a 404.
+  var requested = ''
+  try {
+    requested = (new URLSearchParams(window.location.search).get('param') || '').trim()
+  } catch (error) {
+    requested = ''
+  }
+  if (requested) input.value = requested
+
   fetch(root + '_static/parameter-index.json')
     .then(function (response) { return response.json() })
     .then(function (payload) {
       params = payload.params || []
       status.textContent = params.length + ' parameters indexed (' +
         (payload.vehicle || '') + ' ' + (payload.firmware || '') + '). Start typing.'
+      // An exact hit makes the link behave like a real deep link: land on the
+      // parameter's own section, where its Values/Bitmask tables are (the
+      // results list only says "has value list"). replace(), not assign(), so
+      // Back returns to the app rather than bouncing through this page again.
+      // No match — a fork-only or newer-firmware parameter — falls through to
+      // the rendered search, which says so instead of dead-ending.
+      if (requested && input.value === requested) {
+        var needle = requested.toLowerCase()
+        for (var k = 0; k < params.length; k += 1) {
+          if (params[k].n.toLowerCase() === needle) {
+            window.location.replace(
+              root + 'parameters/group-' + params[k].g + '.html#param-' + needle.replace(/_/g, '-')
+            )
+            return
+          }
+        }
+      }
       render(input.value)
     })
     .catch(function () {


### PR DESCRIPTION
Two commits.

1. `feat(ui): name the raw parameter and link its wiki page from every "i" bubble` — extracts the per-field "i" affordance Config/Networking/Tuning each inlined into one shared `ParamInfoBubble`, and gives it the raw parameter id + description + a reference link. Renders unconditionally (it used to be gated on a description existing, which is why curated Tuning cards had no route to the param name). Fixes two hover mechanics (dead-band bridge, `:focus-within`) so the link is actually reachable, and clamps the tip to viewport width for 390px.

2. `feat(ui): point the parameter "i" bubble at our own reference, not ardupilot.org` — the link is now name-addressed at our own wiki, `parameters/index.html?param=<NAME>`, and `wiki/_static/parameter-search.js` reads `?param=`, resolves it against the index it already fetches, and `location.replace()`s to the section. Deriving the page in the app does not work — the reference is paginated by family and 424/5688 parameters land on the wrong page under a longest-prefix rule. The wiki build is therefore part of this change. Label discloses the 4.7 metadata pin, and `tests/wiki-parameter-reference.test.mjs` pins that label to the generator output plus the rest of the cross-package contract.

ArduCopter byte-identical (presentation only): no parameter value, write path, draft validation, or metadata semantics touched.

Validation (rungs 1-3): `npm run typecheck` clean; `npm run test` 847 pass / 0 fail / 3 skipped; apps/web vitest 640 pass / 0 fail; Playwright 237 passed / 6 skipped (visual baselines) / 0 failed. Rungs 4-5 not walked: no runtime or write-path change.