### PR TITLE
feat(receiver): split the AUX function list into common and long-tail groups

### DIFF
--- a/packages/param-metadata/src/arducopter-enums.ts
+++ b/packages/param-metadata/src/arducopter-enums.ts
@@ -1,3 +1,6 @@
+import { ARDUCOPTER_RC_OPTION_LABELS } from './arducopter-rc-options.generated.js'
+import type { ParameterValueOption } from './types.js'
+
 export const ARDUCOPTER_FLIGHT_MODE_LABELS: Record<number, string> = {
   0: 'Stabilize',
   1: 'Acro',
@@ -1275,4 +1278,130 @@ export const ARDUCOPTER_COMPASS_DISBLMSK_BIT_LABELS: Record<number, string> = {
   21: 'BMM350',
   22: 'IIS2MDC',
   23: 'LIS2MDL'
+}
+
+// ---------------------------------------------------------------------------
+// RCn_OPTION auxiliary functions — common group first, then the long tail.
+// ---------------------------------------------------------------------------
+
+/**
+ * The RCn_OPTION functions an ArduCopter FPV/bench operator actually assigns to
+ * a switch, pinned above the long tail in the AUX function picker.
+ *
+ * This is the SAME mechanism the Ports function picker already uses for
+ * SERIALn_PROTOCOL (see SERIAL_PROTOCOL_PRIORITY_VALUES /
+ * arducopterSerialProtocolOptions above): a curated list of common VALUES
+ * pinned to the top of one flat dropdown, with everything else following. The
+ * two surfaces are deliberately identical so an operator learns the shape once.
+ *
+ * Rationale for membership — the generated list is ~120 entries, and the great
+ * majority of them are for airframes, payloads or bring-up work this
+ * configurator's audience never touches. Included here:
+ *
+ *   - Arming and motor safety: ArmDisarm (4.2+), ArmDisarm with AirMode,
+ *     Arm/Emergency Motor Stop, Disarm, Motor Emergency Stop, Motor Interlock.
+ *     These are the switches that decide whether the aircraft is dangerous.
+ *   - Flight-mode slots an FPV Copter operator flies: STABILIZE, ALTHOLD,
+ *     POSHOLD, LOITER, ACRO, AUTO, AUTO RTL, AUTOTUNE, BRAKE, CIRCLE, FLIP,
+ *     GUIDED, LAND, RTL, SMARTRTL, STANDBY, THROW, TURTLE.
+ *   - Setup/bench work: Save Trim, Save WP, Acro Trainer, Simple Mode,
+ *     Super Simple Mode, Fence Enable, GPS Disable, RangeFinder Enable,
+ *     PrecLoiter Enable, AirMode.
+ *   - Hardware an FPV build carries: VTX Power, Camera Trigger,
+ *     Camera Record Video, Relay1..4 On/Off, Parachute Enable/Release.
+ *
+ * Deliberately left in the tail: mission/companion-specific modes (ZigZag,
+ * Follow, FlowHold, Drift), payload gear (sprayer, winch, gripper, landing
+ * gear, generator, Loweheiser), EKF/IMU bring-up and debug switches (EKF Source
+ * Set, EKF lane switch, Kill IMU 1..3, Force IS_Flying), gimbal/mount minutiae
+ * (Mount1/2 axes, retract, POI/yaw locks), user/scripting function slots,
+ * legacy ArmDisarm (4.1 and lower), Relay5/6, Parachute 3pos, and the
+ * calibration switches that belong in the configurator rather than on a stick.
+ *
+ * Presentation only: no option is added, removed or relabelled by this split,
+ * and nothing written to the FC changes. Edit this one const to retune the
+ * split — it is the only place membership is decided.
+ */
+export const ARDUCOPTER_RC_OPTION_COMMON_VALUES: readonly number[] = [
+  2, // FLIP Mode
+  3, // Simple Mode
+  4, // RTL
+  5, // Save Trim
+  7, // Save WP
+  9, // Camera Trigger
+  10, // RangeFinder Enable
+  11, // Fence Enable
+  13, // Super Simple Mode
+  14, // Acro Trainer
+  16, // AUTO Mode
+  17, // AUTOTUNE Mode
+  18, // LAND Mode
+  21, // Parachute Enable
+  22, // Parachute Release
+  28, // Relay1 On/Off
+  31, // Motor Emergency Stop
+  32, // Motor Interlock
+  33, // BRAKE Mode
+  34, // Relay2 On/Off
+  35, // Relay3 On/Off
+  36, // Relay4 On/Off
+  37, // THROW Mode
+  39, // PrecLoiter Enable
+  42, // SMARTRTL Mode
+  52, // ACRO Mode
+  55, // GUIDED Mode
+  56, // LOITER Mode
+  65, // GPS Disable
+  68, // STABILIZE Mode
+  69, // POSHOLD Mode
+  70, // ALTHOLD Mode
+  72, // CIRCLE Mode
+  76, // STANDBY Mode
+  81, // Disarm
+  84, // AirMode
+  94, // VTX Power
+  99, // AUTO RTL
+  151, // TURTLE Mode
+  153, // ArmDisarm (4.2 and higher)
+  154, // ArmDisarm with AirMode (4.2 and higher)
+  165, // Arm/Emergency Motor Stop
+  166 // Camera Record Video
+]
+
+/**
+ * Numeric- and case-insensitive label sort. Numeric-aware so Relay2 sorts
+ * before Relay10, case-insensitive so capitalisation drift in the firmware
+ * annotations ("use Custom Controller") cannot strand an entry after Z.
+ */
+function compareRcOptionLabels(left: ParameterValueOption, right: ParameterValueOption): number {
+  return left.label.localeCompare(right.label, 'en', { numeric: true, sensitivity: 'base' })
+}
+
+/**
+ * RCn_OPTION options ordered for the AUX function picker: "Do Nothing" first,
+ * then the common group alphabetically, then the long tail alphabetically.
+ *
+ * "Do Nothing" (0) is pinned above BOTH groups rather than filed under D, and
+ * is not a member of either — it is the cleared state, not a function, so it
+ * belongs where you look to UNASSIGN a channel. This mirrors how "None" (-1)
+ * is pinned above the Ports priority group.
+ *
+ * Every value in ARDUCOPTER_RC_OPTION_LABELS appears exactly once: this is a
+ * regrouping, not a curation, so nothing an operator could select before
+ * becomes unreachable. Asserted in tests/metadata.test.mjs.
+ */
+export function arducopterRcOptionOptions(): ParameterValueOption[] {
+  const all: ParameterValueOption[] = Object.entries(ARDUCOPTER_RC_OPTION_LABELS).map(([value, label]) => ({
+    value: Number(value),
+    label
+  }))
+  const common = new Set<number>(ARDUCOPTER_RC_OPTION_COMMON_VALUES)
+  const doNothing = all.filter((option) => option.value === 0)
+  const useful = all
+    .filter((option) => option.value !== 0 && common.has(option.value))
+    .sort(compareRcOptionLabels)
+  const rest = all
+    .filter((option) => option.value !== 0 && !common.has(option.value))
+    .sort(compareRcOptionLabels)
+  return [...doNothing, ...useful, ...rest]
 }

--- a/packages/param-metadata/src/arducopter.ts
+++ b/packages/param-metadata/src/arducopter.ts
@@ -1,6 +1,5 @@
 import type { FirmwareMetadataBundle, ParameterValueOption } from './types.js'
 import { AHRS_ORIENTATION_OPTIONS, LOG_DISARMED_OPTIONS } from './shared-enums.js'
-import { ARDUCOPTER_RC_OPTION_LABELS } from './arducopter-rc-options.generated.js'
 import { buildMountParameterDefinitions } from './shared-mount.js'
 import { buildNetworkParameterDefinitions } from './shared-network.js'
 import { buildRcLogicParameterDefinitions } from './shared-rc-logic.js'
@@ -62,6 +61,7 @@ import {
   ARDUCOPTER_COMPASS_EXTERNAL_LABELS,
   ARDUCOPTER_COMPASS_AUTO_ROT_LABELS,
   ARDUCOPTER_COMPASS_DISBLMSK_BIT_LABELS,
+  arducopterRcOptionOptions,
 } from './arducopter-enums.js'
 
 const enabledDisabledOptions: ParameterValueOption[] = [
@@ -563,30 +563,12 @@ function buildSerialPortParameterDefinitions(maxPortNumber: number): FirmwareMet
 // The option list is generated from ArduPilot's own @Values annotations rather
 // than curated, because a hand-picked subset is exactly how an operator ends up
 // unable to find the function they need.
-/**
- * RCn_OPTION options in ALPHABETICAL order rather than by value.
- *
- * The generated list is ~120 entries in firmware value order, which is an
- * implementation detail of RC_Channel.cpp and means nothing to an operator:
- * finding "Motor Emergency Stop" means scanning the whole list because there is
- * no rule saying where it sits. Mission Planner sorts these by name and that is
- * what people are used to.
- *
- * "Do Nothing" (0) is pinned first. It is the cleared state rather than a
- * function, so it belongs where you look to unassign a channel — not filed
- * under D.
- */
-function rcOptionsAlphabetical(labelMap: Record<number, string>): ParameterValueOption[] {
-  const options = enumOptions(labelMap)
-  const none = options.filter((option) => option.value === 0)
-  const rest = options
-    .filter((option) => option.value !== 0)
-    // Numeric-aware so Relay2 sorts before Relay10, and case-insensitive so
-    // capitalisation in the firmware annotations does not split the list.
-    .sort((left, right) => left.label.localeCompare(right.label, 'en', { numeric: true, sensitivity: 'base' }))
-  return [...none, ...rest]
-}
-
+// Ordering lives in arducopterRcOptionOptions (arducopter-enums.ts), next to
+// the Ports picker's arducopterSerialProtocolOptions it is modelled on: "Do
+// Nothing" pinned, then the common group alphabetically, then the long tail
+// alphabetically. Firmware VALUE order is an implementation detail of
+// RC_Channel.cpp and means nothing to an operator scanning for "Motor
+// Emergency Stop".
 function buildRcOptionParameterDefinitions(
   minChannelNumber: number,
   maxChannelNumber: number
@@ -600,7 +582,7 @@ function buildRcOptionParameterDefinitions(
       description: `Auxiliary function assigned to RC channel ${channelNumber}. "Do Nothing" leaves the channel unused by the flight controller.`,
       category: 'receiver',
       notes: ['Assigning the same function to two channels is undefined — clear the old channel first.'],
-      options: rcOptionsAlphabetical(ARDUCOPTER_RC_OPTION_LABELS)
+      options: arducopterRcOptionOptions()
     }
   }
 

--- a/packages/param-metadata/src/index.ts
+++ b/packages/param-metadata/src/index.ts
@@ -1,6 +1,9 @@
 export * from './arducopter.js'
 export * from './arducopter-4.7-overrides.js'
 export * from './arducopter-enums.js'
+// The raw generated RCn_OPTION label map — public so tests (and any future
+// surface) can assert the AUX picker's regrouping drops nothing.
+export * from './arducopter-rc-options.generated.js'
 export * from './arduplane.js'
 export * from './arduplane-enums.js'
 export * from './ardurover.js'

--- a/tests/e2e/views.spec.ts
+++ b/tests/e2e/views.spec.ts
@@ -2261,6 +2261,12 @@ test.describe('Receiver stick-driven craft', () => {
   })
 })
 
+// Size of ARDUCOPTER_RC_OPTION_COMMON_VALUES (packages/param-metadata/src/
+// arducopter-enums.ts) — the curated AUX functions pinned above the long tail.
+// Mirrored here rather than imported because this spec runs against the built
+// bundle; the exact membership is asserted in tests/metadata.test.mjs.
+const AUX_COMMON_FUNCTION_COUNT = 43
+
 test.describe('Receiver functions tab', () => {
   test('assigns an auxiliary function to an AUX channel and flags a duplicate', async ({ page }) => {
     // Before this tab the only RCn_OPTION reachable from the app was the Arm
@@ -2291,6 +2297,46 @@ test.describe('Receiver functions tab', () => {
     // Clearing one side resolves it.
     await page.getByTestId('receiver-function-8').locator('select').selectOption('0')
     await expect(page.getByTestId('receiver-functions-conflict')).toHaveCount(0)
+  })
+
+  test('the AUX function list leads with the common functions, then the alphabetical tail', async ({ page }) => {
+    // Same grammar as the Ports function picker (SERIALn_PROTOCOL): the cleared
+    // state pinned first, then a curated common group, then everything else —
+    // one flat dropdown, no hidden entries. ~120 firmware AUX functions in raw
+    // value order is unusable; this proves the operator-facing ordering without
+    // removing anything they could previously select.
+    await page.goto('/')
+    await connectViaHeader(page)
+    await openView(page, 'receiver')
+    await page.getByTestId('receiver-task-nav').getByRole('button', { name: 'Functions' }).click()
+
+    const select = page.getByTestId('receiver-function-5').locator('select')
+    await expect(select).toBeVisible()
+    const labels = await select.locator('option').allTextContents()
+
+    // "Do Nothing" (0) is pinned above both groups — the cleared state.
+    expect(labels[0]).toBe('Do Nothing')
+
+    // The common group leads, alphabetically: ACRO Mode is its first entry and
+    // the flight-mode/arming staples sit inside it.
+    const common = labels.slice(1, 1 + AUX_COMMON_FUNCTION_COUNT)
+    expect(common[0]).toBe('ACRO Mode')
+    for (const label of ['ALTHOLD Mode', 'Motor Emergency Stop', 'RTL', 'VTX Power']) {
+      expect(common).toContain(label)
+    }
+
+    // The long tail follows, also alphabetical, and holds the niche entries.
+    const tail = labels.slice(1 + AUX_COMMON_FUNCTION_COUNT)
+    for (const label of ['Gripper', 'KillIMU1', 'Sprayer Enable', 'Winch Enable']) {
+      expect(tail).toContain(label)
+    }
+
+    // Nothing was dropped: every function is still selectable exactly once.
+    expect(new Set(labels).size).toBe(labels.length)
+    expect(labels.length).toBeGreaterThan(100)
+    // And a tail entry is still assignable, not merely listed.
+    await select.selectOption({ label: 'Sprayer Enable' })
+    await expect(select).toHaveValue('15')
   })
 })
 

--- a/tests/metadata.test.mjs
+++ b/tests/metadata.test.mjs
@@ -18,6 +18,9 @@ import {
   arducopterSerialBaudRate,
   encodeArducopterSerialBaud,
   arducopterSerialProtocolOptions,
+  arducopterRcOptionOptions,
+  ARDUCOPTER_RC_OPTION_COMMON_VALUES,
+  ARDUCOPTER_RC_OPTION_LABELS,
   ARDUCOPTER_SERIAL_PROTOCOL_LABELS,
   ARDUCOPTER_SERIAL_OPTION_BIT_LABELS,
   formatArducopterVtxEnable,
@@ -1538,6 +1541,47 @@ test('Serial protocol options put the common roles first, then alphabetical', ()
   assert.deepEqual(tail, sortedTail)
   // No duplicates and every label present.
   assert.equal(new Set(labels).size, labels.length)
+})
+
+// The AUX function picker copies the Ports picker's mechanism (a curated
+// common-VALUES const pinned above the long tail of one flat dropdown), so it
+// gets the same shape of test, plus a strict "nothing was dropped" assertion:
+// this is a REGROUPING, not a curation, and a typo in the common list must not
+// be able to make a function unreachable.
+test('RCn_OPTION options put the common AUX functions first, then the long tail', () => {
+  const options = arducopterRcOptionOptions()
+
+  // "Do Nothing" (0) is pinned above BOTH groups — cleared state, not a function.
+  assert.equal(options[0].value, 0)
+  assert.equal(options[0].label, 'Do Nothing')
+
+  const commonValues = new Set(ARDUCOPTER_RC_OPTION_COMMON_VALUES)
+  const common = options.slice(1, 1 + ARDUCOPTER_RC_OPTION_COMMON_VALUES.length)
+  const tail = options.slice(1 + ARDUCOPTER_RC_OPTION_COMMON_VALUES.length)
+
+  // Group 1 is exactly the curated set; group 2 is exactly the complement.
+  assert.deepEqual(new Set(common.map((option) => option.value)), commonValues)
+  assert.ok(tail.every((option) => !commonValues.has(option.value)))
+
+  // Both groups alphabetical internally, by the same numeric-aware,
+  // case-insensitive collation the builder uses (Relay2 before Relay10).
+  const collate = (left, right) =>
+    left.label.localeCompare(right.label, 'en', { numeric: true, sensitivity: 'base' })
+  assert.deepEqual(common, [...common].sort(collate))
+  assert.deepEqual(tail, [...tail].sort(collate))
+
+  // NOTHING DROPPED: the two groups plus "Do Nothing" reproduce the generated
+  // firmware list exactly — same values, same labels, no duplicates.
+  const allValues = Object.keys(ARDUCOPTER_RC_OPTION_LABELS).map(Number)
+  assert.equal(options.length, allValues.length)
+  assert.deepEqual(new Set(options.map((option) => option.value)), new Set(allValues))
+  for (const option of options) {
+    assert.equal(option.label, ARDUCOPTER_RC_OPTION_LABELS[option.value])
+  }
+
+  // And the catalog the UI actually reads carries that exact ordering.
+  const rc5 = arducopterMetadata.parameters.RC5_OPTION
+  assert.deepEqual(rc5.options, options)
 })
 
 test('FLTMODE_CH offers a Disable option, and unknown flight modes have no label', () => {


### PR DESCRIPTION
Rebased onto current main. The branch originally carried a copy of the alphabetical-sort commit that already merged as #149; that commit is dropped here so the sort is not applied twice, and this PR is the single `feat(receiver): split the AUX function list into common and long-tail groups` commit on top of `main`.

The `RCn_OPTION` picker lists ~120 auxiliary functions. #149 made a name findable, but alphabetical also interleaved the dozen functions a Copter FPV operator actually assigns to a switch with a hundred they never will. Alphabetical is the right tiebreak, not the right first cut.

Follows the Ports precedent exactly rather than inventing a mechanism: `SERIAL_PROTOCOL_PRIORITY_VALUES` / `arducopterSerialProtocolOptions()` in `arducopter-enums.ts` already pins a curated const of common VALUES to the top of one flat `<select>`, cleared state above them, everything else alphabetical after. Same data shape, same file, same shape of test. Membership is decided in one const (`ARDUCOPTER_RC_OPTION_COMMON_VALUES`) so it can be retuned in one place.

Presentation only: no option is added, removed, or relabelled, and nothing written to the FC changes. ArduCopter byte-identical.

Validation: re-run after the rebase — see the CI checks on this PR, plus local `npm run typecheck` and `npm run test`.