### PR TITLE
feat(peripherals): optical flow configuration section

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -305,6 +305,7 @@ import { TuningSubSection } from './sections/TuningSubSection'
 import { VtxSection } from './sections/VtxSection'
 import { PowerView, type PowerDraftItem, type PowerFieldSpec } from './views/Power'
 import { CanBusView } from './views/CanBus'
+import { CanEnablePrompt } from './views/CanEnablePrompt'
 import { NetworkingView, type NetworkingTab } from './views/NetworkingView'
 import { LuaScriptsView } from './views/LuaScripts'
 import { useLuaScripts } from './hooks/use-lua-scripts'
@@ -5741,6 +5742,23 @@ export function App() {
     readRoundedParameter(snapshot, 'CAN_D1_UC_NODE'),
     readRoundedParameter(snapshot, 'CAN_D2_UC_NODE')
   ].filter((id): id is number => typeof id === 'number' && id > 0)
+  // The SAME "enable CAN bus & reboot" offer the CAN tab makes, mirrored into
+  // Servos ▸ Peripherals — but ONLY when the optical-flow driver is what fired
+  // it (FLOW_TYPE = 6 / DroneCAN). A DroneCAN GPS is a real problem too, and the
+  // CAN tab still says so; it just isn't this card's business to interrupt with.
+  // Reason: a CAN sensor on a disabled bus reports absolutely nothing, so the
+  // operator is looking straight at the flow config wondering why it's dead —
+  // which is precisely where the one-click fix belongs.
+  const opticalFlowCanEnablePrompt =
+    canEnablement.needsEnable && canEnablement.triggerParamIds.includes('FLOW_TYPE') && runtime ? (
+      <CanEnablePrompt
+        triggerLabels={canEnablement.triggerLabels}
+        onEnable={() => { void handleEnableCanBus() }}
+        busy={busyAction === 'can:enable'}
+        testId="peripherals-can-enable-prompt"
+        buttonTestId="peripherals-can-enable-button"
+      />
+    ) : undefined
   // Popout windows live at App level so they survive a tab switch (see
   // use-can-device-popouts). They never touch CAN forwarding — the runtime's CAN
   // bus service keeps MAV_CMD_CAN_FORWARD re-armed for as long as the bus is
@@ -8293,7 +8311,8 @@ export function App() {
           relayGroups,
           relayDraftEntries,
           relayStagedDrafts,
-          relayInvalidDrafts
+          relayInvalidDrafts,
+          peripheralsCanEnableSlot: opticalFlowCanEnablePrompt
         }}
         handlers={{
           handleApplyScopedParameterDrafts,

--- a/apps/web/src/sections/OutputsSection.tsx
+++ b/apps/web/src/sections/OutputsSection.tsx
@@ -146,6 +146,15 @@ export interface OutputsSectionDerived {
   relayDraftEntries: ParameterDraftEntry[]
   relayStagedDrafts: ParameterDraftEntry[]
   relayInvalidDrafts: ParameterDraftEntry[]
+  /**
+   * Optional "enable the CAN bus for DroneCAN" offer rendered at the top of the
+   * Peripherals task, above the metadata sections. Supplied by App.tsx ONLY when
+   * a DroneCAN optical-flow sensor (FLOW_TYPE = 6) is selected while CAN bus 1
+   * is off — the trap that makes a correctly wired flow sensor look dead. A
+   * ReactNode slot (the established pattern for complex sub-surfaces here) so
+   * this section keeps no runtime wiring of its own.
+   */
+  peripheralsCanEnableSlot?: ReactNode
 }
 
 export interface OutputsSectionHandlers {
@@ -342,7 +351,8 @@ export function OutputsSection(props: OutputsSectionProps): ReactElement {
     relayGroups,
     relayDraftEntries,
     relayStagedDrafts,
-    relayInvalidDrafts
+    relayInvalidDrafts,
+    peripheralsCanEnableSlot
   } = derived
 
   const {
@@ -973,6 +983,10 @@ export function OutputsSection(props: OutputsSectionProps): ReactElement {
 
               {activeOutputTaskId === 'peripherals' ? (
                 <div className="outputs-task-panel outputs-task-panel--stack">
+                  {/* Sits ABOVE the cards: a DroneCAN sensor on a disabled bus
+                      reports nothing at all, so the fix has to be visible before
+                      the operator starts second-guessing the fields below it. */}
+                  {peripheralsCanEnableSlot}
                   {notificationLedTypesParameter || notificationLedLengthParameter || notificationLedBrightnessParameter || notificationLedOverrideParameter || notificationBuzzTypesParameter || notificationBuzzVolumeParameter ? (
                     <div className="scoped-review-card scoped-review-card--compact">
                       <div className="switch-exercise-card__header">

--- a/apps/web/src/view-models/can-enablement.test.ts
+++ b/apps/web/src/view-models/can-enablement.test.ts
@@ -53,6 +53,31 @@ describe('deriveCanEnablement', () => {
     expect(r.triggerLabels).toEqual(['GPS is set to DroneCAN', 'Battery monitor is set to DroneCAN'])
   })
 
+  // FLOW_TYPE 6 = DroneCAN (AP_OpticalFlow.h Type::UAVCAN). A CAN flow sensor on
+  // a disabled bus is silent in exactly the way a CAN GPS is, and this is the
+  // trigger the Servos ▸ Peripherals optical-flow section keys its own copy of
+  // the prompt off — hence the triggerParamIds assertions.
+  it('triggers on a DroneCAN optical flow sensor', () => {
+    const r = deriveCanEnablement(snap({ FLOW_TYPE: 6, CAN_P1_DRIVER: 0, CAN_D1_PROTOCOL: 0 }))
+    expect(r.needsEnable).toBe(true)
+    expect(r.triggerLabels).toEqual(['Optical flow is set to DroneCAN'])
+    expect(r.triggerParamIds).toEqual(['FLOW_TYPE'])
+  })
+
+  it('does not trigger on a directly-wired flow sensor', () => {
+    // 4 = CXOF (serial), not a CAN device — nothing to enable.
+    const r = deriveCanEnablement(snap({ FLOW_TYPE: 4, CAN_P1_DRIVER: 0, CAN_D1_PROTOCOL: 0 }))
+    expect(r.needsEnable).toBe(false)
+    expect(r.triggerParamIds).toEqual([])
+  })
+
+  it('reports which drivers fired so a scoped surface can filter the prompt', () => {
+    const r = deriveCanEnablement(snap({ GPS_TYPE: 9, FLOW_TYPE: 6, CAN_P1_DRIVER: 0, CAN_D1_PROTOCOL: 0 }))
+    expect(r.triggerParamIds).toEqual(['GPS_TYPE', 'FLOW_TYPE'])
+    // A GPS-only trigger must NOT light up the optical-flow section.
+    expect(deriveCanEnablement(snap({ GPS_TYPE: 9, CAN_P1_DRIVER: 0 })).triggerParamIds).toEqual(['GPS_TYPE'])
+  })
+
   it('handles a missing CAN_D1_PROTOCOL param (writes only the driver)', () => {
     const r = deriveCanEnablement(snap({ GPS_TYPE: 9, CAN_P1_DRIVER: 0 }))
     expect(r.writes).toEqual([{ paramId: 'CAN_P1_DRIVER', paramValue: 1 }])

--- a/apps/web/src/view-models/can-enablement.ts
+++ b/apps/web/src/view-models/can-enablement.ts
@@ -18,7 +18,15 @@ const DRONECAN_DRIVER_TRIGGERS: ReadonlyArray<{ paramId: string; values: readonl
   { paramId: 'GPS_TYPE', values: [9, 22, 23], label: 'GPS is set to DroneCAN' },
   { paramId: 'GPS_TYPE2', values: [9, 22, 23], label: 'GPS 2 is set to DroneCAN' },
   { paramId: 'BATT_MONITOR', values: [8], label: 'Battery monitor is set to DroneCAN' },
-  { paramId: 'BATT2_MONITOR', values: [8], label: 'Battery monitor 2 is set to DroneCAN' }
+  { paramId: 'BATT2_MONITOR', values: [8], label: 'Battery monitor 2 is set to DroneCAN' },
+  // FLOW_TYPE 6 = DroneCAN (HereFlow and friends). Verified against
+  // libraries/AP_OpticalFlow/AP_OpticalFlow.cpp @Values `6:DroneCAN` and
+  // AP_OpticalFlow.h `Type::UAVCAN = 6` (branch origin/ArduPilot-4.7; the
+  // 4.6.3 tag carries the identical value). Added because a CAN flow sensor is
+  // exactly as dead-on-a-disabled-bus as a CAN GPS, and the operator report
+  // that drove the flow config section was a DroneCAN sensor that reported
+  // nothing.
+  { paramId: 'FLOW_TYPE', values: [6], label: 'Optical flow is set to DroneCAN' }
 ]
 
 export interface CanEnablementState {
@@ -26,11 +34,18 @@ export interface CanEnablementState {
   needsEnable: boolean
   /** Human-readable reasons (e.g. "GPS is set to DroneCAN"). */
   triggerLabels: string[]
+  /**
+   * The driver params that fired, so a surface can decide whether the prompt is
+   * ITS business. The CAN tab shows the prompt for any trigger; the Servos ▸
+   * Peripherals optical-flow section only shows it when FLOW_TYPE is one of
+   * them (a DroneCAN GPS is not a reason to interrupt someone editing flow).
+   */
+  triggerParamIds: string[]
   /** The exact writes to enable DroneCAN on bus 1 (only params not already correct). */
   writes: Array<{ paramId: string; paramValue: number }>
 }
 
-const EMPTY: CanEnablementState = { needsEnable: false, triggerLabels: [], writes: [] }
+const EMPTY: CanEnablementState = { needsEnable: false, triggerLabels: [], triggerParamIds: [], writes: [] }
 
 function value(snapshot: ConfiguratorSnapshot, paramId: string): number | undefined {
   return snapshot.parameters.find((p) => p.id === paramId)?.value
@@ -43,10 +58,12 @@ export function deriveCanEnablement(snapshot: ConfiguratorSnapshot): CanEnableme
     return EMPTY
   }
 
-  const triggerLabels = DRONECAN_DRIVER_TRIGGERS.filter((trigger) => {
+  const firedTriggers = DRONECAN_DRIVER_TRIGGERS.filter((trigger) => {
     const current = value(snapshot, trigger.paramId)
     return current !== undefined && trigger.values.includes(Math.round(current))
-  }).map((trigger) => trigger.label)
+  })
+  const triggerLabels = firedTriggers.map((trigger) => trigger.label)
+  const triggerParamIds = firedTriggers.map((trigger) => trigger.paramId)
 
   if (triggerLabels.length === 0) {
     return EMPTY
@@ -71,5 +88,5 @@ export function deriveCanEnablement(snapshot: ConfiguratorSnapshot): CanEnableme
     return EMPTY
   }
 
-  return { needsEnable: true, triggerLabels, writes }
+  return { needsEnable: true, triggerLabels, triggerParamIds, writes }
 }

--- a/apps/web/src/views/CanBus.tsx
+++ b/apps/web/src/views/CanBus.tsx
@@ -13,6 +13,7 @@ import { buildDronecanEscRows, summarizeDronecanNodes } from '../view-models/dro
 import type { DronecanParamCatalogLookup } from '../view-models/dronecan-param-display'
 import { useCanNodeNames } from '../hooks/use-can-node-names'
 import { CanDeviceInspectorView, type CanDeviceExpertActions } from './CanDeviceInspector'
+import { CanEnablePrompt } from './CanEnablePrompt'
 
 // The single CAN surface. Mission Planner-equivalent DroneCAN workflow: connect
 // via MAV_CMD_CAN_FORWARD (so MAVLink stays alive on the same channel), discover
@@ -183,25 +184,15 @@ export function CanBusView(props: CanBusViewProps) {
   return (
     <div id="setup-panel-can">
       <Panel title={title} subtitle={subtitle}>
+        {/* Extracted to CanEnablePrompt so the Servos ▸ Peripherals optical-flow
+            section can raise the identical offer; the default test ids keep this
+            instance byte-identical in the DOM. */}
         {enablement && onEnableCanBus ? (
-          <div className="can-bus-enable-prompt" role="status" data-testid="can-enable-prompt">
-            <div className="can-bus-enable-prompt__body">
-              <strong>Enable the CAN bus for DroneCAN?</strong>
-              <p>
-                {enablement.triggerLabels.join(', ')}, but CAN bus 1 isn’t enabled — nodes won’t be found until it is.
-                This sets <code>CAN_P1_DRIVER=1</code> and <code>CAN_D1_PROTOCOL=1</code> (DroneCAN) and needs a reboot.
-              </p>
-            </div>
-            <button
-              type="button"
-              style={buttonStyle('primary')}
-              data-testid="can-enable-button"
-              onClick={onEnableCanBus}
-              disabled={enableBusy}
-            >
-              {enableBusy ? 'Enabling…' : 'Enable CAN bus & reboot'}
-            </button>
-          </div>
+          <CanEnablePrompt
+            triggerLabels={enablement.triggerLabels}
+            onEnable={onEnableCanBus}
+            busy={enableBusy}
+          />
         ) : null}
         <header className="can-bus-header">
           <div className="can-bus-header__status">

--- a/apps/web/src/views/CanEnablePrompt.tsx
+++ b/apps/web/src/views/CanEnablePrompt.tsx
@@ -1,0 +1,59 @@
+import type { ReactElement } from 'react'
+
+import { buttonStyle } from '@arduconfig/ui-kit'
+
+// The "you picked a DroneCAN peripheral but the bus is still off" prompt.
+//
+// Lifted verbatim out of CanBus.tsx (it lived inline there since the helper
+// shipped) so a SECOND surface can raise the same offer without a second
+// implementation drifting away from the first: the Servos ▸ Peripherals
+// optical-flow section shows it when FLOW_TYPE = 6 (DroneCAN) and CAN bus 1 is
+// disabled. That is the exact trap a real operator hit — a CAN flow sensor
+// configured, wired, and silent — and it is far more useful next to the type
+// dropdown that caused it than three tabs away.
+//
+// Dumb presentational component: the reasons and the handler are computed in
+// App.tsx from deriveCanEnablement. `testId` is a prop rather than a constant
+// because two instances can be mounted in the same app and each needs its own
+// stable hook; the CAN tab keeps the original id so existing e2e is untouched.
+
+export interface CanEnablePromptProps {
+  /** Human-readable reasons, e.g. "Optical flow is set to DroneCAN". */
+  triggerLabels: string[]
+  onEnable: () => void
+  /** Disables the button while the write + reboot is in flight. */
+  busy?: boolean
+  testId?: string
+  buttonTestId?: string
+}
+
+export function CanEnablePrompt({
+  triggerLabels,
+  onEnable,
+  busy,
+  // Defaults reproduce the CAN tab's original hooks exactly, so its e2e block
+  // keeps passing unchanged after the extraction.
+  testId = 'can-enable-prompt',
+  buttonTestId = 'can-enable-button'
+}: CanEnablePromptProps): ReactElement {
+  return (
+    <div className="can-bus-enable-prompt" role="status" data-testid={testId}>
+      <div className="can-bus-enable-prompt__body">
+        <strong>Enable the CAN bus for DroneCAN?</strong>
+        <p>
+          {triggerLabels.join(', ')}, but CAN bus 1 isn’t enabled — nodes won’t be found until it is.
+          This sets <code>CAN_P1_DRIVER=1</code> and <code>CAN_D1_PROTOCOL=1</code> (DroneCAN) and needs a reboot.
+        </p>
+      </div>
+      <button
+        type="button"
+        style={buttonStyle('primary')}
+        data-testid={buttonTestId}
+        onClick={onEnable}
+        disabled={busy}
+      >
+        {busy ? 'Enabling…' : 'Enable CAN bus & reboot'}
+      </button>
+    </div>
+  )
+}

--- a/packages/param-metadata/src/arducopter-4.7-overrides.ts
+++ b/packages/param-metadata/src/arducopter-4.7-overrides.ts
@@ -7,6 +7,7 @@ import {
   ARDUCOPTER_RSSI_TYPE_LABELS,
   ARDUCOPTER_THROTTLE_FAILSAFE_LABELS
 } from './arducopter-enums.js'
+import { OPTICAL_FLOW_TYPE_OPTIONS_4_7 } from './shared-optical-flow.js'
 
 // Local copy of arducopter.ts's (unexported) enumOptions.
 function enumOptions(labelMap: Record<number, string>): ParameterValueOption[] {
@@ -92,5 +93,16 @@ export const ARDUCOPTER_4_7_PARAMETER_OVERRIDES: Record<string, Partial<Paramete
   FS_GCS_ENABLE: { options: enumOptions(FS_GCS_LABELS_4_7) },
   BATT_FS_LOW_ACT: { options: enumOptions(BATTERY_FAILSAFE_ACTION_LABELS_4_7) },
   BATT_FS_CRT_ACT: { options: enumOptions(BATTERY_FAILSAFE_ACTION_LABELS_4_7) },
-  BATT_MONITOR: { maximum: 32, options: enumOptions(BATTERY_MONITOR_LABELS_4_7) }
+  BATT_MONITOR: { maximum: 32, options: enumOptions(BATTERY_MONITOR_LABELS_4_7) },
+  // FLOW_TYPE gains 10:SITL after 4.6. Verified by reading
+  // libraries/AP_OpticalFlow/AP_OpticalFlow.cpp at BOTH refs: the @Values line
+  // ends at `8:UPFLOW` on tag Copter-4.6.3 and at `8:UPFLOW, 10:SITL` on branch
+  // origin/ArduPilot-4.7 (AP_OpticalFlow.h `Type::SITL = 10`; 9 is unassigned).
+  // Base catalog stays 0..8 so a 4.6 FC — and pre-connect / Unknown — is
+  // byte-identical and never offers a value its firmware cannot decode.
+  //
+  // FLOW_OPTIONS is likewise 4.7-only, but needs no entry here: it is a new
+  // PARAMETER, not a changed one, so a 4.6 board simply never reports it and
+  // the curated definition never renders.
+  FLOW_TYPE: { maximum: 10, options: OPTICAL_FLOW_TYPE_OPTIONS_4_7 }
 }

--- a/packages/param-metadata/src/arducopter.ts
+++ b/packages/param-metadata/src/arducopter.ts
@@ -3,6 +3,7 @@ import { AHRS_ORIENTATION_OPTIONS, LOG_DISARMED_OPTIONS } from './shared-enums.j
 import { buildMountParameterDefinitions } from './shared-mount.js'
 import { buildNetworkParameterDefinitions } from './shared-network.js'
 import { buildRcLogicParameterDefinitions } from './shared-rc-logic.js'
+import { buildOpticalFlowParameterDefinitions } from './shared-optical-flow.js'
 import { buildRangefinderParameterDefinitions } from './shared-rangefinder.js'
 import { RELAY_INSTANCE_COUNT, buildRelayParameterDefinitions } from './shared-relay.js'
 import {
@@ -858,6 +859,16 @@ export const arducopterMetadata: FirmwareMetadataBundle = {
       order: 9.6,
       viewId: 'motors'
     },
+    // Sits immediately after Rangefinder because the two are a pair in
+    // practice: flow needs a height reference, and that is almost always the
+    // downward rangefinder configured in the section above.
+    'optical-flow': {
+      id: 'optical-flow',
+      label: 'Optical Flow',
+      description: 'Optical flow sensor driver, yaw alignment, scale correction, and mounting offsets (FLOW_).',
+      order: 9.65,
+      viewId: 'motors'
+    },
     relays: {
       id: 'relays',
       label: 'Relays',
@@ -1204,6 +1215,7 @@ export const arducopterMetadata: FirmwareMetadataBundle = {
     ...buildMountParameterDefinitions(1),
     ...buildMountParameterDefinitions(2),
     ...buildRangefinderParameterDefinitions(1),
+    ...buildOpticalFlowParameterDefinitions(),
     ...Array.from({ length: RELAY_INSTANCE_COUNT }, (_, index) =>
       buildRelayParameterDefinitions(index + 1)
     ).reduce((merged, family) => ({ ...merged, ...family }), {}),

--- a/packages/param-metadata/src/arduplane.ts
+++ b/packages/param-metadata/src/arduplane.ts
@@ -1,6 +1,7 @@
 import type { FirmwareMetadataBundle, ParameterValueOption } from './types.js'
 import { AHRS_ORIENTATION_OPTIONS, LOG_DISARMED_OPTIONS } from './shared-enums.js'
 import { buildMountParameterDefinitions } from './shared-mount.js'
+import { buildOpticalFlowParameterDefinitions } from './shared-optical-flow.js'
 import { buildRangefinderParameterDefinitions } from './shared-rangefinder.js'
 import { RELAY_INSTANCE_COUNT, buildRelayParameterDefinitions } from './shared-relay.js'
 import {
@@ -575,6 +576,14 @@ export const arduplaneMetadata: FirmwareMetadataBundle = {
       label: 'Rangefinder / Lidar',
       description: 'Rangefinder/lidar driver, orientation, range limits, and mounting offsets (RNGFND1).',
       order: 1.6,
+      viewId: 'motors'
+    },
+    // Paired with Rangefinder above — flow needs a height reference.
+    'optical-flow': {
+      id: 'optical-flow',
+      label: 'Optical Flow',
+      description: 'Optical flow sensor driver, yaw alignment, scale correction, and mounting offsets (FLOW_).',
+      order: 1.65,
       viewId: 'motors'
     },
     relays: {
@@ -3371,6 +3380,7 @@ export const arduplaneMetadata: FirmwareMetadataBundle = {
     ...buildMountParameterDefinitions(1),
     ...buildMountParameterDefinitions(2),
     ...buildRangefinderParameterDefinitions(1),
+    ...buildOpticalFlowParameterDefinitions(),
     ...Array.from({ length: RELAY_INSTANCE_COUNT }, (_, index) =>
       buildRelayParameterDefinitions(index + 1)
     ).reduce((merged, family) => ({ ...merged, ...family }), {}),

--- a/packages/param-metadata/src/ardurover.ts
+++ b/packages/param-metadata/src/ardurover.ts
@@ -1,6 +1,7 @@
 import type { FirmwareMetadataBundle, ParameterValueOption } from './types.js'
 import { AHRS_ORIENTATION_OPTIONS, LOG_DISARMED_OPTIONS } from './shared-enums.js'
 import { buildMountParameterDefinitions } from './shared-mount.js'
+import { buildOpticalFlowParameterDefinitions } from './shared-optical-flow.js'
 import { buildRangefinderParameterDefinitions } from './shared-rangefinder.js'
 import { RELAY_INSTANCE_COUNT, buildRelayParameterDefinitions } from './shared-relay.js'
 import {
@@ -277,6 +278,9 @@ export const arduroverMetadata: FirmwareMetadataBundle = {
     motors: { id: 'motors', label: 'Motors & Outputs', description: 'Throttle limits and motor output behavior.', order: 8, viewId: 'motors' },
     gimbal: { id: 'gimbal', label: 'Gimbal / Mount', description: 'Camera gimbal/mount driver, control mode, and per-axis angle limits (MNT1/MNT2).', order: 8.5, viewId: 'motors' },
     rangefinder: { id: 'rangefinder', label: 'Rangefinder / Lidar', description: 'Rangefinder driver, orientation, range limits, and mounting offsets (RNGFND1).', order: 8.6, viewId: 'motors' },
+    // Paired with Rangefinder above. Rover is the one vehicle that can skip the
+    // rangefinder entirely (FLOW_HGT_OVR fixes the sensor height instead).
+    'optical-flow': { id: 'optical-flow', label: 'Optical Flow', description: 'Optical flow sensor driver, yaw alignment, scale correction, height override, and mounting offsets (FLOW_).', order: 8.65, viewId: 'motors' },
     relays: { id: 'relays', label: 'Relays', description: 'GPIO relay function mapping, pin assignment, default state, and signal inversion (RELAY1..RELAY6).', order: 8.7, viewId: 'servos' },
     steering: { id: 'steering', label: 'Steering Tuning', description: 'Steering-rate and steering-angle controller gains.', order: 9, viewId: 'tuning' },
     speed: { id: 'speed', label: 'Speed Tuning', description: 'Throttle/speed controller gains.', order: 10, viewId: 'tuning' },
@@ -333,6 +337,7 @@ export const arduroverMetadata: FirmwareMetadataBundle = {
     ...buildMountParameterDefinitions(1),
     ...buildMountParameterDefinitions(2),
     ...buildRangefinderParameterDefinitions(1),
+    ...buildOpticalFlowParameterDefinitions(),
     ...Array.from({ length: RELAY_INSTANCE_COUNT }, (_, index) =>
       buildRelayParameterDefinitions(index + 1)
     ).reduce((merged, family) => ({ ...merged, ...family }), {}),

--- a/packages/param-metadata/src/ardusub.ts
+++ b/packages/param-metadata/src/ardusub.ts
@@ -1,6 +1,7 @@
 import type { FirmwareMetadataBundle, ParameterValueOption } from './types.js'
 import { AHRS_ORIENTATION_OPTIONS, LOG_DISARMED_OPTIONS } from './shared-enums.js'
 import { buildMountParameterDefinitions } from './shared-mount.js'
+import { buildOpticalFlowParameterDefinitions } from './shared-optical-flow.js'
 import { buildRangefinderParameterDefinitions } from './shared-rangefinder.js'
 import { RELAY_INSTANCE_COUNT, buildRelayParameterDefinitions } from './shared-relay.js'
 import {
@@ -251,6 +252,8 @@ export const ardusubMetadata: FirmwareMetadataBundle = {
     frame: { id: 'frame', label: 'Frame Config', description: 'Thruster frame configuration.', order: 1, viewId: 'motors' },
     gimbal: { id: 'gimbal', label: 'Gimbal / Mount', description: 'Camera gimbal/mount driver, control mode, and per-axis angle limits (MNT1/MNT2).', order: 1.5, viewId: 'motors' },
     rangefinder: { id: 'rangefinder', label: 'Rangefinder / Lidar', description: 'Rangefinder/echosounder driver, orientation, range limits, and mounting offsets (RNGFND1).', order: 1.6, viewId: 'motors' },
+    // Paired with Rangefinder above — flow needs a height reference.
+    'optical-flow': { id: 'optical-flow', label: 'Optical Flow', description: 'Optical flow sensor driver, yaw alignment, scale correction, and mounting offsets (FLOW_).', order: 1.65, viewId: 'motors' },
     relays: { id: 'relays', label: 'Relays', description: 'GPIO relay function mapping, pin assignment, default state, and signal inversion (RELAY1..RELAY6).', order: 1.7, viewId: 'servos' },
     joystick: { id: 'joystick', label: 'Joystick', description: 'Pilot joystick gain and control behavior.', order: 2, viewId: 'receiver' },
     pilot: { id: 'pilot', label: 'Pilot & Depth', description: 'Vertical speed, acceleration, and surface depth.', order: 3, viewId: 'tuning' },
@@ -322,6 +325,7 @@ export const ardusubMetadata: FirmwareMetadataBundle = {
     ...buildMountParameterDefinitions(1),
     ...buildMountParameterDefinitions(2),
     ...buildRangefinderParameterDefinitions(1),
+    ...buildOpticalFlowParameterDefinitions(),
     ...Array.from({ length: RELAY_INSTANCE_COUNT }, (_, index) =>
       buildRelayParameterDefinitions(index + 1)
     ).reduce((merged, family) => ({ ...merged, ...family }), {}),

--- a/packages/param-metadata/src/index.ts
+++ b/packages/param-metadata/src/index.ts
@@ -16,6 +16,9 @@ export { AHRS_ORIENTATION_OPTIONS } from './shared-enums.js'
 export * from './catalog.js'
 export * from './format-number.js'
 export * from './fuzzy.js'
+// FLOW_* builder + the 4.6/4.7 FLOW_TYPE option maps — public so the 4.7
+// override table can extend the base list without duplicating it.
+export * from './shared-optical-flow.js'
 // AP_RC_Logic schema constants (RCL_* term count, OPT bit layout, source-type
 // enum, AUX_FUNC option list) — public because the RC Mixer UI binds to them.
 export * from './shared-rc-logic.js'

--- a/packages/param-metadata/src/shared-optical-flow.ts
+++ b/packages/param-metadata/src/shared-optical-flow.ts
@@ -1,0 +1,189 @@
+// Shared optical-flow (FLOW_*) parameter family. AP_OpticalFlow is a single
+// (non-instanced) driver object shared verbatim by Copter/Plane/Rover/Sub, so —
+// like shared-rangefinder.ts — the definitions are built once here and spread
+// into each vehicle bundle.
+//
+// EVERY value, range, unit and default below was read out of the firmware
+// source, not from memory (the standing rule in this repo after a wrong
+// MNT1_TYPE map shipped). Primary source:
+//
+//   libraries/AP_OpticalFlow/AP_OpticalFlow.cpp — `AP_OpticalFlow::var_info[]`
+//   read at both `Copter-4.6.3` (the operator's shipping firmware) and
+//   `origin/ArduPilot-4.7` (the 4.7.0-beta line). Lines 24–105 on 4.7.
+//
+// The two versions differ in exactly two places, both handled explicitly:
+//   * FLOW_TYPE gains `10:SITL` in 4.7. The base map below stays at the 4.6
+//     set (0..8) and the extra option is applied only on a detected >= 4.7
+//     build via ARDUCOPTER_4_7_PARAMETER_OVERRIDES.
+//   * FLOW_OPTIONS is NEW in 4.7 (absent from 4.6.3 entirely). It is curated
+//     unconditionally here because the peripherals card only renders params
+//     the FC actually reports — a 4.6 board never streams FLOW_OPTIONS, so the
+//     field simply does not appear. Same technique shared-rangefinder.ts uses
+//     for the pre-4.7 `_CM` distance params.
+
+import type { FirmwareMetadataBundle, ParameterValueOption } from './types.js'
+
+// Verbatim from the FLOW_TYPE @Values line, so the labels read identically to
+// the ArduPilot wiki and Mission Planner:
+//   @Values: 0:None, 1:PX4Flow, 2:Pixart, 3:Bebop, 4:CXOF, 5:MAVLink,
+//            6:DroneCAN, 7:MSP, 8:UPFLOW[, 10:SITL]
+// (9 is genuinely unassigned in the enum — AP_OpticalFlow.h `Type` jumps from
+// UPFLOW = 8 to SITL = 10 — so the gap here is correct, not an omission.)
+//
+// Value 6 is DroneCAN, i.e. the HereFlow and every other CAN-attached flow
+// sensor. Calling it out because a stale tooltip in this app once claimed 10
+// was HereFlow, which could never have worked.
+export const OPTICAL_FLOW_TYPE_OPTIONS: ParameterValueOption[] = [
+  { value: 0, label: 'None' },
+  { value: 1, label: 'PX4Flow' },
+  { value: 2, label: 'Pixart' },
+  { value: 3, label: 'Bebop' },
+  { value: 4, label: 'CXOF' },
+  { value: 5, label: 'MAVLink' },
+  { value: 6, label: 'DroneCAN' },
+  { value: 7, label: 'MSP' },
+  { value: 8, label: 'UPFLOW' }
+]
+
+/** 4.7 adds `10:SITL` to the same @Values line. Consumed by the 4.7 overrides. */
+export const OPTICAL_FLOW_TYPE_OPTIONS_4_7: ParameterValueOption[] = [
+  ...OPTICAL_FLOW_TYPE_OPTIONS,
+  { value: 10, label: 'SITL' }
+]
+
+// FLOW_OPTIONS @Bitmask: 0:Roll/Pitch stabilised. Bit INDICES, not values —
+// `bitmask: true` makes the generic editor render a per-bit checkbox grid.
+const OPTICAL_FLOW_OPTION_BITS: ParameterValueOption[] = [
+  { value: 0, label: 'Sensor is roll/pitch stabilised (gimbal-mounted)' }
+]
+
+/**
+ * Builds the FLOW_* parameter family (category `optical-flow`).
+ *
+ * Deliberately NOT gated on FLOW_TYPE being non-zero: the section is a
+ * configuration surface, and an operator fitting a sensor needs to reach the
+ * Type dropdown before anything is enabled. This matches the rangefinder
+ * section, which is likewise always present in the catalog and simply renders
+ * whichever of its params the connected FC reports. In practice FLOW_TYPE is
+ * ArduPilot's AP_PARAM_FLAG_ENABLE for this group, so a board with the sensor
+ * disabled reports only FLOW_TYPE and the card shows exactly one field — the
+ * one that is useful — until the type is set and the board rebooted.
+ *
+ * No `enableGate: true` on FLOW_TYPE even though it carries
+ * AP_PARAM_FLAG_ENABLE: the siblings are hidden from the param tree while the
+ * gate is 0, so they can never be co-staged in the same batch as the gate, and
+ * the write-ordering the flag would buy has nothing to order. shared-rangefinder
+ * leaves RNGFND1_TYPE unmarked for the same reason.
+ */
+export function buildOpticalFlowParameterDefinitions(): FirmwareMetadataBundle['parameters'] {
+  // FLOW_POS_X/Y/Z share one @Param block per axis with identical
+  // @Units/@Range/@Increment (m, -5..5, 0.01) — generated rather than repeated.
+  const pos = (axis: 'X' | 'Y' | 'Z') => {
+    const direction = axis === 'X' ? 'forward' : axis === 'Y' ? 'right' : 'down'
+    return {
+      id: `FLOW_POS_${axis}`,
+      label: `Position ${axis}`,
+      description: `${axis} position of the flow sensor's focal point in body frame (m, ${direction}-positive from the origin).`,
+      category: 'optical-flow',
+      unit: 'm',
+      minimum: -5,
+      maximum: 5,
+      step: 0.01
+    }
+  }
+
+  return {
+    FLOW_TYPE: {
+      id: 'FLOW_TYPE',
+      label: 'Optical Flow Type',
+      description: 'Driver for the optical flow sensor. Pick the backend that matches your sensor.',
+      category: 'optical-flow',
+      // @RebootRequired: True on the FLOW_TYPE @Param block.
+      rebootRequired: true,
+      notes: [
+        // The two traps that make a correctly-wired sensor look dead, both hit
+        // by real operators. Kept as notes rather than extra editable fields:
+        // EK3_SRC* belongs to the EKF, and surfacing it here would invite
+        // edits with a far wider blast radius than a flow sensor.
+        'Reboot after changing the type — the driver is only created at boot.',
+        'DroneCAN (6) sensors — HereFlow and friends — also need the CAN bus itself enabled (CAN_P1_DRIVER=1, CAN_D1_PROTOCOL=1). The CAN tab offers a one-click "Enable CAN bus & reboot" when it spots that combination.',
+        'Flow is only used for navigation once the EKF sources from it: EK3_SRC1_VELXY = 5 (OptFlow). Source: libraries/AP_NavEKF/AP_NavEKF_Source.h, SourceXY::OPTFLOW = 5.',
+        'Flow needs a height reference. A downward rangefinder (RNGFND1_ORIENT = 25) is what supplies it below a few metres.'
+      ],
+      options: OPTICAL_FLOW_TYPE_OPTIONS
+    },
+    FLOW_FXSCALER: {
+      id: 'FLOW_FXSCALER',
+      label: 'X Scale Correction',
+      description:
+        'Parts-per-thousand scale correction for the sensor X-axis optical rate — corrects effective focal-length variation. Each +1 raises the X scale factor by 0.1%.',
+      category: 'optical-flow',
+      // @Range: -800 +800, @Increment: 1
+      minimum: -800,
+      maximum: 800,
+      step: 1
+    },
+    FLOW_FYSCALER: {
+      id: 'FLOW_FYSCALER',
+      label: 'Y Scale Correction',
+      description:
+        'Parts-per-thousand scale correction for the sensor Y-axis optical rate — corrects effective focal-length variation. Each +1 raises the Y scale factor by 0.1%.',
+      category: 'optical-flow',
+      minimum: -800,
+      maximum: 800,
+      step: 1
+    },
+    FLOW_ORIENT_YAW: {
+      id: 'FLOW_ORIENT_YAW',
+      label: 'Yaw Alignment',
+      description:
+        'How far the sensor is yawed relative to the vehicle, in centi-degrees. A sensor whose X axis points to the right of the vehicle X axis has a positive angle.',
+      category: 'optical-flow',
+      // @Units: cdeg, @Range: -17999 +18000, @Increment: 10
+      unit: 'cdeg',
+      minimum: -17999,
+      maximum: 18000,
+      step: 10
+    },
+    FLOW_POS_X: pos('X'),
+    FLOW_POS_Y: pos('Y'),
+    FLOW_POS_Z: pos('Z'),
+    FLOW_ADDR: {
+      id: 'FLOW_ADDR',
+      label: 'Bus Address',
+      description:
+        'Selects between multiple possible I2C addresses for sensor types that offer them (PX4Flow accepts 0–7). Ignored by serial/CAN backends.',
+      category: 'optical-flow',
+      // @Range: 0 127
+      minimum: 0,
+      maximum: 127,
+      step: 1
+    },
+    // 4.7+ only (absent from the 4.6.3 var_info entirely) — renders only when
+    // the connected FC actually reports it.
+    FLOW_OPTIONS: {
+      id: 'FLOW_OPTIONS',
+      label: 'Flow Options',
+      description: 'Optical flow options. Set bit 0 when the sensor is roll/pitch stabilised, e.g. mounted on a gimbal.',
+      category: 'optical-flow',
+      bitmask: true,
+      options: OPTICAL_FLOW_OPTION_BITS
+    },
+    // AP_GROUPINFO_FRAME(..., AP_PARAM_FRAME_ROVER): ArduPilot only exposes
+    // this on Rover frames, so a Copter/Plane/Sub never reports it and the
+    // field never renders there. Curated in the shared builder rather than
+    // branched per-vehicle for the same reason the rangefinder builder curates
+    // both the metre and centimetre distance params in one place.
+    FLOW_HGT_OVR: {
+      id: 'FLOW_HGT_OVR',
+      label: 'Height Override',
+      description: 'Rover only: fixed height of the sensor above the ground (m), used instead of a rangefinder.',
+      category: 'optical-flow',
+      // @Units: m, @Range: 0 2, @Increment: 0.01
+      unit: 'm',
+      minimum: 0,
+      maximum: 2,
+      step: 0.01
+    }
+  }
+}

--- a/packages/protocol-mavlink/src/mock-scenario.ts
+++ b/packages/protocol-mavlink/src/mock-scenario.ts
@@ -159,6 +159,21 @@ const mockParameters: ParameterState = {
   // that report, and specifically exercising the CAN-attached variant rather
   // than a directly-wired one.
   FLOW_TYPE: 6,
+  // The rest of the FLOW_ family, seeded at ArduPilot defaults so the Servos ▸
+  // Peripherals "Optical Flow" config section renders populated rather than as a
+  // lone Type dropdown. Defaults read from AP_OpticalFlow.cpp var_info[]
+  // (all zero). FLOW_OPTIONS and FLOW_HGT_OVR are DELIBERATELY absent: OPTIONS
+  // is 4.7-only and this mock reports 4.6.0 (flightSwVersion 0x040600ff), and
+  // HGT_OVR is AP_PARAM_FRAME_ROVER so a Copter never reports it. Both are
+  // curated in the catalog and must stay invisible here — that is the proof the
+  // "render only what the FC reports" gating works.
+  FLOW_FXSCALER: 0,
+  FLOW_FYSCALER: 0,
+  FLOW_ORIENT_YAW: 0,
+  FLOW_POS_X: 0,
+  FLOW_POS_Y: 0,
+  FLOW_POS_Z: 0,
+  FLOW_ADDR: 0,
   // Relays (RELAY1/RELAY2) — seeded so the demo surfaces the Relays tab
   // populated: relay 1 is a plain operator relay on an AUX pin (default off),
   // relay 2 is mapped to the camera shutter. Metadata ships RELAY1..RELAY6.

--- a/tests/e2e/views.spec.ts
+++ b/tests/e2e/views.spec.ts
@@ -3830,6 +3830,81 @@ test.describe('ArduPlane demo', () => {
     await typeSelect.selectOption({ label: 'MAVLink' })
     await expect(page.getByText('Analog Function', { exact: true })).toBeHidden()
   })
+
+  // The ask: "in the servo > peripheral tab we have the section about
+  // rangefinders, can we add in a section and all the relevant parameters for
+  // optical flow?" — same shape as the Rangefinder section above, one sensor
+  // over. The demo Copter seeds FLOW_TYPE=6 (DroneCAN) with CAN_P1_DRIVER=0,
+  // reproducing the operator's own miswired-CAN-flow situation.
+  test('Servos view exposes an Optical Flow config section, gated the same way as Rangefinder', async ({ page }) => {
+    await page.goto('/')
+    await page.getByTestId('transport-mode-select').selectOption('demo')
+    await page.getByTestId('connect-button').click()
+    await expect(page.getByTestId('session-vehicle-name')).toHaveText('ArduCopter', { timeout: VEHICLE_CONNECT_TIMEOUT })
+    await expect(page.getByTestId('session-parameter-summary')).toHaveText(/^(\d+ params|Params \d+)$/, {
+      timeout: VEHICLE_CONNECT_TIMEOUT
+    })
+    await openView(page, 'servos')
+    await page.getByTestId('outputs-summary-peripherals').click()
+
+    const flowSection = page.getByTestId('metadata-settings-section-optical-flow')
+    await expect(flowSection).toBeVisible({ timeout: 15_000 })
+    await expect(page.getByText('Optical Flow', { exact: true })).toBeVisible()
+    // The seeded FLOW_ family renders as editable fields.
+    await expect(page.getByText('Optical Flow Type', { exact: true })).toBeVisible()
+    await expect(page.getByText('X Scale Correction', { exact: true })).toBeVisible()
+    await expect(page.getByText('Bus Address', { exact: true })).toBeVisible()
+    // Unit-carrying labels render as "<label> (<unit>)" — ScopedField appends the
+    // unit in a nested <small> — so these are substring matches, not exact ones.
+    await expect(flowSection.getByText('Yaw Alignment (cdeg)', { exact: true })).toBeVisible()
+    await expect(flowSection.getByText('Position X (m)', { exact: true })).toBeVisible()
+    // FLOW_OPTIONS (4.7-only) and FLOW_HGT_OVR (Rover-only) are curated but NOT
+    // reported by this 4.6 Copter — proving the section renders only what the
+    // FC actually streams rather than a fixed field list.
+    await expect(page.getByText('Flow Options')).toHaveCount(0)
+    await expect(page.getByText('Height Override')).toHaveCount(0)
+
+    // Every field carries the shared "i" affordance naming the raw param.
+    await expect(page.getByTestId('metadata-field-info-FLOW_TYPE')).toBeVisible()
+
+    // The type is source-correct: 6 is DroneCAN (AP_OpticalFlow.h Type::UAVCAN),
+    // NOT the SITL value the app once mislabelled as HereFlow.
+    const flowType = page.locator('label', { hasText: 'Optical Flow Type' }).getByRole('combobox')
+    await expect(flowType).toHaveValue('6')
+    // 4.6 firmware: SITL (10) must not be offered at all.
+    await expect(flowType.locator('option', { hasText: 'SITL' })).toHaveCount(0)
+
+    // DroneCAN flow + CAN bus off surfaces the same one-click enable the CAN tab
+    // offers — the fix for a flow sensor that reports nothing because the bus
+    // was never turned on.
+    const prompt = page.getByTestId('peripherals-can-enable-prompt')
+    await expect(prompt).toBeVisible()
+    await expect(prompt).toContainText('Optical flow is set to DroneCAN')
+    await expect(page.getByTestId('peripherals-can-enable-button')).toBeEnabled()
+
+    // Editing a flow field stages a draft in the peripherals scope.
+    await flowType.selectOption({ label: 'CXOF' })
+    await expect(page.getByRole('button', { name: /Apply Additional Output Changes \(1\)/ })).toBeEnabled()
+
+    // Section is collapsible like its Rangefinder sibling.
+    await flowSection.locator('summary').click()
+    await expect(flowSection.getByText('Yaw Alignment (cdeg)', { exact: true })).toBeHidden()
+  })
+
+  test('the Optical Flow section fits a 390px phone viewport without horizontal overflow', async ({ page }) => {
+    await page.setViewportSize({ width: 390, height: 844 })
+    await page.goto('/')
+    await page.getByTestId('transport-mode-select').selectOption('demo')
+    await page.getByTestId('connect-button').click()
+    await expect(page.getByTestId('session-vehicle-name')).toHaveText('ArduCopter', { timeout: VEHICLE_CONNECT_TIMEOUT })
+    await openView(page, 'servos')
+    await page.getByTestId('outputs-summary-peripherals').click()
+    await expect(page.getByTestId('metadata-settings-section-optical-flow')).toBeVisible({ timeout: 15_000 })
+    const overflow = await page.evaluate(
+      () => document.documentElement.scrollWidth - document.documentElement.clientWidth
+    )
+    expect(overflow).toBeLessThanOrEqual(0)
+  })
 })
 
 test.describe('ArduRover / ArduSub demo', () => {

--- a/tests/transport.test.mjs
+++ b/tests/transport.test.mjs
@@ -714,8 +714,8 @@ test('MockTransport serializes chunked inbound frames so demo parameter sync com
     const stats = await runtime.waitForParameterSync({ timeoutMs: 120000 })
 
     assert.equal(stats.status, 'complete')
-    assert.equal(stats.downloaded, 1174)
-    assert.equal(stats.total, 1174)
+    assert.equal(stats.downloaded, 1181)
+    assert.equal(stats.total, 1181)
     assert.equal(runtime.getSnapshot().parameters.find((parameter) => parameter.id === 'FRAME_CLASS')?.value, 1)
     assert.equal(runtime.getSnapshot().parameters.find((parameter) => parameter.id === 'FRAME_TYPE')?.value, 1)
   } finally {
@@ -846,7 +846,7 @@ test('Bundled WebSocket bridge can drive runtime heartbeat and parameter sync fr
     assert.equal(runtime.getSnapshot().connection.kind, 'connected')
     assert.equal(runtime.getSnapshot().vehicle?.vehicle, 'ArduCopter')
     assert.equal(stats.status, 'complete')
-    assert.equal(stats.downloaded, 1174)
+    assert.equal(stats.downloaded, 1181)
     assert.equal(runtime.getSnapshot().parameters.find((parameter) => parameter.id === 'FRAME_CLASS')?.value, 1)
   } finally {
     await runtime.disconnect().catch(() => {})


### PR DESCRIPTION
> "in the servo > peripheral tab we have the section about rangefinders, can we add in a section and all the relevant parameters for optical flow?"

## Parameters, with source citations

Read from `/Users/user/ardupilot` at **both `Copter-4.6.3` and `origin/ArduPilot-4.7`**, in `libraries/AP_OpticalFlow/AP_OpticalFlow.cpp` → `AP_OpticalFlow::var_info[]`, cross-checked against `AP_OpticalFlow.h` `enum class Type`:

| Param | Source |
|---|---|
| `FLOW_TYPE` | `@Values 0:None 1:PX4Flow 2:Pixart 3:Bebop 4:CXOF 5:MAVLink 6:DroneCAN 7:MSP 8:UPFLOW` (+`10:SITL` on 4.7); `@RebootRequired: True` |
| `FLOW_FXSCALER` / `FLOW_FYSCALER` | `@Range -800 +800`, `@Increment 1`, no `@Units` |
| `FLOW_ORIENT_YAW` | `@Units cdeg`, `@Range -17999 +18000`, `@Increment 10` |
| `FLOW_POS_X/Y/Z` | `@Units m`, `@Range -5 5`, `@Increment 0.01` |
| `FLOW_ADDR` | `@Range 0 127` |
| `FLOW_OPTIONS` | `@Bitmask 0:Roll/Pitch stabilised` — **4.7 only** |
| `FLOW_HGT_OVR` | `@Units m`, `@Range 0 2`, `@Increment 0.01`, `AP_PARAM_FRAME_ROVER` |

**6 = DroneCAN** confirmed (`AP_OpticalFlow.h`, `Type::UAVCAN = 6`, the HereFlow backend). 10 is SITL; **9 is genuinely unassigned**, so the gap in the option list is correct rather than an omission.

This matters because the app previously shipped a tooltip claiming 10 was HereFlow — pointing operators at a value that could never work on a CAN sensor.

## Mirrors the rangefinder section

The rangefinder "section" is not bespoke UI — it is a metadata category rendered as a collapsible `<details>` by `AdditionalSettingsCard`. Same approach here: `packages/param-metadata/src/shared-optical-flow.ts` (mirroring `shared-rangefinder.ts`, spread into all four vehicle bundles), plus an `optical-flow` category at order 9.65 so it sits directly after Rangefinder. `ScopedField` / `ScopedSelectField` and the `ParamInfoBubble` (i) come for free via `renderMetadataParameterField`.

**Gating matches the precedent exactly**: always in the catalog, but only params the FC actually reports get rendered. So you can reach the Type dropdown before enabling anything — and since `FLOW_TYPE` is ArduPilot's `AP_PARAM_FLAG_ENABLE` for the group, a board with flow off shows exactly one field, the useful one.

## DroneCAN gets the CAN-enable prompt

`FLOW_TYPE=6` now fires the existing `deriveCanEnablement` helper, mirrored into the peripherals card rather than left three tabs away — a DroneCAN flow sensor is dead without `CAN_P1_DRIVER` / `CAN_D1_PROTOCOL`, and that is exactly the silent-dead-sensor case this fleet has already hit.

The prompt markup moved out of `CanBus.tsx` into a shared `views/CanEnablePrompt.tsx`; default test ids reproduce the CAN tab's DOM exactly, so its e2e is untouched. `deriveCanEnablement` gained `triggerParamIds` so this card shows the prompt **only** when flow fired it — a DroneCAN GPS is a real problem the CAN tab still reports, but not this card's business.

## 4.7 gating

`FLOW_TYPE` gains `10:SITL` only on a detected ≥4.7 build, via `ARDUCOPTER_4_7_PARAMETER_OVERRIDES`. `FLOW_OPTIONS` needs no override entry — it is a *new* param rather than a changed one, so a 4.6 board never reports it. The demo mock (4.6.0) deliberately seeds neither it nor `FLOW_HGT_OVR`, and the e2e asserts their absence — that is the proof the render-only-what-the-FC-reports gating actually works.

## Deliberately left out

- **`EK3_SRC*` as editable fields.** Flow is useless if the EKF is not sourcing from it, so `EK3_SRC1_VELXY = 5 (OptFlow)` is cited in `FLOW_TYPE`'s notes (`AP_NavEKF/AP_NavEKF_Source.h`, `SourceXY::OPTFLOW = 5`) — but an EKF source switch has a far wider blast radius than a flow sensor. The rangefinder section makes the same call.
- **`enableGate: true` on `FLOW_TYPE`**, despite the `AP_PARAM_FLAG_ENABLE`: siblings are hidden while the gate is 0, so they can never be co-staged and write-ordering would have nothing to order. `shared-rangefinder` leaves `RNGFND1_TYPE` unmarked for the same reason.
- **Live telemetry.** Status & Info already owns that. `LIVE_TELEMETRY_REQUESTS`, `buildAdvancedSensorCards` and `AdvancedSensorCard` untouched.

## Blast radius — stated honestly

ArduCopter is **not** byte-identical here, and is not meant to be: this is the deliberate scoped Copter change that was requested. Two Copter-visible changes — the new collapsible section, and `FLOW_TYPE=6` with CAN off now also raising the existing CAN-enable prompt. No transport, protocol, runtime, or write-path change.

## Validation

- `npm run typecheck` — clean, all 8 workspaces
- `npm run test` — 859 tests, **855 pass, 0 fail**, 4 skipped
- `apps/web` vitest — 76 files, **681 pass**
- `npm run test:e2e` — **236 passed**, 6 skipped, 1 failure: the known flake `Recent Notices pops out into its own styled, live window`. Both new optical-flow blocks pass (4/4, including the 390px overflow check).

**New information about that flake worth recording:** it takes the shared preview server down with it, so 21 subsequent tests cascade on `ERR_CONNECTION_REFUSED`. All 21 pass on re-run in isolation (21/21). So a single flaky test currently poisons a fifth of the suite — worth fixing on its own.

Incidental: `tests/transport.test.mjs` mock param count 1174 → 1181, for the 7 newly seeded `FLOW_*` params in the demo scenario.