### PR TITLE
fix(status): put the sensor cards under System Info

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -6941,6 +6941,16 @@ export function App() {
                          *  to the right column. The sidebar keeps action-oriented
                          *  cards (Instruments / Guided Setup / GPS). */}
                         <div className="setup-bench__status-trio">
+                        {/* First column: System Info, then the advanced sensor
+                         *  cards directly beneath it. They used to sit at the
+                         *  very bottom of the right-hand sidebar, below the GPS
+                         *  card and its map — roughly 1350px down a 2373px page
+                         *  at 1440x900, i.e. a full screen and a half of
+                         *  scrolling to answer "is my lidar alive?". They are
+                         *  system health, so they belong with the system health
+                         *  block, and moving them here also fills the dead space
+                         *  the main column left below the status trio. */}
+                        <div className="setup-status-syscol">
                         <article className="setup-gui-box">
                           <div className="setup-gui-box__titlebar">
                             <strong>System Info</strong>
@@ -6974,6 +6984,19 @@ export function App() {
                             </div>
                           </div>
                         </article>
+
+                        {/* Advanced sensors, directly under System Info. The
+                         *  builder still decides whether a card exists at all:
+                         *  an unconfigured rangefinder or flow sensor produces
+                         *  nothing and this space collapses back to System Info
+                         *  alone, exactly as before. A CONFIGURED sensor always
+                         *  gets a card, silent or not — that silence is the
+                         *  diagnosis, and it is now the first thing in reach
+                         *  rather than the last. */}
+                        {advancedSensorCards.map((card) => (
+                          <AdvancedSensorCard key={card.id} card={card} />
+                        ))}
+                        </div>
 
                         {/* Middle column: pre-arm on top (it gates flight, so it
                             matters most), lifetime stats compact below it. */}
@@ -7260,15 +7283,6 @@ export function App() {
                             ) : null}
                           </div>
                         </article>
-
-                        {/* Advanced sensors, below GPS. Each card only exists
-                         *  when the operator has actually configured that
-                         *  sensor — GPS and compass are the baseline, anything
-                         *  past them is opt-in, so an FPV quad with no lidar
-                         *  and no flow sees this space unchanged. */}
-                        {advancedSensorCards.map((card) => (
-                          <AdvancedSensorCard key={card.id} card={card} />
-                        ))}
 
                       </div>
                     </div>

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -2889,6 +2889,12 @@ textarea:focus {
   grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
   gap: 14px;
   margin-top: 14px;
+  /* Size every column to its own content instead of stretching all three to
+   * the tallest. With the sensor cards stacked under System Info the first
+   * column can be twice the height of Recent Notices, and stretching left
+   * hundreds of pixels of empty box below the pre-arm and notices content —
+   * empty space the operator still has to scroll past. */
+  align-items: start;
 }
 
 .setup-gui-box {
@@ -3022,6 +3028,17 @@ textarea:focus {
 .setup-gui-box__kv-list {
   display: grid;
   gap: 0;
+}
+
+/* Status first column: System Info on top, then whichever advanced sensor
+ * cards exist (rangefinder / optical flow). Same stacking contract as the
+ * middle column, so a column with no sensor cards is byte-for-byte the old
+ * bare System Info box — the wrapper adds no border, background or padding
+ * of its own, only the gap between stacked boxes. */
+.setup-status-syscol {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
 }
 
 /* Status middle column: pre-arm box on top, compact lifetime stats below. */


### PR DESCRIPTION
> "can we move the rangefinder/optical flow tab underneath system status if available so im not scrolling endlessly"

The rangefinder and optical-flow cards (PR #151) sat at the bottom of the Status & Info sidebar, below the GPS card and its embedded map. They now sit in the first column of the status trio, directly beneath the **System Info** box.

Naming note: there is no section literally titled "System status"; System Info (Transport / Vehicle / Firmware / Battery / RC link / Pre-arm) is the closest match to the request.

## Measurements

Chromium, dev build, demo Copter with `RNGFND1_TYPE=100` and `FLOW_TYPE=6` so both cards render.

| | before | after |
|---|---|---|
| 1440x900 page height | 2373 px | **2017 px** (−15%) |
| 1440x900 rangefinder top | 1598 px | 1208 px |
| 390x844 rangefinder top | 3489 px | **1694 px** (4.1 → 2.0 screens) |
| 390x844 flow top | 3824 px | 2051 px |
| horizontal overflow @390 | 0 px | 0 px |

Phone total grows 26 px (+0.6%), because once the columns stack the trio's 14 px gap replaces the sidebar's 10 px. Traded deliberately: reaching the first card goes from 3489 px to 1694 px, and breaking gap consistency to reclaim 26 px is not worth it.

## The availability gate is unchanged

`buildAdvancedSensorCards` and `AdvancedSensorCard` were not edited — the same `advancedSensorCards.map(...)` renders in a new place.

With both sensors unconfigured (`?demoParamOverrides=RNGFND1_TYPE:0,FLOW_TYPE:0`): **1646 px @1440x900 and 3537 px @390 px, identical before and after**, zero sensor cards, GPS still present. A quad with no lidar and no flow gets a pixel-identical page.

Configured-but-silent still renders, verified in demo ("stalled" and "silent" states with their fault copy). That state is load-bearing — it is what told an operator their CAN flow sensor was miswired — so it deliberately survives the tidy-up.

All `data-testid`s preserved; existing e2e blocks still target the moved cards.

## One bonus change, justified

`align-items: start` on the trio grid. It previously stretched all three columns to the tallest, so with the sensor cards in column one there were several hundred pixels of empty box below Pre-arm and Recent Notices — pure scroll, no information. Nothing was folded, hidden or otherwise reordered; the sidebar's remaining height is the GPS map, which is at-a-glance info and was left alone.

## ArduCopter byte-identical

Layout only. No parameter value, write path, telemetry request or metadata semantics touched. `LIVE_TELEMETRY_REQUESTS` is not in the diff.

## Validation

- `npm run typecheck` — clean
- `npm run test` — 857 tests, **853 pass, 0 fail**, 4 skipped
- `apps/web` vitest — 75 files, **661 pass**
- `npm run test:e2e` — **not run locally**; ports 4173/14550 were held by another session throughout. Relying on CI. The two gates those blocks cover were checked by hand with Playwright against the dev server: 390 px overflow = 0, and the unconfigured case renders zero cards with GPS present.

Rungs 4/5 not applicable — no runtime, protocol or write-path code in the diff.

Note for whoever regenerates visual-regression baselines: `align-items: start` changes the trio's rendered box heights, so this page will differ.