### PR TITLE
feat(status): expand or pop out Recent Notices

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -277,6 +277,8 @@ import { MAX_MAVLINK_PLOTS, useMavlinkInspector } from './hooks/use-mavlink-insp
 import { CanDeviceInspectorView, type DronecanFirmwareOnlineSource } from './views/CanDeviceInspector'
 import { useDronecanBusStats } from './hooks/use-dronecan-bus-stats'
 import { useCanDevicePopouts } from './hooks/use-can-device-popouts'
+import { usePopoutWindows } from './hooks/use-popout-windows'
+import { RecentNoticesFeed, recentNoticesBadge } from './views/RecentNoticesFeed'
 import { filterEscTelemetryForNode } from './view-models/can-device-inspector'
 import { dronecanNodeBoardId, parseApj, decodeApjImage } from '@arduconfig/firmware-flash'
 import { inflateZlib } from './firmware/web-serial-bootloader'
@@ -446,6 +448,11 @@ function describeUnconfirmedWrites(unconfirmed: ParameterUnconfirmedWrite[]): st
 
 const PRESET_AUTO_BACKUP_TAGS = ['auto-backup', 'preset'] as const
 
+// One notices window at a time — the feed is a single stream, so a second
+// window would just be a duplicate of the first. Constant so the open/close/
+// lookup calls can never drift apart.
+const NOTICES_POPOUT_KEY = 'recent-notices'
+
 // 900ms felt "too fast" — the channel locked before the operator had fully
 // exercised the stick — so require a longer, more deliberate sustained
 // movement, with a slightly roomier gap tolerance so a brief stick pause
@@ -500,6 +507,10 @@ export function App() {
   const [activeViewId, setActiveViewId] = useState<AppViewId>('setup')
   // Expert-mode text filter for the Recent Notices panel.
   const [noticeFilter, setNoticeFilter] = useState('')
+  // Expand-in-place for Recent Notices. Collapsed by DEFAULT and deliberately
+  // not persisted: Status & Info is already a long page, so extra height has to
+  // be something the operator asks for every time they want it.
+  const [noticesExpanded, setNoticesExpanded] = useState(false)
   // The selected port is supplied to the transport LAZILY via this ref.
   // It must NOT be a runtime-useMemo dependency: the WebSerial transport
   // calls onPortSelected(port) during connect (with the just-picked
@@ -5724,6 +5735,13 @@ export function App() {
   // bus service keeps MAV_CMD_CAN_FORWARD re-armed for as long as the bus is
   // connected, no matter how many windows are watching it.
   const canDevicePopouts = useCanDevicePopouts()
+  // Recent Notices reuses the SAME popout machinery as the CAN inspectors
+  // (usePopoutWindows: gesture-synchronous window.open, stylesheet + theme
+  // cloning, three-way reaping). A second independent instance rather than a
+  // shared registry, because the two surfaces key their windows differently and
+  // nothing about a notices window should be able to reap a device window.
+  const noticesPopout = usePopoutWindows()
+  const noticesPopoutHandle = noticesPopout.popouts.find((handle) => handle.key === NOTICES_POPOUT_KEY)
   // The destructive per-device actions, shared by the inline and popped-out
   // inspectors. Passed only under Expert mode — they used to be reachable solely
   // from the expert-only DroneCAN Inspector tab.
@@ -6497,6 +6515,51 @@ export function App() {
     ? snapshot.statusTexts.filter((entry) => entry.text.toLowerCase().includes(trimmedNoticeFilter))
     : snapshot.statusTexts
   const recentNotices = buildRecentNotices(filteredNoticeEntries)
+  // Shared by the inline panel and the popped-out window so both do exactly the
+  // same thing — clipboard API first, hidden-textarea execCommand fallback for
+  // the non-secure-context / older-browser case.
+  const copyAllNotices = (): void => {
+    if (setupStatusEntries.length === 0) {
+      return
+    }
+    const payload = setupStatusEntries.map((entry) => `[${entry.severity.toUpperCase()}] ${entry.text}`).join('\n')
+    const finish = (): void => {
+      setNoticesCopied(true)
+      window.setTimeout(() => setNoticesCopied(false), 1500)
+    }
+    const fallbackCopy = (): void => {
+      const textarea = document.createElement('textarea')
+      textarea.value = payload
+      textarea.setAttribute('readonly', '')
+      textarea.style.position = 'fixed'
+      textarea.style.opacity = '0'
+      document.body.appendChild(textarea)
+      textarea.select()
+      try { document.execCommand('copy') } catch {}
+      document.body.removeChild(textarea)
+      finish()
+    }
+    if (navigator.clipboard?.writeText) {
+      navigator.clipboard.writeText(payload).then(finish).catch(fallbackCopy)
+    } else {
+      fallbackCopy()
+    }
+  }
+  // Props every copy of the feed shares. The popped-out window renders the same
+  // component over the same model: it is a portal into this tree, so each new
+  // STATUSTEXT that lands in the snapshot re-renders BOTH copies from the one
+  // subscription. A reconnect can neither stall it (the snapshot is the only
+  // source) nor duplicate entries (buildRecentNotices coalesces by
+  // severity+text, so a repeated message bumps ×N instead of adding a row).
+  const sharedNoticeFeedProps = {
+    notices: recentNotices,
+    hasEntries: setupStatusEntries.length > 0,
+    copied: noticesCopied,
+    onCopyAll: copyAllNotices,
+    onClearAll: () => void runtime.clearStatusTexts(),
+    filterValue: productMode === 'expert' ? noticeFilter : undefined,
+    onFilterChange: productMode === 'expert' ? setNoticeFilter : undefined
+  }
   const setupHasGpsCard = gpsPeripheralViewModels.length > 0 || snapshot.liveVerification.globalPosition.verified
   // "Configured" means "the GPS chain is set up and working." Two routes:
   //   - A non-zero GPS_TYPE / GPS_TYPE2 parameter in the parameter table
@@ -7054,126 +7117,33 @@ export function App() {
                           </article>
                         </div>
 
-                        <article className="setup-gui-box">
+                        <article className="setup-gui-box" data-testid="setup-notices-panel">
                           <div className="setup-gui-box__titlebar">
                             <strong>Recent Notices</strong>
-                            <StatusBadge tone={recentNotices.tone}>
-                              {recentNotices.distinctCount > 0
-                                ? `${recentNotices.distinctCount} notice${recentNotices.distinctCount === 1 ? '' : 's'}${
-                                    recentNotices.totalCount > recentNotices.distinctCount ? ` · ${recentNotices.totalCount} total` : ''
-                                  }`
-                                : 'quiet'}
-                            </StatusBadge>
+                            {recentNoticesBadge(recentNotices)}
                           </div>
                           <div className="setup-gui-box__body">
-                            {/* Controls live in the body (normal flow), not the
-                                floating titlebar pill — the pill grows tall when
-                                the count badge wraps and would cover them. */}
-                            <div className="setup-gui-box__notice-controls">
-                              {productMode === 'expert' ? (
-                                <input
-                                  type="search"
-                                  data-testid="setup-notices-search"
-                                  className="setup-gui-box__notice-filter-input"
-                                  placeholder="Filter notices…"
-                                  value={noticeFilter}
-                                  onChange={(event) => setNoticeFilter(event.target.value)}
-                                  aria-label="Filter recent notices"
-                                />
-                              ) : null}
-                              <button
-                                type="button"
-                                className="setup-gui-box__icon-button"
-                                data-testid="setup-notices-copy-all"
-                                onClick={() => {
-                                  if (setupStatusEntries.length === 0) {
-                                    return
-                                  }
-                                  const payload = setupStatusEntries
-                                    .map((entry) => `[${entry.severity.toUpperCase()}] ${entry.text}`)
-                                    .join('\n')
-                                  const finish = () => {
-                                    setNoticesCopied(true)
-                                    window.setTimeout(() => setNoticesCopied(false), 1500)
-                                  }
-                                  if (navigator.clipboard?.writeText) {
-                                    navigator.clipboard.writeText(payload).then(finish).catch(() => {
-                                      const textarea = document.createElement('textarea')
-                                      textarea.value = payload
-                                      textarea.setAttribute('readonly', '')
-                                      textarea.style.position = 'fixed'
-                                      textarea.style.opacity = '0'
-                                      document.body.appendChild(textarea)
-                                      textarea.select()
-                                      try { document.execCommand('copy') } catch {}
-                                      document.body.removeChild(textarea)
-                                      finish()
-                                    })
-                                  } else {
-                                    const textarea = document.createElement('textarea')
-                                    textarea.value = payload
-                                    textarea.setAttribute('readonly', '')
-                                    textarea.style.position = 'fixed'
-                                    textarea.style.opacity = '0'
-                                    document.body.appendChild(textarea)
-                                    textarea.select()
-                                    try { document.execCommand('copy') } catch {}
-                                    document.body.removeChild(textarea)
-                                    finish()
-                                  }
-                                }}
-                                disabled={setupStatusEntries.length === 0}
-                                title="Copy all notices to clipboard"
-                                aria-label="Copy all notices to clipboard"
-                              >
-                                {noticesCopied ? 'Copied' : 'Copy all'}
-                              </button>
-                              <button
-                                type="button"
-                                className="setup-gui-box__icon-button"
-                                data-testid="setup-notices-clear-all"
-                                onClick={() => void runtime.clearStatusTexts()}
-                                disabled={setupStatusEntries.length === 0}
-                                title="Clear all notices (local display only — the FC keeps sending new ones)"
-                                aria-label="Clear all notices"
-                              >
-                                Clear all
-                              </button>
-                            </div>
-                            <div className="setup-gui-box__status-list setup-gui-box__status-list--scroll" data-testid="setup-notices-list">
-                              {recentNotices.groups.length === 0 ? <span className="setup-gui-box__empty">No status text yet</span> : null}
-                              {recentNotices.groups.map((group) => (
-                                <div
-                                  key={group.key}
-                                  className={`setup-gui-box__status-group setup-gui-box__status-group--${group.key}`}
-                                  data-testid={`setup-notices-group-${group.key}`}
-                                >
-                                  <header className="setup-gui-box__status-group-header">
-                                    <strong>{group.label}</strong>
-                                    <span>{group.notices.length}</span>
-                                  </header>
-                                  {group.notices.map((notice) => (
-                                    <div
-                                      key={`${notice.severity}-${notice.text}`}
-                                      className={`setup-gui-box__status-entry is-${notice.severity}`}
-                                      data-testid={`setup-notice-${group.key}`}
-                                    >
-                                      <strong>{notice.severity}</strong>
-                                      <span>{notice.text}</span>
-                                      {notice.count > 1 ? (
-                                        <span
-                                          className="setup-gui-box__status-count"
-                                          data-testid="setup-notice-count"
-                                          title={`${notice.count} occurrences`}
-                                        >
-                                          ×{notice.count}
-                                        </span>
-                                      ) : null}
-                                    </div>
-                                  ))}
-                                </div>
-                              ))}
-                            </div>
+                            <RecentNoticesFeed
+                              {...sharedNoticeFeedProps}
+                              variant="inline"
+                              testIdPrefix="setup-notices"
+                              entryTestIdPrefix="setup-notice"
+                              expanded={noticesExpanded}
+                              onToggleExpanded={() => setNoticesExpanded((current) => !current)}
+                              poppedOut={noticesPopoutHandle !== undefined}
+                              popoutBlocked={noticesPopout.blockedKey === NOTICES_POPOUT_KEY}
+                              onTogglePopout={() => {
+                                // Synchronous with the click: window.open only
+                                // survives a popup blocker inside the browser's
+                                // user-activation window, so nothing may await
+                                // before this call.
+                                if (noticesPopoutHandle) {
+                                  noticesPopout.close(NOTICES_POPOUT_KEY)
+                                } else {
+                                  noticesPopout.open(NOTICES_POPOUT_KEY, 'Recent Notices')
+                                }
+                              }}
+                            />
                           </div>
                         </article>
                         </div>
@@ -8907,6 +8877,34 @@ export function App() {
           handle.key
         )
       })}
+
+      {/* Popped-out Recent Notices — the same portal contract as the CAN
+          inspectors above, and hosted here at App level for the same reason: the
+          operator pops the feed out precisely so it survives leaving Status &
+          Info. Because it is a portal into this tree it re-renders off the one
+          runtime subscription, so every STATUSTEXT that lands in the snapshot
+          appears in the window with no second session, no second stream request,
+          and nothing to re-arm on reconnect. */}
+      {noticesPopoutHandle
+        ? createPortal(
+            <article className="setup-gui-box" data-testid="notices-popout-panel">
+              <div className="setup-gui-box__titlebar">
+                <strong>Recent Notices</strong>
+                {recentNoticesBadge(recentNotices)}
+              </div>
+              <div className="setup-gui-box__body">
+                <RecentNoticesFeed
+                  {...sharedNoticeFeedProps}
+                  variant="popout"
+                  testIdPrefix="notices-popout"
+                  entryTestIdPrefix="notices-popout-notice"
+                />
+              </div>
+            </article>,
+            noticesPopoutHandle.container,
+            noticesPopoutHandle.key
+          )
+        : null}
 
       {activeViewId === 'calibration' ? (
         <CalibrationSection

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -3009,6 +3009,10 @@ textarea:focus {
   display: flex;
   align-items: center;
   gap: 8px;
+  /* Four controls (filter, Expand, Pop out, Copy/Clear) do not fit on one line
+   * at phone width — wrapping is what keeps the 390px layout from scrolling
+   * sideways. */
+  flex-wrap: wrap;
 }
 
 .setup-gui-box__notice-controls .setup-gui-box__notice-filter-input {
@@ -3142,6 +3146,48 @@ textarea:focus {
   max-height: 240px;
   overflow-y: auto;
   padding-right: 4px;
+  /* Newest notices sort to the TOP, so an arriving message inserts above what
+   * the operator is reading and would shove it down. Scroll anchoring (on by
+   * default, stated here so it is not "optimised" away) pins the row under the
+   * cursor instead, which is why this feed deliberately has no auto-scroll:
+   * nothing jumps, and the newest row is one flick away at the top. */
+  overflow-anchor: auto;
+}
+
+/* Expand-in-place: opt-in extra height, never the default — Status & Info is a
+ * long page and the collapsed 240px box is what keeps it navigable. Capped
+ * against the viewport so a chatty FC cannot make the panel taller than the
+ * screen. */
+.setup-gui-box__status-list--expanded {
+  max-height: min(70vh, 620px);
+}
+
+/* Inside a popped-out window the window IS the scrollport, so the list must not
+ * impose a second one — a nested scroller there is just a smaller box inside a
+ * big empty one. */
+.setup-gui-box__status-list--window {
+  max-height: none;
+  overflow-y: visible;
+}
+
+/* Long STATUSTEXT lines (and unbroken tokens like file paths or a 50-char
+ * parameter dump) must wrap rather than push the panel wide — a 390px phone
+ * must never scroll horizontally, and a notice the operator cannot read is a
+ * notice the FC did not send. No ellipsis, no tooltip-only text. */
+.setup-gui-box__status-text {
+  overflow-wrap: anywhere;
+  white-space: pre-wrap;
+}
+
+.setup-gui-box__popped-out,
+.setup-gui-box__popout-blocked {
+  margin: 0;
+  font-size: 11px;
+  color: var(--text-muted);
+}
+
+.setup-gui-box__popout-blocked {
+  color: var(--warning);
 }
 
 .setup-gui-box__icon-button {
@@ -16273,6 +16319,12 @@ button.mavlink-inspector__sent-row {
 .arduconfig-popout {
   display: block;
   max-width: 100%;
+}
+
+/* The notices window is a single panel filling the whole child window, so drop
+ * the inline bench's fixed box height and let the article grow with the feed. */
+.arduconfig-popout .setup-gui-box {
+  height: auto;
 }
 
 /* Inside a popout there is no surrounding panel, so give the device body its own

--- a/apps/web/src/views/RecentNoticesFeed.tsx
+++ b/apps/web/src/views/RecentNoticesFeed.tsx
@@ -1,0 +1,210 @@
+// The Recent Notices feed — the FC's STATUSTEXT stream, severity-grouped.
+//
+// Rendered twice over from the same props shape: inline in the Status & Info
+// bench (collapsed and compact by default, because that page is already long),
+// and inside a popped-out child window (Mission Planner / DroneCAN-GUI style)
+// so the operator can park the feed beside the app while working elsewhere in
+// the UI. The popout is a React portal into the opener's tree — one runtime,
+// one transport, one snapshot — so this component never needs to know which
+// window it is in beyond how much vertical room it may take.
+//
+// Presentational only: the coalesced model, the filter text, and every handler
+// come from App.tsx.
+
+import type { ReactElement } from 'react'
+
+import { StatusBadge } from '@arduconfig/ui-kit'
+
+import type { RecentNoticesModel } from '../view-models/recent-notices'
+
+export interface RecentNoticesFeedProps {
+  /** Coalesced + severity-grouped notices (already filtered by the caller). */
+  notices: RecentNoticesModel
+  /** Prefix for every data-testid, so the inline copy and the popped-out copy
+   *  never collide in the DOM (both live in the same React tree). */
+  testIdPrefix: string
+  /** Prefix for per-notice rows. Kept separate from testIdPrefix because the
+   *  inline panel's row hooks (`setup-notice-*`) predate this component and are
+   *  already asserted on in the e2e suite. */
+  entryTestIdPrefix: string
+  /** Expert-mode text filter. Undefined hides the search box entirely. */
+  filterValue?: string
+  onFilterChange?: (value: string) => void
+  /** False disables Copy all / Clear all (nothing has arrived yet). */
+  hasEntries: boolean
+  copied: boolean
+  onCopyAll: () => void
+  onClearAll: () => void
+  /** Expand-in-place: undefined in the popout, where the window IS the room. */
+  expanded?: boolean
+  onToggleExpanded?: () => void
+  /** Pop-out control. Undefined in the popped-out copy itself. */
+  poppedOut?: boolean
+  onTogglePopout?: () => void
+  /** True when the browser blocked the last window.open, so we can say so
+   *  rather than looking like a dead button. */
+  popoutBlocked?: boolean
+  /** Popped-out windows have their own scrollport, so the list must not carry
+   *  its own max-height there. */
+  variant: 'inline' | 'popout'
+}
+
+export function RecentNoticesFeed({
+  notices,
+  testIdPrefix,
+  entryTestIdPrefix,
+  filterValue,
+  onFilterChange,
+  hasEntries,
+  copied,
+  onCopyAll,
+  onClearAll,
+  expanded,
+  onToggleExpanded,
+  poppedOut,
+  onTogglePopout,
+  popoutBlocked,
+  variant
+}: RecentNoticesFeedProps): ReactElement {
+  // Inline: bounded box, taller when expanded. Popout: the window's own scroll
+  // is the bound, so no max-height at all.
+  const listClassName = [
+    'setup-gui-box__status-list',
+    variant === 'inline' ? 'setup-gui-box__status-list--scroll' : 'setup-gui-box__status-list--window',
+    variant === 'inline' && expanded ? 'setup-gui-box__status-list--expanded' : ''
+  ]
+    .filter(Boolean)
+    .join(' ')
+
+  return (
+    <>
+      {/* Controls live in the body (normal flow), not the floating titlebar
+          pill — the pill grows tall when the count badge wraps and would cover
+          them. */}
+      <div className="setup-gui-box__notice-controls">
+        {filterValue !== undefined && onFilterChange ? (
+          <input
+            type="search"
+            data-testid={`${testIdPrefix}-search`}
+            className="setup-gui-box__notice-filter-input"
+            placeholder="Filter notices…"
+            value={filterValue}
+            onChange={(event) => onFilterChange(event.target.value)}
+            aria-label="Filter recent notices"
+          />
+        ) : null}
+        {onToggleExpanded ? (
+          <button
+            type="button"
+            className="setup-gui-box__icon-button"
+            data-testid={`${testIdPrefix}-expand`}
+            onClick={onToggleExpanded}
+            aria-expanded={expanded === true}
+            title={expanded ? 'Shrink the notice list back to the compact height' : 'Show more notices without leaving the page'}
+          >
+            {expanded ? 'Collapse' : 'Expand'}
+          </button>
+        ) : null}
+        {onTogglePopout ? (
+          <button
+            type="button"
+            className="setup-gui-box__icon-button"
+            data-testid={`${testIdPrefix}-popout`}
+            // Straight off the click: window.open only survives a popup blocker
+            // inside the user-activation window, so this must never be deferred
+            // into an effect or an await.
+            onClick={onTogglePopout}
+            title={poppedOut ? 'Close the notices window' : 'Open the notices in their own window'}
+          >
+            {poppedOut ? 'Close window' : 'Pop out'}
+          </button>
+        ) : null}
+        <button
+          type="button"
+          className="setup-gui-box__icon-button"
+          data-testid={`${testIdPrefix}-copy-all`}
+          onClick={onCopyAll}
+          disabled={!hasEntries}
+          title="Copy all notices to clipboard"
+          aria-label="Copy all notices to clipboard"
+        >
+          {copied ? 'Copied' : 'Copy all'}
+        </button>
+        <button
+          type="button"
+          className="setup-gui-box__icon-button"
+          data-testid={`${testIdPrefix}-clear-all`}
+          onClick={onClearAll}
+          disabled={!hasEntries}
+          title="Clear all notices (local display only — the FC keeps sending new ones)"
+          aria-label="Clear all notices"
+        >
+          Clear all
+        </button>
+      </div>
+
+      {popoutBlocked ? (
+        <p className="setup-gui-box__popout-blocked" data-testid={`${testIdPrefix}-popout-blocked`}>
+          Your browser blocked the notices window. Allow pop-ups for this site and try again.
+        </p>
+      ) : null}
+
+      {poppedOut ? (
+        <p className="setup-gui-box__popped-out" data-testid={`${testIdPrefix}-popped-out`}>
+          Notices are open in their own window — still live, and still listed here.
+        </p>
+      ) : null}
+
+      <div className={listClassName} data-testid={`${testIdPrefix}-list`}>
+        {notices.groups.length === 0 ? <span className="setup-gui-box__empty">No status text yet</span> : null}
+        {notices.groups.map((group) => (
+          <div
+            key={group.key}
+            className={`setup-gui-box__status-group setup-gui-box__status-group--${group.key}`}
+            data-testid={`${testIdPrefix}-group-${group.key}`}
+          >
+            <header className="setup-gui-box__status-group-header">
+              <strong>{group.label}</strong>
+              <span>{group.notices.length}</span>
+            </header>
+            {group.notices.map((notice) => (
+              <div
+                key={`${notice.severity}-${notice.text}`}
+                className={`setup-gui-box__status-entry is-${notice.severity}`}
+                data-testid={`${entryTestIdPrefix}-${group.key}`}
+              >
+                <strong>{notice.severity}</strong>
+                {/* Full text, always wrapped — a notice the operator cannot read
+                    is a notice the FC did not send. No truncation, no tooltip. */}
+                <span className="setup-gui-box__status-text">{notice.text}</span>
+                {notice.count > 1 ? (
+                  <span
+                    className="setup-gui-box__status-count"
+                    data-testid={`${entryTestIdPrefix}-count`}
+                    title={`${notice.count} occurrences`}
+                  >
+                    ×{notice.count}
+                  </span>
+                ) : null}
+              </div>
+            ))}
+          </div>
+        ))}
+      </div>
+    </>
+  )
+}
+
+/** Titlebar badge text for a notices panel (shared by the inline panel and the
+ *  popped-out window so both report the same counts). */
+export function recentNoticesBadge(notices: RecentNoticesModel): ReactElement {
+  return (
+    <StatusBadge tone={notices.tone}>
+      {notices.distinctCount > 0
+        ? `${notices.distinctCount} notice${notices.distinctCount === 1 ? '' : 's'}${
+            notices.totalCount > notices.distinctCount ? ` · ${notices.totalCount} total` : ''
+          }`
+        : 'quiet'}
+    </StatusBadge>
+  )
+}

--- a/tests/e2e/views.spec.ts
+++ b/tests/e2e/views.spec.ts
@@ -4133,6 +4133,60 @@ test('Recent Notices: clear-all button and expert-mode search bar', async ({ pag
   await expect(page.getByTestId('setup-notices-search')).toBeVisible()
 })
 
+test('Recent Notices expands in place and stays collapsed by default', async ({ page }) => {
+  await page.goto('/')
+  await page.getByTestId('transport-mode-select').selectOption('demo')
+  await page.getByTestId('connect-button').click()
+  await expect(page.getByTestId('session-vehicle-name')).toHaveText('ArduCopter', { timeout: VEHICLE_CONNECT_TIMEOUT })
+  const list = page.getByTestId('setup-notices-list')
+  await expect(list).toBeVisible({ timeout: 15_000 })
+  // Collapsed is the default — Status & Info is long enough already, so the
+  // extra height has to be asked for.
+  const collapsed = await list.evaluate((node) => getComputedStyle(node).maxHeight)
+  expect(collapsed).toBe('240px')
+  await page.getByTestId('setup-notices-expand').click()
+  const expanded = await list.evaluate((node) => getComputedStyle(node).maxHeight)
+  expect(Number.parseFloat(expanded)).toBeGreaterThan(240)
+  await page.getByTestId('setup-notices-expand').click()
+  expect(await list.evaluate((node) => getComputedStyle(node).maxHeight)).toBe('240px')
+})
+
+test('Recent Notices pops out into its own styled, live window', async ({ page, context }) => {
+  await page.goto('/')
+  await page.getByTestId('transport-mode-select').selectOption('demo')
+  await page.getByTestId('connect-button').click()
+  await expect(page.getByTestId('session-vehicle-name')).toHaveText('ArduCopter', { timeout: VEHICLE_CONNECT_TIMEOUT })
+  await expect(page.getByTestId('setup-notices-popout')).toBeVisible({ timeout: 15_000 })
+
+  // window.open fires straight from the click, so the popup survives the blocker.
+  const [popout] = await Promise.all([
+    context.waitForEvent('page'),
+    page.getByTestId('setup-notices-popout').click()
+  ])
+  await popout.waitForLoadState('domcontentloaded')
+  await expect(popout.getByTestId('notices-popout-panel')).toBeVisible()
+  // The window has no nested scroller and no pop-out button of its own.
+  await expect(popout.getByTestId('notices-popout-popout')).toHaveCount(0)
+
+  // The opener's stylesheets were cloned in — an unstyled popout is the classic
+  // failure, and it shows up as a transparent body with no themed background.
+  const background = await popout.evaluate(() => getComputedStyle(document.body).backgroundColor)
+  expect(background).not.toBe('rgba(0, 0, 0, 0)')
+  expect(background).not.toBe('transparent')
+
+  // Live: the window is a portal into the opener's tree, so clearing the feed
+  // from the main window empties the popped-out copy in the same render.
+  await expect(popout.getByTestId('notices-popout-list')).toBeVisible()
+  await page.getByTestId('setup-notices-clear-all').click()
+  await expect(popout.getByText('No status text yet')).toBeVisible({ timeout: 10_000 })
+
+  // The inline panel says where the feed went, and the button closes it again.
+  await expect(page.getByTestId('setup-notices-popped-out')).toBeVisible()
+  await page.getByTestId('setup-notices-popout').click()
+  await expect(page.getByTestId('setup-notices-popped-out')).toHaveCount(0)
+  expect(popout.isClosed()).toBe(true)
+})
+
 test.describe('Direct Sockets (IWA) transport options', () => {
   test('exposes UDP + TCP (direct) options and fields when Direct Sockets exist', async ({ page }) => {
     // Simulate the Isolated Web App context where the Direct Sockets API is


### PR DESCRIPTION
> "for recent notices, can you make it so i can click to expand or pop out so its easier to read?"

## Both, because they solve different problems

- **Expand in place** — one button takes the list from 240 px to `min(70vh, 620px)`. Collapsed is the default and is **deliberately not persisted**: this page is in the middle of a length-reduction effort (#157 and more in flight), so extra height is opt-in every time rather than a taller default that creeps back.
- **Pop out** — the feed in its own window, so it can sit beside the app while you work in Ports or Receiver. This is the Mission Planner / DroneCAN GUI workflow that prompted the CAN inspector popouts in #154.

## Reused, not reimplemented

`use-popout-windows.tsx` from #154 turned out to be genuinely surface-agnostic and needed **no refactor**: gesture-synchronous `window.open`, blocked-open reporting, cloning the opener's stylesheets and `data-theme` (with a MutationObserver keeping theme mirrored), and three-way reaping (child `pagehide`, opener `pagehide`/unmount, `win.closed` poll).

Recent Notices takes a **second instance** keyed `'recent-notices'`, hosted at App level like the CAN windows. Deliberately not one shared registry — the two surfaces key windows differently, and a notices window must never be able to reap a device window. `use-can-device-popouts.ts` is untouched.

The panel body moved into a new dumb view `RecentNoticesFeed.tsx`, rendered twice from one props object so the inline copy and the window cannot drift apart.

## The live feed

`createPortal` into the opener's React tree — one runtime subscription, no second session or transport, `LIVE_TELEMETRY_REQUESTS` untouched. A reconnect can't stall it (the snapshot is the only source) or duplicate rows (`buildRecentNotices` coalesces by severity+text into `×N`).

Ordering stays newest-first-within-severity with **no auto-scroll**: new rows land at the top, one flick away, and scroll anchoring (now stated explicitly in CSS so it isn't optimised away) pins the row you're reading when something inserts above it. A live feed that jumps while you read is worse than one that doesn't.

Severity grouping and colours, filter, Copy all and Clear all all carry over unchanged. Long messages now wrap via `overflow-wrap: anywhere` — no ellipsis, no tooltip-only text.

## Verified by actually using it

Popped the window out by hand in Chrome against the demo Copter. It rendered **fully styled** in the app's dark theme with WARNINGS & CRITICAL / INFO groups and the orange/red severity borders intact. Hitting **Clear all** in the opener emptied the popped-out window in lock-step, and ~20 s later it repopulated live with fresh notices including an ERROR row ("Battery 1 critical: land immediately", red border) and the badge at "2 NOTICES". The close button reaped the window (confirmed gone at OS level). A programmatic, non-gesture open correctly surfaced the blocked-popup explanation.

## ArduCopter byte-identical

Presentation only. No parameter value, write path, or telemetry request changed.

## Validation

- `npm run typecheck` — clean
- `npm run test` — **859 tests, 855 pass, 0 fail**, 4 skipped
- **390 px**: the Chrome window would not resize narrow enough, so the constraint was measured directly instead — panel forced to 320 px gives `scrollWidth === clientWidth` for panel (316/316), controls (292/292) and list (292/292). No horizontal overflow. `.setup-gui-box__notice-controls` gained `flex-wrap: wrap` for the two extra buttons.
- **`npm run test:e2e` not run locally** — ports 4173/14550 held by concurrent work. The two new blocks (expand 240 → >240 → 240; popout styled + scoped + live-clears + closes) rely on CI.

## Coordination

Nothing touched in `CalibrationSection.tsx`, guided setup, `ParamInfoBubble.tsx`, or the GPS/rangefinder/flow cards — all new CSS uses additive class names, so this merges cleanly alongside the concurrent Status & Info restructuring.