### PR TITLE
feat(status): let the operator arrange the Status & Info cards

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -340,6 +340,13 @@ import { SetupBenchActions } from './sections/SetupBenchActions'
 import { AdvancedSensorCard } from './views/AdvancedSensorCard'
 import { buildAdvancedSensorCards } from './view-models/advanced-sensor-cards'
 import { useStatusClock } from './hooks/use-status-clock'
+import {
+  StatusDashboardProvider,
+  StatusDashboardZone,
+  type StatusDashboardCardEntry
+} from './views/StatusDashboard'
+import { useStatusDashboardLayout } from './hooks/use-status-dashboard-layout'
+import type { StatusDashboardCardSpec } from './view-models/status-dashboard-layout'
 import { ResetToDefaultsButton } from './views/ResetToDefaultsButton'
 import { CalibrationLocationButton } from './sections/CalibrationLocationCard'
 import { resolveSetupConfirmationRecord } from './view-models/setup-confirmation-resolve'
@@ -6708,6 +6715,328 @@ export function App() {
     flowType: flowTypeValue,
     nowMs: statusClockMs
   })
+
+  // ── Status & Info dashboard ─────────────────────────────────────────────
+  //
+  // Every status card is built here, exactly as it was built inline before,
+  // and handed to the dashboard as an opaque node. The dashboard decides only
+  // WHERE a card sits — never what it says, whether it exists, or what it
+  // requests. The conditional sensor cards keep coming straight from
+  // buildAdvancedSensorCards, so an unconfigured sensor still produces no
+  // card and a configured-but-silent one still produces its fault card.
+  const statusDashboardCards: StatusDashboardCardEntry[] = [
+    {
+      id: 'gps',
+      label: 'GPS',
+      node: (
+        <article className="setup-gui-box">
+          <div className="setup-gui-box__titlebar">
+            <strong>GPS</strong>
+            <StatusBadge tone={snapshot.preArmStatus.healthy ? 'success' : 'warning'}>
+              {snapshot.preArmStatus.healthy ? 'ready' : 'attention'}
+            </StatusBadge>
+          </div>
+          <div className="setup-gui-box__body">
+            <div className="setup-gui-box__kv-list">
+              <div className="setup-gui-box__kv-row"><span>Driver</span><strong>{setupGpsConfigured ? 'Configured' : 'Not configured'}</strong></div>
+              <div className="setup-gui-box__kv-row"><span>Fix</span><strong>{setupHasGpsCard && snapshot.liveVerification.globalPosition.verified ? 'Verified' : 'Waiting'}</strong></div>
+              <div className="setup-gui-box__kv-row setup-gui-box__kv-row--control">
+                <span>Format</span>
+                <select
+                  className="setup-gui-box__inline-select"
+                  value={gpsCoordFormat}
+                  onChange={(event) => setGpsCoordFormat(event.target.value as GpsCoordFormat)}
+                  data-testid="setup-gps-format-select"
+                  aria-label="GPS coordinate display format"
+                  title="Display format only — does not affect OSD or vehicle."
+                >
+                  {GPS_COORD_FORMAT_VALUES.map((value) => (
+                    <option key={value} value={value}>{GPS_COORD_FORMAT_LABELS[value]}</option>
+                  ))}
+                </select>
+              </div>
+              {gpsCoordFormat === 'mgrs' ? (
+                <div className="setup-gui-box__kv-row"><span>Grid (MGRS)</span><strong data-testid="setup-gps-mgrs">{formatMgrs(snapshot.liveVerification.globalPosition.latitudeDeg, snapshot.liveVerification.globalPosition.longitudeDeg)}</strong></div>
+              ) : gpsCoordFormat === 'utm' ? (
+                <div className="setup-gui-box__kv-row"><span>Grid (UTM)</span><strong data-testid="setup-gps-utm">{formatUtm(snapshot.liveVerification.globalPosition.latitudeDeg, snapshot.liveVerification.globalPosition.longitudeDeg)}</strong></div>
+              ) : gpsCoordFormat === 'dms' ? (
+                <>
+                  <div className="setup-gui-box__kv-row"><span>Latitude</span><strong>{formatLatitudeDms(snapshot.liveVerification.globalPosition.latitudeDeg)}</strong></div>
+                  <div className="setup-gui-box__kv-row"><span>Longitude</span><strong>{formatLongitudeDms(snapshot.liveVerification.globalPosition.longitudeDeg)}</strong></div>
+                </>
+              ) : (
+                <>
+                  <div className="setup-gui-box__kv-row"><span>Latitude</span><strong>{formatLatitudeDecimal(snapshot.liveVerification.globalPosition.latitudeDeg)}</strong></div>
+                  <div className="setup-gui-box__kv-row"><span>Longitude</span><strong>{formatLongitudeDecimal(snapshot.liveVerification.globalPosition.longitudeDeg)}</strong></div>
+                </>
+              )}
+            </div>
+            <p className="setup-gui-box__note">
+              {setupHasGpsCard
+                ? snapshot.liveVerification.globalPosition.verified
+                  ? 'Live GPS is arriving. Treat the map as a side check while the craft preview stays primary.'
+                  : 'A GPS driver is configured, but live position is not verified yet. Finish the port and GPS workflow, then return here.'
+                : 'No verified GPS source yet. That is acceptable for bench work, but guided modes should wait until GPS is configured.'}
+            </p>
+            {setupHasGpsCard ? (
+              <div className="setup-gui-box__map">
+                <LiveGpsMapCard
+                  snapshot={snapshot}
+                  title="GPS map"
+                  subtitle="Side check"
+                  compact
+                  testId="setup-gps-map-widget"
+                />
+              </div>
+            ) : null}
+          </div>
+        </article>
+      )
+    },
+    ...advancedSensorCards.map((card) => ({
+      id: card.id,
+      label: card.title,
+      node: <AdvancedSensorCard card={card} />
+    })),
+    {
+      id: 'prearm',
+      label: 'Pre-arm',
+      node: (
+        <article className="setup-gui-box" data-testid="setup-prearm">
+          <div className="setup-gui-box__titlebar">
+            <strong>Pre-arm</strong>
+            <StatusBadge tone={snapshot.preArmStatus.healthy ? 'success' : 'warning'}>
+              {snapshot.preArmStatus.healthy ? 'Clear' : `${snapshot.preArmStatus.issues.length} issues`}
+            </StatusBadge>
+          </div>
+          <div className="setup-gui-box__body">
+            {snapshot.preArmStatus.healthy ? (
+              <p className="telemetry-note">No active pre-arm issues.</p>
+            ) : (
+              <ul className="setup-statistics__prearm-list">
+                {snapshot.preArmStatus.issues.map((issue, index) => (
+                  <li key={`prearm:${index}:${issue.text}`}>{issue.text}</li>
+                ))}
+              </ul>
+            )}
+          </div>
+        </article>
+      )
+    },
+    {
+      id: 'statistics',
+      label: 'Statistics',
+      node: (
+        <article className="setup-gui-box setup-gui-box--compact" data-testid="setup-statistics">
+          <div className="setup-gui-box__titlebar">
+            <strong>Statistics</strong>
+            <StatusBadge tone="neutral">lifetime</StatusBadge>
+          </div>
+          <div className="setup-gui-box__body">
+            <div className="setup-gui-box__kv-list">
+              <div className="setup-gui-box__kv-row"><span>Total runtime</span><strong>{formatStatHours(readRoundedParameter(snapshot, 'STAT_RUNTIME'))}</strong></div>
+              <div className="setup-gui-box__kv-row"><span>Flight time</span><strong>{formatStatHours(readRoundedParameter(snapshot, 'STAT_FLTTIME'))}</strong></div>
+              <div className="setup-gui-box__kv-row"><span>Boot count</span><strong>{readRoundedParameter(snapshot, 'STAT_BOOTCNT') ?? '—'}</strong></div>
+            </div>
+          </div>
+        </article>
+      )
+    },
+    {
+      id: 'notices',
+      label: 'Recent Notices',
+      node: (
+        <article className="setup-gui-box" data-testid="setup-notices-panel">
+          <div className="setup-gui-box__titlebar">
+            <strong>Recent Notices</strong>
+            {recentNoticesBadge(recentNotices)}
+          </div>
+          <div className="setup-gui-box__body">
+            <RecentNoticesFeed
+              {...sharedNoticeFeedProps}
+              variant="inline"
+              testIdPrefix="setup-notices"
+              entryTestIdPrefix="setup-notice"
+              expanded={noticesExpanded}
+              onToggleExpanded={toggleNoticesExpanded}
+              poppedOut={noticesPopoutHandle !== undefined}
+              popoutBlocked={noticesPopout.blockedKey === NOTICES_POPOUT_KEY}
+              onTogglePopout={() => {
+                // Synchronous with the click: window.open only
+                // survives a popup blocker inside the browser's
+                // user-activation window, so nothing may await
+                // before this call.
+                if (noticesPopoutHandle) {
+                  noticesPopout.close(NOTICES_POPOUT_KEY)
+                } else {
+                  noticesPopout.open(NOTICES_POPOUT_KEY, 'Recent Notices')
+                }
+              }}
+            />
+          </div>
+        </article>
+      )
+    },
+    {
+      id: 'system-info',
+      label: 'System Info',
+      node: (
+        <article className="setup-gui-box">
+          <div className="setup-gui-box__titlebar">
+            <strong>System Info</strong>
+            <StatusBadge tone={toneForConnection(snapshot.connection.kind)}>{snapshot.connection.kind}</StatusBadge>
+          </div>
+          <div className="setup-gui-box__body">
+            <div className="setup-gui-box__kv-list">
+              <div className="setup-gui-box__kv-row"><span>Transport</span><strong>{setupTransportLabel}</strong></div>
+              <div className="setup-gui-box__kv-row"><span>Vehicle</span><strong>{snapshot.vehicle?.vehicle ?? '—'}</strong></div>
+              <div className="setup-gui-box__kv-row"><span>Firmware</span><strong>{snapshot.vehicle?.firmware ?? '—'}</strong></div>
+              {/* The FW version doubles as the way into the
+               *  Flash tab. It replaces the "Enter DFU mode"
+               *  button that used to sit above the craft view:
+               *  flashing is discoverable from the value that
+               *  makes an operator want to flash in the first
+               *  place, without a link-drops-the-vehicle action
+               *  living on a read-only status page.
+               *
+               *  A <button>, not an <a>: routing here is state
+               *  (`setActiveViewId`), and an href would reload
+               *  the SPA and drop the MAVLink link — the exact
+               *  thing this change is trying to stop happening
+               *  by accident. The row renders at all only when
+               *  a version is known, so there is no dead link
+               *  before the board has answered. */}
+              {snapshot.hardware.board?.firmwareVersion ? (
+                <div className="setup-gui-box__kv-row">
+                  <span>FW version</span>
+                  <strong>
+                    <button
+                      type="button"
+                      className="setup-gui-box__value-link"
+                      data-testid="setup-firmware-flash-link"
+                      onClick={() => setActiveViewId('flash')}
+                      aria-label={`Firmware ${snapshot.hardware.board.firmwareVersion} — open Flash tab`}
+                      title="Open the Flash tab (firmware, DFU / bootloader, flash wizard)"
+                    >
+                      {snapshot.hardware.board.firmwareVersion}
+                    </button>
+                  </strong>
+                </div>
+              ) : null}
+              {snapshot.hardware.board?.firmwareGitHash ? (
+                <div className="setup-gui-box__kv-row">
+                  <span>FW git hash</span>
+                  <strong><code>{snapshot.hardware.board.firmwareGitHash}</code></strong>
+                </div>
+              ) : null}
+              <div className="setup-gui-box__kv-row">
+                <span>Configurator build</span>
+                <strong><code>{GIT_BRANCH}@{GIT_HASH}</code></strong>
+              </div>
+              <div className="setup-gui-box__kv-row">
+                <span>Parameters</span>
+                <strong>{snapshot.parameterStats.status === 'complete' ? `${snapshot.parameterStats.downloaded}` : formatParameterSync(snapshot)}</strong>
+              </div>
+              <div className="setup-gui-box__kv-row"><span>Battery</span><strong>{formatBatteryTelemetry(snapshot)}</strong></div>
+              <div className="setup-gui-box__kv-row"><span>RC link</span><strong>{formatRcLink(snapshot)}</strong></div>
+              <div className="setup-gui-box__kv-row"><span>Pre-arm</span><strong>{snapshot.preArmStatus.healthy ? 'Clear' : `${snapshot.preArmStatus.issues.length} issues`}</strong></div>
+            </div>
+          </div>
+        </article>
+      )
+    },
+    {
+      id: 'instruments',
+      label: 'Instruments',
+      node: (
+        <article className="setup-gui-box">
+          <div className="setup-gui-box__titlebar">
+            <strong>Instruments</strong>
+            <StatusBadge tone={snapshot.liveVerification.attitudeTelemetry.verified ? 'success' : 'warning'}>
+              {snapshot.liveVerification.attitudeTelemetry.verified ? 'live' : 'waiting'}
+            </StatusBadge>
+          </div>
+          <div className="setup-gui-box__body">
+            <div className="setup-gui-box__kv-list">
+              <div className="setup-gui-box__kv-row"><span>Flight mode</span><strong>{snapshot.vehicle?.flightMode ?? 'Waiting'}</strong></div>
+              <div className="setup-gui-box__kv-row" data-testid="setup-vehicle-system-status"><span>System state</span><strong>{formatVehicleSystemStatus(snapshot.vehicle?.systemStatus)}</strong></div>
+              <div className="setup-gui-box__kv-row"><span>Roll</span><strong>{formatDegreeTelemetry(snapshot.liveVerification.attitudeTelemetry.rollDeg)}</strong></div>
+              <div className="setup-gui-box__kv-row"><span>Pitch</span><strong>{formatDegreeTelemetry(snapshot.liveVerification.attitudeTelemetry.pitchDeg)}</strong></div>
+              <div className="setup-gui-box__kv-row"><span>Heading</span><strong>{formatHeadingTelemetry(snapshot.liveVerification.attitudeTelemetry.yawDeg)}</strong></div>
+              <div className="setup-gui-box__kv-row"><span>Link state</span><strong>{snapshot.liveVerification.attitudeTelemetry.verified ? 'Synced' : 'Waiting'}</strong></div>
+            </div>
+          </div>
+        </article>
+      )
+    },
+    {
+      id: 'guided-setup',
+      label: 'Guided setup',
+      node: (
+        <article className={`setup-gui-box setup-gui-box--guided${guidedSetupComplete ? ' is-complete' : ''}`}>
+          <div className="setup-gui-box__titlebar">
+            <strong>{guidedSetupComplete ? 'Guided setup complete' : 'Guided setup'}</strong>
+            <StatusBadge tone={guidedSetupComplete ? 'success' : 'warning'}>
+              {completedSetupSectionCount}/{setupFlowSections.length}
+            </StatusBadge>
+          </div>
+          <div className="setup-gui-box__body">
+            <p className="setup-gui-box__note">
+              {guidedSetupComplete
+                ? guidedSetupHasExceptions
+                  ? 'All steps were resolved, but there are deferred or skipped decisions to review before flight.'
+                  : 'All setup steps were verified. Use the task rail for refinement.'
+                : selectedSetupSection
+                  ? `Next recommended step: ${selectedSetupSection.title}.`
+                  : 'Start guided setup to move through the ArduPilot-specific checklist one step at a time.'}
+            </p>
+            {guidedSetupComplete && guidedSetupOutcomeSummary ? (
+              <p className="setup-gui-box__note">{guidedSetupOutcomeSummary}</p>
+            ) : null}
+            <div className="setup-gui-box__button-row">
+              <button
+                className="setup-launch-button"
+                style={buttonStyle('hero')}
+                onClick={() => openSetupWizard()}
+                disabled={!recommendedSetupSection}
+                data-testid="setup-start-guided-button"
+              >
+                {guidedSetupComplete ? 'Review Setup' : completedSetupSectionCount > 0 ? 'Resume Setup' : 'Start Guided Setup'}
+              </button>
+            </div>
+          </div>
+        </article>
+      )
+    }
+  ]
+
+  // The DEFAULT arrangement, and the ONLY description of it: this list is what
+  // the page renders when nothing has been dragged, so it has to be the shipped
+  // layout exactly.
+  //
+  //   * the sensor row under the craft model — GPS plus whichever advanced
+  //     sensor cards exist — because the three answer one question and used to
+  //     be split across two columns and two scroll positions;
+  //   * Pre-arm above Statistics in the first status column, Recent Notices
+  //     beside them in the second;
+  //   * System Info at the TOP of the sidebar, above Instruments and Guided
+  //     setup: it is reference data the operator goes looking for, not
+  //     something they scan, so it does not hold prime main-column space.
+  //
+  // A stored layout is reconciled against this list every render, which is how
+  // a sensor card appearing or disappearing mid-session stays graceful.
+  const statusDashboardSpecs: StatusDashboardCardSpec[] = [
+    { id: 'gps', label: 'GPS', zone: 'sensors' },
+    ...advancedSensorCards.map((card) => ({ id: card.id, label: card.title, zone: 'sensors' as const })),
+    { id: 'prearm', label: 'Pre-arm', zone: 'midcol' },
+    { id: 'statistics', label: 'Statistics', zone: 'midcol' },
+    { id: 'notices', label: 'Recent Notices', zone: 'noticecol' },
+    { id: 'system-info', label: 'System Info', zone: 'sidebar' },
+    { id: 'instruments', label: 'Instruments', zone: 'sidebar' },
+    { id: 'guided-setup', label: 'Guided setup', zone: 'sidebar' }
+  ]
+  const statusDashboard = useStatusDashboardLayout(statusDashboardSpecs)
+
   const headerWarningActive =
     !snapshot.preArmStatus.healthy || snapshot.statusTexts.some((entry) => entry.severity === 'warning' || entry.severity === 'error')
   const headerBatteryLabel = snapshot.liveVerification.batteryTelemetry.verified
@@ -6995,6 +7324,32 @@ export function App() {
                      *  Nothing was lost; a disconnect-the-vehicle button simply
                      *  stopped living one stray click from read-only status.
                      *  The route in is the FW version value in System Info. */}
+
+                    {/* The arrangement below is user-rearrangeable: drag a card
+                     *  by its handle, drag its bottom edge to cap its height.
+                     *  The controls only appear on viewports wide enough for
+                     *  the multi-column layout to mean anything — on a phone
+                     *  the page is one column and the default order stands. */}
+                    <StatusDashboardProvider controller={statusDashboard} cards={statusDashboardCards}>
+                    {statusDashboard.customisable ? (
+                      <div className="status-dash-toolbar" data-testid="status-dash-toolbar">
+                        <span className="status-dash-toolbar__hint">
+                          Drag a card by its ⠿ handle to rearrange, or focus a handle and use the arrow keys. Drag a
+                          card's bottom edge to set its height.
+                        </span>
+                        {statusDashboard.customised ? (
+                          <button
+                            type="button"
+                            style={buttonStyle()}
+                            data-testid="status-dash-reset-layout"
+                            onClick={statusDashboard.resetLayout}
+                            title="Put every Status card back where it shipped"
+                          >
+                            Reset Layout to Default
+                          </button>
+                        ) : null}
+                      </div>
+                    ) : null}
                     <div className="setup-bench__workspace">
                       <div className="setup-bench__viewer">
                         <div className="setup-bench__viewer-header">
@@ -7018,318 +7373,33 @@ export function App() {
                           frameTypeLabel={airframe.frameTypeLabel}
                         />
 
-                        {/* The sensor group: GPS, then whichever advanced sensor
-                         *  cards exist (rangefinder / optical flow), all in one
-                         *  row directly under the 3D craft model.
+                        {/* The sensor row, the two status columns and the
+                         *  sidebar are all DROP ZONES now. Each keeps the class
+                         *  name — and therefore the grid/flex behaviour — that
+                         *  it had before the dashboard existed, and the default
+                         *  arrangement in `statusDashboardSpecs` puts every card
+                         *  back exactly where it shipped, so with nothing
+                         *  dragged this renders identically to the static tree
+                         *  it replaced.
                          *
-                         *  "Can we make it so that GPS, rangefinder and optical
-                         *  flow are all next to each other" — they answer the
-                         *  same question ("is the thing I bolted on actually
-                         *  reporting?") and used to be answered in two different
-                         *  places: GPS at the bottom of the right sidebar,
-                         *  rangefinder and flow stacked under System Info in the
-                         *  main column. Reading them meant scanning two columns
-                         *  and scrolling twice. One row, one glance.
-                         *
-                         *  Row and not column: stacking three sensor cards is
-                         *  what made this page long in the first place. GPS is
-                         *  unconditional, so this row is never empty and never
-                         *  collapses — with no lidar and no flow sensor (the
-                         *  common board) it is a single full-width GPS card,
-                         *  which reads as a deliberate panel rather than a
-                         *  widow, and gives the map the width a map wants. */}
-                        <div className="setup-status-sensors" data-testid="setup-sensor-group">
-                        <article className="setup-gui-box">
-                          <div className="setup-gui-box__titlebar">
-                            <strong>GPS</strong>
-                            <StatusBadge tone={snapshot.preArmStatus.healthy ? 'success' : 'warning'}>
-                              {snapshot.preArmStatus.healthy ? 'ready' : 'attention'}
-                            </StatusBadge>
-                          </div>
-                          <div className="setup-gui-box__body">
-                            <div className="setup-gui-box__kv-list">
-                              <div className="setup-gui-box__kv-row"><span>Driver</span><strong>{setupGpsConfigured ? 'Configured' : 'Not configured'}</strong></div>
-                              <div className="setup-gui-box__kv-row"><span>Fix</span><strong>{setupHasGpsCard && snapshot.liveVerification.globalPosition.verified ? 'Verified' : 'Waiting'}</strong></div>
-                              <div className="setup-gui-box__kv-row setup-gui-box__kv-row--control">
-                                <span>Format</span>
-                                <select
-                                  className="setup-gui-box__inline-select"
-                                  value={gpsCoordFormat}
-                                  onChange={(event) => setGpsCoordFormat(event.target.value as GpsCoordFormat)}
-                                  data-testid="setup-gps-format-select"
-                                  aria-label="GPS coordinate display format"
-                                  title="Display format only — does not affect OSD or vehicle."
-                                >
-                                  {GPS_COORD_FORMAT_VALUES.map((value) => (
-                                    <option key={value} value={value}>{GPS_COORD_FORMAT_LABELS[value]}</option>
-                                  ))}
-                                </select>
-                              </div>
-                              {gpsCoordFormat === 'mgrs' ? (
-                                <div className="setup-gui-box__kv-row"><span>Grid (MGRS)</span><strong data-testid="setup-gps-mgrs">{formatMgrs(snapshot.liveVerification.globalPosition.latitudeDeg, snapshot.liveVerification.globalPosition.longitudeDeg)}</strong></div>
-                              ) : gpsCoordFormat === 'utm' ? (
-                                <div className="setup-gui-box__kv-row"><span>Grid (UTM)</span><strong data-testid="setup-gps-utm">{formatUtm(snapshot.liveVerification.globalPosition.latitudeDeg, snapshot.liveVerification.globalPosition.longitudeDeg)}</strong></div>
-                              ) : gpsCoordFormat === 'dms' ? (
-                                <>
-                                  <div className="setup-gui-box__kv-row"><span>Latitude</span><strong>{formatLatitudeDms(snapshot.liveVerification.globalPosition.latitudeDeg)}</strong></div>
-                                  <div className="setup-gui-box__kv-row"><span>Longitude</span><strong>{formatLongitudeDms(snapshot.liveVerification.globalPosition.longitudeDeg)}</strong></div>
-                                </>
-                              ) : (
-                                <>
-                                  <div className="setup-gui-box__kv-row"><span>Latitude</span><strong>{formatLatitudeDecimal(snapshot.liveVerification.globalPosition.latitudeDeg)}</strong></div>
-                                  <div className="setup-gui-box__kv-row"><span>Longitude</span><strong>{formatLongitudeDecimal(snapshot.liveVerification.globalPosition.longitudeDeg)}</strong></div>
-                                </>
-                              )}
-                            </div>
-                            <p className="setup-gui-box__note">
-                              {setupHasGpsCard
-                                ? snapshot.liveVerification.globalPosition.verified
-                                  ? 'Live GPS is arriving. Treat the map as a side check while the craft preview stays primary.'
-                                  : 'A GPS driver is configured, but live position is not verified yet. Finish the port and GPS workflow, then return here.'
-                                : 'No verified GPS source yet. That is acceptable for bench work, but guided modes should wait until GPS is configured.'}
-                            </p>
-                            {setupHasGpsCard ? (
-                              <div className="setup-gui-box__map">
-                                <LiveGpsMapCard
-                                  snapshot={snapshot}
-                                  title="GPS map"
-                                  subtitle="Side check"
-                                  compact
-                                  testId="setup-gps-map-widget"
-                                />
-                              </div>
-                            ) : null}
-                          </div>
-                        </article>
+                         *  The comments that used to justify each card's
+                         *  position now live on `statusDashboardSpecs`, which is
+                         *  the single place the default arrangement is stated. */}
+                        <StatusDashboardZone
+                          zone="sensors"
+                          className="setup-status-sensors"
+                          testId="setup-sensor-group"
+                        />
 
-                        {/* The builder still decides whether a card exists at
-                         *  all: an unconfigured rangefinder or flow sensor
-                         *  produces nothing and the row falls back to GPS
-                         *  alone. A CONFIGURED sensor always gets a card,
-                         *  silent or not — that silence is the diagnosis, and
-                         *  it now sits beside GPS instead of a screen and a
-                         *  half further down the page. */}
-                        {advancedSensorCards.map((card) => (
-                          <AdvancedSensorCard key={card.id} card={card} />
-                        ))}
-                        </div>
-
-                        {/* Pre-arm / Statistics / Recent Notices live UNDER the
-                         *  sensor group in the main column (not in the sidebar)
-                         *  so the operator can read them at-glance alongside the
-                         *  model without having their eye dragged to the right
-                         *  column. System Info moved OUT of here to the top of
-                         *  the sidebar: it is reference data (transport, build
-                         *  strings, counters) that the operator goes looking for,
-                         *  not something they scan, so it does not deserve prime
-                         *  main-column space above the pre-arm state. */}
                         <div className="setup-bench__status-trio">
-                        {/* Middle column: pre-arm on top (it gates flight, so it
-                            matters most), lifetime stats compact below it. */}
-                        <div className="setup-status-midcol">
-                          <article className="setup-gui-box" data-testid="setup-prearm">
-                            <div className="setup-gui-box__titlebar">
-                              <strong>Pre-arm</strong>
-                              <StatusBadge tone={snapshot.preArmStatus.healthy ? 'success' : 'warning'}>
-                                {snapshot.preArmStatus.healthy ? 'Clear' : `${snapshot.preArmStatus.issues.length} issues`}
-                              </StatusBadge>
-                            </div>
-                            <div className="setup-gui-box__body">
-                              {snapshot.preArmStatus.healthy ? (
-                                <p className="telemetry-note">No active pre-arm issues.</p>
-                              ) : (
-                                <ul className="setup-statistics__prearm-list">
-                                  {snapshot.preArmStatus.issues.map((issue, index) => (
-                                    <li key={`prearm:${index}:${issue.text}`}>{issue.text}</li>
-                                  ))}
-                                </ul>
-                              )}
-                            </div>
-                          </article>
-
-                          <article className="setup-gui-box setup-gui-box--compact" data-testid="setup-statistics">
-                            <div className="setup-gui-box__titlebar">
-                              <strong>Statistics</strong>
-                              <StatusBadge tone="neutral">lifetime</StatusBadge>
-                            </div>
-                            <div className="setup-gui-box__body">
-                              <div className="setup-gui-box__kv-list">
-                                <div className="setup-gui-box__kv-row"><span>Total runtime</span><strong>{formatStatHours(readRoundedParameter(snapshot, 'STAT_RUNTIME'))}</strong></div>
-                                <div className="setup-gui-box__kv-row"><span>Flight time</span><strong>{formatStatHours(readRoundedParameter(snapshot, 'STAT_FLTTIME'))}</strong></div>
-                                <div className="setup-gui-box__kv-row"><span>Boot count</span><strong>{readRoundedParameter(snapshot, 'STAT_BOOTCNT') ?? '—'}</strong></div>
-                              </div>
-                            </div>
-                          </article>
-                        </div>
-
-                        <article className="setup-gui-box" data-testid="setup-notices-panel">
-                          <div className="setup-gui-box__titlebar">
-                            <strong>Recent Notices</strong>
-                            {recentNoticesBadge(recentNotices)}
-                          </div>
-                          <div className="setup-gui-box__body">
-                            <RecentNoticesFeed
-                              {...sharedNoticeFeedProps}
-                              variant="inline"
-                              testIdPrefix="setup-notices"
-                              entryTestIdPrefix="setup-notice"
-                              expanded={noticesExpanded}
-                              onToggleExpanded={toggleNoticesExpanded}
-                              poppedOut={noticesPopoutHandle !== undefined}
-                              popoutBlocked={noticesPopout.blockedKey === NOTICES_POPOUT_KEY}
-                              onTogglePopout={() => {
-                                // Synchronous with the click: window.open only
-                                // survives a popup blocker inside the browser's
-                                // user-activation window, so nothing may await
-                                // before this call.
-                                if (noticesPopoutHandle) {
-                                  noticesPopout.close(NOTICES_POPOUT_KEY)
-                                } else {
-                                  noticesPopout.open(NOTICES_POPOUT_KEY, 'Recent Notices')
-                                }
-                              }}
-                            />
-                          </div>
-                        </article>
+                          <StatusDashboardZone zone="midcol" className="setup-status-midcol" />
+                          <StatusDashboardZone zone="noticecol" className="setup-status-noticecol" />
                         </div>
                       </div>
 
-                      <div className="setup-bench__sidebar">
-                        {/* System Info leads the sidebar, above Instruments. It
-                         *  is the "what am I talking to" card — transport, board,
-                         *  firmware, build hash, param count — which the operator
-                         *  reads once on connect and then only returns to when
-                         *  something is wrong. Keeping it in the main column cost
-                         *  a full column of prime space above the pre-arm state
-                         *  and pushed the sensor cards down with it; the sidebar
-                         *  is where reference material belongs. It stays ABOVE
-                         *  Instruments because "am I connected to the right
-                         *  board?" is the question that comes first, and because
-                         *  Instruments and Guided Setup are the action pair that
-                         *  should stay adjacent. */}
-                        <article className="setup-gui-box">
-                          <div className="setup-gui-box__titlebar">
-                            <strong>System Info</strong>
-                            <StatusBadge tone={toneForConnection(snapshot.connection.kind)}>{snapshot.connection.kind}</StatusBadge>
-                          </div>
-                          <div className="setup-gui-box__body">
-                            <div className="setup-gui-box__kv-list">
-                              <div className="setup-gui-box__kv-row"><span>Transport</span><strong>{setupTransportLabel}</strong></div>
-                              <div className="setup-gui-box__kv-row"><span>Vehicle</span><strong>{snapshot.vehicle?.vehicle ?? '—'}</strong></div>
-                              <div className="setup-gui-box__kv-row"><span>Firmware</span><strong>{snapshot.vehicle?.firmware ?? '—'}</strong></div>
-                              {/* The FW version doubles as the way into the
-                               *  Flash tab. It replaces the "Enter DFU mode"
-                               *  button that used to sit above the craft view:
-                               *  flashing is discoverable from the value that
-                               *  makes an operator want to flash in the first
-                               *  place, without a link-drops-the-vehicle action
-                               *  living on a read-only status page.
-                               *
-                               *  A <button>, not an <a>: routing here is state
-                               *  (`setActiveViewId`), and an href would reload
-                               *  the SPA and drop the MAVLink link — the exact
-                               *  thing this change is trying to stop happening
-                               *  by accident. The row renders at all only when
-                               *  a version is known, so there is no dead link
-                               *  before the board has answered. */}
-                              {snapshot.hardware.board?.firmwareVersion ? (
-                                <div className="setup-gui-box__kv-row">
-                                  <span>FW version</span>
-                                  <strong>
-                                    <button
-                                      type="button"
-                                      className="setup-gui-box__value-link"
-                                      data-testid="setup-firmware-flash-link"
-                                      onClick={() => setActiveViewId('flash')}
-                                      aria-label={`Firmware ${snapshot.hardware.board.firmwareVersion} — open Flash tab`}
-                                      title="Open the Flash tab (firmware, DFU / bootloader, flash wizard)"
-                                    >
-                                      {snapshot.hardware.board.firmwareVersion}
-                                    </button>
-                                  </strong>
-                                </div>
-                              ) : null}
-                              {snapshot.hardware.board?.firmwareGitHash ? (
-                                <div className="setup-gui-box__kv-row">
-                                  <span>FW git hash</span>
-                                  <strong><code>{snapshot.hardware.board.firmwareGitHash}</code></strong>
-                                </div>
-                              ) : null}
-                              <div className="setup-gui-box__kv-row">
-                                <span>Configurator build</span>
-                                <strong><code>{GIT_BRANCH}@{GIT_HASH}</code></strong>
-                              </div>
-                              <div className="setup-gui-box__kv-row">
-                                <span>Parameters</span>
-                                <strong>{snapshot.parameterStats.status === 'complete' ? `${snapshot.parameterStats.downloaded}` : formatParameterSync(snapshot)}</strong>
-                              </div>
-                              <div className="setup-gui-box__kv-row"><span>Battery</span><strong>{formatBatteryTelemetry(snapshot)}</strong></div>
-                              <div className="setup-gui-box__kv-row"><span>RC link</span><strong>{formatRcLink(snapshot)}</strong></div>
-                              <div className="setup-gui-box__kv-row"><span>Pre-arm</span><strong>{snapshot.preArmStatus.healthy ? 'Clear' : `${snapshot.preArmStatus.issues.length} issues`}</strong></div>
-                            </div>
-                          </div>
-                        </article>
-
-                        <article className="setup-gui-box">
-                          <div className="setup-gui-box__titlebar">
-                            <strong>Instruments</strong>
-                            <StatusBadge tone={snapshot.liveVerification.attitudeTelemetry.verified ? 'success' : 'warning'}>
-                              {snapshot.liveVerification.attitudeTelemetry.verified ? 'live' : 'waiting'}
-                            </StatusBadge>
-                          </div>
-                          <div className="setup-gui-box__body">
-                            <div className="setup-gui-box__kv-list">
-                              <div className="setup-gui-box__kv-row"><span>Flight mode</span><strong>{snapshot.vehicle?.flightMode ?? 'Waiting'}</strong></div>
-                              <div className="setup-gui-box__kv-row" data-testid="setup-vehicle-system-status"><span>System state</span><strong>{formatVehicleSystemStatus(snapshot.vehicle?.systemStatus)}</strong></div>
-                              <div className="setup-gui-box__kv-row"><span>Roll</span><strong>{formatDegreeTelemetry(snapshot.liveVerification.attitudeTelemetry.rollDeg)}</strong></div>
-                              <div className="setup-gui-box__kv-row"><span>Pitch</span><strong>{formatDegreeTelemetry(snapshot.liveVerification.attitudeTelemetry.pitchDeg)}</strong></div>
-                              <div className="setup-gui-box__kv-row"><span>Heading</span><strong>{formatHeadingTelemetry(snapshot.liveVerification.attitudeTelemetry.yawDeg)}</strong></div>
-                              <div className="setup-gui-box__kv-row"><span>Link state</span><strong>{snapshot.liveVerification.attitudeTelemetry.verified ? 'Synced' : 'Waiting'}</strong></div>
-                            </div>
-                          </div>
-                        </article>
-
-                        {/* Guided setup sits directly under Instruments so the
-                         *  primary action ("Start / Resume Setup") stays high in
-                         *  the sidebar — the operator's eye flows from "is the
-                         *  model responding?" → "what's the next step?" without
-                         *  scrolling past GPS or Statistics first. */}
-                        <article className={`setup-gui-box setup-gui-box--guided${guidedSetupComplete ? ' is-complete' : ''}`}>
-                          <div className="setup-gui-box__titlebar">
-                            <strong>{guidedSetupComplete ? 'Guided setup complete' : 'Guided setup'}</strong>
-                            <StatusBadge tone={guidedSetupComplete ? 'success' : 'warning'}>
-                              {completedSetupSectionCount}/{setupFlowSections.length}
-                            </StatusBadge>
-                          </div>
-                          <div className="setup-gui-box__body">
-                            <p className="setup-gui-box__note">
-                              {guidedSetupComplete
-                                ? guidedSetupHasExceptions
-                                  ? 'All steps were resolved, but there are deferred or skipped decisions to review before flight.'
-                                  : 'All setup steps were verified. Use the task rail for refinement.'
-                                : selectedSetupSection
-                                  ? `Next recommended step: ${selectedSetupSection.title}.`
-                                  : 'Start guided setup to move through the ArduPilot-specific checklist one step at a time.'}
-                            </p>
-                            {guidedSetupComplete && guidedSetupOutcomeSummary ? (
-                              <p className="setup-gui-box__note">{guidedSetupOutcomeSummary}</p>
-                            ) : null}
-                            <div className="setup-gui-box__button-row">
-                              <button
-                                className="setup-launch-button"
-                                style={buttonStyle('hero')}
-                                onClick={() => openSetupWizard()}
-                                disabled={!recommendedSetupSection}
-                                data-testid="setup-start-guided-button"
-                              >
-                                {guidedSetupComplete ? 'Review Setup' : completedSetupSectionCount > 0 ? 'Resume Setup' : 'Start Guided Setup'}
-                              </button>
-                            </div>
-                          </div>
-                        </article>
-
-                      </div>
+                      <StatusDashboardZone zone="sidebar" className="setup-bench__sidebar" />
                     </div>
+                    </StatusDashboardProvider>
   	              </div>
 
                   {setupFlowFollowUp ? (

--- a/apps/web/src/hooks/use-status-dashboard-layout.ts
+++ b/apps/web/src/hooks/use-status-dashboard-layout.ts
@@ -1,0 +1,154 @@
+// Persistence + interaction state for the Status & Info dashboard arrangement.
+//
+// Storage is per browser (localStorage), namespaced and versioned exactly like
+// `arduconfig.can-node-names.v1`: the version is part of the KEY, so shipping a
+// new default arrangement is a one-line bump that makes every stale saved
+// layout simply not be found. Unreadable or untrusted values fall back to the
+// default silently — see `parseStoredStatusDashboardLayout`.
+//
+// Customisation is deliberately a desktop-only affordance. Below the width at
+// which the workspace collapses to a single column (1024px, the existing
+// `.setup-bench__workspace` breakpoint) a stored arrangement is IGNORED and the
+// default stacking order renders instead: pointer-dragging a card on a phone
+// fights the scroll gesture, and a four-zone arrangement has no meaning in one
+// column anyway.
+
+import { useCallback, useEffect, useMemo, useState } from 'react'
+
+import {
+  STATUS_DASHBOARD_STORAGE_KEY,
+  defaultStatusDashboardLayout,
+  isDefaultStatusDashboardLayout,
+  moveStatusDashboardCard,
+  nudgeStatusDashboardCard,
+  parseStoredStatusDashboardLayout,
+  reconcileStatusDashboardLayout,
+  resizeStatusDashboardCard,
+  shiftStatusDashboardCardZone,
+  type StatusDashboardCardSpec,
+  type StatusDashboardLayout,
+  type StatusDashboardZoneId
+} from '../view-models/status-dashboard-layout'
+
+/** Width below which the Status workspace is a single column; see styles.css. */
+export const STATUS_DASHBOARD_CUSTOMISE_MIN_WIDTH_PX = 1025
+
+function readStoredLayout(): StatusDashboardLayout | undefined {
+  try {
+    if (typeof localStorage === 'undefined') {
+      return undefined
+    }
+    return parseStoredStatusDashboardLayout(localStorage.getItem(STATUS_DASHBOARD_STORAGE_KEY))
+  } catch {
+    // Storage disabled entirely (some embedded contexts throw on access).
+    return undefined
+  }
+}
+
+function useIsWideEnough(): boolean {
+  const [wide, setWide] = useState(() => {
+    if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') {
+      return true
+    }
+    return window.matchMedia(`(min-width: ${STATUS_DASHBOARD_CUSTOMISE_MIN_WIDTH_PX}px)`).matches
+  })
+
+  useEffect(() => {
+    if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') {
+      return
+    }
+    const query = window.matchMedia(`(min-width: ${STATUS_DASHBOARD_CUSTOMISE_MIN_WIDTH_PX}px)`)
+    const onChange = (): void => setWide(query.matches)
+    onChange()
+    query.addEventListener('change', onChange)
+    return () => query.removeEventListener('change', onChange)
+  }, [])
+
+  return wide
+}
+
+export interface StatusDashboardLayoutController {
+  /** The arrangement to render. Always exactly the cards that exist right now. */
+  layout: StatusDashboardLayout
+  /** False on narrow viewports: hide handles and render the default order. */
+  customisable: boolean
+  /** True when the operator has changed something, so "Reset layout" is useful. */
+  customised: boolean
+  moveCard: (id: string, zone: StatusDashboardZoneId, index: number) => void
+  nudgeCard: (id: string, delta: -1 | 1) => void
+  shiftCardZone: (id: string, delta: -1 | 1) => void
+  resizeCard: (id: string, heightRows: number | undefined) => void
+  resetLayout: () => void
+}
+
+export function useStatusDashboardLayout(
+  specs: readonly StatusDashboardCardSpec[]
+): StatusDashboardLayoutController {
+  const customisable = useIsWideEnough()
+  const [stored, setStored] = useState<StatusDashboardLayout | undefined>(readStoredLayout)
+
+  // Reconcile on every render against the cards that are actually present:
+  // conditional sensor cards appear and disappear as the operator configures
+  // them, and a saved layout must degrade to something sane either way.
+  const layout = useMemo(
+    () => (customisable ? reconcileStatusDashboardLayout(stored, specs) : defaultStatusDashboardLayout(specs)),
+    [customisable, stored, specs]
+  )
+
+  const persist = useCallback((next: StatusDashboardLayout) => {
+    setStored(next)
+    try {
+      localStorage.setItem(STATUS_DASHBOARD_STORAGE_KEY, JSON.stringify(next))
+    } catch {
+      // Quota or unavailable storage — the arrangement just won't outlive the tab.
+    }
+  }, [])
+
+  const apply = useCallback(
+    (transform: (current: StatusDashboardLayout) => StatusDashboardLayout) => {
+      const next = transform(layout)
+      if (next !== layout) {
+        persist(next)
+      }
+    },
+    [layout, persist]
+  )
+
+  const moveCard = useCallback(
+    (id: string, zone: StatusDashboardZoneId, index: number) =>
+      apply((current) => moveStatusDashboardCard(current, id, zone, index)),
+    [apply]
+  )
+
+  const nudgeCard = useCallback(
+    (id: string, delta: -1 | 1) => apply((current) => nudgeStatusDashboardCard(current, id, delta)),
+    [apply]
+  )
+
+  const shiftCardZone = useCallback(
+    (id: string, delta: -1 | 1) => apply((current) => shiftStatusDashboardCardZone(current, id, delta)),
+    [apply]
+  )
+
+  const resizeCard = useCallback(
+    (id: string, heightRows: number | undefined) =>
+      apply((current) => resizeStatusDashboardCard(current, id, heightRows)),
+    [apply]
+  )
+
+  const resetLayout = useCallback(() => {
+    setStored(undefined)
+    try {
+      localStorage.removeItem(STATUS_DASHBOARD_STORAGE_KEY)
+    } catch {
+      // Ignore — the in-memory reset above already took effect.
+    }
+  }, [])
+
+  const customised = useMemo(
+    () => customisable && stored !== undefined && !isDefaultStatusDashboardLayout(layout, specs),
+    [customisable, stored, layout, specs]
+  )
+
+  return { layout, customisable, customised, moveCard, nudgeCard, shiftCardZone, resizeCard, resetLayout }
+}

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -3102,8 +3102,17 @@ textarea:focus {
  * CARD's width rather than the viewport's. The same card is 856px wide when
  * GPS is alone in the row, 421px when there are two, 276px when there are
  * three and 330px on a phone — four widths that no viewport media query can
- * tell apart, because they depend on how many sensors the vehicle has. */
-.setup-status-sensors > .setup-gui-box {
+ * tell apart, because they depend on how many sensors the vehicle has.
+ *
+ * `.status-dash-card` is in the selector because the dashboard wraps every card
+ * in one, which makes the WRAPPER the grid item and pushes `.setup-gui-box` a
+ * level down where `>` no longer reaches it. Naming only the card would have
+ * silently dropped the container off the sensor row and taken the GPS map's
+ * whole compaction ruleset with it — the `@container` queries below would find
+ * no container and never match. The wrapper is the same width as the card it
+ * holds, so measuring it measures the same thing. */
+.setup-status-sensors > .setup-gui-box,
+.setup-status-sensors > .status-dash-card {
   container-type: inline-size;
 }
 
@@ -3202,6 +3211,166 @@ textarea:focus {
   display: flex;
   flex-direction: column;
   gap: 14px;
+}
+
+/* Status third column. Recent Notices used to be a bare child of the trio
+ * grid; it now has the same stacking wrapper as the other two columns purely
+ * so a dragged card has somewhere to land next to it. With one card in it the
+ * rendering is identical to the bare article it replaced. */
+.setup-status-noticecol {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+/* ── Status & Info dashboard: drag / resize chrome ─────────────────────────
+ *
+ * Purely additive around the existing cards. With nothing dragged and no
+ * height cap set, every rule below is inert and the page renders exactly as
+ * it did before the dashboard existed. */
+
+.status-dash-toolbar {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+
+.status-dash-toolbar__hint {
+  color: var(--text-muted);
+  font-size: 12px;
+}
+
+.status-dash-zone {
+  position: relative;
+}
+
+/* Only while a drag is in flight: give an emptied column enough height to
+ * still be a target, and outline the one under the pointer. */
+.status-dash-zone--armed {
+  min-height: 72px;
+  border-radius: 12px;
+}
+
+.status-dash-zone--armed.is-drop-target {
+  outline: 1px dashed color-mix(in srgb, var(--primary-500) 55%, transparent);
+  outline-offset: 6px;
+}
+
+.status-dash-card {
+  position: relative;
+  min-width: 0;
+}
+
+/* The dragged card stays in place, ghosted, and stops swallowing hit-tests so
+ * `elementFromPoint` can see the zone underneath it. */
+.status-dash-card.is-dragging {
+  opacity: 0.32;
+  pointer-events: none;
+}
+
+/* A user-set height cap. The negative margin + matching padding keeps the
+ * card's floating titlebar pill (top: -10px) inside the scroll container
+ * instead of being clipped off by `overflow`. */
+.status-dash-card.is-capped > .status-dash-card__content {
+  max-height: var(--status-dash-height);
+  overflow-y: auto;
+  padding-top: 14px;
+  margin-top: -14px;
+}
+
+.status-dash-card__handle {
+  position: absolute;
+  top: -11px;
+  right: 10px;
+  z-index: 4;
+  width: 22px;
+  height: 22px;
+  padding: 0;
+  display: grid;
+  place-items: center;
+  border: 1px solid var(--surface-400);
+  border-radius: 999px;
+  background: var(--surface-300);
+  color: var(--text-muted);
+  font-size: 11px;
+  line-height: 1;
+  cursor: grab;
+  opacity: 0.5;
+  transition: opacity 120ms ease, background 120ms ease;
+  touch-action: none;
+}
+
+.status-dash-card:hover > .status-dash-card__handle,
+.status-dash-card__handle:focus-visible {
+  opacity: 1;
+  background: var(--primary-500);
+  color: #000;
+}
+
+.status-dash-card__handle:focus-visible {
+  outline: 2px solid var(--primary-500);
+  outline-offset: 2px;
+}
+
+.status-dash-card__resize {
+  position: absolute;
+  left: 50%;
+  bottom: -8px;
+  transform: translateX(-50%);
+  z-index: 4;
+  width: 48px;
+  height: 16px;
+  padding: 0;
+  border: none;
+  background: transparent;
+  display: grid;
+  place-items: center;
+  cursor: ns-resize;
+  touch-action: none;
+}
+
+.status-dash-card__resize > span {
+  display: block;
+  width: 34px;
+  height: 4px;
+  border-radius: 999px;
+  background: var(--surface-400);
+  opacity: 0.55;
+  transition: opacity 120ms ease, background 120ms ease;
+}
+
+.status-dash-card:hover > .status-dash-card__resize > span,
+.status-dash-card__resize:focus-visible > span {
+  opacity: 1;
+  background: var(--primary-500);
+}
+
+.status-dash-card__resize:focus-visible {
+  outline: 2px solid var(--primary-500);
+  outline-offset: 2px;
+  border-radius: 6px;
+}
+
+/* Where the card will land. */
+.status-dash-drop {
+  height: 4px;
+  border-radius: 999px;
+  background: var(--primary-500);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--primary-500) 22%, transparent);
+}
+
+body.is-status-dash-dragging {
+  user-select: none;
+  cursor: grabbing;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .status-dash-card__handle,
+  .status-dash-card__resize > span {
+    transition: none;
+  }
 }
 /* Lifetime stats are secondary to pre-arm — render them smaller/denser. */
 .setup-gui-box--compact .setup-gui-box__body {

--- a/apps/web/src/view-models/status-dashboard-layout.test.ts
+++ b/apps/web/src/view-models/status-dashboard-layout.test.ts
@@ -1,0 +1,280 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  STATUS_DASHBOARD_LAYOUT_VERSION,
+  STATUS_DASHBOARD_MAX_ROWS,
+  STATUS_DASHBOARD_MIN_ROWS,
+  defaultStatusDashboardLayout,
+  isDefaultStatusDashboardLayout,
+  moveStatusDashboardCard,
+  nudgeStatusDashboardCard,
+  parseStoredStatusDashboardLayout,
+  reconcileStatusDashboardLayout,
+  resizeStatusDashboardCard,
+  shiftStatusDashboardCardZone,
+  zoneCardIds,
+  type StatusDashboardCardSpec
+} from './status-dashboard-layout'
+
+/**
+ * The default card set with both conditional sensor cards present. This mirrors
+ * `statusDashboardSpecs` in App.tsx, which is the page exactly as it ships:
+ * GPS + the two advanced sensors in one row, Pre-arm/Statistics and Recent
+ * Notices in the two status columns below it, and System Info leading the
+ * sidebar above Instruments and Guided setup.
+ */
+const specsWithSensors: StatusDashboardCardSpec[] = [
+  { id: 'gps', label: 'GPS', zone: 'sensors' },
+  { id: 'rangefinder', label: 'Rangefinder', zone: 'sensors' },
+  { id: 'optical-flow', label: 'Optical Flow', zone: 'sensors' },
+  { id: 'prearm', label: 'Pre-arm', zone: 'midcol' },
+  { id: 'statistics', label: 'Statistics', zone: 'midcol' },
+  { id: 'notices', label: 'Recent Notices', zone: 'noticecol' },
+  { id: 'system-info', label: 'System Info', zone: 'sidebar' },
+  { id: 'instruments', label: 'Instruments', zone: 'sidebar' },
+  { id: 'guided-setup', label: 'Guided setup', zone: 'sidebar' }
+]
+
+/** The same page with the sensors unconfigured — those two cards do not exist. */
+const specsWithoutSensors = specsWithSensors.filter(
+  (spec) => spec.id !== 'rangefinder' && spec.id !== 'optical-flow'
+)
+
+describe('defaultStatusDashboardLayout', () => {
+  it('describes the shipped arrangement, one placement per card', () => {
+    const layout = defaultStatusDashboardLayout(specsWithSensors)
+    expect(layout.version).toBe(STATUS_DASHBOARD_LAYOUT_VERSION)
+    expect(zoneCardIds(layout, 'sensors')).toEqual(['gps', 'rangefinder', 'optical-flow'])
+    expect(zoneCardIds(layout, 'midcol')).toEqual(['prearm', 'statistics'])
+    expect(zoneCardIds(layout, 'noticecol')).toEqual(['notices'])
+    expect(zoneCardIds(layout, 'sidebar')).toEqual(['system-info', 'instruments', 'guided-setup'])
+    expect(isDefaultStatusDashboardLayout(layout, specsWithSensors)).toBe(true)
+  })
+})
+
+describe('parseStoredStatusDashboardLayout', () => {
+  it('round-trips a layout it wrote', () => {
+    const layout = resizeStatusDashboardCard(defaultStatusDashboardLayout(specsWithSensors), 'notices', 12)
+    expect(parseStoredStatusDashboardLayout(JSON.stringify(layout))).toEqual(layout)
+  })
+
+  it('falls back to undefined on anything it cannot trust', () => {
+    // Nothing stored, unparseable JSON, wrong shape, wrong version: all must
+    // degrade to "use the default", never throw.
+    expect(parseStoredStatusDashboardLayout(null)).toBeUndefined()
+    expect(parseStoredStatusDashboardLayout('')).toBeUndefined()
+    expect(parseStoredStatusDashboardLayout('{not json')).toBeUndefined()
+    expect(parseStoredStatusDashboardLayout('[]')).toBeUndefined()
+    expect(parseStoredStatusDashboardLayout('"a string"')).toBeUndefined()
+    expect(parseStoredStatusDashboardLayout(JSON.stringify({ version: 999, cards: [] }))).toBeUndefined()
+    expect(parseStoredStatusDashboardLayout(JSON.stringify({ version: 1 }))).toBeUndefined()
+    expect(
+      parseStoredStatusDashboardLayout(JSON.stringify({ version: 1, cards: 'nope' }))
+    ).toBeUndefined()
+  })
+
+  it('drops junk entries and repairs bad fields instead of failing whole', () => {
+    const parsed = parseStoredStatusDashboardLayout(
+      JSON.stringify({
+        version: 1,
+        cards: [
+          { id: 'system-info', zone: 'sidebar' },
+          { id: 'system-info', zone: 'midcol' }, // duplicate id — ignored
+          { id: '', zone: 'midcol' }, // empty id — ignored
+          { id: 42, zone: 'midcol' }, // non-string id — ignored
+          null,
+          'notices',
+          { id: 'notices', zone: 'from-the-future' }, // unknown zone — repaired
+          { id: 'gps', zone: 'sidebar', heightRows: 9999 }, // out of range — clamped
+          { id: 'prearm', zone: 'midcol', heightRows: 'tall' } // wrong type — dropped
+        ]
+      })
+    )
+    expect(parsed).toEqual({
+      version: 1,
+      cards: [
+        { id: 'system-info', zone: 'sidebar' },
+        { id: 'notices', zone: 'sensors' },
+        { id: 'gps', zone: 'sidebar', heightRows: STATUS_DASHBOARD_MAX_ROWS },
+        { id: 'prearm', zone: 'midcol' }
+      ]
+    })
+  })
+})
+
+describe('reconcileStatusDashboardLayout', () => {
+  it('uses the default when there is nothing stored', () => {
+    expect(reconcileStatusDashboardLayout(undefined, specsWithSensors)).toEqual(
+      defaultStatusDashboardLayout(specsWithSensors)
+    )
+  })
+
+  it('drops cards that are no longer on the page', () => {
+    // Layout saved while a rangefinder and flow sensor were configured, then
+    // reopened with both set to type 0 — the cards do not render at all.
+    const saved = moveStatusDashboardCard(
+      defaultStatusDashboardLayout(specsWithSensors),
+      'rangefinder',
+      'sidebar',
+      0
+    )
+    const reconciled = reconcileStatusDashboardLayout(saved, specsWithoutSensors)
+    expect(reconciled.cards.map((card) => card.id).sort()).toEqual(
+      specsWithoutSensors.map((spec) => spec.id).sort()
+    )
+    expect(zoneCardIds(reconciled, 'sidebar')).toEqual(['system-info', 'instruments', 'guided-setup'])
+    expect(zoneCardIds(reconciled, 'sensors')).toEqual(['gps'])
+  })
+
+  it('inserts a newly-present card at its default neighbourhood', () => {
+    // Saved with no sensors; the operator then wires up a lidar mid-session.
+    const saved = defaultStatusDashboardLayout(specsWithoutSensors)
+    const reconciled = reconcileStatusDashboardLayout(saved, specsWithSensors)
+    expect(zoneCardIds(reconciled, 'sensors')).toEqual(['gps', 'rangefinder', 'optical-flow'])
+    expect(reconciled.cards).toHaveLength(specsWithSensors.length)
+  })
+
+  it('honours a customised position for the anchor when inserting new cards', () => {
+    // GPS dragged to the sidebar; a rangefinder then appears. The new card takes
+    // its DEFAULT zone (the sensor row — a rangefinder card belongs with the
+    // other sensors however the operator has arranged them), but its slot in the
+    // flat order follows its anchor, so it never lands orphaned at the bottom.
+    const saved = moveStatusDashboardCard(
+      defaultStatusDashboardLayout(specsWithoutSensors),
+      'gps',
+      'sidebar',
+      0
+    )
+    const reconciled = reconcileStatusDashboardLayout(saved, specsWithSensors)
+    const rangefinder = reconciled.cards.find((card) => card.id === 'rangefinder')
+    expect(rangefinder?.zone).toBe('sensors')
+    // Immediately after GPS in the flat list, wherever that ended up.
+    const ids = reconciled.cards.map((card) => card.id)
+    expect(ids[ids.indexOf('gps') + 1]).toBe('rangefinder')
+  })
+
+  it('never yields duplicates or losses even from a hostile stored layout', () => {
+    const reconciled = reconcileStatusDashboardLayout(
+      { version: 1, cards: [{ id: 'ghost', zone: 'midcol' }] },
+      specsWithSensors
+    )
+    expect(reconciled.cards.map((card) => card.id).sort()).toEqual(
+      specsWithSensors.map((spec) => spec.id).sort()
+    )
+  })
+})
+
+describe('moveStatusDashboardCard', () => {
+  it('reorders inside a zone', () => {
+    const layout = moveStatusDashboardCard(
+      defaultStatusDashboardLayout(specsWithSensors),
+      'guided-setup',
+      'sidebar',
+      0
+    )
+    expect(zoneCardIds(layout, 'sidebar')).toEqual(['guided-setup', 'system-info', 'instruments'])
+  })
+
+  it('moves between zones at the requested index', () => {
+    const layout = moveStatusDashboardCard(
+      defaultStatusDashboardLayout(specsWithSensors),
+      'gps',
+      'midcol',
+      1
+    )
+    expect(zoneCardIds(layout, 'midcol')).toEqual(['prearm', 'gps', 'statistics'])
+    expect(zoneCardIds(layout, 'sensors')).toEqual(['rangefinder', 'optical-flow'])
+  })
+
+  it('clamps an out-of-range index and lands in an empty zone', () => {
+    const base = defaultStatusDashboardLayout(specsWithSensors)
+    const emptied = moveStatusDashboardCard(base, 'notices', 'sidebar', 99)
+    expect(zoneCardIds(emptied, 'noticecol')).toEqual([])
+    expect(zoneCardIds(emptied, 'sidebar')).toEqual([
+      'system-info',
+      'instruments',
+      'guided-setup',
+      'notices'
+    ])
+    const back = moveStatusDashboardCard(emptied, 'gps', 'noticecol', -5)
+    expect(zoneCardIds(back, 'noticecol')).toEqual(['gps'])
+  })
+
+  it('returns the same object when nothing changes', () => {
+    const base = defaultStatusDashboardLayout(specsWithSensors)
+    expect(moveStatusDashboardCard(base, 'prearm', 'midcol', 0)).toBe(base)
+    expect(moveStatusDashboardCard(base, 'no-such-card', 'midcol', 0)).toBe(base)
+  })
+})
+
+describe('keyboard moves', () => {
+  it('nudges up and down within a zone and stops at the ends', () => {
+    const base = defaultStatusDashboardLayout(specsWithSensors)
+    expect(zoneCardIds(nudgeStatusDashboardCard(base, 'guided-setup', -1), 'sidebar')).toEqual([
+      'system-info',
+      'guided-setup',
+      'instruments'
+    ])
+    // Already first in the zone: up is a no-op rather than an escape into the
+    // previous zone, so a held arrow key cannot walk a card off the page.
+    expect(zoneCardIds(nudgeStatusDashboardCard(base, 'system-info', -1), 'sidebar')).toEqual([
+      'system-info',
+      'instruments',
+      'guided-setup'
+    ])
+    expect(zoneCardIds(nudgeStatusDashboardCard(base, 'guided-setup', 1), 'sidebar')).toEqual([
+      'system-info',
+      'instruments',
+      'guided-setup'
+    ])
+  })
+
+  it('shifts a card to the neighbouring zone and refuses past the edges', () => {
+    const base = defaultStatusDashboardLayout(specsWithSensors)
+    const shifted = shiftStatusDashboardCardZone(base, 'notices', -1)
+    expect(zoneCardIds(shifted, 'midcol')).toEqual(['notices', 'prearm', 'statistics'])
+    // GPS is in the first zone and Guided setup in the last, so there is no
+    // zone to their left / right respectively.
+    expect(shiftStatusDashboardCardZone(base, 'gps', -1)).toBe(base)
+    expect(shiftStatusDashboardCardZone(base, 'guided-setup', 1)).toBe(base)
+  })
+})
+
+describe('resizeStatusDashboardCard', () => {
+  it('snaps, clamps and clears the height cap', () => {
+    const base = defaultStatusDashboardLayout(specsWithSensors)
+    expect(resizeStatusDashboardCard(base, 'notices', 12.4).cards.find((c) => c.id === 'notices')).toEqual({
+      id: 'notices',
+      zone: 'noticecol',
+      heightRows: 12
+    })
+    expect(resizeStatusDashboardCard(base, 'notices', 1).cards.find((c) => c.id === 'notices')?.heightRows).toBe(
+      STATUS_DASHBOARD_MIN_ROWS
+    )
+    expect(
+      resizeStatusDashboardCard(base, 'notices', 10_000).cards.find((c) => c.id === 'notices')?.heightRows
+    ).toBe(STATUS_DASHBOARD_MAX_ROWS)
+    const sized = resizeStatusDashboardCard(base, 'notices', 12)
+    expect(resizeStatusDashboardCard(sized, 'notices', undefined).cards.find((c) => c.id === 'notices')).toEqual({
+      id: 'notices',
+      zone: 'noticecol'
+    })
+    expect(resizeStatusDashboardCard(base, 'notices', undefined)).toBe(base)
+  })
+})
+
+describe('isDefaultStatusDashboardLayout', () => {
+  it('is false once anything has been moved or resized', () => {
+    const base = defaultStatusDashboardLayout(specsWithSensors)
+    expect(isDefaultStatusDashboardLayout(moveStatusDashboardCard(base, 'gps', 'midcol', 0), specsWithSensors)).toBe(
+      false
+    )
+    expect(
+      isDefaultStatusDashboardLayout(resizeStatusDashboardCard(base, 'gps', 10), specsWithSensors)
+    ).toBe(false)
+    // A default layout built for a different card set is not "the default" here.
+    expect(isDefaultStatusDashboardLayout(defaultStatusDashboardLayout(specsWithoutSensors), specsWithSensors)).toBe(
+      false
+    )
+  })
+})

--- a/apps/web/src/view-models/status-dashboard-layout.ts
+++ b/apps/web/src/view-models/status-dashboard-layout.ts
@@ -1,0 +1,336 @@
+// Status & Info dashboard layout — the pure, unit-testable half of the
+// drag-and-resize arrangement.
+//
+// WHY a layout MODEL rather than a grid library: the Status page is a nested
+// arrangement of narrow columns whose cards keep their NATURAL height (see the
+// `align-items: start` note on `.setup-bench__status-trio`). Absolute-positioned
+// grid libraries need an explicit pixel height for every card, which turns a
+// card whose content grew — one more pre-arm issue, a firmware git hash row —
+// into a clipped or half-empty box. So the model here is deliberately smaller
+// than a 2-D grid: a card lives in one of a few named ZONES, at an index within
+// that zone, with an optional height cap. Cards can never overlap, never leave
+// a hole, and never need a collision pass; the worst a user can do is stack
+// everything into one zone, which still renders as a normal column.
+//
+// Width is a property of the zone, not the card: the sidebar zone is narrow,
+// the status columns are a share of the main column each. Moving a card is
+// therefore also how you resize it horizontally, and no arrangement can produce
+// a card wider than the page or narrower than its content.
+//
+// The zone list mirrors the page as it ships: a full-width SENSOR ROW under the
+// craft model (GPS + rangefinder + optical flow, grouped there so the three
+// answers to "is the thing I bolted on reporting?" sit side by side), then the
+// two status columns below it, then the sidebar of reference and action cards.
+// `sensors` is a grid ROW rather than a column, which the model does not care
+// about — a zone is an ordered list of cards, and CSS decides whether that list
+// flows down or across.
+
+/** The drop zones on the Status & Info page. Widths come from CSS, not layout. */
+export type StatusDashboardZoneId = 'sensors' | 'midcol' | 'noticecol' | 'sidebar'
+
+export const STATUS_DASHBOARD_ZONE_IDS: readonly StatusDashboardZoneId[] = [
+  'sensors',
+  'midcol',
+  'noticecol',
+  'sidebar'
+]
+
+export const STATUS_DASHBOARD_ZONE_LABELS: Record<StatusDashboardZoneId, string> = {
+  sensors: 'Sensor row',
+  midcol: 'Column 1',
+  noticecol: 'Column 2',
+  sidebar: 'Sidebar'
+}
+
+/** One vertical resize step, in pixels. Heights snap to a multiple of this. */
+export const STATUS_DASHBOARD_ROW_PX = 24
+
+/** Smallest and largest user-set height, in rows. Outside this range: clamped. */
+export const STATUS_DASHBOARD_MIN_ROWS = 5
+export const STATUS_DASHBOARD_MAX_ROWS = 60
+
+/**
+ * Bump when the SHAPE of a stored layout changes, or when the default
+ * arrangement changes enough that a stale saved layout would look broken.
+ * A stored layout with a different version is discarded, silently, in favour
+ * of the current default — never rendered.
+ */
+export const STATUS_DASHBOARD_LAYOUT_VERSION = 1
+
+export const STATUS_DASHBOARD_STORAGE_KEY = `arduconfig.status-dashboard.v${STATUS_DASHBOARD_LAYOUT_VERSION}`
+
+/** Where one card sits, and how tall the operator has made it. */
+export interface StatusDashboardPlacement {
+  id: string
+  zone: StatusDashboardZoneId
+  /** User-set height cap in rows. Undefined means "as tall as its content". */
+  heightRows?: number
+}
+
+export interface StatusDashboardLayout {
+  version: number
+  cards: StatusDashboardPlacement[]
+}
+
+/** A card that exists on the page right now. `label` names it for assistive tech. */
+export interface StatusDashboardCardSpec {
+  id: string
+  label: string
+  zone: StatusDashboardZoneId
+}
+
+export function isStatusDashboardZoneId(value: unknown): value is StatusDashboardZoneId {
+  return typeof value === 'string' && (STATUS_DASHBOARD_ZONE_IDS as readonly string[]).includes(value)
+}
+
+export function clampHeightRows(rows: number): number {
+  if (!Number.isFinite(rows)) {
+    return STATUS_DASHBOARD_MIN_ROWS
+  }
+  return Math.min(STATUS_DASHBOARD_MAX_ROWS, Math.max(STATUS_DASHBOARD_MIN_ROWS, Math.round(rows)))
+}
+
+/** The layout that describes the page exactly as it ships, before any dragging. */
+export function defaultStatusDashboardLayout(specs: readonly StatusDashboardCardSpec[]): StatusDashboardLayout {
+  return {
+    version: STATUS_DASHBOARD_LAYOUT_VERSION,
+    cards: specs.map((spec) => ({ id: spec.id, zone: spec.zone }))
+  }
+}
+
+/**
+ * Parse a stored layout defensively. Anything we cannot fully trust — bad JSON,
+ * a different version, a non-array `cards`, an entry without a string id —
+ * returns undefined so the caller falls back to the default. A corrupt value in
+ * localStorage must never be able to white-screen the Status page.
+ */
+export function parseStoredStatusDashboardLayout(raw: string | null): StatusDashboardLayout | undefined {
+  if (!raw) {
+    return undefined
+  }
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(raw)
+  } catch {
+    return undefined
+  }
+  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    return undefined
+  }
+  const candidate = parsed as { version?: unknown; cards?: unknown }
+  if (candidate.version !== STATUS_DASHBOARD_LAYOUT_VERSION) {
+    return undefined
+  }
+  if (!Array.isArray(candidate.cards)) {
+    return undefined
+  }
+  const cards: StatusDashboardPlacement[] = []
+  const seen = new Set<string>()
+  for (const entry of candidate.cards) {
+    if (!entry || typeof entry !== 'object') {
+      continue
+    }
+    const record = entry as { id?: unknown; zone?: unknown; heightRows?: unknown }
+    if (typeof record.id !== 'string' || record.id.length === 0 || seen.has(record.id)) {
+      continue
+    }
+    seen.add(record.id)
+    const placement: StatusDashboardPlacement = {
+      id: record.id,
+      // An unknown zone (a zone we removed in a later release) is not fatal:
+      // the reconcile pass below puts the card back where it belongs.
+      zone: isStatusDashboardZoneId(record.zone) ? record.zone : 'sensors'
+    }
+    if (typeof record.heightRows === 'number' && Number.isFinite(record.heightRows)) {
+      placement.heightRows = clampHeightRows(record.heightRows)
+    }
+    cards.push(placement)
+  }
+  return { version: STATUS_DASHBOARD_LAYOUT_VERSION, cards }
+}
+
+/**
+ * Reconcile a (possibly stale) layout against the cards that actually exist
+ * right now.
+ *
+ * This is the conditional-card contract. The rangefinder and optical-flow cards
+ * only exist when the sensor is configured, so a saved layout routinely names
+ * cards that are gone, and routinely lacks cards that just appeared:
+ *
+ *  - a placement for a card that is NOT present is dropped;
+ *  - a present card with NO placement is inserted at its DEFAULT position,
+ *    immediately after the nearest earlier default-neighbour that the operator
+ *    still has on screen — so a rangefinder card that appears mid-session lands
+ *    beside GPS in the sensor row where it belongs, not orphaned at the bottom
+ *    of a zone.
+ *
+ * The result always contains exactly the present cards, exactly once.
+ */
+export function reconcileStatusDashboardLayout(
+  layout: StatusDashboardLayout | undefined,
+  specs: readonly StatusDashboardCardSpec[]
+): StatusDashboardLayout {
+  if (!layout) {
+    return defaultStatusDashboardLayout(specs)
+  }
+  const specById = new Map(specs.map((spec) => [spec.id, spec]))
+  const cards = layout.cards.filter((placement) => specById.has(placement.id))
+  const placed = new Set(cards.map((placement) => placement.id))
+
+  for (const [index, spec] of specs.entries()) {
+    if (placed.has(spec.id)) {
+      continue
+    }
+    // Find the nearest earlier card in DEFAULT order that survived, and land
+    // directly after it. Falls back to the end of the list.
+    let insertAt = cards.length
+    for (let back = index - 1; back >= 0; back -= 1) {
+      const anchor = specs[back]
+      if (!anchor) {
+        continue
+      }
+      const anchorIndex = cards.findIndex((placement) => placement.id === anchor.id)
+      if (anchorIndex >= 0) {
+        insertAt = anchorIndex + 1
+        break
+      }
+    }
+    cards.splice(insertAt, 0, { id: spec.id, zone: spec.zone })
+    placed.add(spec.id)
+  }
+
+  return { version: STATUS_DASHBOARD_LAYOUT_VERSION, cards }
+}
+
+/** The ids in one zone, in render order. */
+export function zoneCardIds(layout: StatusDashboardLayout, zone: StatusDashboardZoneId): string[] {
+  return layout.cards.filter((placement) => placement.zone === zone).map((placement) => placement.id)
+}
+
+export function findPlacement(
+  layout: StatusDashboardLayout,
+  id: string
+): StatusDashboardPlacement | undefined {
+  return layout.cards.find((placement) => placement.id === id)
+}
+
+/**
+ * Move `id` into `zone` at `index` (index counted within that zone, after the
+ * card has been removed). Returns the same object when nothing would change, so
+ * callers can skip a re-render and a localStorage write.
+ */
+export function moveStatusDashboardCard(
+  layout: StatusDashboardLayout,
+  id: string,
+  zone: StatusDashboardZoneId,
+  index: number
+): StatusDashboardLayout {
+  const moving = findPlacement(layout, id)
+  if (!moving) {
+    return layout
+  }
+  const rest = layout.cards.filter((placement) => placement.id !== id)
+  const zoneIds = rest.filter((placement) => placement.zone === zone)
+  const clampedIndex = Math.min(Math.max(index, 0), zoneIds.length)
+
+  if (moving.zone === zone) {
+    const currentIndex = zoneCardIds(layout, zone).indexOf(id)
+    if (currentIndex === clampedIndex) {
+      return layout
+    }
+  }
+
+  const next: StatusDashboardPlacement[] = []
+  let zoneSeen = 0
+  let inserted = false
+  const relocated: StatusDashboardPlacement = { ...moving, zone }
+
+  for (const placement of rest) {
+    if (placement.zone === zone) {
+      if (zoneSeen === clampedIndex && !inserted) {
+        next.push(relocated)
+        inserted = true
+      }
+      zoneSeen += 1
+    }
+    next.push(placement)
+  }
+  if (!inserted) {
+    next.push(relocated)
+  }
+  return { version: layout.version, cards: next }
+}
+
+/** Step a card one slot earlier/later inside its own zone. The keyboard path. */
+export function nudgeStatusDashboardCard(
+  layout: StatusDashboardLayout,
+  id: string,
+  delta: -1 | 1
+): StatusDashboardLayout {
+  const placement = findPlacement(layout, id)
+  if (!placement) {
+    return layout
+  }
+  const index = zoneCardIds(layout, placement.zone).indexOf(id)
+  return moveStatusDashboardCard(layout, id, placement.zone, index + delta)
+}
+
+/** Move a card to the neighbouring zone, keeping roughly its vertical slot. */
+export function shiftStatusDashboardCardZone(
+  layout: StatusDashboardLayout,
+  id: string,
+  delta: -1 | 1
+): StatusDashboardLayout {
+  const placement = findPlacement(layout, id)
+  if (!placement) {
+    return layout
+  }
+  const zoneIndex = STATUS_DASHBOARD_ZONE_IDS.indexOf(placement.zone)
+  const targetZone = STATUS_DASHBOARD_ZONE_IDS[zoneIndex + delta]
+  if (!targetZone) {
+    return layout
+  }
+  const index = zoneCardIds(layout, placement.zone).indexOf(id)
+  return moveStatusDashboardCard(layout, id, targetZone, index)
+}
+
+/** Set (or, with undefined, clear) a card's height cap. Always snapped+clamped. */
+export function resizeStatusDashboardCard(
+  layout: StatusDashboardLayout,
+  id: string,
+  heightRows: number | undefined
+): StatusDashboardLayout {
+  const placement = findPlacement(layout, id)
+  if (!placement) {
+    return layout
+  }
+  const next = heightRows === undefined ? undefined : clampHeightRows(heightRows)
+  if (placement.heightRows === next) {
+    return layout
+  }
+  return {
+    version: layout.version,
+    cards: layout.cards.map((entry) =>
+      entry.id === id ? (next === undefined ? { id: entry.id, zone: entry.zone } : { ...entry, heightRows: next }) : entry
+    )
+  }
+}
+
+/** True when the layout is the shipped default — used to hide "Reset layout". */
+export function isDefaultStatusDashboardLayout(
+  layout: StatusDashboardLayout,
+  specs: readonly StatusDashboardCardSpec[]
+): boolean {
+  if (layout.cards.length !== specs.length) {
+    return false
+  }
+  return layout.cards.every((placement, index) => {
+    const spec = specs[index]
+    return (
+      spec !== undefined &&
+      spec.id === placement.id &&
+      spec.zone === placement.zone &&
+      placement.heightRows === undefined
+    )
+  })
+}

--- a/apps/web/src/views/StatusDashboard.tsx
+++ b/apps/web/src/views/StatusDashboard.tsx
@@ -1,0 +1,409 @@
+// The drag-and-resize chrome for the Status & Info page.
+//
+// This is chrome ONLY. Every card it renders is passed in already built by
+// App.tsx and is handed through untouched — no card knows it lives in a
+// dashboard, so the sensor-availability gate, the telemetry requests and every
+// value on the page behave exactly as they did before.
+//
+// LIBRARY vs HAND-ROLLED. react-grid-layout (MIT, which is GPL-3.0 compatible,
+// so licensing was not the deciding factor) solves free 2-D placement by
+// absolutely positioning every card at an explicit pixel size. That is the
+// wrong shape for this page twice over: the Status cards are natural-height
+// (a pre-arm card grows with the number of issues), and free placement is
+// exactly what lets a user produce the broken-looking, hole-riddled page we
+// have to avoid. The model here — named zones, order within a zone, optional
+// height cap — cannot overlap, cannot leave a hole, needs no collision solver,
+// and is ~250 lines of pointer handling. So: hand-rolled, no dependency added.
+//
+// Pointer events, not HTML5 drag-and-drop: HTML5 DnD has no touch story, no
+// keyboard story, and drags a browser-drawn ghost we cannot style.
+
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type KeyboardEvent as ReactKeyboardEvent,
+  type PointerEvent as ReactPointerEvent,
+  type ReactElement,
+  type ReactNode
+} from 'react'
+
+import type { StatusDashboardLayoutController } from '../hooks/use-status-dashboard-layout'
+import {
+  STATUS_DASHBOARD_MIN_ROWS,
+  STATUS_DASHBOARD_ROW_PX,
+  STATUS_DASHBOARD_ZONE_LABELS,
+  findPlacement,
+  isStatusDashboardZoneId,
+  zoneCardIds,
+  type StatusDashboardZoneId
+} from '../view-models/status-dashboard-layout'
+
+/** One card as the dashboard sees it: an id, a name for screen readers, a node. */
+export interface StatusDashboardCardEntry {
+  id: string
+  label: string
+  node: ReactNode
+}
+
+interface DragState {
+  id: string
+  pointerId: number
+  zone: StatusDashboardZoneId
+  index: number
+}
+
+interface DashboardContextValue {
+  controller: StatusDashboardLayoutController
+  cardsById: Map<string, StatusDashboardCardEntry>
+  drag: DragState | undefined
+  beginDrag: (id: string, pointerId: number, zone: StatusDashboardZoneId, index: number) => void
+  resizePreview: { id: string; rows: number } | undefined
+  setResizePreview: (preview: { id: string; rows: number } | undefined) => void
+}
+
+const DashboardContext = createContext<DashboardContextValue | undefined>(undefined)
+
+export interface StatusDashboardProviderProps {
+  controller: StatusDashboardLayoutController
+  cards: readonly StatusDashboardCardEntry[]
+  children: ReactNode
+}
+
+export function StatusDashboardProvider({
+  controller,
+  cards,
+  children
+}: StatusDashboardProviderProps): ReactElement {
+  const [drag, setDrag] = useState<DragState | undefined>(undefined)
+  const [resizePreview, setResizePreview] = useState<{ id: string; rows: number } | undefined>(undefined)
+  const cardsById = useMemo(() => new Map(cards.map((card) => [card.id, card])), [cards])
+
+  const { moveCard } = controller
+  const layout = controller.layout
+
+  // Start with the card's own slot as the "drop target" so nothing jumps before
+  // the pointer has actually moved anywhere.
+  const beginDrag = useCallback(
+    (id: string, pointerId: number, zone: StatusDashboardZoneId, index: number) => {
+      setDrag({ id, pointerId, zone, index })
+    },
+    []
+  )
+
+  // Resolve where the pointer currently is: which zone, and which slot in it.
+  // Computed against the zone list with the dragged card already removed, so
+  // the index we hand to `moveCard` is the final index.
+  const resolveDropTarget = useCallback(
+    (id: string, clientX: number, clientY: number): { zone: StatusDashboardZoneId; index: number } | undefined => {
+      const element = document.elementFromPoint(clientX, clientY)
+      if (!element) {
+        return undefined
+      }
+      const zoneElement = element.closest('[data-status-dash-zone]')
+      const zoneId = zoneElement?.getAttribute('data-status-dash-zone')
+      if (!isStatusDashboardZoneId(zoneId)) {
+        return undefined
+      }
+      const remaining = zoneCardIds(layout, zoneId).filter((cardId) => cardId !== id)
+      const cardElement = element.closest('[data-status-dash-card]')
+      const cardId = cardElement?.getAttribute('data-status-dash-card')
+      if (cardElement && cardId && cardId !== id) {
+        const position = remaining.indexOf(cardId)
+        if (position >= 0) {
+          const rect = cardElement.getBoundingClientRect()
+          return { zone: zoneId, index: clientY < rect.top + rect.height / 2 ? position : position + 1 }
+        }
+      }
+      // Empty space in the zone: land at the end (or the start, if the pointer
+      // is above every card in it).
+      const firstCard = zoneElement?.querySelector('[data-status-dash-card]')
+      if (firstCard && clientY < firstCard.getBoundingClientRect().top) {
+        return { zone: zoneId, index: 0 }
+      }
+      return { zone: zoneId, index: remaining.length }
+    },
+    [layout]
+  )
+
+  useEffect(() => {
+    if (!drag) {
+      return
+    }
+    const onMove = (event: PointerEvent): void => {
+      if (event.pointerId !== drag.pointerId) {
+        return
+      }
+      event.preventDefault()
+      const target = resolveDropTarget(drag.id, event.clientX, event.clientY)
+      if (!target) {
+        return
+      }
+      setDrag((current) =>
+        current && (current.zone !== target.zone || current.index !== target.index)
+          ? { ...current, ...target }
+          : current
+      )
+    }
+    const onUp = (event: PointerEvent): void => {
+      if (event.pointerId !== drag.pointerId) {
+        return
+      }
+      // Commit the slot the operator was LAST SHOWN, not a fresh hit-test of the
+      // release coordinates. Re-resolving here looks equivalent and is not: the
+      // drop indicator is a real element, so inserting it reflows the target
+      // zone and pushes the cards below it down — measured at 56px dropping GPS
+      // onto Pre-arm. That slides the zone the pointer is over out from under a
+      // pointer that never moved, and the release then hit-tests a DIFFERENT
+      // zone than the indicator was promising. The card landed back in the
+      // sensor row while the line said column 1.
+      //
+      // `drag` is the state that rendered the indicator (the effect re-subscribes
+      // whenever it changes), so honouring it makes the drop land exactly where
+      // the line was. A drag that never moved still carries the card's own slot
+      // from `beginDrag`, which `moveStatusDashboardCard` recognises as a no-op.
+      moveCard(drag.id, drag.zone, drag.index)
+      setDrag(undefined)
+    }
+    const onCancel = (): void => setDrag(undefined)
+    const onKey = (event: KeyboardEvent): void => {
+      if (event.key === 'Escape') {
+        setDrag(undefined)
+      }
+    }
+    window.addEventListener('pointermove', onMove, { passive: false })
+    window.addEventListener('pointerup', onUp)
+    window.addEventListener('pointercancel', onCancel)
+    window.addEventListener('keydown', onKey)
+    document.body.classList.add('is-status-dash-dragging')
+    return () => {
+      window.removeEventListener('pointermove', onMove)
+      window.removeEventListener('pointerup', onUp)
+      window.removeEventListener('pointercancel', onCancel)
+      window.removeEventListener('keydown', onKey)
+      document.body.classList.remove('is-status-dash-dragging')
+    }
+  }, [drag, moveCard, resolveDropTarget])
+
+  const value = useMemo<DashboardContextValue>(
+    () => ({ controller, cardsById, drag, beginDrag, resizePreview, setResizePreview }),
+    [controller, cardsById, drag, beginDrag, resizePreview]
+  )
+
+  return <DashboardContext.Provider value={value}>{children}</DashboardContext.Provider>
+}
+
+export interface StatusDashboardZoneProps {
+  zone: StatusDashboardZoneId
+  /** The existing container class, so the zone keeps the layout it always had. */
+  className: string
+  /**
+   * The container's existing `data-testid`, where it had one. A zone replaces a
+   * plain `<div>` that tests already reach for by name — the sensor row is
+   * asserted on as `setup-sensor-group` — so the zone has to answer to that name
+   * rather than mint a new one and quietly break those tests.
+   */
+  testId?: string
+  children?: ReactNode
+}
+
+/**
+ * A drop zone. It renders whichever cards the layout currently assigns to it,
+ * in layout order, and keeps the class name the container always had — the
+ * default arrangement is therefore pixel-identical to the page without this
+ * feature.
+ */
+export function StatusDashboardZone({ zone, className, testId, children }: StatusDashboardZoneProps): ReactElement {
+  const context = useContext(DashboardContext)
+  if (!context) {
+    throw new Error('StatusDashboardZone must be rendered inside StatusDashboardProvider')
+  }
+  const { controller, cardsById, drag } = context
+  const ids = zoneCardIds(controller.layout, zone)
+  const isDropTarget = drag?.zone === zone
+
+  // The dragged card stays MOUNTED (ghosted) rather than being pulled out of
+  // the tree: several cards own expensive children — the GPS card hosts a
+  // Leaflet map — and unmounting them mid-drag would tear the map down and
+  // rebuild it on every drop. `slot` counts only the cards that are not being
+  // dragged, which is the index space `moveCard` expects.
+  const rendered: ReactNode[] = []
+  let slot = 0
+  for (const id of ids) {
+    const dragged = drag?.id === id
+    if (!dragged) {
+      if (isDropTarget && drag && drag.index === slot) {
+        rendered.push(<div key={`drop:${slot}`} className="status-dash-drop" aria-hidden="true" />)
+      }
+      slot += 1
+    }
+    const card = cardsById.get(id)
+    if (card) {
+      rendered.push(<StatusDashboardCard key={id} entry={card} zone={zone} index={ids.indexOf(id)} />)
+    }
+  }
+  if (isDropTarget && drag && drag.index >= slot) {
+    rendered.push(<div key="drop:end" className="status-dash-drop" aria-hidden="true" />)
+  }
+
+  return (
+    <div
+      className={`${className} status-dash-zone${
+        controller.customisable ? ' status-dash-zone--live' : ''
+      }${drag ? ' status-dash-zone--armed' : ''}${isDropTarget ? ' is-drop-target' : ''}`}
+      data-status-dash-zone={zone}
+      data-testid={testId ?? `status-dash-zone-${zone}`}
+    >
+      {rendered}
+      {children}
+    </div>
+  )
+}
+
+interface StatusDashboardCardProps {
+  entry: StatusDashboardCardEntry
+  zone: StatusDashboardZoneId
+  index: number
+}
+
+function StatusDashboardCard({ entry, zone, index }: StatusDashboardCardProps): ReactElement {
+  const context = useContext(DashboardContext)
+  if (!context) {
+    throw new Error('StatusDashboardCard must be rendered inside StatusDashboardProvider')
+  }
+  const { controller, drag, beginDrag, resizePreview, setResizePreview } = context
+  const { customisable } = controller
+  const contentRef = useRef<HTMLDivElement | null>(null)
+  const resizeStart = useRef<{ pointerId: number; y: number; rows: number } | undefined>(undefined)
+
+  const placement = findPlacement(controller.layout, entry.id)
+  const previewRows = resizePreview?.id === entry.id ? resizePreview.rows : undefined
+  const rows = previewRows ?? placement?.heightRows
+  const isDragging = drag?.id === entry.id
+
+  const onResizePointerDown = (event: ReactPointerEvent<HTMLButtonElement>): void => {
+    event.preventDefault()
+    const measured = contentRef.current?.getBoundingClientRect().height ?? 0
+    resizeStart.current = {
+      pointerId: event.pointerId,
+      y: event.clientY,
+      rows: rows ?? Math.max(STATUS_DASHBOARD_MIN_ROWS, Math.round(measured / STATUS_DASHBOARD_ROW_PX))
+    }
+    try {
+      event.currentTarget.setPointerCapture(event.pointerId)
+    } catch {
+      // Some input paths (synthetic events, exotic pointer devices) refuse
+      // capture. The resize still tracks; it just stops if the pointer leaves.
+    }
+    setResizePreview({ id: entry.id, rows: resizeStart.current.rows })
+  }
+
+  const onResizePointerMove = (event: ReactPointerEvent<HTMLButtonElement>): void => {
+    const start = resizeStart.current
+    if (!start || start.pointerId !== event.pointerId) {
+      return
+    }
+    const next = start.rows + (event.clientY - start.y) / STATUS_DASHBOARD_ROW_PX
+    setResizePreview({ id: entry.id, rows: Math.round(next) })
+  }
+
+  const endResize = (event: ReactPointerEvent<HTMLButtonElement>): void => {
+    const start = resizeStart.current
+    if (!start || start.pointerId !== event.pointerId) {
+      return
+    }
+    resizeStart.current = undefined
+    const committed = resizePreview?.id === entry.id ? resizePreview.rows : start.rows
+    setResizePreview(undefined)
+    controller.resizeCard(entry.id, committed)
+  }
+
+  const onHandleKeyDown = (event: ReactKeyboardEvent<HTMLButtonElement>): void => {
+    // The keyboard path. Drag-only reordering is unusable without a pointer, so
+    // the handle is a real button: up/down reorders inside the column, left/
+    // right walks the card across columns.
+    const handled = ['ArrowUp', 'ArrowDown', 'ArrowLeft', 'ArrowRight'].includes(event.key)
+    if (!handled) {
+      return
+    }
+    event.preventDefault()
+    if (event.key === 'ArrowUp') {
+      controller.nudgeCard(entry.id, -1)
+    } else if (event.key === 'ArrowDown') {
+      controller.nudgeCard(entry.id, 1)
+    } else if (event.key === 'ArrowLeft') {
+      controller.shiftCardZone(entry.id, -1)
+    } else {
+      controller.shiftCardZone(entry.id, 1)
+    }
+  }
+
+  const onResizeKeyDown = (event: ReactKeyboardEvent<HTMLButtonElement>): void => {
+    if (event.key === 'ArrowUp' || event.key === 'ArrowDown') {
+      event.preventDefault()
+      const measured = contentRef.current?.getBoundingClientRect().height ?? 0
+      const current = rows ?? Math.round(measured / STATUS_DASHBOARD_ROW_PX)
+      controller.resizeCard(entry.id, current + (event.key === 'ArrowUp' ? -1 : 1))
+    } else if (event.key === 'Escape' || event.key === 'Backspace' || event.key === 'Delete') {
+      event.preventDefault()
+      controller.resizeCard(entry.id, undefined)
+    }
+  }
+
+  const style = rows === undefined ? undefined : { ['--status-dash-height' as string]: `${rows * STATUS_DASHBOARD_ROW_PX}px` }
+
+  return (
+    <div
+      className={`status-dash-card${isDragging ? ' is-dragging' : ''}${
+        rows === undefined ? '' : ' is-capped'
+      }`}
+      data-status-dash-card={entry.id}
+      data-testid={`status-dash-card-${entry.id}`}
+      style={style}
+    >
+      <div className="status-dash-card__content" ref={contentRef}>
+        {entry.node}
+      </div>
+      {customisable ? (
+        <>
+          <button
+            type="button"
+            className="status-dash-card__handle"
+            data-testid={`status-dash-handle-${entry.id}`}
+            aria-label={`Move ${entry.label} card. Currently in ${STATUS_DASHBOARD_ZONE_LABELS[zone]}. Drag, or use the arrow keys to move it up, down, left or right.`}
+            title={`Drag to move ${entry.label} — or focus and use the arrow keys`}
+            onPointerDown={(event) => {
+              if (event.button !== 0) {
+                return
+              }
+              event.preventDefault()
+              beginDrag(entry.id, event.pointerId, zone, index)
+            }}
+            onKeyDown={onHandleKeyDown}
+          >
+            <span aria-hidden="true">⠿</span>
+          </button>
+          <button
+            type="button"
+            className="status-dash-card__resize"
+            data-testid={`status-dash-resize-${entry.id}`}
+            aria-label={`Resize ${entry.label} card height. Drag, use the up and down arrow keys, or press Escape to fit the content.`}
+            title="Drag to set the card height — double-click to fit the content"
+            onPointerDown={onResizePointerDown}
+            onPointerMove={onResizePointerMove}
+            onPointerUp={endResize}
+            onPointerCancel={endResize}
+            onDoubleClick={() => controller.resizeCard(entry.id, undefined)}
+            onKeyDown={onResizeKeyDown}
+          >
+            <span aria-hidden="true" />
+          </button>
+        </>
+      ) : null}
+    </div>
+  )
+}

--- a/tests/e2e/views.spec.ts
+++ b/tests/e2e/views.spec.ts
@@ -5057,3 +5057,145 @@ test.describe('Status & Info advanced sensor cards', () => {
     expect(overflow).toBeLessThanOrEqual(2)
   })
 })
+
+test.describe('Status & Info dashboard layout', () => {
+  // The ask: "can we just make all the various boxes click and drag and
+  // resizable so users can click and drag them around how they want it?"
+  //
+  // The mechanism is chrome AROUND the existing cards — no card content, gate
+  // or telemetry changed — so these tests assert ARRANGEMENT: where a card
+  // sits, that a move sticks, that a reload keeps it, that Reset puts it back,
+  // and that a stale saved arrangement can never render a broken page.
+
+  const STORAGE_KEY = 'arduconfig.status-dashboard.v1'
+
+  async function connectDemo(page: Page): Promise<void> {
+    await page.goto('/')
+    await page.getByTestId('transport-mode-select').selectOption('demo')
+    await page.getByTestId('connect-button').click()
+    await expect(page.getByTestId('session-vehicle-name')).toHaveText('ArduCopter', { timeout: VEHICLE_CONNECT_TIMEOUT })
+    await expect(page.getByTestId('status-dash-card-system-info')).toBeVisible({ timeout: VEHICLE_CONNECT_TIMEOUT })
+  }
+
+  async function zoneIds(page: Page, zone: string): Promise<string[]> {
+    return page.$$eval(`[data-status-dash-zone="${zone}"] [data-status-dash-card]`, (nodes) =>
+      nodes.map((node) => node.getAttribute('data-status-dash-card') ?? '')
+    )
+  }
+
+  test('ships the familiar arrangement, with no Reset offered until something moves', async ({ page }) => {
+    // "Familiar" is the whole acceptance test: with nothing dragged the page has
+    // to be the page that shipped — the sensor row under the craft model, the
+    // two status columns below it, System Info leading the sidebar.
+    await connectDemo(page)
+    // Poll: the two advanced sensor cards appear only once RNGFND1_TYPE /
+    // FLOW_TYPE have arrived, which is later than the unconditional cards.
+    await expect.poll(() => zoneIds(page, 'sensors')).toEqual(['gps', 'rangefinder', 'optical-flow'])
+    expect(await zoneIds(page, 'midcol')).toEqual(['prearm', 'statistics'])
+    expect(await zoneIds(page, 'noticecol')).toEqual(['notices'])
+    expect(await zoneIds(page, 'sidebar')).toEqual(['system-info', 'instruments', 'guided-setup'])
+    // Reset only appears once there is something to reset — an always-on
+    // "Reset Layout" on a page nobody has customised is just noise.
+    await expect(page.getByTestId('status-dash-reset-layout')).toHaveCount(0)
+  })
+
+  test('a card can be moved with the keyboard alone, and Reset puts it back', async ({ page }) => {
+    // Drag-only reordering is inaccessible, so the handle is a real button:
+    // left/right walk the card between columns, up/down reorder within one.
+    await connectDemo(page)
+    await page.getByTestId('status-dash-handle-guided-setup').focus()
+    await page.keyboard.press('ArrowLeft')
+    await expect.poll(() => zoneIds(page, 'noticecol')).toEqual(['notices', 'guided-setup'])
+    expect(await zoneIds(page, 'sidebar')).toEqual(['system-info', 'instruments'])
+
+    // The move is saved, so it survives a reload.
+    await page.reload()
+    await page.getByTestId('connect-button').click()
+    await expect(page.getByTestId('session-vehicle-name')).toHaveText('ArduCopter', { timeout: VEHICLE_CONNECT_TIMEOUT })
+    await expect(page.getByTestId('status-dash-card-guided-setup')).toBeVisible({ timeout: VEHICLE_CONNECT_TIMEOUT })
+    expect(await zoneIds(page, 'noticecol')).toEqual(['notices', 'guided-setup'])
+
+    await page.getByTestId('status-dash-reset-layout').click()
+    await expect.poll(() => zoneIds(page, 'sidebar')).toEqual(['system-info', 'instruments', 'guided-setup'])
+    await expect(page.getByTestId('status-dash-reset-layout')).toHaveCount(0)
+    // Reset CLEARS the saved arrangement rather than saving a copy of today's
+    // default, so a later default change still reaches the operator.
+    expect(await page.evaluate((key) => window.localStorage.getItem(key), STORAGE_KEY)).toBeNull()
+  })
+
+  test('a card height cap is applied and saved', async ({ page }) => {
+    await connectDemo(page)
+    const card = page.getByTestId('status-dash-card-system-info')
+    const before = (await card.boundingBox())?.height ?? 0
+    expect(before).toBeGreaterThan(150)
+
+    // Each press is one 24px row, so the shrink is deterministic.
+    await page.getByTestId('status-dash-resize-system-info').focus()
+    await page.keyboard.press('ArrowUp')
+    await page.keyboard.press('ArrowUp')
+    await page.keyboard.press('ArrowUp')
+    await expect(card).toHaveClass(/is-capped/)
+    expect((await card.boundingBox())?.height ?? 0).toBeLessThan(before)
+
+    expect(await page.evaluate((key) => window.localStorage.getItem(key), STORAGE_KEY)).toContain('heightRows')
+  })
+
+  test('a layout saved with the sensor cards present degrades when they are gone', async ({ page }) => {
+    // The most likely source of a broken-looking page: the rangefinder and
+    // optical-flow cards only exist when the sensor is configured, so a saved
+    // arrangement routinely names cards that are not there.
+    await connectDemo(page)
+    await expect.poll(() => zoneIds(page, 'sensors')).toEqual(['gps', 'rangefinder', 'optical-flow'])
+    await page.getByTestId('status-dash-handle-rangefinder').focus()
+    await page.keyboard.press('ArrowRight')
+    await expect.poll(() => zoneIds(page, 'midcol')).toContain('rangefinder')
+
+    await page.goto('/?demoParamOverrides=RNGFND1_TYPE:0,FLOW_TYPE:0')
+    await page.getByTestId('connect-button').click()
+    await expect(page.getByTestId('session-vehicle-name')).toHaveText('ArduCopter', { timeout: VEHICLE_CONNECT_TIMEOUT })
+    await expect(page.getByTestId('status-dash-card-system-info')).toBeVisible({ timeout: VEHICLE_CONNECT_TIMEOUT })
+
+    // The absent cards are simply not placed; every card that IS present is.
+    expect(await zoneIds(page, 'sensors')).toEqual(['gps'])
+    expect(await zoneIds(page, 'midcol')).toEqual(['prearm', 'statistics'])
+    expect(await zoneIds(page, 'sidebar')).toEqual(['system-info', 'instruments', 'guided-setup'])
+  })
+
+  test('an unreadable saved layout falls back to the default silently', async ({ page }) => {
+    await page.goto('/')
+    await page.evaluate(
+      ([key, value]) => window.localStorage.setItem(key, value),
+      [STORAGE_KEY, '{"version":1,"cards":[{"id":"gho'] as const
+    )
+    await page.getByTestId('transport-mode-select').selectOption('demo')
+    await page.getByTestId('connect-button').click()
+    await expect(page.getByTestId('session-vehicle-name')).toHaveText('ArduCopter', { timeout: VEHICLE_CONNECT_TIMEOUT })
+    await expect(page.getByTestId('status-dash-card-system-info')).toBeVisible({ timeout: VEHICLE_CONNECT_TIMEOUT })
+    expect(await zoneIds(page, 'sidebar')).toEqual(['system-info', 'instruments', 'guided-setup'])
+  })
+
+  test('phone width drops the drag affordances and keeps the default order', async ({ page }) => {
+    // Dragging a card on a phone fights the scroll gesture, and a four-zone
+    // arrangement means nothing in a single column. Below the breakpoint the
+    // controls are gone and a saved arrangement is ignored.
+    await page.setViewportSize({ width: 390, height: 844 })
+    await page.goto('/')
+    await page.evaluate(
+      ([key, value]) => window.localStorage.setItem(key, value),
+      [STORAGE_KEY, JSON.stringify({ version: 1, cards: [{ id: 'gps', zone: 'sidebar', heightRows: 6 }] })] as const
+    )
+    await page.getByTestId('transport-mode-select').selectOption('demo')
+    await page.getByTestId('connect-button').click()
+    await expect(page.getByTestId('session-vehicle-name')).toHaveText('ArduCopter', { timeout: VEHICLE_CONNECT_TIMEOUT })
+    await expect(page.getByTestId('status-dash-card-system-info')).toBeVisible({ timeout: VEHICLE_CONNECT_TIMEOUT })
+
+    await expect(page.getByTestId('status-dash-toolbar')).toHaveCount(0)
+    await expect(page.locator('.status-dash-card__handle')).toHaveCount(0)
+    expect(await zoneIds(page, 'sidebar')).toEqual(['system-info', 'instruments', 'guided-setup'])
+
+    const overflow = await page.evaluate(
+      () => document.documentElement.scrollWidth - document.documentElement.clientWidth
+    )
+    expect(overflow).toBeLessThanOrEqual(2)
+  })
+})


### PR DESCRIPTION
> "for the status page, can we just make all the various boxes click and drag and resizable so users can click and drag them around how they want it?"

Cards on Status & Info can now be dragged between and within columns, and resized vertically. The arrangement persists per browser, with a Reset.

## The design decision

**Hand-rolled, no dependency.** react-grid-layout was the obvious candidate and its **MIT licence is GPL-3.0 compatible**, so licensing did not decide it — its *data model* did.

It solves free 2-D placement by absolutely positioning every card at an explicit pixel size. That is wrong here twice over: these cards are **natural-height** (the pre-arm card grows with the issue count, System Info grows when a firmware git hash exists), so a fixed pixel height either clips content or leaves dead space. And free 2-D placement is exactly what lets a user produce a page full of holes.

So the model is deliberately **smaller than a grid**: a card lives in one of four named **zones** (the three status columns + the sidebar), at an index in that zone, with an optional height cap. No overlap, no holes, no collision solver — a pure layout model plus pointer/keyboard handling.

**Resize is vertical only**, snapped to 24 px rows. **Width is a property of the zone, not the card** — moving a card between columns *is* the horizontal resize. That is a deliberate limitation, and it is why nothing can end up wider than the page or narrower than its content. Per-card column spans would need the flat-grid model rejected above.

## Additive — the default is untouched

Card JSX moved verbatim into a card list; the existing containers became zones keeping their class names. **With nothing dragged, the page renders exactly as it does today** — the shipped layout from #161 (sensor row, System Info in the sidebar) is the default arrangement.

Structure follows the repo's layering: a pure `view-models/status-dashboard-layout.ts` with a co-located test, `hooks/use-status-dashboard-layout.ts`, and `views/StatusDashboard.tsx`.

## Persistence, conditional cards, mobile, a11y

- `localStorage`, key `arduconfig.status-dashboard.v1` — version in the key, matching `arduconfig.can-node-names.v1`. Bad JSON, wrong version, junk entries, unknown zone, out-of-range height all fall back silently to the default. **Reset clears the key** rather than saving a copy of today's default.
- **Conditional cards reconciled every render**: absent ones dropped, newly-present ones inserted after their nearest surviving default neighbour. This is the classic way a customisable dashboard breaks — a layout saved with the flow card present, loaded on a board without it.
- Below 1025 px (where the workspace already collapses to one column): no handles, no toolbar, stored layout ignored, default order.
- Handles are real labelled buttons — arrows move up/down within a column and left/right between columns; the resize grip takes up/down plus Escape-to-fit. Not pointer-only.

## Verified by driving it

Interactive Chrome plus a headless run against the demo runtime: dragged GPS out of the sidebar into column 2 (drop indicator mid-drag, source ghosted, persisted); resized System Info 354 → 178 px by dragging and by keyboard; reloaded into a fresh session and got the arrangement and height cap back; Reset restored the shipped layout with the stored value `null`; the same saved layout with `?demoParamOverrides=RNGFND1_TYPE:0,FLOW_TYPE:0` degraded to System Info alone with no errors and the stored value untouched so the cards return; truncated JSON and `version:99` both fell back to default; 390 px showed 0 handles, 0 toolbar, default order, **0 px horizontal overflow**.

## ArduCopter byte-identical

Chrome around existing cards. `buildAdvancedSensorCards`, `AdvancedSensorCard` and `LIVE_TELEMETRY_REQUESTS` are untouched, so the sensor availability gate and the configured-but-silent fault state are unchanged.

## Validation

- `npm run typecheck` — clean
- `npm run test` — 859 total, **855 pass / 0 fail** / 4 skipped
- `apps/web` vitest — **678 pass / 76 files**, including **17 new** unit tests for the layout model
- Six new Playwright cases added; the full e2e suite relies on CI (ports were contended locally)

## Known limits

- No per-card width span — the honest limit of the zone model.
- No touch drag, by design.