### PR TITLE
refactor(ui): every parameter identifies itself the same way

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -5894,7 +5894,7 @@ export function App() {
     )
   }
 
-  function renderMetadataParameterField(parameter: ParameterState) {
+  function renderMetadataParameterField(parameter: ParameterState, infoTestIdPrefix = 'metadata-field-info') {
     // Shared metadata-driven editor used across Power additional
     // settings, Output additional settings, Tuning, and other generic
     // surfaces. The ScopedField dispatcher picks: bitmask -> per-bit
@@ -5916,16 +5916,29 @@ export function App() {
       }
     }
 
+    // Every "Additional settings" card in the app (Servos ▸ Peripherals &
+    // Alerts, Power, Failsafe, Ports, Receiver, guided Setup) funnels through
+    // this one renderer, so the per-parameter "i" is attached here rather than
+    // at each of those call sites. The bubble is a SIBLING of the editor, not a
+    // child: ScopedField wraps its control in a <label>, and an anchor (the
+    // wiki link) nested inside a <label> is both invalid and unclickable.
     return (
-      <ScopedField
-        key={parameter.id}
-        parameter={parameter}
-        liveValue={parameter.value}
-        editedValues={editedValues}
-        onChange={(paramId, value) => setDraft(paramId, value)}
-        draftStatusById={parameterDraftById}
-        stepFallback={parameter.definition?.step ?? 1}
-      />
+      <div key={parameter.id} className="config-section__field-row">
+        <ScopedField
+          parameter={parameter}
+          liveValue={parameter.value}
+          editedValues={editedValues}
+          onChange={(paramId, value) => setDraft(paramId, value)}
+          draftStatusById={parameterDraftById}
+          stepFallback={parameter.definition?.step ?? 1}
+        />
+        <ParamInfoBubble
+          paramId={parameter.id}
+          label={parameter.definition?.label ?? parameter.id}
+          description={parameter.definition?.description}
+          testId={`${infoTestIdPrefix}-${parameter.id}`}
+        />
+      </div>
     )
   }
 
@@ -6018,7 +6031,12 @@ export function App() {
     if (/^NET_(?:IPADDR|GWADDR|REMPPP_IP|P\d+_IP)[1-3]$/.test(parameter.id)) {
       return null
     }
-    return withNetworkingFieldInfo(parameter, renderMetadataParameterField(parameter))
+    // Plain NET_ params go through the generic renderer, which now attaches the
+    // "i" itself — wrapping again here would render two bubbles per field. Pass
+    // the networking test-id prefix through so `networking-field-info-*` hooks
+    // keep resolving. withNetworkingFieldInfo stays for the composed
+    // dotted-quad/MAC editors above, which the generic renderer never sees.
+    return renderMetadataParameterField(parameter, 'networking-field-info')
   }
 
   function handleStageTuningParameterValue(parameter: ParameterState, nextValue: string): void {

--- a/apps/web/src/sections/AutotuneCopterSection.tsx
+++ b/apps/web/src/sections/AutotuneCopterSection.tsx
@@ -18,33 +18,30 @@ import { formatParameterValue } from '../parameter-format'
 import { selectParameterById } from '../selectors/parameter-read'
 import { toneForParameterDraftStatus, toneForScopedDraftReview } from '../tone-helpers'
 import { InfoDot } from '../views/InfoDot'
+import { ParamInfoBubble } from '../views/ParamInfoBubble'
 import { ScopedBitmaskField, ScopedField } from '../views/ScopedField'
 
 // Wrap a scoped Autotune field with the same per-field "i" info bubble used on
 // the Config / Networking tabs and the curated tuning controls — hover/focus
 // reveals the ArduPilot parameter description right next to the control, so the
 // always-on explanatory paragraph can be retired without losing the guidance.
+//
+// Now the SHARED ParamInfoBubble rather than a local copy of its markup. Two
+// things were wrong with the copy: it rendered only when the metadata carried a
+// description, so an Autotune knob whose description we don't ship showed a
+// friendly label with no route to its raw name at all; and it had no link to the
+// parameter reference. Both exist for every parameter, so the bubble is
+// unconditional and the description is the optional part.
 function withAutotuneFieldInfo(parameter: ParameterState, node: ReactNode): ReactNode {
-  const description = parameter.definition?.description
-  if (!description) {
-    return node
-  }
   return (
     <div key={parameter.id} className="config-section__field-row">
       {node}
-      <span className="config-section__info-wrap">
-        <button
-          type="button"
-          className="config-section__info"
-          data-testid={`autotune-field-info-${parameter.id}`}
-          aria-label={`About ${parameter.definition?.label ?? parameter.id}`}
-        >
-          i
-        </button>
-        <span className="config-section__info-tip" role="tooltip">
-          {description}
-        </span>
-      </span>
+      <ParamInfoBubble
+        paramId={parameter.id}
+        label={parameter.definition?.label ?? parameter.id}
+        description={parameter.definition?.description}
+        testId={`autotune-field-info-${parameter.id}`}
+      />
     </div>
   )
 }
@@ -124,7 +121,7 @@ export function AutotuneCopterSection(props: AutotuneCopterSectionProps): ReactE
       <div className="bf-gui-box__titlebar">
         <span className="tuning-card-title">
           <strong>ArduCopter AutoTune</strong>
-          <InfoDot label="About the AutoTune surface" testId="autotune-copter-info" wide>
+          <InfoDot label="About the AutoTune surface" testId="autotune-copter-info" wide wikiTopic="tuningAutotune">
             <span className="info-dot-line">Each control is the real ArduPilot parameter from the loaded catalog.</span>
             <span className="info-dot-line">Edits stage here and apply through the same verified review path as the other tabs — nothing is written until you apply.</span>
             <span className="info-dot-line">These set up AutoTune; the tuning itself happens in the air.</span>
@@ -137,7 +134,7 @@ export function AutotuneCopterSection(props: AutotuneCopterSectionProps): ReactE
           <div className="tuning-axis-card__header">
             <span className="tuning-card-title">
               <strong>AutoTune configuration</strong>
-              <InfoDot label="About the AutoTune configuration parameters" testId="autotune-config-info" wide>
+              <InfoDot label="About the AutoTune configuration parameters" testId="autotune-config-info" wide wikiTopic="tuningAutotune">
                 <span className="info-dot-line">AUTOTUNE_AXES picks which axes are tuned (Roll / Pitch / Yaw / YawD).</span>
                 <span className="info-dot-line">AUTOTUNE_AGGR is the bounce-back aggressiveness used to size the D term.</span>
                 <span className="info-dot-line">AUTOTUNE_MIN_D is the lowest D gain AutoTune may set.</span>

--- a/apps/web/src/sections/OutputsSection.tsx
+++ b/apps/web/src/sections/OutputsSection.tsx
@@ -63,6 +63,7 @@ import {
   toneForScopedDraftReview
 } from '../tone-helpers'
 import { OutputsView } from '../views/Outputs'
+import { ParamInfoBubble } from '../views/ParamInfoBubble'
 import type { OutputsTaskId, OutputsViewProps } from '../views/Outputs'
 import { ScopedField, ScopedSelectField } from '../views/ScopedField'
 import { RelaysView } from '../views/RelaysView'
@@ -202,6 +203,38 @@ export interface OutputsSectionProps {
    *  expert ceiling when product-mode is 'expert' so a longer soak is
    *  allowed; basic mode keeps the 5-second cap. */
   motorTestMaxDurationSeconds: number
+}
+
+/**
+ * One field of the Peripherals & Alerts (LED & buzzer) card plus the shared
+ * per-parameter "i". The card is curated: it shows "LED drivers" / "Buzzer
+ * volume", never NTF_LED_TYPES / NTF_BUZZ_VOLUME, so without this an operator
+ * had no route from the friendly name to the parameter they'd have to search
+ * for in Parameters or look up in the reference.
+ *
+ * The bubble is a SIBLING of the editor, never a child: these editors wrap
+ * their control in a <label>, and the bubble contains the wiki anchor — an
+ * anchor inside a <label> is invalid markup and the label's click handling
+ * swallows it.
+ */
+function NotificationFieldRow({
+  parameter,
+  children
+}: {
+  parameter: ParameterState
+  children: ReactNode
+}): ReactElement {
+  return (
+    <div className="config-section__field-row">
+      {children}
+      <ParamInfoBubble
+        paramId={parameter.id}
+        label={parameter.definition?.label ?? parameter.id}
+        description={parameter.definition?.description}
+        testId={`peripheral-field-info-${parameter.id}`}
+      />
+    </div>
+  )
 }
 
 export function OutputsSection(props: OutputsSectionProps): ReactElement {
@@ -970,121 +1003,133 @@ export function OutputsSection(props: OutputsSectionProps): ReactElement {
 
                       <div className="scoped-editor-grid">
                         {notificationLedTypesParameter ? (
-                          <label className={`scoped-editor-field scoped-editor-field--${parameterDraftById.get(notificationLedTypesParameter.id)?.status ?? 'unchanged'}`}>
-                            <span>{notificationLedTypesParameter.definition?.label ?? notificationLedTypesParameter.id}</span>
-                            <div className="scoped-bitmask-bits">
-                              {Object.entries(ARDUCOPTER_NOTIFICATION_LED_TYPE_BIT_LABELS).map(([bit, label]) => {
-                                const numericBit = Number(bit)
-                                const checked = hasBitmaskFlag(editedNotificationLedTypes, numericBit)
-                                return (
-                                  <button
-                                    type="button"
-                                    key={`${notificationLedTypesParameter.id}:${bit}`}
-                                    className={`scoped-bitmask-bit${checked ? ' is-set' : ''}`}
-                                    aria-pressed={checked}
-                                    onClick={() =>
-                                      updateDrafts((existing) => {
-                                        const currentValue = normalizeBitmaskValue(existing[notificationLedTypesParameter.id], notificationLedTypes)
-                                        const nextValue = toggleBitmaskFlag(currentValue, numericBit, !checked)
+                          <NotificationFieldRow parameter={notificationLedTypesParameter}>
+                            <label className={`scoped-editor-field scoped-editor-field--${parameterDraftById.get(notificationLedTypesParameter.id)?.status ?? 'unchanged'}`}>
+                              <span>{notificationLedTypesParameter.definition?.label ?? notificationLedTypesParameter.id}</span>
+                              <div className="scoped-bitmask-bits">
+                                {Object.entries(ARDUCOPTER_NOTIFICATION_LED_TYPE_BIT_LABELS).map(([bit, label]) => {
+                                  const numericBit = Number(bit)
+                                  const checked = hasBitmaskFlag(editedNotificationLedTypes, numericBit)
+                                  return (
+                                    <button
+                                      type="button"
+                                      key={`${notificationLedTypesParameter.id}:${bit}`}
+                                      className={`scoped-bitmask-bit${checked ? ' is-set' : ''}`}
+                                      aria-pressed={checked}
+                                      onClick={() =>
+                                        updateDrafts((existing) => {
+                                          const currentValue = normalizeBitmaskValue(existing[notificationLedTypesParameter.id], notificationLedTypes)
+                                          const nextValue = toggleBitmaskFlag(currentValue, numericBit, !checked)
 
-                                        return {
-                                          ...existing,
-                                          [notificationLedTypesParameter.id]: String(nextValue)
-                                        }
-                                      })
-                                    }
-                                  >
-                                    {label}
-                                  </button>
-                                )
-                              })}
-                            </div>
-                            <small>
-                              {parameterDraftById.get(notificationLedTypesParameter.id)?.status === 'staged'
-                                ? `Staged ${describeBitmaskSelections(parameterDraftById.get(notificationLedTypesParameter.id)?.nextValue, ARDUCOPTER_NOTIFICATION_LED_TYPE_BIT_LABELS, 'Disabled')}`
-                                : parameterDraftById.get(notificationLedTypesParameter.id)?.reason ??
-                                  `Current ${describeBitmaskSelections(notificationLedTypes, ARDUCOPTER_NOTIFICATION_LED_TYPE_BIT_LABELS, 'Disabled')}`}
-                            </small>
-                          </label>
+                                          return {
+                                            ...existing,
+                                            [notificationLedTypesParameter.id]: String(nextValue)
+                                          }
+                                        })
+                                      }
+                                    >
+                                      {label}
+                                    </button>
+                                  )
+                                })}
+                              </div>
+                              <small>
+                                {parameterDraftById.get(notificationLedTypesParameter.id)?.status === 'staged'
+                                  ? `Staged ${describeBitmaskSelections(parameterDraftById.get(notificationLedTypesParameter.id)?.nextValue, ARDUCOPTER_NOTIFICATION_LED_TYPE_BIT_LABELS, 'Disabled')}`
+                                  : parameterDraftById.get(notificationLedTypesParameter.id)?.reason ??
+                                    `Current ${describeBitmaskSelections(notificationLedTypes, ARDUCOPTER_NOTIFICATION_LED_TYPE_BIT_LABELS, 'Disabled')}`}
+                              </small>
+                            </label>
+                          </NotificationFieldRow>
                         ) : null}
 
                         {notificationLedBrightnessParameter ? (
-                          <ScopedSelectField
-                            parameter={notificationLedBrightnessParameter}
-                            liveValue={notificationLedBrightness}
-                            editedValues={editedValues}
-                            onChange={(paramId, value) => setDraft(paramId, value)}
-                            draftStatusById={parameterDraftById}
-                          />
+                          <NotificationFieldRow parameter={notificationLedBrightnessParameter}>
+                            <ScopedSelectField
+                              parameter={notificationLedBrightnessParameter}
+                              liveValue={notificationLedBrightness}
+                              editedValues={editedValues}
+                              onChange={(paramId, value) => setDraft(paramId, value)}
+                              draftStatusById={parameterDraftById}
+                            />
+                          </NotificationFieldRow>
                         ) : null}
 
                         {notificationLedLengthParameter ? (
-                          <ScopedField
-                            parameter={notificationLedLengthParameter}
-                            liveValue={notificationLedLength}
-                            editedValues={editedValues}
-                            onChange={(paramId, value) => setDraft(paramId, value)}
-                            draftStatusById={parameterDraftById}
-                          />
+                          <NotificationFieldRow parameter={notificationLedLengthParameter}>
+                            <ScopedField
+                              parameter={notificationLedLengthParameter}
+                              liveValue={notificationLedLength}
+                              editedValues={editedValues}
+                              onChange={(paramId, value) => setDraft(paramId, value)}
+                              draftStatusById={parameterDraftById}
+                            />
+                          </NotificationFieldRow>
                         ) : null}
 
                         {notificationLedOverrideParameter ? (
-                          <ScopedSelectField
-                            parameter={notificationLedOverrideParameter}
-                            liveValue={notificationLedOverride}
-                            editedValues={editedValues}
-                            onChange={(paramId, value) => setDraft(paramId, value)}
-                            draftStatusById={parameterDraftById}
-                          />
+                          <NotificationFieldRow parameter={notificationLedOverrideParameter}>
+                            <ScopedSelectField
+                              parameter={notificationLedOverrideParameter}
+                              liveValue={notificationLedOverride}
+                              editedValues={editedValues}
+                              onChange={(paramId, value) => setDraft(paramId, value)}
+                              draftStatusById={parameterDraftById}
+                            />
+                          </NotificationFieldRow>
                         ) : null}
 
                         {notificationBuzzTypesParameter ? (
-                          <label className={`scoped-editor-field scoped-editor-field--${parameterDraftById.get(notificationBuzzTypesParameter.id)?.status ?? 'unchanged'}`}>
-                            <span>{notificationBuzzTypesParameter.definition?.label ?? notificationBuzzTypesParameter.id}</span>
-                            <div className="scoped-bitmask-bits">
-                              {Object.entries(ARDUCOPTER_NOTIFICATION_BUZZER_TYPE_BIT_LABELS).map(([bit, label]) => {
-                                const numericBit = Number(bit)
-                                const checked = hasBitmaskFlag(editedNotificationBuzzTypes, numericBit)
-                                return (
-                                  <button
-                                    type="button"
-                                    key={`${notificationBuzzTypesParameter.id}:${bit}`}
-                                    className={`scoped-bitmask-bit${checked ? ' is-set' : ''}`}
-                                    aria-pressed={checked}
-                                    onClick={() =>
-                                      updateDrafts((existing) => {
-                                        const currentValue = normalizeBitmaskValue(existing[notificationBuzzTypesParameter.id], notificationBuzzTypes)
-                                        const nextValue = toggleBitmaskFlag(currentValue, numericBit, !checked)
+                          <NotificationFieldRow parameter={notificationBuzzTypesParameter}>
+                            <label className={`scoped-editor-field scoped-editor-field--${parameterDraftById.get(notificationBuzzTypesParameter.id)?.status ?? 'unchanged'}`}>
+                              <span>{notificationBuzzTypesParameter.definition?.label ?? notificationBuzzTypesParameter.id}</span>
+                              <div className="scoped-bitmask-bits">
+                                {Object.entries(ARDUCOPTER_NOTIFICATION_BUZZER_TYPE_BIT_LABELS).map(([bit, label]) => {
+                                  const numericBit = Number(bit)
+                                  const checked = hasBitmaskFlag(editedNotificationBuzzTypes, numericBit)
+                                  return (
+                                    <button
+                                      type="button"
+                                      key={`${notificationBuzzTypesParameter.id}:${bit}`}
+                                      className={`scoped-bitmask-bit${checked ? ' is-set' : ''}`}
+                                      aria-pressed={checked}
+                                      onClick={() =>
+                                        updateDrafts((existing) => {
+                                          const currentValue = normalizeBitmaskValue(existing[notificationBuzzTypesParameter.id], notificationBuzzTypes)
+                                          const nextValue = toggleBitmaskFlag(currentValue, numericBit, !checked)
 
-                                        return {
-                                          ...existing,
-                                          [notificationBuzzTypesParameter.id]: String(nextValue)
-                                        }
-                                      })
-                                    }
-                                  >
-                                    {label}
-                                  </button>
-                                )
-                              })}
-                            </div>
-                            <small>
-                              {parameterDraftById.get(notificationBuzzTypesParameter.id)?.status === 'staged'
-                                ? `Staged ${describeBitmaskSelections(parameterDraftById.get(notificationBuzzTypesParameter.id)?.nextValue, ARDUCOPTER_NOTIFICATION_BUZZER_TYPE_BIT_LABELS, 'Disabled')}`
-                                : parameterDraftById.get(notificationBuzzTypesParameter.id)?.reason ??
-                                  `Current ${describeBitmaskSelections(notificationBuzzTypes, ARDUCOPTER_NOTIFICATION_BUZZER_TYPE_BIT_LABELS, 'Disabled')}`}
-                            </small>
-                          </label>
+                                          return {
+                                            ...existing,
+                                            [notificationBuzzTypesParameter.id]: String(nextValue)
+                                          }
+                                        })
+                                      }
+                                    >
+                                      {label}
+                                    </button>
+                                  )
+                                })}
+                              </div>
+                              <small>
+                                {parameterDraftById.get(notificationBuzzTypesParameter.id)?.status === 'staged'
+                                  ? `Staged ${describeBitmaskSelections(parameterDraftById.get(notificationBuzzTypesParameter.id)?.nextValue, ARDUCOPTER_NOTIFICATION_BUZZER_TYPE_BIT_LABELS, 'Disabled')}`
+                                  : parameterDraftById.get(notificationBuzzTypesParameter.id)?.reason ??
+                                    `Current ${describeBitmaskSelections(notificationBuzzTypes, ARDUCOPTER_NOTIFICATION_BUZZER_TYPE_BIT_LABELS, 'Disabled')}`}
+                              </small>
+                            </label>
+                          </NotificationFieldRow>
                         ) : null}
 
                         {notificationBuzzVolumeParameter ? (
-                          <ScopedField
-                            parameter={notificationBuzzVolumeParameter}
-                            liveValue={notificationBuzzVolume}
-                            editedValues={editedValues}
-                            onChange={(paramId, value) => setDraft(paramId, value)}
-                            draftStatusById={parameterDraftById}
-                          />
+                          <NotificationFieldRow parameter={notificationBuzzVolumeParameter}>
+                            <ScopedField
+                              parameter={notificationBuzzVolumeParameter}
+                              liveValue={notificationBuzzVolume}
+                              editedValues={editedValues}
+                              onChange={(paramId, value) => setDraft(paramId, value)}
+                              draftStatusById={parameterDraftById}
+                            />
+                          </NotificationFieldRow>
                         ) : null}
                       </div>
 

--- a/apps/web/src/sections/ReceiverSection.tsx
+++ b/apps/web/src/sections/ReceiverSection.tsx
@@ -48,6 +48,7 @@ import { RC_CALIBRATION_AXIS_ORDER, RC_CALIBRATION_SWITCH_CHANNELS, rcCalibratio
 import { StickCraftPreview } from '../preview-components'
 import { formatRxRssi } from '../status-formatters'
 import { toneForModeSwitchExercise, toneForParameterDraftStatus, toneForScopedDraftReview } from '../tone-helpers'
+import { InfoDot } from '../views/InfoDot'
 import { ReceiverView } from '../views/Receiver'
 import { ScopedBitmaskField, ScopedField, ScopedSelectField } from '../views/ScopedField'
 
@@ -442,14 +443,15 @@ export function ReceiverSection(props: ReceiverSectionProps): ReactElement {
                     >
                       {bindFlash ? 'Bind sent ✓' : 'Bind RX (ELRS / CRSF)'}
                     </button>
-                    <span className="receiver-info-dot" aria-hidden="true">
-                      i
-                      <span className="receiver-info-tip" role="tooltip">
-                        Tells ArduPilot to send the bind command to the receiver (MAV_CMD_START_RX_PAIR).
-                        Put your transmitter / ELRS module into bind mode too; the receiver LED confirms pairing.
-                        ELRS receivers with a bind phrase set ignore this — bind by phrase or power-cycle instead.
-                      </span>
-                    </span>
+                    {/* The shared InfoDot rather than a hand-rolled copy of its
+                        markup: the copy could not carry the wiki link, and being
+                        aria-hidden it hid the only explanation of what Bind does
+                        from screen-reader users entirely. */}
+                    <InfoDot label="About binding an ELRS / CRSF receiver" testId="receiver-bind-info" wikiTopic="receiverBind">
+                      Tells ArduPilot to send the bind command to the receiver (MAV_CMD_START_RX_PAIR).
+                      Put your transmitter / ELRS module into bind mode too; the receiver LED confirms pairing.
+                      ELRS receivers with a bind phrase set ignore this — bind by phrase or power-cycle instead.
+                    </InfoDot>
                   </div>
                   ) : null}
                 </div>

--- a/apps/web/src/sections/TuningCopterSection.tsx
+++ b/apps/web/src/sections/TuningCopterSection.tsx
@@ -226,7 +226,7 @@ export function TuningCopterSection(props: TuningCopterSectionProps): ReactEleme
                           <div>
                             <span className="tuning-card-title">
                               <strong>Rates, expo, and accel shaping</strong>
-                              <InfoDot label="About rates, expo, and accel shaping" testId="tuning-info-acro" wide>
+                              <InfoDot label="About rates, expo, and accel shaping" testId="tuning-info-acro" wide wikiTopic="tuningPilot">
                                 <span className="info-dot-line">Rates set maximum rotation speed. Expo softens the center without reducing full-stick authority.</span>
                                 <span className="info-dot-line">Acceleration limits control how aggressively the controller tries to reach the commanded rate.</span>
                                 <span className="info-dot-line">Keep changes small and save a known-good snapshot before pushing responsiveness higher.</span>
@@ -253,7 +253,7 @@ export function TuningCopterSection(props: TuningCopterSectionProps): ReactEleme
                           <div>
                             <span className="tuning-card-title">
                               <strong>General response</strong>
-                              <InfoDot label="About general response" testId="tuning-info-angle" wide>
+                              <InfoDot label="About general response" testId="tuning-info-angle" wide wikiTopic="tuningPilot">
                                 <span className="info-dot-line">Lower smoothing makes the quad feel more immediate; higher smoothing makes it calmer and softer.</span>
                                 <span className="info-dot-line">Lean-angle changes are shown in degrees even though ANGLE_MAX is stored in centidegrees.</span>
                                 <span className="info-dot-line">Increase yaw values slowly and validate feel with a short hover or line-of-sight test before pushing further.</span>
@@ -329,7 +329,7 @@ export function TuningCopterSection(props: TuningCopterSectionProps): ReactEleme
                           <div>
                             <span className="tuning-card-title">
                               <strong>Axis controller gains</strong>
-                              <InfoDot label="About axis controller gains" testId="tuning-info-pid" wide>
+                              <InfoDot label="About axis controller gains" testId="tuning-info-pid" wide wikiTopic="tuningPidGains">
                                 <span className="info-dot-line">Keep roll and pitch close unless the aircraft has a real asymmetry that justifies diverging them.</span>
                                 <span className="info-dot-line">Feedforward increases stick-to-rate immediacy; use it deliberately rather than masking a weak base tune.</span>
                                 <span className="info-dot-line">If you move P, I, or D significantly, re-check filters and do a short test flight before stacking more changes.</span>
@@ -562,7 +562,7 @@ export function TuningCopterSection(props: TuningCopterSectionProps): ReactEleme
                           <div>
                             <span className="tuning-card-title">
                               <strong>Axis bandwidth and smoothing</strong>
-                              <InfoDot label="About axis bandwidth and smoothing" testId="tuning-info-filters" wide>
+                              <InfoDot label="About axis bandwidth and smoothing" testId="tuning-info-filters" wide wikiTopic="tuningFilters">
                                 <span className="info-dot-line">Higher filter frequencies preserve response but pass more noise. Lower values smooth noise at the cost of latency.</span>
                                 <span className="info-dot-line">Zero values are valid for some ArduPilot filter parameters and can intentionally disable a filter path.</span>
                                 <span className="info-dot-line">Change filters carefully and listen for noise or oscillation before moving on to more aggressive gain changes.</span>

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -6161,6 +6161,37 @@ textarea:focus {
   opacity: 1;
   visibility: visible;
 }
+/* A tip carrying a wiki link has to be reachable. Three things block that on the
+   plain tip, and all three are deliberate there: it has pointer-events: none, it
+   sits 6px below a 14px dot with a dead band in between, and it only opens while
+   the DOT itself is hovered/focused. Undo each of them — for linked tips only. */
+.receiver-info-tip--linked {
+  pointer-events: auto;
+}
+/* Invisible bridge across the 6px gap so a pointer travelling from the dot to
+   the link never leaves the dot's hover area and close the tip under the cursor. */
+.receiver-info-tip--linked::before {
+  content: '';
+  position: absolute;
+  left: 0;
+  right: 0;
+  top: -8px;
+  height: 8px;
+}
+/* focus-within, not the dot's own :focus-visible: tabbing onto the link inside
+   blurs the dot, which would close the tip and make the link unreachable by
+   keyboard. Scoped to linked tips so text-only dots keep their existing rules. */
+.receiver-info-dot:focus-within .receiver-info-tip--linked {
+  opacity: 1;
+  visibility: visible;
+}
+.receiver-info-wiki {
+  display: inline-block;
+  margin-top: 6px;
+  color: var(--accent-strong, var(--accent));
+  font-size: 11px;
+  text-decoration: underline;
+}
 /* Multi-point guidance inside a tip: each point on its own line so a card's
    condensed help stays scannable in the hover box (replaces the always-on
    output-note-list bullet walls on the tuning cards). */

--- a/apps/web/src/view-models/param-docs.ts
+++ b/apps/web/src/view-models/param-docs.ts
@@ -84,3 +84,52 @@ export function parameterWikiUrl(paramId: string): string {
   }
   return `${WIKI_PARAMETER_REFERENCE_URL}?${WIKI_PARAMETER_QUERY_KEY}=${encodeURIComponent(paramId)}`
 }
+
+/**
+ * Root of our own wiki (the Sphinx build that ships into the app bundle at
+ * /wiki — see .github/workflows/web-deploy.yml).
+ *
+ * The parameter reference above is one page of it; the wiki also carries
+ * hand-written topic pages (Tuning, Config, Lua, CAN/DroneCAN, Networking,
+ * Files, Logs & Inspectors, and the First Time Setup walkthroughs). Those are
+ * what the app's NON-parameter "i" bubbles — the ones that explain a card or a
+ * workflow rather than a single parameter — can point at.
+ */
+export const WIKI_BASE_URL = 'https://arduconfigurator.com/wiki'
+
+/**
+ * Wiki destinations for concept-level "i" bubbles, as `page.html#anchor`
+ * relative to WIKI_BASE_URL.
+ *
+ * Every entry here is asserted against the wiki sources by
+ * tests/wiki-topic-links.test.mjs: the page must exist and the anchor must be
+ * the docutils slug of a real heading on it. That test is the whole reason this
+ * map is centralised rather than each bubble carrying its own string — a
+ * concept link that 404s teaches operators the "i" is unreliable, and renaming
+ * a wiki heading is exactly the silent way that happens.
+ *
+ * ONLY topics with a genuinely matching page belong here. Where the wiki has
+ * nothing to say about a surface, the bubble stays text-only — an approximate
+ * destination is worse than none.
+ */
+export const WIKI_TOPIC_PATHS = {
+  /** Tuning ▸ Pilot: stick feel, acro rates/expo, accel limits, Loiter/AltHold. */
+  tuningPilot: 'tuning.html#pilot',
+  /** Tuning ▸ PID Gains: the per-axis rate controllers. */
+  tuningPidGains: 'tuning.html#rate-controllers-pid-gains',
+  /** Tuning ▸ Filters: rate-controller filtering and the notch set. */
+  tuningFilters: 'tuning.html#filters',
+  /** Tuning ▸ Autotune: running the on-vehicle tune and its configuration. */
+  tuningAutotune: 'tuning.html#autotune',
+  /** Lua ▸ how scripts get onto the vehicle and what the catalog is. */
+  luaInstallingScripts: 'lua.html#installing-scripts',
+  /** Receiver ▸ binding an ELRS / CRSF receiver from the configurator. */
+  receiverBind: 'first-time-setup/receiver.html#bind-elrs-crsf'
+} as const
+
+export type WikiTopic = keyof typeof WIKI_TOPIC_PATHS
+
+/** Absolute URL for a concept-level wiki topic. */
+export function wikiTopicUrl(topic: WikiTopic): string {
+  return `${WIKI_BASE_URL}/${WIKI_TOPIC_PATHS[topic]}`
+}

--- a/apps/web/src/views/Config.tsx
+++ b/apps/web/src/views/Config.tsx
@@ -172,7 +172,14 @@ export function ConfigView(props: ConfigViewProps) {
           data-testid={`config-field-missing-${field.paramId}`}
         >
           <span>{field.label}</span>
-          <small>{field.paramId}</small>
+          {/* Same "i" affordance as a live row rather than a bare id string: the
+              parameter is absent from this firmware, so the wiki deep link is
+              the only place left to find out what it would have done. */}
+          <ParamInfoBubble
+            paramId={field.paramId}
+            label={field.label}
+            testId={`config-field-info-${field.paramId}`}
+          />
           <span className="config-section__missing-value">— (not reported)</span>
         </div>
       )
@@ -281,7 +288,16 @@ export function ConfigView(props: ConfigViewProps) {
                       <div key={field.paramId} className="config-section__value-row">
                         <dt>
                           <span>{field.label}</span>
-                          <small>{field.paramId}</small>
+                          {/* Read-only rows carried the raw id as a bare second
+                              line while every editable row beside them offered
+                              the "i". Same affordance here, so a read-only
+                              value is just as traceable to its parameter. */}
+                          <ParamInfoBubble
+                            paramId={field.paramId}
+                            label={field.label}
+                            description={parameter?.definition?.description}
+                            testId={`config-field-info-${field.paramId}`}
+                          />
                         </dt>
                         <dd>{formatReadOnlyValue(parameter, field)}</dd>
                       </div>

--- a/apps/web/src/views/InfoDot.tsx
+++ b/apps/web/src/views/InfoDot.tsx
@@ -1,5 +1,7 @@
 import type { ReactElement, ReactNode } from 'react'
 
+import { wikiTopicUrl, type WikiTopic } from '../view-models/param-docs'
+
 export interface InfoDotProps {
   /** Accessible label naming what the tooltip documents (e.g. "About PID gains"). */
   label: string
@@ -9,6 +11,13 @@ export interface InfoDotProps {
   testId?: string
   /** Widen the tip for longer card/section guidance (vs the terse tab detail). */
   wide?: boolean
+  /**
+   * Optional deep link into our own wiki's topic page for this concept. Only a
+   * key of WIKI_TOPIC_PATHS is accepted — no free-form href — so a destination
+   * cannot be invented at a call site and every link stays covered by the
+   * page/anchor assertions in tests/wiki-topic-links.test.mjs.
+   */
+  wikiTopic?: WikiTopic
 }
 
 /**
@@ -21,7 +30,7 @@ export interface InfoDotProps {
  * `tabIndex={0}` makes the tip keyboard-reachable via the CSS `:focus-visible`
  * rule.
  */
-export function InfoDot({ label, children, testId, wide = false }: InfoDotProps): ReactElement {
+export function InfoDot({ label, children, testId, wide = false, wikiTopic }: InfoDotProps): ReactElement {
   return (
     <span
       className="receiver-info-dot"
@@ -31,8 +40,30 @@ export function InfoDot({ label, children, testId, wide = false }: InfoDotProps)
       data-testid={testId}
     >
       i
-      <span className={`receiver-info-tip${wide ? ' receiver-info-tip--wide' : ''}`} role="tooltip">
+      {/* `--linked` re-enables pointer events on the tip and bridges the gap
+          under the dot. Applied ONLY when there is something to click: an
+          always-clickable tip would start intercepting clicks on whatever it
+          overlaps, and every text-only dot in the app must keep behaving
+          exactly as it does today. */}
+      <span
+        className={`receiver-info-tip${wide ? ' receiver-info-tip--wide' : ''}${wikiTopic ? ' receiver-info-tip--linked' : ''}`}
+        role="tooltip"
+      >
         {children}
+        {wikiTopic ? (
+          // Plain external anchor, and it must stay one. Pulling wiki content
+          // into the SPA poisoned the app shell once (a P1 production bug) —
+          // that rule holds even though the wiki is on our own origin.
+          <a
+            className="receiver-info-wiki"
+            href={wikiTopicUrl(wikiTopic)}
+            target="_blank"
+            rel="noopener noreferrer"
+            data-testid={testId ? `${testId}-wiki` : undefined}
+          >
+            Read this in the wiki ↗
+          </a>
+        ) : null}
       </span>
     </span>
   )

--- a/apps/web/src/views/LuaScripts.tsx
+++ b/apps/web/src/views/LuaScripts.tsx
@@ -395,7 +395,7 @@ export function LuaScriptsView(props: LuaScriptsViewProps) {
               <div className="lua-section-head">
                 <h3>
                   Common scripts
-                  <InfoDot label="About the curated catalog" wide testId="lua-catalog-info">
+                  <InfoDot label="About the curated catalog" wide testId="lua-catalog-info" wikiTopic="luaInstallingScripts">
                     Curated single-file ArduPilot applets (GPL-3.0), each bundled in the app so install is one click —
                     no network fetch. The “prerequisites” on a card are best-effort warnings, never blockers.
                   </InfoDot>

--- a/apps/web/src/views/Modes.tsx
+++ b/apps/web/src/views/Modes.tsx
@@ -1,6 +1,7 @@
 import type { ParameterState } from '@arduconfig/ardupilot-core'
 import { Panel, StatusBadge, buttonStyle } from '@arduconfig/ui-kit'
 
+import { ParamInfoBubble } from './ParamInfoBubble'
 import { ScopedSelectField, type ScopedFieldDraftMap } from './ScopedField'
 
 export interface ModesViewSlot {
@@ -152,8 +153,16 @@ export function ModesView(props: ModesViewProps) {
                   ) : (
                     <span className="modes-table__mode-readonly">
                       {slot.modeLabel}
+                      {/* The read-only slot used to trail a bare "FLTMODE3"; the
+                          bubble keeps that id one hover away and adds the
+                          description and reference link the plain text lacked. */}
                       {slot.parameter ? (
-                        <small className="scoped-editor-field__param-id">{slot.parameter.id}</small>
+                        <ParamInfoBubble
+                          paramId={slot.parameter.id}
+                          label={`Flight mode slot ${slot.position}`}
+                          description={slot.parameter.definition?.description}
+                          testId={`modes-slot-info-${slot.parameter.id}`}
+                        />
                       ) : null}
                     </span>
                   )}

--- a/tests/wiki-topic-links.test.mjs
+++ b/tests/wiki-topic-links.test.mjs
@@ -1,0 +1,105 @@
+// The app's concept-level "i" bubbles (InfoDot) can deep-link a topic page in
+// our own wiki. Those destinations live in one map — WIKI_TOPIC_PATHS in
+// apps/web/src/view-models/param-docs.ts — and this test is why.
+//
+// A concept link is `page.html#anchor`, and BOTH halves rot silently:
+//
+//   - renaming or moving a wiki page leaves the app pointing at a 404, and
+//   - editing a heading ("Filters" -> "Filtering") changes the docutils slug the
+//     anchor is built from, so the link still loads the page but lands at the
+//     top of it with no indication anything is wrong.
+//
+// Neither is a build failure on either side. A dead "i" link is worse than no
+// link — it teaches an operator the affordance is unreliable — so the map is
+// asserted against the wiki sources here.
+//
+// Asserting against the .rst sources rather than built HTML keeps this test
+// hermetic: `npm run test` has no Sphinx. The anchors were additionally checked
+// against a real `sphinx-build -b html wiki` run when they were introduced; the
+// slug rule below is docutils' own and is what produced those ids.
+
+import assert from 'node:assert/strict'
+import { existsSync, readFileSync, readdirSync } from 'node:fs'
+import path from 'node:path'
+import test from 'node:test'
+import { fileURLToPath } from 'node:url'
+
+const REPO = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..')
+const WIKI = path.join(REPO, 'wiki')
+const PARAM_DOCS = path.join(REPO, 'apps', 'web', 'src', 'view-models', 'param-docs.ts')
+
+/** The topic map, read out of the app source it is declared in. */
+function readTopicPaths() {
+  const source = readFileSync(PARAM_DOCS, 'utf8')
+  const block = /export const WIKI_TOPIC_PATHS = \{([\s\S]*?)\n\} as const/.exec(source)
+  assert.ok(block, 'WIKI_TOPIC_PATHS not found in param-docs.ts')
+  const entries = [...block[1].matchAll(/^\s*(\w+):\s*'([^']+)'/gm)].map(([, key, value]) => [key, value])
+  assert.ok(entries.length > 0, 'WIKI_TOPIC_PATHS parsed as empty')
+  return entries
+}
+
+/**
+ * docutils' id rule for a section title: lowercase, every run of non-alphanumeric
+ * characters becomes a single '-', and leading/trailing '-' are dropped. This is
+ * what turns "Rate controllers (PID gains)" into "rate-controllers-pid-gains".
+ */
+function slugify(title) {
+  return title
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+}
+
+/** Every heading anchor an .rst page declares (title line + underline line). */
+function anchorsInPage(rstPath) {
+  const lines = readFileSync(rstPath, 'utf8').split('\n')
+  const anchors = new Set()
+  for (let index = 1; index < lines.length; index += 1) {
+    const underline = lines[index]
+    const title = lines[index - 1].trim()
+    if (title === '' || !/^[=\-~^"'`#*+_:.]{3,}$/.test(underline.trim())) continue
+    if (underline.trim().length < title.length) continue
+    anchors.add(slugify(title))
+  }
+  return anchors
+}
+
+test('every wiki topic an "i" bubble links resolves to a real page and heading', () => {
+  const broken = []
+  for (const [key, value] of readTopicPaths()) {
+    const [page, anchor] = value.split('#')
+    assert.match(page, /\.html$/, `${key}: topic paths are page.html#anchor, saw "${value}"`)
+    const rst = path.join(WIKI, `${page.replace(/\.html$/, '')}.rst`)
+    if (!existsSync(rst)) {
+      broken.push(`${key} -> ${value}: no such wiki page (${path.relative(REPO, rst)})`)
+      continue
+    }
+    if (anchor && !anchorsInPage(rst).has(anchor)) {
+      broken.push(`${key} -> ${value}: page has no heading slugging to "#${anchor}"`)
+    }
+  }
+  assert.deepEqual(broken, [], `dead wiki topic links:\n${broken.join('\n')}`)
+})
+
+test('a topic page reached by a bubble is reachable from the wiki nav too', () => {
+  // A page that no toctree lists still builds, but Sphinx warns and the page is
+  // orphaned — an operator who follows the link has no way back into the wiki.
+  // Toctrees nest (wiki/index.rst lists first-time-setup/index, which lists the
+  // pages under it), so a doc counts as reachable if ANY toctree names it —
+  // either by full path from the wiki root or relative to its own directory.
+  const toctrees = readdirSync(WIKI, { recursive: true })
+    .filter((entry) => typeof entry === 'string' && entry.endsWith('.rst') && !entry.startsWith('parameters/'))
+    .map((entry) => ({ dir: path.dirname(entry), text: readFileSync(path.join(WIKI, entry), 'utf8') }))
+  const missing = []
+  for (const [key, value] of readTopicPaths()) {
+    const doc = value.split('#')[0].replace(/\.html$/, '')
+    const listed = toctrees.some(({ dir, text }) => {
+      const relative = dir === '.' ? doc : path.relative(dir, doc)
+      return new RegExp(`^\\s+(${doc}|${relative})\\s*$`, 'm').test(text)
+    })
+    if (!listed) {
+      missing.push(`${key} -> ${doc} is in no wiki toctree`)
+    }
+  }
+  assert.deepEqual(missing, [], missing.join('\n'))
+})


### PR DESCRIPTION
> "in the servo > peripherals and alerts tabs, we have the param below the title, we should be using the i like we do elsewhere"
> "spawn an agent to do the i thing anywhere we are showing raw param names in the UI"
> "and all of our i's should link to our wiki when appropriate/able"

PR #153 introduced `ParamInfoBubble` — the shared (i) carrying the raw param id, its description, and a link to our own wiki. This sweeps the rest of the app onto it.

## Converted

| Surface | Note |
|---|---|
| Servos ▸ Peripherals & Alerts, LED & buzzer card | The two hand-rolled bitmask editors showed **no** id at all |
| Every "Additional settings" card — Servos, Power, Failsafe, Ports, Receiver, guided Setup | Fixed once in the shared `renderMetadataParameterField`, not per site |
| Autotune per-field info | Was a local copy of the bubble markup, **gated on a description existing** — the exact bug #153 removed elsewhere — and had no wiki link |
| Config "(not reported)" placeholder rows | Bare `<small>{paramId}</small>` |
| Config read-only value rows | Bare `<small>{paramId}</small>` |
| Modes read-only slot cell | Bare `FLTMODE3` |

## Deliberately left alone — the id IS the content

Converting these would be a regression, not consistency: hiding a primary identifier behind a hover.

Parameters tab rows; `ScopedField`'s `scoped-editor-field__param-id` (per #153 — linking it would nest an anchor inside the `<label>` wrapping the control); staged-changes / import-diff / snapshot-restore lists; `MavlinkInspector`; `RcMixer` / `AiAssistant` id listings; `Failsafe.tsx` not-synced fallback (no friendly label exists there, so the id *is* the label).

**Flagged for a decision — the Ports matrix** (Baud / Flow / Serial, 3 sites). The id there identifies *which port row* you are on (`SERIAL1_BAUD` vs `SERIAL2_BAUD`), not just what a generic word means, and a hover affordance in a dense 4-column matrix is a phone-width risk. An e2e test also asserts those hints. Contained follow-up if wanted.

## Wiki links on non-parameter (i)s

Our wiki is **not** only a parameter reference — it has hand-written topic pages. Sphinx was installed in a throwaway venv, `sphinx-build` was run for real, and **every anchor below was read out of the generated HTML**. None were guessed.

`InfoDot` gained an optional `wikiTopic`, keyed off a closed `WIKI_TOPIC_PATHS` map so call sites cannot pass free-form hrefs.

| (i) | Links to |
|---|---|
| Tuning "rates, expo, accel shaping" | `tuning.html#pilot` |
| Tuning "general response" | `tuning.html#pilot` |
| Tuning "axis controller gains" | `tuning.html#rate-controllers-pid-gains` |
| Tuning "axis bandwidth and smoothing" | `tuning.html#filters` |
| Autotune surface + config params | `tuning.html#autotune` |
| Lua curated catalog | `lua.html#installing-scripts` |
| Receiver Bind (ELRS/CRSF) | `first-time-setup/receiver.html#bind-elrs-crsf` |

**Left text-only:** the per-Lua-script dots. The wiki documents *installing* scripts, not individual applets — there is no appropriate page, and one was not invented. A link that 404s is worse than no link.

The Receiver Bind dot was a hand-rolled `aria-hidden` copy of InfoDot; it is now the shared component, so its guidance reaches screen readers too.

**New guard:** `tests/wiki-topic-links.test.mjs` asserts each topic page exists, each anchor is the docutils slug of a real heading on it, and each page is reachable from a toctree. Mutation-tested — changing `#filters` to `#filtering` fails it.

## ArduCopter byte-identical

Presentation only. No value, write path, draft validation or metadata semantics touched.

390 px: the param tip keeps the existing `max-width: min(260px, calc(100vw - 32px))` clamp; InfoDot tips only grew *taller* by one link line. The clickable-tip CSS (pointer-events, hover bridge, focus-within) is scoped to a `--linked` modifier, so existing text-only dots behave exactly as before.

## Validation

- `npm run typecheck` — clean
- `npm run test` — **859 tests, 855 pass, 0 fail**, 4 skipped (2 new wiki-link tests)
- `apps/web` vitest — 75 files, **661 pass**
- `apps/web` vite build — clean
- `npm run test:e2e` — **not run locally.** Another agent's Playwright run held 4173/14550 throughout. Relying on CI. The affected hooks were checked by hand: `networking-field-info-*` is preserved (the prefix threads through the shared renderer), and the Ports / compass / `INS_FAST_SAMPLE` / `OSD_TYPE` assertions are untouched because `ScopedField` and the Ports matrix are unchanged.

## Coverage honesty

Confident about surfaces that *print* an id (grepped `param-id`, `.id}`, `.paramId}` across all `.tsx`). Less confident every friendly-label surface that shows *no* id and has *no* bubble was found — `Osd`, `Logs`, `RelaysView`, `ServoFunctionMapping`, `VtxSection` all render curated labels. That larger population was deliberately not swept, since the brief was id-showing surfaces.