### PR TITLE
refactor(setup): stop guided setup steps from making you scroll

### DIFF
--- a/apps/web/src/sections/SetupWizardAside.tsx
+++ b/apps/web/src/sections/SetupWizardAside.tsx
@@ -1,11 +1,33 @@
-// Guided-setup wizard aside — the "Next Action" card (primary / context /
-// support action buttons) and the Previous / Continue step navigation.
+// Guided-setup wizard aside — the step's action card (primary / context /
+// support buttons plus the Previous / Continue navigation) and, below it, the
+// "where you stand" card: the completion-criteria checklist and the live
+// evidence pills.
 //
 // Extracted verbatim from the wizardSlot JSX in App.tsx as part of the setup
 // view decomposition. Purely presentational: the action descriptors and
 // neighbour-section state come from the guided-setup-overview view-model, and
 // the dispatch/navigation intent is passed in as onAction / onMove. App.tsx
-// keeps the FC-facing handlers. Behavior-preserving.
+// keeps the FC-facing handlers.
+//
+// Two deliberate simplifications, from operator feedback that this panel is
+// "pretty busy on the right side for each step":
+//
+//  1. The action card and the prev/next card were two separate bordered cards
+//     stacked on top of each other, and the action card led with a paragraph
+//     that restated the primary button's own label ("Continue to Outputs" above
+//     a button reading "Continue to Outputs"). One card now, and that paragraph
+//     only renders when there is NO action to point at — i.e. only when it says
+//     something the buttons do not.
+//  2. The "→ Do this now" pointer block above the targeted button is gone. The
+//     hero button styling, the `--target` class and the arrow glyph inside the
+//     button already carry that signal three times over.
+//
+// What did NOT change: every action descriptor the view-model produces is still
+// rendered (primary + context + support). Those descriptors include the step
+// waivers ("Orientation Verified Elsewhere — Continue", "Already Calibrated —
+// Continue") that are the only escape hatch on steps whose exercise cannot run
+// on a given build — dropping or folding any of them away would dead-end the
+// flow, which is exactly the class of bug this surface has shipped before.
 
 import type { ReactElement } from 'react'
 
@@ -39,42 +61,39 @@ export function SetupWizardAside({
   onAction,
   onMove
 }: SetupWizardAsideProps): ReactElement {
+  const stepComplete = selectedSetupSection.status === 'complete'
+  // Only worth saying when neither the primary button nor the Continue button
+  // is the answer — otherwise it is a caption for a button that is right there.
+  const showActionGuidance = !guidedSetupPrimaryAction && !continueButtonTargeted
+
   return (
     <aside className="setup-wizard__aside">
       <div className="setup-wizard__action-card">
         <strong>Next Action</strong>
-        <p>
-          {continueButtonTargeted && nextSetupSection
-            ? `Continue to ${nextSetupSection.title}`
-            : guidedSetupPrimaryAction
-            ? guidedSetupPrimaryAction.label
-            : 'Complete the current criteria or use the workspace navigation for more context.'}
-        </p>
+        {showActionGuidance ? <p>Complete the current criteria or use the workspace navigation for more context.</p> : null}
         {guidedSetupPrimaryAction ? (
-          <>
-            <div className="setup-wizard__action-pointer" aria-hidden="true">
-              <span>→</span>
-              <strong>Do this now</strong>
-            </div>
-            <button
-              id={SETUP_WIZARD_PRIMARY_ACTION_ID}
-              className={`setup-wizard__primary-button${
-                guidedSetupPrimaryAction.disabled ? '' : ' setup-wizard__primary-button--target'
-              }`}
-              data-testid="setup-wizard-primary-action"
-              style={buttonStyle(guidedSetupPrimaryAction.disabled ? 'secondary' : 'hero')}
-              onClick={() => onAction(guidedSetupPrimaryAction)}
-              disabled={guidedSetupPrimaryAction.disabled}
-            >
-              <span aria-hidden="true">→</span>
-              <span>{guidedSetupPrimaryAction.label}</span>
-            </button>
-          </>
+          <button
+            id={SETUP_WIZARD_PRIMARY_ACTION_ID}
+            className={`setup-wizard__primary-button${
+              guidedSetupPrimaryAction.disabled ? '' : ' setup-wizard__primary-button--target'
+            }`}
+            data-testid="setup-wizard-primary-action"
+            style={buttonStyle(guidedSetupPrimaryAction.disabled ? 'secondary' : 'hero')}
+            onClick={() => onAction(guidedSetupPrimaryAction)}
+            disabled={guidedSetupPrimaryAction.disabled}
+          >
+            <span aria-hidden="true">→</span>
+            <span>{guidedSetupPrimaryAction.label}</span>
+          </button>
         ) : null}
         {guidedSetupContextAction ? (
           <>
+            {/* Always secondary. This is the "go look at another view" action;
+             *  rendering it at its descriptor tone put a second primary-weight
+             *  button directly under the hero, so the operator had to read both
+             *  to find out which one advances the step. */}
             <button
-              style={buttonStyle(guidedSetupContextAction.tone ?? 'primary')}
+              style={buttonStyle('secondary')}
               onClick={() => onAction(guidedSetupContextAction)}
               disabled={guidedSetupContextAction.disabled}
             >
@@ -97,19 +116,11 @@ export function SetupWizardAside({
             ))}
           </div>
         ) : null}
-      </div>
 
-      <div className="setup-wizard__nav">
-        <button style={buttonStyle()} onClick={() => onMove(-1)} disabled={!previousSetupSection}>
-          Previous Step
-        </button>
-        <div className="setup-wizard__continue-slot">
-          {continueButtonTargeted && nextSetupSection ? (
-            <div className="setup-wizard__action-pointer" aria-hidden="true">
-              <span>→</span>
-              <strong>Do this now</strong>
-            </div>
-          ) : null}
+        <div className="setup-wizard__nav">
+          <button style={buttonStyle()} onClick={() => onMove(-1)} disabled={!previousSetupSection}>
+            Previous Step
+          </button>
           <button
             id={SETUP_WIZARD_NEXT_STEP_ID}
             className={`setup-wizard__continue-button${continueButtonTargeted ? ' setup-wizard__continue-button--target guided-action-pulse' : ''}`}
@@ -121,9 +132,50 @@ export function SetupWizardAside({
             onClick={() => onMove(1)}
             disabled={!nextSetupSection || selectedSetupSection.status !== 'complete'}
           >
+            {continueButtonTargeted ? <span aria-hidden="true">→ </span> : null}
             {nextSetupSection ? `Continue to ${nextSetupSection.title}` : 'Setup Complete'}
           </button>
         </div>
+      </div>
+
+      {/* The panel's real job: why the step is or is not satisfied. Kept in the
+       *  right column so the left column is only the task, and kept OPEN while
+       *  the step is incomplete — a stuck step whose blocking criterion is
+       *  folded away is undiagnosable. */}
+      <div className="setup-wizard__status-card">
+        <details className="setup-flow__criteria" data-testid="setup-wizard-criteria" open={!stepComplete}>
+          <summary>
+            <strong>Completion Criteria</strong>
+            <span className="setup-flow__criteria-count">
+              {selectedSetupSection.criteriaMetCount}/{selectedSetupSection.criteria.length} done
+            </span>
+          </summary>
+          <ul>
+            {selectedSetupSection.criteria.map((criterion) => (
+              <li key={criterion.label} className={criterion.met ? 'is-met' : undefined}>
+                {/* The met/unmet word was an 88px column of "Complete"/"Pending"
+                 *  repeated down the list. A glyph carries the same signal in a
+                 *  fraction of the height; the word stays for screen readers. */}
+                <span aria-hidden="true" className="setup-flow__criteria-mark">
+                  {criterion.met ? '✓' : '○'}
+                </span>
+                <span className="visually-hidden">{criterion.met ? 'Complete' : 'Pending'}</span>
+                <span>{criterion.label}</span>
+              </li>
+            ))}
+          </ul>
+        </details>
+
+        {selectedSetupSection.evidence.length > 0 ? (
+          <div className="setup-wizard__evidence">
+            <strong>Live Evidence</strong>
+            <div className="config-pills">
+              {selectedSetupSection.evidence.map((item) => (
+                <span key={item}>{item}</span>
+              ))}
+            </div>
+          </div>
+        ) : null}
       </div>
     </aside>
   )

--- a/apps/web/src/sections/SetupWizardDetail.tsx
+++ b/apps/web/src/sections/SetupWizardDetail.tsx
@@ -1,10 +1,20 @@
 // Guided-setup wizard detail panel — the "What to do" copy, the
-// accelerometer pose guide (accelerometer step only), the completion-criteria
-// checklist, the live-evidence pills, and any blocking-reason copy.
+// accelerometer pose guide (accelerometer step only), and any blocking-reason
+// copy.
 //
 // Extracted verbatim from the wizardSlot JSX in App.tsx as part of the setup
 // view decomposition. Purely presentational over the selected section
-// descriptor and the live snapshot. Behavior-preserving.
+// descriptor and the live snapshot.
+//
+// The completion-criteria checklist and the live-evidence pills used to live
+// here, at the bottom of the LEFT column. That is why every step scrolled: the
+// left column carried the task card, the copy, the criteria AND the evidence
+// while the right column held only a short action card, so the page was as tall
+// as the tallest single column instead of the taller of two balanced ones. They
+// now render in SetupWizardAside — "left = what you do, right = where you
+// stand" — which is the one layout rule every step follows. The criteria are
+// still shown (same data-testid, same open-when-incomplete behaviour); only the
+// column they sit in changed.
 
 import type { ReactElement, ReactNode } from 'react'
 
@@ -33,10 +43,9 @@ export function SetupWizardDetail({
   // The criteria list is what actually gates the step, but it lived inside a
   // collapsed <details> and the header only showed "2/5 criteria" — never WHICH
   // one was unmet. That is the mechanical reason a blocked step reads as
-  // "unclear what's wanted". Name the first unmet criterion up front, and leave
-  // the full list open whenever the step is not complete.
+  // "unclear what's wanted". Name the first unmet criterion up front; the full
+  // list is one column over in the aside.
   const nextUnmetCriterion = selectedSetupSection.criteria.find((criterion) => !criterion.met)
-  const stepComplete = selectedSetupSection.status === 'complete'
 
   return (
     <div className="setup-wizard__detail">
@@ -64,34 +73,6 @@ export function SetupWizardDetail({
           pitchDeg={snapshot.liveVerification.attitudeTelemetry.pitchDeg}
           attitudeVerified={snapshot.liveVerification.attitudeTelemetry.verified}
         />
-      ) : null}
-
-      <details className="setup-flow__criteria" data-testid="setup-wizard-criteria" open={!stepComplete}>
-        <summary>
-          <strong>Completion Criteria</strong>
-          <span className="setup-flow__criteria-count">
-            {selectedSetupSection.criteriaMetCount}/{selectedSetupSection.criteria.length} done
-          </span>
-        </summary>
-        <ul>
-          {selectedSetupSection.criteria.map((criterion) => (
-            <li key={criterion.label} className={criterion.met ? 'is-met' : undefined}>
-              <span>{criterion.met ? 'Complete' : 'Pending'}</span>
-              <span>{criterion.label}</span>
-            </li>
-          ))}
-        </ul>
-      </details>
-
-      {selectedSetupSection.evidence.length > 0 ? (
-        <div className="setup-wizard__evidence">
-          <strong>Live Evidence</strong>
-          <div className="config-pills">
-            {selectedSetupSection.evidence.map((item) => (
-              <span key={item}>{item}</span>
-            ))}
-          </div>
-        </div>
       ) : null}
 
       {selectedSetupSection.blockingReason ? <p className="setup-flow__blocking-copy">{selectedSetupSection.blockingReason}</p> : null}

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -2266,34 +2266,41 @@ textarea:focus {
 
 .setup-flow__criteria ul {
   display: grid;
-  gap: 10px;
+  gap: 4px;
   margin: 0;
   padding: 0;
   list-style: none;
 }
 
+/* Compact rows. Each criterion used to be a bordered card with an 88px column
+   spelling out "Complete"/"Pending" — six of those ran 335px tall on the Radio
+   and Airframe steps, which is most of a laptop viewport spent on a checklist.
+   Same information, a glyph instead of the repeated word, no per-row border. */
 .setup-flow__criteria li {
   display: grid;
-  grid-template-columns: 88px minmax(0, 1fr);
-  gap: 12px;
-  align-items: start;
-  padding: 10px 12px;
-  border-radius: var(--radius-lg);
-  border: 1px solid var(--border);
-  background: rgba(var(--fill-rgb), 0.9);
-  color: var(--text);
+  grid-template-columns: 14px minmax(0, 1fr);
+  gap: 8px;
+  align-items: baseline;
+  padding: 4px 2px;
+  border-radius: var(--radius-md);
+  color: var(--text-muted);
+  font-size: 12.5px;
+  line-height: 1.45;
 }
 
 .setup-flow__criteria li.is-met {
-  border-color: rgba(111, 143, 120, 0.52);
-  box-shadow: inset 0 0 0 1px rgba(111, 143, 120, 0.12);
+  color: var(--text);
 }
 
-.setup-flow__criteria li span:first-child {
-  color: var(--text-muted);
+.setup-flow__criteria-mark {
+  color: var(--text-dim);
   font-size: 12px;
-  text-transform: uppercase;
-  letter-spacing: 0.08em;
+  line-height: 1.45;
+  text-align: center;
+}
+
+.setup-flow__criteria li.is-met .setup-flow__criteria-mark {
+  color: rgba(111, 143, 120, 0.95);
 }
 
 .setup-flow__blocking-copy {
@@ -4297,17 +4304,26 @@ textarea:focus {
   gap: 10px;
 }
 
+/* The step rail is navigation, not content: 11 chunky two-line cards wrapped
+   to two rows and cost ~146px of every step before the operator saw anything
+   they had to do. One scrollable row of compact chips instead — same buttons,
+   same accessible names ("Step 4 · Outputs"), ~46px. */
 .setup-wizard__steps {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
-  gap: 8px;
+  display: flex;
+  flex-wrap: nowrap;
+  overflow-x: auto;
+  gap: 6px;
+  padding-bottom: 2px;
+  scrollbar-width: thin;
 }
 
 .setup-wizard-step {
   position: relative;
   display: grid;
-  gap: 4px;
-  padding: 10px 12px;
+  gap: 1px;
+  flex: 1 1 0;
+  min-width: 96px;
+  padding: 6px 10px;
   border-radius: var(--radius-md);
   border: 1px solid var(--border-soft);
   background: linear-gradient(180deg, rgba(var(--fill-rgb), 0.96), rgba(var(--fill-rgb), 1));
@@ -4331,23 +4347,34 @@ textarea:focus {
 
 .setup-wizard-step small {
   color: var(--text-dim);
-  font-size: 10px;
+  font-size: 9px;
   text-transform: uppercase;
-  letter-spacing: 0.08em;
+  letter-spacing: 0.06em;
   font-family: var(--font-data);
+  white-space: nowrap;
 }
 
 .setup-wizard-step span {
-  font-size: 13px;
+  font-size: 11.5px;
   font-weight: 700;
-  line-height: 1.35;
+  line-height: 1.25;
+  /* One line per chip keeps the rail a fixed height regardless of how long a
+     step title is; the full title stays in the accessible name. */
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
+/* The compact rail marks the current step with the is-current border + the ::after
+   arrow, so this second "Do this now →" line would only add a row of height to
+   every chip. Kept in the DOM for assistive tech, hidden visually. */
 .setup-wizard-step__cue {
-  display: inline-flex;
-  align-items: center;
-  gap: 6px;
-  margin-top: 4px;
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+  clip-path: inset(50%);
+  white-space: nowrap;
   color: rgba(230, 194, 108, 0.96);
   font-size: 10px;
   font-style: normal;
@@ -4375,10 +4402,10 @@ textarea:focus {
 .setup-wizard-step.is-current::after {
   content: "→";
   position: absolute;
-  top: 12px;
-  right: 12px;
+  top: 6px;
+  right: 7px;
   color: rgba(230, 194, 108, 0.96);
-  font-size: 15px;
+  font-size: 12px;
   font-weight: 700;
   line-height: 1;
 }
@@ -4409,7 +4436,7 @@ textarea:focus {
 
 .setup-wizard__detail,
 .setup-wizard__action-card,
-.setup-wizard__nav,
+.setup-wizard__status-card,
 .setup-wizard__task-card {
   display: grid;
   gap: 10px;
@@ -4420,7 +4447,7 @@ textarea:focus {
 }
 
 .setup-wizard__detail h4,
-.setup-wizard__action-card strong,
+.setup-wizard__action-card > strong,
 .setup-wizard__evidence strong,
 .setup-wizard__task-header strong {
   margin: 0;
@@ -4747,6 +4774,27 @@ textarea:focus {
   background: rgba(var(--fill-rgb), 0.64);
 }
 
+/* The Airframe step's orientation card embeds the shared FlightDeckPreview. In
+   its compact mode that came to 564px inside the wizard — the single tallest
+   thing in guided setup — because the model frame is sized for the Status tab
+   and the instrument cards stack one per row. Scoped down here only: shorter
+   model box, instruments two-up. The shared preview is untouched everywhere
+   else (same override pattern as .setup-bench__viewer). */
+.setup-wizard__task-visual .flight-deck--compact .flight-deck__model-frame {
+  height: clamp(150px, 13vw, 200px);
+}
+
+.setup-wizard__task-visual .flight-deck--compact {
+  gap: 10px;
+}
+
+/* Compact mode stacks the four live readouts two-up, which is right for a
+   narrow Status-tab column but costs a second row inside the wizard's wide
+   left column. One row here. */
+.setup-wizard__task-visual .flight-deck--compact .flight-deck__readout-grid {
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+}
+
 .setup-wizard__task-copy {
   display: grid;
   gap: 12px;
@@ -4841,9 +4889,20 @@ textarea:focus {
   gap: 10px;
 }
 
+/* Support actions (waivers, "run it instead", re-sync, jump-to-view) are the
+   long tail of the action card — the Radio step has five. Two-up on a desktop
+   aside halves the rows without hiding any of them; a waiver folded away is a
+   dead-ended step, so none of these may become a disclosure. */
 .setup-wizard__support-actions {
   display: grid;
-  gap: 10px;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 8px;
+}
+
+@media (max-width: 1100px) {
+  .setup-wizard__support-actions {
+    grid-template-columns: minmax(0, 1fr);
+  }
 }
 
 .setup-wizard__context-hint {
@@ -4853,22 +4912,11 @@ textarea:focus {
   line-height: 1.5;
 }
 
-.setup-wizard__action-pointer {
-  display: inline-flex;
-  align-items: center;
-  gap: 8px;
-  margin: -2px 0 2px;
-  color: rgba(230, 194, 108, 0.96);
-  font-family: var(--font-data);
-  font-size: 11px;
-  font-weight: 700;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-}
-
-.setup-wizard__action-pointer span {
-  font-size: 15px;
-  line-height: 1;
+/* The "Where you stand" card (criteria + live evidence). Sits under the action
+   card in the right column so the left column carries only the task — the
+   single layout rule every guided step follows. */
+.setup-wizard__status-card {
+  gap: 12px;
 }
 
 .guided-action-pulse {
@@ -4892,13 +4940,13 @@ textarea:focus {
   }
 }
 
+/* Prev/Continue now live INSIDE the action card (one card, not two stacked
+   bordered cards) — so this is a plain two-up row, not a card of its own. */
 .setup-wizard__nav {
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-}
-
-.setup-wizard__continue-slot {
   display: grid;
-  gap: 8px;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 10px;
+  align-items: stretch;
 }
 
 .setup-wizard__continue-button--target {
@@ -12030,9 +12078,9 @@ details.metadata-settings-section:not([open]) > summary::after {
     display: grid;
   }
 
-  .setup-flow__criteria li {
-    grid-template-columns: 1fr;
-  }
+  /* The criterion rows stay glyph + label inline at phone width — the 14px
+     mark column costs nothing, and stacking it put a lone tick on its own
+     line above every label. */
 }
 
 .landing {

--- a/tests/e2e/views.spec.ts
+++ b/tests/e2e/views.spec.ts
@@ -3103,6 +3103,15 @@ test.describe('ArduPlane demo', () => {
     await expect(firstCriterion).toBeVisible()
     await criteria.locator('summary').click()
     await expect(firstCriterion).toBeHidden()
+    await criteria.locator('summary').click()
+    await expect(firstCriterion).toBeVisible()
+
+    // The checklist lives in the RIGHT column now ("left = what you do, right =
+    // where you stand"). Both columns used to be lopsided — the left one
+    // carried the task card AND the criteria AND the evidence while the right
+    // held a short action card, so every step was as tall as one long column.
+    await expect(page.locator('.setup-wizard__aside [data-testid="setup-wizard-criteria"]')).toBeVisible()
+    await expect(page.locator('.setup-wizard__aside .setup-wizard__evidence')).toBeVisible()
 
     // The single blocking criterion is also promoted out of the disclosure, so
     // the step says what it still wants without any expanding at all.
@@ -3117,6 +3126,42 @@ test.describe('ArduPlane demo', () => {
     // the live session is preserved.
     await page.getByRole('button', { name: /Vehicle Link/ }).click()
     await expect(page.getByTestId('setup-wizard-complete-banner')).toContainText('complete')
+  })
+
+  test('a guided step keeps its primary action and Continue on screen without scrolling', async ({ page }) => {
+    // Operator report: "i dont love the airframe tab, i dont think people
+    // should need to be scrolling up and down". Airframe was the worst step
+    // (1992px of document against a 900px viewport) but every step had the same
+    // shape, so the fix is one layout rule applied to all of them: the task on
+    // the left, the action + criteria on the right, a one-row step rail, and
+    // the shared 3D preview scoped down inside the wizard.
+    //
+    // Assert the OUTCOME the operator cares about — the thing to click is on
+    // screen at rest — not a pixel height, which moves with font rendering.
+    await page.setViewportSize({ width: 1440, height: 900 })
+    await page.goto('/?guidedSetupStep=airframe')
+    await page.getByTestId('transport-mode-select').selectOption('demo')
+    await page.getByTestId('connect-button').click()
+    await expect(page.getByTestId('session-vehicle-name')).toHaveText('ArduCopter', { timeout: VEHICLE_CONNECT_TIMEOUT })
+    await expect(page.getByTestId('setup-wizard')).toBeVisible()
+
+    const onScreen = async (testId: string): Promise<boolean> =>
+      page.getByTestId(testId).evaluate((el) => {
+        const rect = el.getBoundingClientRect()
+        return rect.top >= 0 && rect.bottom <= window.innerHeight
+      })
+
+    expect(await page.evaluate(() => window.scrollY)).toBe(0)
+    expect(await onScreen('setup-wizard-primary-action')).toBe(true)
+    expect(await onScreen('setup-wizard-next-step')).toBe(true)
+
+    // The step rail is one scrollable row of chips, so its own overflow must
+    // never become the page's — a side-by-side layout at phone width is exactly
+    // what breaks the horizontal-overflow gate.
+    await page.setViewportSize({ width: 390, height: 844 })
+    await expect(page.getByTestId('setup-wizard')).toBeVisible()
+    const overflow = await page.evaluate(() => document.documentElement.scrollWidth - document.documentElement.clientWidth)
+    expect(overflow).toBeLessThanOrEqual(2)
   })
 
   test('the orientation waiver unblocks the Airframe step and unlocks the rest of the flow', async ({ page }) => {


### PR DESCRIPTION
> "i dont love the airframe tab, i dont think peeople should need to be scrolling uip and down"
> "lets do that on the entire guided setup please"
> "also the action tab is pretty busy on the right side for each step, we should be able to make that a lot simpler"

## Measured, all 11 steps

document scrollHeight vs viewport, demo copter.

| step | 1440x900 | 390x844 |
|---|---|---|
| link | 900 → **900** | 1760 → 1327 |
| ports | 900 → **900** | 1749 → 1316 |
| **airframe** | **1992 → 1285** | 3580 → 2685 |
| outputs | 1260 → **951** | 2267 → 1842 |
| accelerometer | 1392 → 1083 | 2383 → 1969 |
| level | 900 → **900** | 1862 → 1447 |
| compass | 1008 → **900** | 2063 → 1603 |
| radio | 1133 → 1113 | 2590 → 1887 |
| failsafe | 1017 → 933 | 2190 → 1520 |
| modes | 919 → **900** | 2060 → 1487 |
| power | 996 → 970 | 2196 → 1575 |

Six of eleven now fit a 900 px viewport exactly. Airframe, the worst offender, is down 35%.

**Radio barely moved (−20 px)** and that is stated rather than dressed up: its content lives almost entirely in the action column, so shortening the left column does not help it.

At `scrollY 0`, 1440x900, on **every** step the primary action button *and* Continue are inside the viewport. Horizontal overflow is **0 px on all 11 steps at 390 px**.

## One pattern: left = what you do, right = where you stand

- **Criteria checklist + Live Evidence moved to the right column.** That imbalance was the mechanical cause — the left column carried task card + copy + criteria + evidence while the right held a short action card, so a step was as tall as one long column instead of the taller of two balanced ones.
- **Compact criterion rows** — glyph instead of an 88 px column repeating "Complete"/"Pending". 48 → 26 px per row (335 → 227 px on six-criterion steps). The word is retained for screen readers.
- **Step rail** — one scrollable row of chips instead of 11 two-line cards on two rows. **146 → 44 px on every step.** Accessible names unchanged, since e2e depends on them.
- **Action panel** — action card and prev/next merged; the paragraph restating the primary button's own label now renders only when there is no action to point at; both "→ Do this now" pointer blocks removed (hero styling, `--target`, and the arrow already said it three times); context action is always `secondary` so it stops competing with the hero. Radio's panel went from 8 buttons in one stack plus 2 paragraphs to 6 in a 2-up grid.
- **FlightDeckPreview in the Airframe orientation card was 564 px** — the single tallest thing in guided setup, because its model box is sized for the Status tab. Scoped down inside `.setup-wizard__task-visual` only; the shared preview is untouched elsewhere.

Nothing was deleted or hidden.

## Coupling audit — done in full before touching anything

This repo has form here: guided steps gate on state specific UI sets, and moving that UI silently breaks the step (the "power step" report, and the step-2 hard-lock of #114).

- Every gate in `buildSetupFlowSections` derives from the snapshot, the exercise state machines and the confirmation records. **No criterion reads the DOM**, and neither the criteria list nor the evidence pills set anything — they are read-only renderings, so moving them between columns cannot affect a gate.
- What *does* set gates is the action descriptors, split into primary / context / **support = everything else**. The support bucket holds the escape hatches: "Orientation Verified Elsewhere — Continue", "Already Calibrated — Continue", "Radio Verified Elsewhere — Continue", "Flight Modes Verified Elsewhere — Continue", "Record No-Compass Skip". **Folding any of those behind a disclosure would dead-end a step and lock everything after it**, so the aside renders primary + context + every support action unconditionally, and criteria stay open while a step is incomplete.
- `panelAnchorForSetupSection` / `setupPanelActionForSection` / `appViewForPanel` were not modified, so the Radio step's RCIN detour to `setup-panel-ports` and the receiver/motors detours resolve exactly as before.

## End-to-end flow walk

All 11 steps clicked through in demo mode after the changes: Link → Ports → Airframe (orientation check + confirm) → Outputs → Accelerometer (6 poses) → Level → Compass → *Continue correctly refused*, because the compass cal queued a parameter refresh and Vehicle Link went incomplete again; the rail pointed back at step 1 and a re-sync fixed it → Radio (detour into the Receiver workbench landed and returned, waiver worked) → Failsafe → Flight Modes → Battery. All 11 unlocked, no step dead-ended.

## ArduCopter byte-identical

Layout only — two presentational components, CSS, and a test. No parameter value, write path, gating logic or metadata semantics changed.

## Validation

- `npm run typecheck` — clean
- `npm run test` — **853 passed, 0 failed**, 4 skipped
- `npm run test:e2e` — **247 passed, 0 failed**, 6 skipped (visual baselines), ports confirmed free first. Includes a new test asserting primary + Continue on screen at rest and 0 horizontal overflow at 390 px.

## Known, not done

Radio's criteria would be better back in the left column *for that step only* — but a per-step exception is exactly the bespoke-layout outcome worth avoiding, so it stays uniform.