### PR TITLE
fix(status): remember whether Recent Notices was expanded

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -359,6 +359,7 @@ import { useRuntimeSnapshot } from './hooks/use-runtime-snapshot'
 import { useMavftpBrowser } from './hooks/use-mavftp-browser'
 import { useOnboardLogs } from './hooks/use-onboard-logs'
 import { useProductMode } from './hooks/use-product-mode'
+import { useRecentNoticesExpanded } from './hooks/use-recent-notices-expanded'
 import { useGpsCoordFormat } from './hooks/use-gps-coord-format'
 import {
   formatLatitudeDecimal,
@@ -506,10 +507,16 @@ export function App() {
   const [activeViewId, setActiveViewId] = useState<AppViewId>('setup')
   // Expert-mode text filter for the Recent Notices panel.
   const [noticeFilter, setNoticeFilter] = useState('')
-  // Expand-in-place for Recent Notices. Collapsed by DEFAULT and deliberately
-  // not persisted: Status & Info is already a long page, so extra height has to
-  // be something the operator asks for every time they want it.
-  const [noticesExpanded, setNoticesExpanded] = useState(false)
+  // Expand-in-place for the INLINE Recent Notices list. Collapsed for a fresh
+  // profile — Status & Info is a long page and nobody who never touches this
+  // control pays for it — but the choice is remembered once made, because
+  // wanting to read the FC's message feed is a standing preference, not a
+  // per-visit one. See hooks/use-recent-notices-expanded.ts.
+  //
+  // Scope note: this is the inline height ONLY. The popped-out window sizes
+  // itself and is passed no `expanded` at all, so toggling here can never make
+  // that window jump.
+  const [noticesExpanded, toggleNoticesExpanded] = useRecentNoticesExpanded()
   // The selected port is supplied to the transport LAZILY via this ref.
   // It must NOT be a runtime-useMemo dependency: the WebSerial transport
   // calls onPortSelected(port) during connect (with the just-picked
@@ -7167,7 +7174,7 @@ export function App() {
                               testIdPrefix="setup-notices"
                               entryTestIdPrefix="setup-notice"
                               expanded={noticesExpanded}
-                              onToggleExpanded={() => setNoticesExpanded((current) => !current)}
+                              onToggleExpanded={toggleNoticesExpanded}
                               poppedOut={noticesPopoutHandle !== undefined}
                               popoutBlocked={noticesPopout.blockedKey === NOTICES_POPOUT_KEY}
                               onTogglePopout={() => {

--- a/apps/web/src/hooks/use-recent-notices-expanded.ts
+++ b/apps/web/src/hooks/use-recent-notices-expanded.ts
@@ -1,0 +1,118 @@
+// Durable expand-in-place state for the Recent Notices feed.
+//
+// The panel shipped (PR #160) collapsed-by-default and NOT persisted, on the
+// theory that Status & Info is already a long page so extra height should be
+// asked for every time. The operator pushed back — "eh, idk about collapsed by
+// default" — and the reason is obvious in use: someone who wants to read the
+// FC's STATUSTEXT feed wants to read it on every visit, not re-click Expand
+// after every reload and every reconnect-triggered refresh.
+//
+// The compromise this hook implements: collapsed is still what a fresh profile
+// gets, so the page-length win holds for everyone who never touches the
+// control and nothing regresses for them. But the choice, once made, sticks —
+// expanded survives reloads until it is collapsed again.
+//
+// This is display state only. It never gates, derives, or writes a parameter.
+
+import { useCallback, useEffect, useState } from 'react'
+
+// Namespaced like every other persisted local preference here
+// (arduconfig:gps-coord-format, arduconfig:transport-mode, …).
+const RECENT_NOTICES_EXPANDED_STORAGE_KEY = 'arduconfig:recent-notices-expanded'
+
+// Versioned the way setup-progress-storage.ts versions its payload — a field
+// inside the JSON rather than a suffix on the key, so a stale value is REJECTED
+// on read instead of being orphaned in storage forever under a dead key. Bump
+// this whenever "expanded" stops meaning what it means today (a third height,
+// a per-view height, a docked/undocked mode) so old profiles fall back to the
+// safe default instead of restoring something nonsensical.
+const RECENT_NOTICES_EXPANDED_VERSION = 1
+
+interface StoredNoticesExpanded {
+  version: number
+  expanded: boolean
+}
+
+/**
+ * localStorage, or undefined when it is unavailable. Access itself can throw
+ * (embedded contexts, some private-mode configurations, storage disabled by
+ * policy), so even reaching for the object is guarded — a throw here would
+ * white-screen the whole app at first render, which is a wildly
+ * disproportionate outcome for a panel height.
+ */
+function resolveStorage(): Pick<Storage, 'getItem' | 'setItem'> | undefined {
+  if (typeof window === 'undefined') {
+    return undefined
+  }
+
+  try {
+    return window.localStorage
+  } catch {
+    return undefined
+  }
+}
+
+/**
+ * Stored preference, or false (collapsed) for anything we cannot positively
+ * read as "expanded": missing key, unparseable JSON, wrong shape, wrong
+ * version. Silent by design — there is no user-actionable failure here, and
+ * a console error on every load would be noise in the one place operators are
+ * told to look for real problems.
+ */
+function readStoredExpanded(): boolean {
+  const storage = resolveStorage()
+  if (!storage) {
+    return false
+  }
+
+  try {
+    const raw = storage.getItem(RECENT_NOTICES_EXPANDED_STORAGE_KEY)
+    if (!raw) {
+      return false
+    }
+
+    const parsed = JSON.parse(raw) as StoredNoticesExpanded | null
+    if (parsed?.version !== RECENT_NOTICES_EXPANDED_VERSION || typeof parsed.expanded !== 'boolean') {
+      return false
+    }
+
+    return parsed.expanded
+  } catch {
+    return false
+  }
+}
+
+/**
+ * [expanded, toggle] for the inline Recent Notices list height, persisted
+ * across reloads. When storage is unavailable the state still works for the
+ * life of the tab — it just does not outlive it, which is exactly the
+ * behaviour the panel had before this hook.
+ */
+export function useRecentNoticesExpanded(): [boolean, () => void] {
+  // Lazy initialiser: read once at mount, not on every render, and before the
+  // first paint so an expanded panel never flashes collapsed first.
+  const [expanded, setExpanded] = useState<boolean>(readStoredExpanded)
+
+  useEffect(() => {
+    const storage = resolveStorage()
+    if (!storage) {
+      return
+    }
+
+    try {
+      storage.setItem(
+        RECENT_NOTICES_EXPANDED_STORAGE_KEY,
+        JSON.stringify({ version: RECENT_NOTICES_EXPANDED_VERSION, expanded } satisfies StoredNoticesExpanded)
+      )
+    } catch {
+      // Quota exhausted or storage disabled mid-session: the height still
+      // applies to this tab, it just will not be remembered.
+    }
+  }, [expanded])
+
+  const toggle = useCallback(() => {
+    setExpanded((current) => !current)
+  }, [])
+
+  return [expanded, toggle]
+}

--- a/apps/web/src/views/RecentNoticesFeed.tsx
+++ b/apps/web/src/views/RecentNoticesFeed.tsx
@@ -35,7 +35,10 @@ export interface RecentNoticesFeedProps {
   copied: boolean
   onCopyAll: () => void
   onClearAll: () => void
-  /** Expand-in-place: undefined in the popout, where the window IS the room. */
+  /** Expand-in-place: undefined in the popout, where the window IS the room —
+   *  so the operator's persisted inline height (see
+   *  hooks/use-recent-notices-expanded.ts) deliberately does not reach the
+   *  popped-out copy, and toggling one never resizes the other. */
   expanded?: boolean
   onToggleExpanded?: () => void
   /** Pop-out control. Undefined in the popped-out copy itself. */

--- a/tests/e2e/views.spec.ts
+++ b/tests/e2e/views.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test, type Page } from '@playwright/test'
+import { expect, test, type Locator, type Page } from '@playwright/test'
 import { deflateSync } from 'node:zlib'
 
 // The in-browser demo transport delivers inbound frames (param sync, command
@@ -4133,22 +4133,58 @@ test('Recent Notices: clear-all button and expert-mode search bar', async ({ pag
   await expect(page.getByTestId('setup-notices-search')).toBeVisible()
 })
 
-test('Recent Notices expands in place and stays collapsed by default', async ({ page }) => {
+test('Recent Notices expands in place, and the choice survives a reload', async ({ page }) => {
+  const connect = async (): Promise<Locator> => {
+    await page.getByTestId('transport-mode-select').selectOption('demo')
+    await page.getByTestId('connect-button').click()
+    await expect(page.getByTestId('session-vehicle-name')).toHaveText('ArduCopter', {
+      timeout: VEHICLE_CONNECT_TIMEOUT
+    })
+    const list = page.getByTestId('setup-notices-list')
+    await expect(list).toBeVisible({ timeout: 15_000 })
+    return list
+  }
+  const maxHeight = (list: Locator) =>
+    list.evaluate((node) => getComputedStyle(node).maxHeight)
+
   await page.goto('/')
-  await page.getByTestId('transport-mode-select').selectOption('demo')
-  await page.getByTestId('connect-button').click()
-  await expect(page.getByTestId('session-vehicle-name')).toHaveText('ArduCopter', { timeout: VEHICLE_CONNECT_TIMEOUT })
-  const list = page.getByTestId('setup-notices-list')
-  await expect(list).toBeVisible({ timeout: 15_000 })
-  // Collapsed is the default — Status & Info is long enough already, so the
-  // extra height has to be asked for.
-  const collapsed = await list.evaluate((node) => getComputedStyle(node).maxHeight)
-  expect(collapsed).toBe('240px')
+  // A fresh Playwright context IS a fresh profile — nothing stored for this
+  // origin — so this leg asserts what someone who has never touched the control
+  // gets, and it must stay collapsed: Status & Info is long enough already.
+  // (Don't assert the key is absent here: App mounts and persists the resolved
+  // default immediately, so the key exists by the time anything can read it.
+  // The height is the behaviour that matters.)
+  let list = await connect()
+  expect(await maxHeight(list)).toBe('240px')
+
   await page.getByTestId('setup-notices-expand').click()
-  const expanded = await list.evaluate((node) => getComputedStyle(node).maxHeight)
-  expect(Number.parseFloat(expanded)).toBeGreaterThan(240)
+  expect(Number.parseFloat(await maxHeight(list))).toBeGreaterThan(240)
+
+  // Expanded must be inherited on the next visit: re-clicking Expand after
+  // every reload (and every reboot-driven refresh) was the operator complaint.
+  await page.reload()
+  list = await connect()
+  expect(Number.parseFloat(await maxHeight(list))).toBeGreaterThan(240)
+
+  // …and collapsing must stick just as hard, or the setting is a one-way door.
   await page.getByTestId('setup-notices-expand').click()
-  expect(await list.evaluate((node) => getComputedStyle(node).maxHeight)).toBe('240px')
+  expect(await maxHeight(list)).toBe('240px')
+  await page.reload()
+  list = await connect()
+  expect(await maxHeight(list)).toBe('240px')
+
+  // Corrupt and stale-version values are both treated as "never set" rather
+  // than throwing: the panel height is not worth a white screen, and a bumped
+  // version must fall back to the safe default instead of restoring a meaning
+  // the stored flag no longer has.
+  for (const poison of ['{not json', '{"version":999,"expanded":true}', 'true']) {
+    await page.evaluate((value) => {
+      window.localStorage.setItem('arduconfig:recent-notices-expanded', value)
+    }, poison)
+    await page.reload()
+    list = await connect()
+    expect(await maxHeight(list)).toBe('240px')
+  }
 })
 
 test('Recent Notices pops out into its own styled, live window', async ({ page, context }) => {


### PR DESCRIPTION
> "eh, idk about collapsed by default, and yes no autoscroll"

#160 shipped Recent Notices with expand-in-place, but it reset to collapsed on every visit. That was a deliberate choice (this page has been in a length-reduction effort all day, so extra height was opt-in), but it means anyone who wants the taller feed re-expands it every single time.

Now the choice persists. A first visit is still collapsed, so the page-length win holds for anyone who never touches it — but once you expand it, it stays expanded across reloads and reconnects until you collapse it again.

**No auto-scroll is unchanged** — that was confirmed as correct and is untouched.

## Storage

Key `arduconfig:recent-notices-expanded`, namespaced like the other local preferences here (`arduconfig:gps-coord-format`, `arduconfig:transport-mode`, `arduconfig:product-mode`).

Versioned as a **field inside the payload** — `{"version":1,"expanded":true}` — rather than a `:v1` key suffix. That matches this repo's only existing versioned-local-state precedent (`setup-progress-storage.ts`), and it invalidates better: a stale value is rejected on read instead of being orphaned forever under a dead key that nothing will ever clean up.

New hook `use-recent-notices-expanded.ts`, shaped after `use-gps-coord-format.ts`.

Anything not positively readable as expanded falls back to collapsed, silently: missing key, unparseable JSON, wrong shape, wrong version. `window.localStorage` **access itself** is inside the try/catch, not just `getItem` — access can throw outright, and an unguarded throw at first render would white-screen the app over a panel height. With storage unavailable the toggle still works for the life of the tab, i.e. it degrades to exactly the pre-existing behaviour.

## The popped-out window

**It has no notion of this setting at all**, and that was left as-is rather than wiring one in. It was already passed no `expanded` and renders with `variant="popout"` (no max-height — the window's own scrollport is the bound). The window *is* the room, and the height you drag it to is the only height it has.

Because the flag never reaches that render path, a surprising jump between the two is impossible by construction rather than by care: toggling inline cannot resize the window, and the window has no toggle to affect the inline list. Documented at both the prop and the call site.

## Evidence it survives a reload

Rewritten e2e block run headlessly against a production preview build:

```
FRESH                                    240px
EXPANDED                                 504px  {"version":1,"expanded":true}
AFTER RELOAD                             504px
COLLAPSED AFTER RELOAD                   240px
POISON "{not json"                       240px
POISON {"version":999,"expanded":true}   240px
POISON "true"                            240px
CLEARED KEY                              240px
```

Also confirmed by hand in Chrome against the dev server: fresh profile 240 px, click Expand → 541.1 px with the value written.

One deliberate omission, commented in the test: it does **not** assert the key is absent on a fresh profile, because App mounts and persists the resolved default immediately, so the key exists before anything can read it. The height is the behaviour that matters.

## ArduCopter byte-identical

A localStorage display preference. No parameter value, write path, or telemetry involvement.

## Validation

- `npm run typecheck` — clean
- `npm run test` — **859 tests, 855 pass, 0 fail**, 4 skipped
- Full `npm run test:e2e` not run (ports contended by concurrent work); the three Recent Notices blocks were run against a private-port preview server.

## Known flaky, pre-existing — not from this change

`Recent Notices pops out into its own styled, live window` fails locally at the post-`Clear all` "No status text yet" assertion. Confirmed failing identically on unmodified `ada5847` with these changes stashed: the demo feed re-emits STATUSTEXT inside the 10 s budget, so the emptied state is never observable on this machine. It passed on CI for #160. Flagged rather than "fixed" blind inside a persistence commit.