### PR TITLE
feat(status): free-form dashboard layout, and drag that does not fight you

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -342,7 +342,7 @@ import { buildAdvancedSensorCards } from './view-models/advanced-sensor-cards'
 import { useStatusClock } from './hooks/use-status-clock'
 import {
   StatusDashboardProvider,
-  StatusDashboardZone,
+  StatusDashboardRegion,
   type StatusDashboardCardEntry
 } from './views/StatusDashboard'
 import { useStatusDashboardLayout } from './hooks/use-status-dashboard-layout'
@@ -7010,13 +7010,16 @@ export function App() {
     }
   ]
 
-  // The DEFAULT arrangement, and the ONLY description of it: this list is what
-  // the page renders when nothing has been dragged, so it has to be the shipped
-  // layout exactly.
+  // The DEFAULT arrangement, and the ONLY description of it: this list — with
+  // `DEFAULT_STATUS_DASHBOARD_COLUMNS`, which names the columns themselves —
+  // is what the page renders when nothing has been dragged, so between them
+  // they have to be the shipped layout exactly.
   //
   //   * the sensor row under the craft model — GPS plus whichever advanced
   //     sensor cards exist — because the three answer one question and used to
-  //     be split across two columns and two scroll positions;
+  //     be split across two columns and two scroll positions. It is a SHELF
+  //     column, so a sensor card that appears mid-session lands beside its
+  //     neighbours rather than under them;
   //   * Pre-arm above Statistics in the first status column, Recent Notices
   //     beside them in the second;
   //   * System Info at the TOP of the sidebar, above Instruments and Guided
@@ -7026,14 +7029,14 @@ export function App() {
   // A stored layout is reconciled against this list every render, which is how
   // a sensor card appearing or disappearing mid-session stays graceful.
   const statusDashboardSpecs: StatusDashboardCardSpec[] = [
-    { id: 'gps', label: 'GPS', zone: 'sensors' },
-    ...advancedSensorCards.map((card) => ({ id: card.id, label: card.title, zone: 'sensors' as const })),
-    { id: 'prearm', label: 'Pre-arm', zone: 'midcol' },
-    { id: 'statistics', label: 'Statistics', zone: 'midcol' },
-    { id: 'notices', label: 'Recent Notices', zone: 'noticecol' },
-    { id: 'system-info', label: 'System Info', zone: 'sidebar' },
-    { id: 'instruments', label: 'Instruments', zone: 'sidebar' },
-    { id: 'guided-setup', label: 'Guided setup', zone: 'sidebar' }
+    { id: 'gps', label: 'GPS', column: 'sensors' },
+    ...advancedSensorCards.map((card) => ({ id: card.id, label: card.title, column: 'sensors' })),
+    { id: 'prearm', label: 'Pre-arm', column: 'midcol' },
+    { id: 'statistics', label: 'Statistics', column: 'midcol' },
+    { id: 'notices', label: 'Recent Notices', column: 'noticecol' },
+    { id: 'system-info', label: 'System Info', column: 'sidebar' },
+    { id: 'instruments', label: 'Instruments', column: 'sidebar' },
+    { id: 'guided-setup', label: 'Guided setup', column: 'sidebar' }
   ]
   const statusDashboard = useStatusDashboardLayout(statusDashboardSpecs)
 
@@ -7326,27 +7329,46 @@ export function App() {
                      *  The route in is the FW version value in System Info. */}
 
                     {/* The arrangement below is user-rearrangeable: drag a card
-                     *  by its handle, drag its bottom edge to cap its height.
-                     *  The controls only appear on viewports wide enough for
-                     *  the multi-column layout to mean anything — on a phone
-                     *  the page is one column and the default order stands. */}
+                     *  by its handle anywhere on the page, drag a column's edge
+                     *  to set its width, drag a card's bottom edge to cap its
+                     *  height. The controls only appear on viewports wide
+                     *  enough for the multi-column layout to mean anything —
+                     *  on a phone the page is one column and the default order
+                     *  stands. */}
                     <StatusDashboardProvider controller={statusDashboard} cards={statusDashboardCards}>
                     {statusDashboard.customisable ? (
                       <div className="status-dash-toolbar" data-testid="status-dash-toolbar">
                         <span className="status-dash-toolbar__hint">
-                          Drag a card by its ⠿ handle to rearrange, or focus a handle and use the arrow keys. Drag a
-                          card's bottom edge to set its height.
+                          Drag a card by its ⠿ handle to put it anywhere — beside another card, into a gap to open a new
+                          column, or above or below everything for a new row. Drag a column's right edge to set its
+                          width, or a card's bottom edge to set its height. Keyboard: focus a handle and use the arrow
+                          keys, with shift for width.
                         </span>
                         {statusDashboard.customised ? (
-                          <button
-                            type="button"
-                            style={buttonStyle()}
-                            data-testid="status-dash-reset-layout"
-                            onClick={statusDashboard.resetLayout}
-                            title="Put every Status card back where it shipped"
-                          >
-                            Reset Layout to Default
-                          </button>
+                          <>
+                            {/* Tidy is the way out of a mess that is not a full
+                             *  Reset: it drops the columns the operator emptied
+                             *  and evens up the widths, keeping the arrangement
+                             *  they actually built. */}
+                            <button
+                              type="button"
+                              style={buttonStyle()}
+                              data-testid="status-dash-tidy-layout"
+                              onClick={statusDashboard.tidyLayout}
+                              title="Close up empty columns and even out the widths, keeping your arrangement"
+                            >
+                              Tidy Up
+                            </button>
+                            <button
+                              type="button"
+                              style={buttonStyle()}
+                              data-testid="status-dash-reset-layout"
+                              onClick={statusDashboard.resetLayout}
+                              title="Put every Status card back where it shipped"
+                            >
+                              Reset Layout to Default
+                            </button>
+                          </>
                         ) : null}
                       </div>
                     ) : null}
@@ -7373,31 +7395,38 @@ export function App() {
                           frameTypeLabel={airframe.frameTypeLabel}
                         />
 
-                        {/* The sensor row, the two status columns and the
-                         *  sidebar are all DROP ZONES now. Each keeps the class
-                         *  name — and therefore the grid/flex behaviour — that
-                         *  it had before the dashboard existed, and the default
-                         *  arrangement in `statusDashboardSpecs` puts every card
-                         *  back exactly where it shipped, so with nothing
-                         *  dragged this renders identically to the static tree
-                         *  it replaced.
+                        {/* Everything below the craft model is one 12-column
+                         *  grid with auto rows: the sensor shelf is band 0, the
+                         *  two status columns are band 1, and the operator can
+                         *  put any card in any column, at any width, in either
+                         *  band — or open new ones.
+                         *
+                         *  There are two regions rather than one because the
+                         *  sidebar is a SIBLING of the viewer in the page shell
+                         *  and runs alongside the craft preview; folding it in
+                         *  would move it below the preview.
+                         *
+                         *  The default arrangement (`statusDashboardSpecs` plus
+                         *  `DEFAULT_STATUS_DASHBOARD_COLUMNS`) reproduces the
+                         *  shipped page exactly — span 6 of 12 with a 14px
+                         *  gutter is the same width as one of the two auto-fit
+                         *  tracks it replaces — so with nothing dragged this
+                         *  renders identically to the static tree it replaced.
                          *
                          *  The comments that used to justify each card's
                          *  position now live on `statusDashboardSpecs`, which is
                          *  the single place the default arrangement is stated. */}
-                        <StatusDashboardZone
-                          zone="sensors"
-                          className="setup-status-sensors"
-                          testId="setup-sensor-group"
+                        <StatusDashboardRegion
+                          region="main"
+                          className="status-dash-region--main"
+                          testId="setup-sensor-group-region"
                         />
-
-                        <div className="setup-bench__status-trio">
-                          <StatusDashboardZone zone="midcol" className="setup-status-midcol" />
-                          <StatusDashboardZone zone="noticecol" className="setup-status-noticecol" />
-                        </div>
                       </div>
 
-                      <StatusDashboardZone zone="sidebar" className="setup-bench__sidebar" />
+                      <StatusDashboardRegion
+                        region="side"
+                        className="setup-bench__sidebar status-dash-region--side"
+                      />
                     </div>
                     </StatusDashboardProvider>
   	              </div>

--- a/apps/web/src/hooks/use-status-dashboard-layout.ts
+++ b/apps/web/src/hooks/use-status-dashboard-layout.ts
@@ -4,30 +4,39 @@
 // `arduconfig.can-node-names.v1`: the version is part of the KEY, so shipping a
 // new default arrangement is a one-line bump that makes every stale saved
 // layout simply not be found. Unreadable or untrusted values fall back to the
-// default silently — see `parseStoredStatusDashboardLayout`.
+// default silently — see `parseStoredStatusDashboardLayout`. The v1 key from
+// the zone model is left alone rather than migrated: a v1 layout has no columns
+// to migrate, so those operators get the (unchanged) default back and rearrange
+// once on the much freer model.
 //
-// Customisation is deliberately a desktop-only affordance. Below the width at
-// which the workspace collapses to a single column (1024px, the existing
-// `.setup-bench__workspace` breakpoint) a stored arrangement is IGNORED and the
-// default stacking order renders instead: pointer-dragging a card on a phone
-// fights the scroll gesture, and a four-zone arrangement has no meaning in one
-// column anyway.
+// Customisation is a POINTER-WIDTH affordance, not a desktop-only one. Below
+// the width at which the workspace collapses to a single column (1024px, the
+// existing `.setup-bench__workspace` breakpoint) a stored arrangement is
+// IGNORED and the default stacking order renders instead: a multi-column
+// arrangement has no meaning in one column, and a drag gesture on a phone
+// fights the scroll. At or above it, touch and pen drags work exactly like
+// mouse drags — a landscape tablet is a real target for this page.
 
 import { useCallback, useEffect, useMemo, useState } from 'react'
 
 import {
   STATUS_DASHBOARD_STORAGE_KEY,
+  applyStatusDashboardDrop,
   defaultStatusDashboardLayout,
   isDefaultStatusDashboardLayout,
   moveStatusDashboardCard,
   nudgeStatusDashboardCard,
+  nudgeStatusDashboardCardWidth,
   parseStoredStatusDashboardLayout,
   reconcileStatusDashboardLayout,
   resizeStatusDashboardCard,
-  shiftStatusDashboardCardZone,
+  resizeStatusDashboardColumn,
+  shiftStatusDashboardCardColumn,
+  tidyStatusDashboardLayout,
+  toggleStatusDashboardColumnFlow,
   type StatusDashboardCardSpec,
-  type StatusDashboardLayout,
-  type StatusDashboardZoneId
+  type StatusDashboardDropTarget,
+  type StatusDashboardLayout
 } from '../view-models/status-dashboard-layout'
 
 /** Width below which the Status workspace is a single column; see styles.css. */
@@ -74,10 +83,16 @@ export interface StatusDashboardLayoutController {
   customisable: boolean
   /** True when the operator has changed something, so "Reset layout" is useful. */
   customised: boolean
-  moveCard: (id: string, zone: StatusDashboardZoneId, index: number) => void
+  moveCard: (id: string, columnId: string, index: number) => void
+  /** Commit a resolved drop target — a move, a new column, or a new band. */
+  dropCard: (id: string, target: StatusDashboardDropTarget) => void
   nudgeCard: (id: string, delta: -1 | 1) => void
-  shiftCardZone: (id: string, delta: -1 | 1) => void
+  shiftCardColumn: (id: string, delta: -1 | 1) => void
+  nudgeCardWidth: (id: string, delta: -1 | 1) => void
+  resizeColumn: (columnId: string, span: number) => void
+  toggleColumnFlow: (columnId: string) => void
   resizeCard: (id: string, heightRows: number | undefined) => void
+  tidyLayout: () => void
   resetLayout: () => void
 }
 
@@ -115,8 +130,14 @@ export function useStatusDashboardLayout(
   )
 
   const moveCard = useCallback(
-    (id: string, zone: StatusDashboardZoneId, index: number) =>
-      apply((current) => moveStatusDashboardCard(current, id, zone, index)),
+    (id: string, columnId: string, index: number) =>
+      apply((current) => moveStatusDashboardCard(current, id, columnId, index)),
+    [apply]
+  )
+
+  const dropCard = useCallback(
+    (id: string, target: StatusDashboardDropTarget) =>
+      apply((current) => applyStatusDashboardDrop(current, id, target)),
     [apply]
   )
 
@@ -125,8 +146,23 @@ export function useStatusDashboardLayout(
     [apply]
   )
 
-  const shiftCardZone = useCallback(
-    (id: string, delta: -1 | 1) => apply((current) => shiftStatusDashboardCardZone(current, id, delta)),
+  const shiftCardColumn = useCallback(
+    (id: string, delta: -1 | 1) => apply((current) => shiftStatusDashboardCardColumn(current, id, delta)),
+    [apply]
+  )
+
+  const nudgeCardWidth = useCallback(
+    (id: string, delta: -1 | 1) => apply((current) => nudgeStatusDashboardCardWidth(current, id, delta)),
+    [apply]
+  )
+
+  const resizeColumn = useCallback(
+    (columnId: string, span: number) => apply((current) => resizeStatusDashboardColumn(current, columnId, span)),
+    [apply]
+  )
+
+  const toggleColumnFlow = useCallback(
+    (columnId: string) => apply((current) => toggleStatusDashboardColumnFlow(current, columnId)),
     [apply]
   )
 
@@ -135,6 +171,8 @@ export function useStatusDashboardLayout(
       apply((current) => resizeStatusDashboardCard(current, id, heightRows)),
     [apply]
   )
+
+  const tidyLayout = useCallback(() => apply((current) => tidyStatusDashboardLayout(current)), [apply])
 
   const resetLayout = useCallback(() => {
     setStored(undefined)
@@ -150,5 +188,19 @@ export function useStatusDashboardLayout(
     [customisable, stored, layout, specs]
   )
 
-  return { layout, customisable, customised, moveCard, nudgeCard, shiftCardZone, resizeCard, resetLayout }
+  return {
+    layout,
+    customisable,
+    customised,
+    moveCard,
+    dropCard,
+    nudgeCard,
+    shiftCardColumn,
+    nudgeCardWidth,
+    resizeColumn,
+    toggleColumnFlow,
+    resizeCard,
+    tidyLayout,
+    resetLayout
+  }
 }

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -2886,23 +2886,10 @@ textarea:focus {
   gap: 10px;
 }
 
-/* Status boxes (Pre-arm + Statistics / Recent Notices) render directly
- * underneath the sensor group in the main column — the operator reads them
- * at-glance alongside the model rather than having to glance over to the
- * sidebar. Auto-fit so they shape up as columns on wide screens and stack on
- * narrow. The class is still named "trio" from when System Info was the third
- * column here; it moved to the sidebar, and renaming the class would collide
- * with concurrent work on the notices panel for no behavioural gain. */
-.setup-bench__status-trio {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-  gap: 14px;
-  margin-top: 14px;
-  /* Size every column to its own content instead of stretching them all to the
-   * tallest — stretching leaves hundreds of pixels of empty box below the
-   * shorter one, empty space the operator still has to scroll past. */
-  align-items: start;
-}
+/* `.setup-bench__status-trio` used to live here: a hard-coded `auto-fit` pair
+ * holding Pre-arm/Statistics and Recent Notices. Those two are now band 1 of
+ * the main dashboard region, two 6-of-12 columns, which is the same width and
+ * the same gutter — see `.status-dash-region`. */
 
 .setup-gui-box {
   display: grid;
@@ -3090,11 +3077,12 @@ textarea:focus {
  * card carries a map and is taller than the two readout cards even after the
  * compaction below, and stretching would hang dead space off the bottom of
  * the short ones. */
+/* The row's own top margin is gone: the region grid below owns the 14px gap
+ * between bands now, and keeping both would double it. */
 .setup-status-sensors {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(min(260px, 100%), 1fr));
   gap: 14px;
-  margin-top: 14px;
   align-items: start;
 }
 
@@ -3206,28 +3194,148 @@ textarea:focus {
   }
 }
 
-/* Status middle column: pre-arm box on top, compact lifetime stats below. */
-.setup-status-midcol {
+/* ── Status & Info dashboard: the free grid ────────────────────────────────
+ *
+ * A REGION is a 12-column grid with AUTO rows. Auto rows are the whole reason
+ * cards can be placed freely without any of them being clipped or padded out:
+ * a card is exactly as tall as its content, decided by the layout engine, and
+ * a pre-arm card that grows an issue simply makes its column taller.
+ *
+ * `align-items: start` is load-bearing, not cosmetic. It is what stops a tall
+ * column in a band from stretching a short one beside it — and, in the default
+ * arrangement, what keeps Statistics sitting directly under Pre-arm instead of
+ * below the bottom of a much taller Recent Notices. Cards stack inside a
+ * COLUMN, so a column packs tightly regardless of its neighbours' height.
+ *
+ * The default arrangement is arithmetically identical to the page that shipped
+ * before this feature: with a uniform 14px gutter, `span 6` of 12 is exactly
+ * the width of one of two `auto-fit minmax(220px, 1fr)` tracks, and `span 4`
+ * exactly one of three. */
+.status-dash-region {
+  display: grid;
+  grid-template-columns: repeat(12, minmax(0, 1fr));
+  align-items: start;
+}
+
+.status-dash-region--main {
+  gap: 14px;
+  margin-top: 14px;
+}
+
+/* The sidebar region keeps the 10px rhythm `.setup-bench__sidebar` always had. */
+.status-dash-region--side {
+  gap: 10px;
+}
+
+/* A column: a stack of cards, or a wrapping shelf of them. */
+.status-dash-col {
+  position: relative;
+  min-width: 0;
+}
+
+.status-dash-col--stack {
   display: flex;
   flex-direction: column;
   gap: 14px;
 }
 
-/* Status third column. Recent Notices used to be a bare child of the trio
- * grid; it now has the same stacking wrapper as the other two columns purely
- * so a dragged card has somewhere to land next to it. With one card in it the
- * rendering is identical to the bare article it replaced. */
-.setup-status-noticecol {
+.status-dash-region--side .status-dash-col--stack {
+  gap: 10px;
+}
+
+/* A shelf also carries `.setup-status-sensors`, which supplies the auto-fit
+ * grid and the GPS map compaction; nothing more is needed here. */
+
+/* An emptied column still has to be a target you can hit. */
+.status-dash-col--empty {
+  min-height: 64px;
+  border-radius: 12px;
+  border: 1px dashed color-mix(in srgb, var(--surface-400) 70%, transparent);
+}
+
+/* Column chrome sits OUTSIDE the flow — inside a shelf column it would
+ * otherwise become an auto-fit grid track and steal a sensor card's width. */
+.status-dash-col__chrome {
+  position: absolute;
+  inset: 0 -7px 0 auto;
+  width: 14px;
+  pointer-events: none;
   display: flex;
   flex-direction: column;
-  gap: 14px;
+  align-items: center;
+  justify-content: flex-start;
+  gap: 6px;
+  z-index: 3;
+}
+
+.status-dash-col__flow,
+.status-dash-col__width {
+  pointer-events: auto;
+  padding: 0;
+  border: none;
+  background: transparent;
+  opacity: 0;
+  transition: opacity 120ms ease;
+}
+
+.status-dash-col:hover .status-dash-col__flow,
+.status-dash-col:hover .status-dash-col__width,
+.status-dash-col__flow:focus-visible,
+.status-dash-col__width:focus-visible {
+  opacity: 1;
+}
+
+.status-dash-col__flow {
+  margin-top: -2px;
+  width: 18px;
+  height: 18px;
+  display: grid;
+  place-items: center;
+  border-radius: 999px;
+  border: 1px solid var(--surface-400);
+  background: var(--surface-300);
+  color: var(--text-muted);
+  font-size: 10px;
+  line-height: 1;
+  cursor: pointer;
+}
+
+/* The horizontal resize: drag a column's right edge to change its width in
+ * twelfths. Snapping to a whole twelfth is also the throttle — the layout
+ * changes at most eleven times across a whole gesture. */
+.status-dash-col__width {
+  flex: 1;
+  width: 14px;
+  cursor: ew-resize;
+  display: grid;
+  place-items: center;
+  touch-action: none;
+}
+
+.status-dash-col__width > span {
+  display: block;
+  width: 4px;
+  height: min(48px, 100%);
+  border-radius: 999px;
+  background: var(--primary-500);
+  opacity: 0.55;
+}
+
+.status-dash-col__width:focus-visible,
+.status-dash-col__flow:focus-visible {
+  outline: 2px solid var(--primary-500);
+  outline-offset: 2px;
+  border-radius: 6px;
+}
+
+.status-dash-col__width:disabled {
+  display: none;
 }
 
 /* ── Status & Info dashboard: drag / resize chrome ─────────────────────────
  *
  * Purely additive around the existing cards. With nothing dragged and no
- * height cap set, every rule below is inert and the page renders exactly as
- * it did before the dashboard existed. */
+ * height cap set, every rule below is inert. */
 
 .status-dash-toolbar {
   display: flex;
@@ -3242,32 +3350,21 @@ textarea:focus {
   font-size: 12px;
 }
 
-.status-dash-zone {
-  position: relative;
-}
-
-/* Only while a drag is in flight: give an emptied column enough height to
- * still be a target, and outline the one under the pointer. */
-.status-dash-zone--armed {
-  min-height: 72px;
-  border-radius: 12px;
-}
-
-.status-dash-zone--armed.is-drop-target {
-  outline: 1px dashed color-mix(in srgb, var(--primary-500) 55%, transparent);
-  outline-offset: 6px;
-}
-
 .status-dash-card {
   position: relative;
   min-width: 0;
 }
 
-/* The dragged card stays in place, ghosted, and stops swallowing hit-tests so
- * `elementFromPoint` can see the zone underneath it. */
+/* The dragged card is LIFTED, not removed: it keeps its slot in the flow (so
+ * nothing below it moves) and follows the pointer on a composited transform,
+ * which costs no layout at all. `will-change` promotes it to its own layer for
+ * the duration; leaving that on permanently would pin a layer per card. */
 .status-dash-card.is-dragging {
-  opacity: 0.32;
+  z-index: 30;
   pointer-events: none;
+  will-change: transform;
+  opacity: 0.92;
+  filter: drop-shadow(0 12px 22px rgba(0, 0, 0, 0.45));
 }
 
 /* A user-set height cap. The negative margin + matching padding keeps the
@@ -3353,9 +3450,17 @@ textarea:focus {
   border-radius: 6px;
 }
 
-/* Where the card will land. */
+/* Where the card will land.
+ *
+ * Fixed-position and OUT OF FLOW. v1 inserted a real element into the target
+ * column to show this, which pushed every card below it down and relaid the
+ * page out on every pointer move — the single biggest reason the drag felt
+ * clunky, and the reason a drop could land somewhere the indicator had not
+ * promised. Painting a line over the page moves nothing. */
 .status-dash-drop {
-  height: 4px;
+  position: fixed;
+  z-index: 40;
+  pointer-events: none;
   border-radius: 999px;
   background: var(--primary-500);
   box-shadow: 0 0 0 3px color-mix(in srgb, var(--primary-500) 22%, transparent);
@@ -3366,9 +3471,27 @@ body.is-status-dash-dragging {
   cursor: grabbing;
 }
 
+/* Below the multi-column breakpoint the whole page is one column, so every
+ * column spans the full width and the bands simply stack in order — which is
+ * the phone rendering the page has always had. Customisation is off here
+ * (`useStatusDashboardLayout` renders the default), so this only ever lays out
+ * the four default columns. */
+@media (max-width: 1024px) {
+  .status-dash-region {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .status-dash-region > .status-dash-col {
+    grid-column: 1 / -1 !important;
+    grid-row: auto !important;
+  }
+}
+
 @media (prefers-reduced-motion: reduce) {
   .status-dash-card__handle,
-  .status-dash-card__resize > span {
+  .status-dash-card__resize > span,
+  .status-dash-col__flow,
+  .status-dash-col__width {
     transition: none;
   }
 }

--- a/apps/web/src/view-models/status-dashboard-layout.test.ts
+++ b/apps/web/src/view-models/status-dashboard-layout.test.ts
@@ -1,38 +1,52 @@
 import { describe, expect, it } from 'vitest'
 
 import {
+  DEFAULT_STATUS_DASHBOARD_COLUMNS,
+  STATUS_DASHBOARD_GRID_COLUMNS,
   STATUS_DASHBOARD_LAYOUT_VERSION,
   STATUS_DASHBOARD_MAX_ROWS,
   STATUS_DASHBOARD_MIN_ROWS,
+  applyStatusDashboardDrop,
+  bandFreeSpan,
+  columnCardIds,
+  columnStartLine,
   defaultStatusDashboardLayout,
+  insertStatusDashboardBand,
   isDefaultStatusDashboardLayout,
   moveStatusDashboardCard,
   nudgeStatusDashboardCard,
+  nudgeStatusDashboardCardWidth,
   parseStoredStatusDashboardLayout,
   reconcileStatusDashboardLayout,
+  regionBands,
   resizeStatusDashboardCard,
-  shiftStatusDashboardCardZone,
-  zoneCardIds,
-  type StatusDashboardCardSpec
+  resizeStatusDashboardColumn,
+  resolveStatusDashboardDrop,
+  shiftStatusDashboardCardColumn,
+  splitStatusDashboardColumn,
+  tidyStatusDashboardLayout,
+  toggleStatusDashboardColumnFlow,
+  type StatusDashboardCardSpec,
+  type StatusDashboardGeometry
 } from './status-dashboard-layout'
 
 /**
  * The default card set with both conditional sensor cards present. This mirrors
  * `statusDashboardSpecs` in App.tsx, which is the page exactly as it ships:
- * GPS + the two advanced sensors in one row, Pre-arm/Statistics and Recent
+ * GPS + the two advanced sensors in one shelf, Pre-arm/Statistics and Recent
  * Notices in the two status columns below it, and System Info leading the
  * sidebar above Instruments and Guided setup.
  */
 const specsWithSensors: StatusDashboardCardSpec[] = [
-  { id: 'gps', label: 'GPS', zone: 'sensors' },
-  { id: 'rangefinder', label: 'Rangefinder', zone: 'sensors' },
-  { id: 'optical-flow', label: 'Optical Flow', zone: 'sensors' },
-  { id: 'prearm', label: 'Pre-arm', zone: 'midcol' },
-  { id: 'statistics', label: 'Statistics', zone: 'midcol' },
-  { id: 'notices', label: 'Recent Notices', zone: 'noticecol' },
-  { id: 'system-info', label: 'System Info', zone: 'sidebar' },
-  { id: 'instruments', label: 'Instruments', zone: 'sidebar' },
-  { id: 'guided-setup', label: 'Guided setup', zone: 'sidebar' }
+  { id: 'gps', label: 'GPS', column: 'sensors' },
+  { id: 'rangefinder', label: 'Rangefinder', column: 'sensors' },
+  { id: 'optical-flow', label: 'Optical Flow', column: 'sensors' },
+  { id: 'prearm', label: 'Pre-arm', column: 'midcol' },
+  { id: 'statistics', label: 'Statistics', column: 'midcol' },
+  { id: 'notices', label: 'Recent Notices', column: 'noticecol' },
+  { id: 'system-info', label: 'System Info', column: 'sidebar' },
+  { id: 'instruments', label: 'Instruments', column: 'sidebar' },
+  { id: 'guided-setup', label: 'Guided setup', column: 'sidebar' }
 ]
 
 /** The same page with the sensors unconfigured — those two cards do not exist. */
@@ -44,237 +58,599 @@ describe('defaultStatusDashboardLayout', () => {
   it('describes the shipped arrangement, one placement per card', () => {
     const layout = defaultStatusDashboardLayout(specsWithSensors)
     expect(layout.version).toBe(STATUS_DASHBOARD_LAYOUT_VERSION)
-    expect(zoneCardIds(layout, 'sensors')).toEqual(['gps', 'rangefinder', 'optical-flow'])
-    expect(zoneCardIds(layout, 'midcol')).toEqual(['prearm', 'statistics'])
-    expect(zoneCardIds(layout, 'noticecol')).toEqual(['notices'])
-    expect(zoneCardIds(layout, 'sidebar')).toEqual(['system-info', 'instruments', 'guided-setup'])
-    expect(isDefaultStatusDashboardLayout(layout, specsWithSensors)).toBe(true)
+    expect(columnCardIds(layout, 'sensors')).toEqual(['gps', 'rangefinder', 'optical-flow'])
+    expect(columnCardIds(layout, 'midcol')).toEqual(['prearm', 'statistics'])
+    expect(columnCardIds(layout, 'noticecol')).toEqual(['notices'])
+    expect(columnCardIds(layout, 'sidebar')).toEqual(['system-info', 'instruments', 'guided-setup'])
+    expect(layout.cards.every((placement) => placement.heightRows === undefined)).toBe(true)
+  })
+
+  it('lays the default columns out exactly as the pre-dashboard page did', () => {
+    // This is the arithmetic behind "the default renders identically to main".
+    // The sensor shelf is the full width; the two status columns are half each,
+    // which with a uniform gutter is the same width as the `auto-fit` pair they
+    // replaced; the sidebar fills its own region.
+    const layout = defaultStatusDashboardLayout(specsWithSensors)
+    const main = regionBands(layout, 'main')
+    expect(main.map((band) => band.columns.map((column) => column.id))).toEqual([
+      ['sensors'],
+      ['midcol', 'noticecol']
+    ])
+    expect(main[0]!.columns[0]!.span).toBe(STATUS_DASHBOARD_GRID_COLUMNS)
+    expect(main[1]!.columns.map((column) => column.span)).toEqual([6, 6])
+    // Explicit start lines, so a band that does not add up to 12 leaves its
+    // free space at the right instead of the grid repacking the row.
+    expect(columnStartLine(main[1]!, 'midcol')).toBe(1)
+    expect(columnStartLine(main[1]!, 'noticecol')).toBe(7)
+    expect(bandFreeSpan(main[1]!)).toBe(0)
+
+    const side = regionBands(layout, 'side')
+    expect(side.map((band) => band.columns.map((column) => column.id))).toEqual([['sidebar']])
+
+    // The sensor shelf flows across, not down — that is why a sensor card that
+    // appears mid-session lands BESIDE its neighbours.
+    expect(main[0]!.columns[0]!.flow).toBe('shelf')
+    expect(main[1]!.columns.every((column) => column.flow === 'stack')).toBe(true)
   })
 })
 
 describe('parseStoredStatusDashboardLayout', () => {
-  it('round-trips a layout it wrote', () => {
-    const layout = resizeStatusDashboardCard(defaultStatusDashboardLayout(specsWithSensors), 'notices', 12)
-    expect(parseStoredStatusDashboardLayout(JSON.stringify(layout))).toEqual(layout)
-  })
-
-  it('falls back to undefined on anything it cannot trust', () => {
-    // Nothing stored, unparseable JSON, wrong shape, wrong version: all must
-    // degrade to "use the default", never throw.
+  it('rejects anything it cannot fully trust', () => {
     expect(parseStoredStatusDashboardLayout(null)).toBeUndefined()
     expect(parseStoredStatusDashboardLayout('')).toBeUndefined()
-    expect(parseStoredStatusDashboardLayout('{not json')).toBeUndefined()
+    expect(parseStoredStatusDashboardLayout('{"version":2,"columns":[{"id":"a"')).toBeUndefined()
     expect(parseStoredStatusDashboardLayout('[]')).toBeUndefined()
-    expect(parseStoredStatusDashboardLayout('"a string"')).toBeUndefined()
-    expect(parseStoredStatusDashboardLayout(JSON.stringify({ version: 999, cards: [] }))).toBeUndefined()
-    expect(parseStoredStatusDashboardLayout(JSON.stringify({ version: 1 }))).toBeUndefined()
-    expect(
-      parseStoredStatusDashboardLayout(JSON.stringify({ version: 1, cards: 'nope' }))
-    ).toBeUndefined()
+    expect(parseStoredStatusDashboardLayout('{"version":2}')).toBeUndefined()
+    // A layout with no columns at all cannot render anything.
+    expect(parseStoredStatusDashboardLayout('{"version":2,"columns":[],"cards":[]}')).toBeUndefined()
   })
 
-  it('drops junk entries and repairs bad fields instead of failing whole', () => {
+  it('discards a layout saved by the zone model, rather than half-reading it', () => {
+    // v1 stored `{version:1, cards:[{id, zone}]}`. There are no columns in it
+    // to migrate, so those operators get the (unchanged) default back.
+    const v1 = JSON.stringify({ version: 1, cards: [{ id: 'gps', zone: 'sidebar' }] })
+    expect(parseStoredStatusDashboardLayout(v1)).toBeUndefined()
+  })
+
+  it('keeps the good entries and clamps the suspicious ones', () => {
     const parsed = parseStoredStatusDashboardLayout(
       JSON.stringify({
-        version: 1,
+        version: STATUS_DASHBOARD_LAYOUT_VERSION,
+        columns: [
+          { id: 'a', region: 'main', band: 0, span: 99, flow: 'shelf' },
+          { id: 'b', region: 'nowhere', band: -4, span: 0, flow: 'sideways' },
+          { id: 'a', region: 'main', band: 0, span: 4 },
+          { notAnId: true }
+        ],
         cards: [
-          { id: 'system-info', zone: 'sidebar' },
-          { id: 'system-info', zone: 'midcol' }, // duplicate id — ignored
-          { id: '', zone: 'midcol' }, // empty id — ignored
-          { id: 42, zone: 'midcol' }, // non-string id — ignored
-          null,
-          'notices',
-          { id: 'notices', zone: 'from-the-future' }, // unknown zone — repaired
-          { id: 'gps', zone: 'sidebar', heightRows: 9999 }, // out of range — clamped
-          { id: 'prearm', zone: 'midcol', heightRows: 'tall' } // wrong type — dropped
+          { id: 'gps', column: 'a', heightRows: 9000 },
+          { id: 'prearm', column: 'ghost-column' },
+          { id: 'gps', column: 'b' },
+          { column: 'a' }
         ]
       })
     )
-    expect(parsed).toEqual({
-      version: 1,
-      cards: [
-        { id: 'system-info', zone: 'sidebar' },
-        { id: 'notices', zone: 'sensors' },
-        { id: 'gps', zone: 'sidebar', heightRows: STATUS_DASHBOARD_MAX_ROWS },
-        { id: 'prearm', zone: 'midcol' }
-      ]
-    })
+    expect(parsed?.columns.map((column) => column.id)).toEqual(['a', 'b'])
+    expect(parsed?.columns[0]).toMatchObject({ span: STATUS_DASHBOARD_GRID_COLUMNS, flow: 'shelf' })
+    // Bad region/band/span/flow are repaired rather than thrown away.
+    expect(parsed?.columns[1]).toMatchObject({ region: 'main', band: 0, span: 1, flow: 'stack' })
+    expect(parsed?.cards.map((card) => card.id)).toEqual(['gps', 'prearm'])
+    expect(parsed?.cards[0]?.heightRows).toBe(STATUS_DASHBOARD_MAX_ROWS)
+    // A card naming a column that does not exist is re-homed, not dropped.
+    expect(parsed?.cards[1]?.column).toBe('a')
   })
 })
 
 describe('reconcileStatusDashboardLayout', () => {
-  it('uses the default when there is nothing stored', () => {
-    expect(reconcileStatusDashboardLayout(undefined, specsWithSensors)).toEqual(
-      defaultStatusDashboardLayout(specsWithSensors)
-    )
+  it('falls back to the default when there is nothing stored', () => {
+    const layout = reconcileStatusDashboardLayout(undefined, specsWithSensors)
+    expect(isDefaultStatusDashboardLayout(layout, specsWithSensors)).toBe(true)
   })
 
-  it('drops cards that are no longer on the page', () => {
-    // Layout saved while a rangefinder and flow sensor were configured, then
-    // reopened with both set to type 0 — the cards do not render at all.
-    const saved = moveStatusDashboardCard(
-      defaultStatusDashboardLayout(specsWithSensors),
-      'rangefinder',
-      'sidebar',
-      0
-    )
-    const reconciled = reconcileStatusDashboardLayout(saved, specsWithoutSensors)
-    expect(reconciled.cards.map((card) => card.id).sort()).toEqual(
-      specsWithoutSensors.map((spec) => spec.id).sort()
-    )
-    expect(zoneCardIds(reconciled, 'sidebar')).toEqual(['system-info', 'instruments', 'guided-setup'])
-    expect(zoneCardIds(reconciled, 'sensors')).toEqual(['gps'])
+  it('drops placements for cards that are not on the page', () => {
+    const saved = defaultStatusDashboardLayout(specsWithSensors)
+    const layout = reconcileStatusDashboardLayout(saved, specsWithoutSensors)
+    expect(columnCardIds(layout, 'sensors')).toEqual(['gps'])
+    expect(layout.cards).toHaveLength(specsWithoutSensors.length)
   })
 
-  it('inserts a newly-present card at its default neighbourhood', () => {
-    // Saved with no sensors; the operator then wires up a lidar mid-session.
-    const saved = defaultStatusDashboardLayout(specsWithoutSensors)
-    const reconciled = reconcileStatusDashboardLayout(saved, specsWithSensors)
-    expect(zoneCardIds(reconciled, 'sensors')).toEqual(['gps', 'rangefinder', 'optical-flow'])
-    expect(reconciled.cards).toHaveLength(specsWithSensors.length)
-  })
-
-  it('honours a customised position for the anchor when inserting new cards', () => {
-    // GPS dragged to the sidebar; a rangefinder then appears. The new card takes
-    // its DEFAULT zone (the sensor row — a rangefinder card belongs with the
-    // other sensors however the operator has arranged them), but its slot in the
-    // flat order follows its anchor, so it never lands orphaned at the bottom.
-    const saved = moveStatusDashboardCard(
+  it('lands a sensor card that reappears beside the neighbour it belongs to', () => {
+    // The conditional-card contract, and the case that actually bites: an
+    // operator drags GPS somewhere, then plugs a rangefinder in.
+    const moved = moveStatusDashboardCard(
       defaultStatusDashboardLayout(specsWithoutSensors),
       'gps',
-      'sidebar',
+      'midcol',
       0
     )
-    const reconciled = reconcileStatusDashboardLayout(saved, specsWithSensors)
-    const rangefinder = reconciled.cards.find((card) => card.id === 'rangefinder')
-    expect(rangefinder?.zone).toBe('sensors')
-    // Immediately after GPS in the flat list, wherever that ended up.
-    const ids = reconciled.cards.map((card) => card.id)
-    expect(ids[ids.indexOf('gps') + 1]).toBe('rangefinder')
+    const layout = reconcileStatusDashboardLayout(moved, specsWithSensors)
+    expect(layout.cards).toHaveLength(specsWithSensors.length)
+    // Rangefinder and optical flow follow GPS into midcol, directly after it,
+    // rather than being orphaned at the end of the page.
+    expect(columnCardIds(layout, 'midcol')).toEqual([
+      'gps',
+      'rangefinder',
+      'optical-flow',
+      'prearm',
+      'statistics'
+    ])
   })
 
-  it('never yields duplicates or losses even from a hostile stored layout', () => {
-    const reconciled = reconcileStatusDashboardLayout(
-      { version: 1, cards: [{ id: 'ghost', zone: 'midcol' }] },
-      specsWithSensors
+  it('keeps a column the operator emptied, so a returning card has its room', () => {
+    const emptied = moveStatusDashboardCard(
+      defaultStatusDashboardLayout(specsWithSensors),
+      'notices',
+      'midcol',
+      0
     )
-    expect(reconciled.cards.map((card) => card.id).sort()).toEqual(
-      specsWithSensors.map((spec) => spec.id).sort()
-    )
+    const layout = reconcileStatusDashboardLayout(emptied, specsWithSensors)
+    expect(layout.columns.map((column) => column.id)).toContain('noticecol')
+    expect(columnCardIds(layout, 'noticecol')).toEqual([])
+  })
+
+  it('re-homes a card whose column the operator deleted', () => {
+    const saved = defaultStatusDashboardLayout(specsWithSensors)
+    const withoutSidebar = {
+      ...saved,
+      columns: saved.columns.filter((column) => column.id !== 'sidebar')
+    }
+    const layout = reconcileStatusDashboardLayout(withoutSidebar, specsWithSensors)
+    expect(layout.cards).toHaveLength(specsWithSensors.length)
+    const columnIds = new Set(layout.columns.map((column) => column.id))
+    expect(layout.cards.every((placement) => columnIds.has(placement.column))).toBe(true)
+  })
+
+  it('never loses or duplicates a card, whatever it is handed', () => {
+    const nonsense = {
+      version: STATUS_DASHBOARD_LAYOUT_VERSION,
+      columns: [{ id: 'only', region: 'main' as const, band: 0, span: 12, flow: 'stack' as const }],
+      cards: [{ id: 'ghost', column: 'only' }]
+    }
+    const layout = reconcileStatusDashboardLayout(nonsense, specsWithSensors)
+    const ids = layout.cards.map((placement) => placement.id).sort()
+    expect(ids).toEqual(specsWithSensors.map((spec) => spec.id).sort())
   })
 })
 
 describe('moveStatusDashboardCard', () => {
-  it('reorders inside a zone', () => {
+  it('moves a card into another column at the requested index', () => {
     const layout = moveStatusDashboardCard(
       defaultStatusDashboardLayout(specsWithSensors),
-      'guided-setup',
-      'sidebar',
-      0
-    )
-    expect(zoneCardIds(layout, 'sidebar')).toEqual(['guided-setup', 'system-info', 'instruments'])
-  })
-
-  it('moves between zones at the requested index', () => {
-    const layout = moveStatusDashboardCard(
-      defaultStatusDashboardLayout(specsWithSensors),
-      'gps',
+      'system-info',
       'midcol',
       1
     )
-    expect(zoneCardIds(layout, 'midcol')).toEqual(['prearm', 'gps', 'statistics'])
-    expect(zoneCardIds(layout, 'sensors')).toEqual(['rangefinder', 'optical-flow'])
+    expect(columnCardIds(layout, 'midcol')).toEqual(['prearm', 'system-info', 'statistics'])
+    expect(columnCardIds(layout, 'sidebar')).toEqual(['instruments', 'guided-setup'])
   })
 
-  it('clamps an out-of-range index and lands in an empty zone', () => {
-    const base = defaultStatusDashboardLayout(specsWithSensors)
-    const emptied = moveStatusDashboardCard(base, 'notices', 'sidebar', 99)
-    expect(zoneCardIds(emptied, 'noticecol')).toEqual([])
-    expect(zoneCardIds(emptied, 'sidebar')).toEqual([
+  it('clamps an out-of-range index instead of dropping the card', () => {
+    const layout = moveStatusDashboardCard(
+      defaultStatusDashboardLayout(specsWithSensors),
+      'gps',
+      'sidebar',
+      99
+    )
+    expect(columnCardIds(layout, 'sidebar')).toEqual([
       'system-info',
       'instruments',
       'guided-setup',
-      'notices'
+      'gps'
     ])
-    const back = moveStatusDashboardCard(emptied, 'gps', 'noticecol', -5)
-    expect(zoneCardIds(back, 'noticecol')).toEqual(['gps'])
   })
 
-  it('returns the same object when nothing changes', () => {
-    const base = defaultStatusDashboardLayout(specsWithSensors)
-    expect(moveStatusDashboardCard(base, 'prearm', 'midcol', 0)).toBe(base)
-    expect(moveStatusDashboardCard(base, 'no-such-card', 'midcol', 0)).toBe(base)
+  it('returns the SAME object for a no-op, so nothing re-renders or is persisted', () => {
+    const before = defaultStatusDashboardLayout(specsWithSensors)
+    expect(moveStatusDashboardCard(before, 'prearm', 'midcol', 0)).toBe(before)
+    expect(moveStatusDashboardCard(before, 'not-a-card', 'midcol', 0)).toBe(before)
+    expect(moveStatusDashboardCard(before, 'prearm', 'not-a-column', 0)).toBe(before)
   })
 })
 
-describe('keyboard moves', () => {
-  it('nudges up and down within a zone and stops at the ends', () => {
-    const base = defaultStatusDashboardLayout(specsWithSensors)
-    expect(zoneCardIds(nudgeStatusDashboardCard(base, 'guided-setup', -1), 'sidebar')).toEqual([
+describe('columns: the freedom the zone model did not have', () => {
+  it('opens a new column in a band, taking the free space when there is any', () => {
+    const start = resizeStatusDashboardColumn(defaultStatusDashboardLayout(specsWithSensors), 'midcol', 4)
+    const band = regionBands(start, 'main').find((entry) => entry.band === 1)!
+    expect(bandFreeSpan(band)).toBe(2)
+
+    const layout = splitStatusDashboardColumn(start, 'system-info', 'main', 1, 2)
+    const after = regionBands(layout, 'main').find((entry) => entry.band === 1)!
+    expect(after.columns).toHaveLength(3)
+    const created = after.columns[2]!
+    expect(created.span).toBe(2)
+    expect(columnCardIds(layout, created.id)).toEqual(['system-info'])
+    // The columns that were already there are untouched.
+    expect(after.columns[0]!.span).toBe(4)
+    expect(after.columns[1]!.span).toBe(6)
+  })
+
+  it('halves the widest neighbour when a band is already full', () => {
+    const layout = splitStatusDashboardColumn(
+      defaultStatusDashboardLayout(specsWithSensors),
       'system-info',
-      'guided-setup',
-      'instruments'
+      'main',
+      1,
+      0
+    )
+    const band = regionBands(layout, 'main').find((entry) => entry.band === 1)!
+    expect(band.columns.map((column) => column.span)).toEqual([3, 3, 6])
+    expect(band.columns.reduce((total, column) => total + column.span, 0)).toBe(
+      STATUS_DASHBOARD_GRID_COLUMNS
+    )
+  })
+
+  it('opens a new band and pushes the bands below it down', () => {
+    const layout = insertStatusDashboardBand(
+      defaultStatusDashboardLayout(specsWithSensors),
+      'notices',
+      'main',
+      1
+    )
+    const bands = regionBands(layout, 'main')
+    expect(bands.map((band) => band.band)).toEqual([0, 1, 2])
+    expect(bands[0]!.columns.map((column) => column.id)).toEqual(['sensors'])
+    expect(columnCardIds(layout, bands[1]!.columns[0]!.id)).toEqual(['notices'])
+    expect(bands[1]!.columns[0]!.span).toBe(STATUS_DASHBOARD_GRID_COLUMNS)
+    expect(bands[2]!.columns.map((column) => column.id)).toEqual(['midcol', 'noticecol'])
+  })
+
+  it('resizes a column, taking from the next one along once the band is full', () => {
+    const layout = resizeStatusDashboardColumn(
+      defaultStatusDashboardLayout(specsWithSensors),
+      'midcol',
+      9
+    )
+    const band = regionBands(layout, 'main').find((entry) => entry.band === 1)!
+    expect(band.columns.map((column) => [column.id, column.span])).toEqual([
+      ['midcol', 9],
+      ['noticecol', 3]
     ])
-    // Already first in the zone: up is a no-op rather than an escape into the
-    // previous zone, so a held arrow key cannot walk a card off the page.
-    expect(zoneCardIds(nudgeStatusDashboardCard(base, 'system-info', -1), 'sidebar')).toEqual([
-      'system-info',
-      'instruments',
-      'guided-setup'
-    ])
-    expect(zoneCardIds(nudgeStatusDashboardCard(base, 'guided-setup', 1), 'sidebar')).toEqual([
+    // A band can never overflow 12: that is the one arrangement the operator
+    // cannot see themselves making, and it wraps into a broken-looking page.
+    expect(band.columns.reduce((total, column) => total + column.span, 0)).toBeLessThanOrEqual(
+      STATUS_DASHBOARD_GRID_COLUMNS
+    )
+  })
+
+  it('never squeezes a neighbour out of existence', () => {
+    const layout = resizeStatusDashboardColumn(
+      defaultStatusDashboardLayout(specsWithSensors),
+      'midcol',
+      STATUS_DASHBOARD_GRID_COLUMNS
+    )
+    const band = regionBands(layout, 'main').find((entry) => entry.band === 1)!
+    expect(band.columns.map((column) => column.span)).toEqual([11, 1])
+  })
+
+  it('lets a shrink leave a gap — a mess the operator made is allowed', () => {
+    const layout = resizeStatusDashboardColumn(
+      defaultStatusDashboardLayout(specsWithSensors),
+      'noticecol',
+      2
+    )
+    const band = regionBands(layout, 'main').find((entry) => entry.band === 1)!
+    expect(bandFreeSpan(band)).toBe(4)
+    expect(columnStartLine(band, 'noticecol')).toBe(7)
+  })
+
+  it('flips a column between stacking and shelving', () => {
+    const layout = toggleStatusDashboardColumnFlow(
+      defaultStatusDashboardLayout(specsWithSensors),
+      'midcol'
+    )
+    expect(layout.columns.find((column) => column.id === 'midcol')?.flow).toBe('shelf')
+  })
+})
+
+describe('applyStatusDashboardDrop', () => {
+  it('routes each kind of drop target to the right transform', () => {
+    const start = defaultStatusDashboardLayout(specsWithSensors)
+
+    const moved = applyStatusDashboardDrop(start, 'gps', {
+      kind: 'column',
+      columnId: 'midcol',
+      index: 0
+    })
+    expect(columnCardIds(moved, 'midcol')).toEqual(['gps', 'prearm', 'statistics'])
+
+    const split = applyStatusDashboardDrop(start, 'gps', {
+      kind: 'new-column',
+      region: 'main',
+      band: 1,
+      at: 0
+    })
+    expect(regionBands(split, 'main').find((band) => band.band === 1)!.columns).toHaveLength(3)
+
+    const banded = applyStatusDashboardDrop(start, 'gps', { kind: 'new-band', region: 'main', band: 0 })
+    expect(regionBands(banded, 'main')).toHaveLength(3)
+  })
+})
+
+describe('keyboard transforms', () => {
+  it('nudges a card inside its column', () => {
+    const layout = nudgeStatusDashboardCard(defaultStatusDashboardLayout(specsWithSensors), 'statistics', -1)
+    expect(columnCardIds(layout, 'midcol')).toEqual(['statistics', 'prearm'])
+  })
+
+  it('walks a card across every column in visual order, bands and sidebar included', () => {
+    const start = defaultStatusDashboardLayout(specsWithSensors)
+    // Visual order is sensors, midcol, noticecol, then the sidebar — so one
+    // step right out of noticecol reaches the sidebar, which the zone model
+    // could also do, and one step right out of sensors reaches midcol, which
+    // means the keyboard can cross a BAND boundary.
+    const intoMid = shiftStatusDashboardCardColumn(start, 'gps', 1)
+    expect(columnCardIds(intoMid, 'midcol')).toEqual(['gps', 'prearm', 'statistics'])
+
+    const intoSidebar = shiftStatusDashboardCardColumn(start, 'notices', 1)
+    expect(columnCardIds(intoSidebar, 'sidebar')).toEqual([
+      'notices',
       'system-info',
       'instruments',
       'guided-setup'
     ])
   })
 
-  it('shifts a card to the neighbouring zone and refuses past the edges', () => {
-    const base = defaultStatusDashboardLayout(specsWithSensors)
-    const shifted = shiftStatusDashboardCardZone(base, 'notices', -1)
-    expect(zoneCardIds(shifted, 'midcol')).toEqual(['notices', 'prearm', 'statistics'])
-    // GPS is in the first zone and Guided setup in the last, so there is no
-    // zone to their left / right respectively.
-    expect(shiftStatusDashboardCardZone(base, 'gps', -1)).toBe(base)
-    expect(shiftStatusDashboardCardZone(base, 'guided-setup', 1)).toBe(base)
+  it('refuses to walk a card off either end', () => {
+    const start = defaultStatusDashboardLayout(specsWithSensors)
+    expect(shiftStatusDashboardCardColumn(start, 'gps', -1)).toBe(start)
+    expect(shiftStatusDashboardCardColumn(start, 'guided-setup', 1)).toBe(start)
+  })
+
+  it('changes the width of the column a card sits in', () => {
+    const layout = nudgeStatusDashboardCardWidth(
+      defaultStatusDashboardLayout(specsWithSensors),
+      'prearm',
+      1
+    )
+    expect(layout.columns.find((column) => column.id === 'midcol')?.span).toBe(7)
+    expect(layout.columns.find((column) => column.id === 'noticecol')?.span).toBe(5)
   })
 })
 
 describe('resizeStatusDashboardCard', () => {
-  it('snaps, clamps and clears the height cap', () => {
-    const base = defaultStatusDashboardLayout(specsWithSensors)
-    expect(resizeStatusDashboardCard(base, 'notices', 12.4).cards.find((c) => c.id === 'notices')).toEqual({
-      id: 'notices',
-      zone: 'noticecol',
-      heightRows: 12
-    })
-    expect(resizeStatusDashboardCard(base, 'notices', 1).cards.find((c) => c.id === 'notices')?.heightRows).toBe(
+  it('snaps and clamps a height cap, and clears it with undefined', () => {
+    const start = defaultStatusDashboardLayout(specsWithSensors)
+    expect(resizeStatusDashboardCard(start, 'notices', 1).cards.find((card) => card.id === 'notices')?.heightRows).toBe(
       STATUS_DASHBOARD_MIN_ROWS
     )
     expect(
-      resizeStatusDashboardCard(base, 'notices', 10_000).cards.find((c) => c.id === 'notices')?.heightRows
+      resizeStatusDashboardCard(start, 'notices', 5000).cards.find((card) => card.id === 'notices')?.heightRows
     ).toBe(STATUS_DASHBOARD_MAX_ROWS)
-    const sized = resizeStatusDashboardCard(base, 'notices', 12)
-    expect(resizeStatusDashboardCard(sized, 'notices', undefined).cards.find((c) => c.id === 'notices')).toEqual({
-      id: 'notices',
-      zone: 'noticecol'
-    })
-    expect(resizeStatusDashboardCard(base, 'notices', undefined)).toBe(base)
+    expect(
+      resizeStatusDashboardCard(start, 'notices', Number.NaN).cards.find((card) => card.id === 'notices')?.heightRows
+    ).toBe(STATUS_DASHBOARD_MIN_ROWS)
+
+    const capped = resizeStatusDashboardCard(start, 'notices', 12)
+    const cleared = resizeStatusDashboardCard(capped, 'notices', undefined)
+    expect(cleared.cards.find((card) => card.id === 'notices')?.heightRows).toBeUndefined()
+    expect(resizeStatusDashboardCard(start, 'notices', undefined)).toBe(start)
+  })
+})
+
+describe('tidyStatusDashboardLayout', () => {
+  it('drops emptied columns, closes the band gaps, and evens up the widths', () => {
+    // Build a genuine mess: notices dragged out of its column into a new band,
+    // leaving noticecol empty and band 1 half used.
+    const messy = insertStatusDashboardBand(
+      defaultStatusDashboardLayout(specsWithSensors),
+      'notices',
+      'main',
+      2
+    )
+    expect(regionBands(messy, 'main')).toHaveLength(3)
+    expect(columnCardIds(messy, 'noticecol')).toEqual([])
+
+    const tidy = tidyStatusDashboardLayout(messy)
+    const bands = regionBands(tidy, 'main')
+    // The empty column is gone, the bands are renumbered contiguously, and
+    // every band fills the full width.
+    expect(tidy.columns.some((column) => column.id === 'noticecol')).toBe(false)
+    expect(bands.map((band) => band.band)).toEqual([0, 1, 2])
+    for (const band of bands) {
+      expect(bandFreeSpan(band)).toBe(0)
+    }
+    // The arrangement the operator built is kept — only the geometry changed.
+    expect(columnCardIds(tidy, 'midcol')).toEqual(['prearm', 'statistics'])
+    expect(columnCardIds(tidy, 'sensors')).toEqual(['gps', 'rangefinder', 'optical-flow'])
+  })
+
+  it('gives the remainder to the leftmost columns of a band', () => {
+    const start = defaultStatusDashboardLayout(specsWithSensors)
+    const three = splitStatusDashboardColumn(start, 'system-info', 'main', 1, 2)
+    const tidy = tidyStatusDashboardLayout(three)
+    const band = regionBands(tidy, 'main').find((entry) => entry.band === 1)!
+    expect(band.columns.map((column) => column.span)).toEqual([4, 4, 4])
+  })
+
+  it('is a no-op on a layout that is already tidy', () => {
+    const start = defaultStatusDashboardLayout(specsWithSensors)
+    expect(tidyStatusDashboardLayout(start)).toBe(start)
   })
 })
 
 describe('isDefaultStatusDashboardLayout', () => {
-  it('is false once anything has been moved or resized', () => {
-    const base = defaultStatusDashboardLayout(specsWithSensors)
-    expect(isDefaultStatusDashboardLayout(moveStatusDashboardCard(base, 'gps', 'midcol', 0), specsWithSensors)).toBe(
+  it('is true only for the untouched default', () => {
+    const start = defaultStatusDashboardLayout(specsWithSensors)
+    expect(isDefaultStatusDashboardLayout(start, specsWithSensors)).toBe(true)
+    expect(start.columns).toHaveLength(DEFAULT_STATUS_DASHBOARD_COLUMNS.length)
+    expect(isDefaultStatusDashboardLayout(moveStatusDashboardCard(start, 'gps', 'sidebar', 0), specsWithSensors)).toBe(
       false
     )
+    expect(isDefaultStatusDashboardLayout(resizeStatusDashboardCard(start, 'gps', 10), specsWithSensors)).toBe(false)
+    // A width change alone counts: the page no longer looks like it shipped.
     expect(
-      isDefaultStatusDashboardLayout(resizeStatusDashboardCard(base, 'gps', 10), specsWithSensors)
+      isDefaultStatusDashboardLayout(resizeStatusDashboardColumn(start, 'midcol', 8), specsWithSensors)
     ).toBe(false)
-    // A default layout built for a different card set is not "the default" here.
-    expect(isDefaultStatusDashboardLayout(defaultStatusDashboardLayout(specsWithoutSensors), specsWithSensors)).toBe(
-      false
-    )
+    expect(
+      isDefaultStatusDashboardLayout(toggleStatusDashboardColumnFlow(start, 'midcol'), specsWithSensors)
+    ).toBe(false)
+  })
+})
+
+// ── Drop-target hit testing ───────────────────────────────────────────────
+//
+// The whole point of making this a pure function over a snapshot is that it is
+// testable without a DOM, and that the drag itself does no layout reads. These
+// rects are a plausible 1440px page: a full-width sensor shelf of three cards
+// over two half-width status columns, with the sidebar to the right.
+
+const geometry: StatusDashboardGeometry = {
+  regions: [
+    { region: 'main', rect: { left: 20, top: 300, right: 900, bottom: 900 } },
+    { region: 'side', rect: { left: 920, top: 300, right: 1200, bottom: 900 } }
+  ],
+  columns: [
+    {
+      id: 'sensors',
+      region: 'main',
+      band: 0,
+      rect: { left: 20, top: 300, right: 900, bottom: 500 },
+      cards: [
+        { id: 'gps', rect: { left: 20, top: 300, right: 300, bottom: 500 } },
+        { id: 'rangefinder', rect: { left: 320, top: 300, right: 600, bottom: 420 } },
+        { id: 'optical-flow', rect: { left: 620, top: 300, right: 900, bottom: 420 } }
+      ]
+    },
+    {
+      id: 'midcol',
+      region: 'main',
+      band: 1,
+      rect: { left: 20, top: 520, right: 450, bottom: 800 },
+      cards: [
+        { id: 'prearm', rect: { left: 20, top: 520, right: 450, bottom: 650 } },
+        { id: 'statistics', rect: { left: 20, top: 664, right: 450, bottom: 800 } }
+      ]
+    },
+    {
+      id: 'noticecol',
+      region: 'main',
+      band: 1,
+      rect: { left: 470, top: 520, right: 900, bottom: 900 },
+      cards: [{ id: 'notices', rect: { left: 470, top: 520, right: 900, bottom: 900 } }]
+    },
+    {
+      id: 'sidebar',
+      region: 'side',
+      band: 0,
+      rect: { left: 920, top: 300, right: 1200, bottom: 860 },
+      cards: [
+        { id: 'system-info', rect: { left: 920, top: 300, right: 1200, bottom: 480 } },
+        { id: 'instruments', rect: { left: 920, top: 490, right: 1200, bottom: 670 } },
+        { id: 'guided-setup', rect: { left: 920, top: 680, right: 1200, bottom: 860 } }
+      ]
+    }
+  ]
+}
+
+describe('resolveStatusDashboardDrop', () => {
+  it('drops into a column, above or below the card under the pointer', () => {
+    // Above Statistics' midpoint: index 1, between Pre-arm and Statistics.
+    expect(resolveStatusDashboardDrop(geometry, 200, 700, 'gps')).toEqual({
+      kind: 'column',
+      columnId: 'midcol',
+      index: 1
+    })
+    // Below both midpoints: the end of the column.
+    expect(resolveStatusDashboardDrop(geometry, 200, 790, 'gps')).toEqual({
+      kind: 'column',
+      columnId: 'midcol',
+      index: 2
+    })
+    // Above Pre-arm's midpoint: the top of the column.
+    expect(resolveStatusDashboardDrop(geometry, 200, 540, 'gps')).toEqual({
+      kind: 'column',
+      columnId: 'midcol',
+      index: 0
+    })
+  })
+
+  it('compares horizontally inside a shelf column, where cards sit side by side', () => {
+    // Between GPS and the rangefinder in the sensor shelf.
+    expect(resolveStatusDashboardDrop(geometry, 310, 400, 'notices')).toEqual({
+      kind: 'column',
+      columnId: 'sensors',
+      index: 1
+    })
+    // 700 is left of optical flow's midpoint (760), so the card lands before it.
+    expect(resolveStatusDashboardDrop(geometry, 700, 400, 'notices')).toEqual({
+      kind: 'column',
+      columnId: 'sensors',
+      index: 2
+    })
+  })
+
+  it('ignores the dragged card when counting slots, so a drag is a no-op where it started', () => {
+    // Dragging Statistics and hovering its own place must resolve to index 1 —
+    // where it already is — not index 2.
+    expect(resolveStatusDashboardDrop(geometry, 200, 700, 'statistics')).toEqual({
+      kind: 'column',
+      columnId: 'midcol',
+      index: 1
+    })
+  })
+
+  it('opens a new column in the gutter between two', () => {
+    expect(resolveStatusDashboardDrop(geometry, 462, 700, 'gps')).toEqual({
+      kind: 'new-column',
+      region: 'main',
+      band: 1,
+      at: 1
+    })
+    // Hard against the left edge of the first column: a new leading column.
+    expect(resolveStatusDashboardDrop(geometry, 24, 700, 'gps')).toEqual({
+      kind: 'new-column',
+      region: 'main',
+      band: 1,
+      at: 0
+    })
+  })
+
+  it('opens a new band above, below, and between the existing ones', () => {
+    expect(resolveStatusDashboardDrop(geometry, 200, 260, 'notices')).toEqual({
+      kind: 'new-band',
+      region: 'main',
+      band: 0
+    })
+    expect(resolveStatusDashboardDrop(geometry, 200, 950, 'gps')).toEqual({
+      kind: 'new-band',
+      region: 'main',
+      band: 2
+    })
+  })
+
+  it('keeps the sidebar and the main area apart', () => {
+    expect(resolveStatusDashboardDrop(geometry, 1000, 400, 'gps')).toEqual({
+      kind: 'column',
+      columnId: 'sidebar',
+      index: 1
+    })
+  })
+
+  it('does the obvious thing for a pointer just outside everything', () => {
+    // A release past the right-hand edge of the page must still land somewhere
+    // sensible rather than snapping back, which is a large part of what made
+    // the shipped version feel unresponsive. Here: the nearest region is the
+    // sidebar, and past its right edge means a new column beside it.
+    expect(resolveStatusDashboardDrop(geometry, 1400, 600, 'gps')).toEqual({
+      kind: 'new-column',
+      region: 'side',
+      band: 0,
+      at: 1
+    })
+  })
+
+  it('does not treat the inside of the rightmost card as a gutter', () => {
+    // The bug this guards: a 16px gutter applied on BOTH sides of every column
+    // edge turned the last 16px of every card into a new-column zone, so the
+    // right-hand card of the sensor shelf was nearly impossible to drop onto.
+    expect(resolveStatusDashboardDrop(geometry, 880, 400, 'notices')).toEqual({
+      kind: 'column',
+      columnId: 'sensors',
+      index: 3
+    })
+  })
+
+  it('returns undefined only when there is no dashboard at all', () => {
+    expect(resolveStatusDashboardDrop({ regions: [], columns: [] }, 10, 10, 'gps')).toBeUndefined()
   })
 })

--- a/apps/web/src/view-models/status-dashboard-layout.ts
+++ b/apps/web/src/view-models/status-dashboard-layout.ts
@@ -1,48 +1,75 @@
 // Status & Info dashboard layout — the pure, unit-testable half of the
 // drag-and-resize arrangement.
 //
-// WHY a layout MODEL rather than a grid library: the Status page is a nested
-// arrangement of narrow columns whose cards keep their NATURAL height (see the
-// `align-items: start` note on `.setup-bench__status-trio`). Absolute-positioned
-// grid libraries need an explicit pixel height for every card, which turns a
-// card whose content grew — one more pre-arm issue, a firmware git hash row —
-// into a clipped or half-empty box. So the model here is deliberately smaller
-// than a 2-D grid: a card lives in one of a few named ZONES, at an index within
-// that zone, with an optional height cap. Cards can never overlap, never leave
-// a hole, and never need a collision pass; the worst a user can do is stack
-// everything into one zone, which still renders as a normal column.
+// ── THE PLACEMENT MODEL, AND WHY IT IS THIS ONE ───────────────────────────
 //
-// Width is a property of the zone, not the card: the sidebar zone is narrow,
-// the status columns are a share of the main column each. Moving a card is
-// therefore also how you resize it horizontally, and no arrangement can produce
-// a card wider than the page or narrower than its content.
+// v1 shipped a deliberately constrained ZONE model: four named zones, a card
+// at an index in one of them, width owned by the zone. The operator's verdict
+// was that it was too tight — "drag and drop how I please". So the guardrails
+// come off, but not by switching to absolute pixel positioning, which is the
+// one thing this page cannot have: a Status card's height is its CONTENT's
+// height (pre-arm grows with the issue count, System Info grows with a
+// firmware git hash), and pinning a pixel height either clips that or hangs
+// dead space off the bottom.
 //
-// The zone list mirrors the page as it ships: a full-width SENSOR ROW under the
-// craft model (GPS + rangefinder + optical flow, grouped there so the three
-// answers to "is the thing I bolted on reporting?" sit side by side), then the
-// two status columns below it, then the sidebar of reference and action cards.
-// `sensors` is a grid ROW rather than a column, which the model does not care
-// about — a zone is an ordered list of cards, and CSS decides whether that list
-// flows down or across.
+// So: a real CSS grid, 12 columns, AUTO rows.
+//
+//   REGION  — 'main' (under the craft model) or 'side' (the page sidebar).
+//             Two regions rather than one grid because the sidebar is a
+//             sibling of the viewer in the page shell and runs alongside the
+//             craft preview; flattening them would move the sidebar below it.
+//   BAND    — a horizontal shelf inside a region. Bands stack top to bottom.
+//   COLUMN  — a vertical stack of cards inside a band, `span` grid columns
+//             wide. THIS is the horizontal resize v1 was missing.
+//   CARD    — belongs to a column, at an index, with an optional height cap.
+//
+// A column is a stack, not a grid cell, which is the detail that keeps the
+// page packing tightly: two cards in one column sit directly on top of each
+// other no matter how tall the column NEXT to them is. A flat card-per-cell
+// grid cannot do that — grid rows share a height, so a tall Recent Notices
+// would shove Statistics down below its bottom edge and leave a hole. That is
+// also precisely why the default arrangement here still renders pixel-identical
+// to the page that shipped (see `defaultStatusDashboardLayout`).
+//
+// Freedom the operator now has that v1 denied:
+//   * any number of columns, in any band, in either region;
+//   * per-column width (span), dragged or nudged, snapped to a 12th;
+//   * new columns and new bands created by dropping a card in a gutter;
+//   * gaps: spans need not add up to 12, and a band may hold one narrow
+//     column with the rest of the row empty. Nothing forbids a mess — `tidy`
+//     exists to climb back out of one without a full Reset.
+//
+// ── LIBRARY vs HAND-ROLLED, re-evaluated ──────────────────────────────────
+//
+// react-grid-layout was reconsidered from scratch for this change, not
+// inherited from v1's verdict. Its MIT licence is GPL-3.0 compatible, so
+// licensing is not the objection. The objection is its core data model: RGL
+// positions every item absolutely at `h * rowHeight` pixels. Its `autoSize`
+// prop sizes the CONTAINER to its items; it does not give an item a
+// content-driven height, and the usual workaround (a ResizeObserver writing a
+// measured `h` back into the layout) fights the operator's own resize and
+// re-runs the collision solver every time a pre-arm issue appears or a
+// STATUSTEXT lands — on a page whose whole job is live telemetry. It would
+// also have to own the craft preview and the sidebar to lay them out at all.
+// A CSS grid with auto rows gets content-driven heights for free, from the
+// layout engine, with no dependency and no solver. Hand-rolled again — but
+// this time the reasoning is "auto rows beat a pixel solver", not "freedom is
+// dangerous".
 
-/** The drop zones on the Status & Info page. Widths come from CSS, not layout. */
-export type StatusDashboardZoneId = 'sensors' | 'midcol' | 'noticecol' | 'sidebar'
+/** The two independently-laid-out areas of the Status page. */
+export type StatusDashboardRegionId = 'main' | 'side'
 
-export const STATUS_DASHBOARD_ZONE_IDS: readonly StatusDashboardZoneId[] = [
-  'sensors',
-  'midcol',
-  'noticecol',
-  'sidebar'
-]
+export const STATUS_DASHBOARD_REGION_IDS: readonly StatusDashboardRegionId[] = ['main', 'side']
 
-export const STATUS_DASHBOARD_ZONE_LABELS: Record<StatusDashboardZoneId, string> = {
-  sensors: 'Sensor row',
-  midcol: 'Column 1',
-  noticecol: 'Column 2',
-  sidebar: 'Sidebar'
+export const STATUS_DASHBOARD_REGION_LABELS: Record<StatusDashboardRegionId, string> = {
+  main: 'Main area',
+  side: 'Sidebar'
 }
 
-/** One vertical resize step, in pixels. Heights snap to a multiple of this. */
+/** Grid columns per region. 12 divides by 2, 3, 4 and 6 — every useful split. */
+export const STATUS_DASHBOARD_GRID_COLUMNS = 12
+
+/** One vertical resize step, in pixels. Card height caps snap to a multiple. */
 export const STATUS_DASHBOARD_ROW_PX = 24
 
 /** Smallest and largest user-set height, in rows. Outside this range: clamped. */
@@ -54,21 +81,49 @@ export const STATUS_DASHBOARD_MAX_ROWS = 60
  * arrangement changes enough that a stale saved layout would look broken.
  * A stored layout with a different version is discarded, silently, in favour
  * of the current default — never rendered.
+ *
+ * v1 → v2: zones became regions/bands/columns, and cards gained a width via
+ * their column's span. A v1 layout has no columns at all, so it cannot be
+ * migrated into something meaningful; it is dropped and the operator gets the
+ * (unchanged) default back.
  */
-export const STATUS_DASHBOARD_LAYOUT_VERSION = 1
+export const STATUS_DASHBOARD_LAYOUT_VERSION = 2
 
 export const STATUS_DASHBOARD_STORAGE_KEY = `arduconfig.status-dashboard.v${STATUS_DASHBOARD_LAYOUT_VERSION}`
+
+/**
+ * How a column arranges the cards inside it.
+ *
+ *  - `stack`: top to bottom. The ordinary column.
+ *  - `shelf`: side by side, wrapping — an auto-fit row. The sensor row ships
+ *    like this so GPS / rangefinder / optical flow answer their one shared
+ *    question side by side, and so a sensor card that appears mid-session
+ *    lands BESIDE its neighbours rather than under them.
+ */
+export type StatusDashboardColumnFlow = 'stack' | 'shelf'
+
+export interface StatusDashboardColumn {
+  id: string
+  region: StatusDashboardRegionId
+  /** Which horizontal shelf of the region. Bands render in ascending order. */
+  band: number
+  /** Width in grid columns, 1..12. */
+  span: number
+  flow: StatusDashboardColumnFlow
+}
 
 /** Where one card sits, and how tall the operator has made it. */
 export interface StatusDashboardPlacement {
   id: string
-  zone: StatusDashboardZoneId
+  /** The id of the column this card lives in. */
+  column: string
   /** User-set height cap in rows. Undefined means "as tall as its content". */
   heightRows?: number
 }
 
 export interface StatusDashboardLayout {
   version: number
+  columns: StatusDashboardColumn[]
   cards: StatusDashboardPlacement[]
 }
 
@@ -76,11 +131,12 @@ export interface StatusDashboardLayout {
 export interface StatusDashboardCardSpec {
   id: string
   label: string
-  zone: StatusDashboardZoneId
+  /** The column this card belongs to in the shipped default arrangement. */
+  column: string
 }
 
-export function isStatusDashboardZoneId(value: unknown): value is StatusDashboardZoneId {
-  return typeof value === 'string' && (STATUS_DASHBOARD_ZONE_IDS as readonly string[]).includes(value)
+export function isStatusDashboardRegionId(value: unknown): value is StatusDashboardRegionId {
+  return typeof value === 'string' && (STATUS_DASHBOARD_REGION_IDS as readonly string[]).includes(value)
 }
 
 export function clampHeightRows(rows: number): number {
@@ -90,19 +146,53 @@ export function clampHeightRows(rows: number): number {
   return Math.min(STATUS_DASHBOARD_MAX_ROWS, Math.max(STATUS_DASHBOARD_MIN_ROWS, Math.round(rows)))
 }
 
+export function clampSpan(span: number): number {
+  if (!Number.isFinite(span)) {
+    return STATUS_DASHBOARD_GRID_COLUMNS
+  }
+  return Math.min(STATUS_DASHBOARD_GRID_COLUMNS, Math.max(1, Math.round(span)))
+}
+
+/**
+ * The columns of the shipped page, and the ONLY description of them.
+ *
+ * These four reproduce the page exactly as it renders without this feature:
+ *
+ *  - `sensors`  full-width shelf under the craft model (GPS + whichever
+ *               advanced sensor cards exist), which is the same auto-fit row
+ *               `.setup-status-sensors` always was;
+ *  - `midcol` / `noticecol`  the two half-width status columns below it —
+ *               span 6 of 12 with a 14px gutter is arithmetically the same
+ *               width as the `auto-fit minmax(220px, 1fr)` pair they replace;
+ *  - `sidebar`  the full width of the page sidebar.
+ */
+export const DEFAULT_STATUS_DASHBOARD_COLUMNS: readonly StatusDashboardColumn[] = [
+  { id: 'sensors', region: 'main', band: 0, span: 12, flow: 'shelf' },
+  { id: 'midcol', region: 'main', band: 1, span: 6, flow: 'stack' },
+  { id: 'noticecol', region: 'main', band: 1, span: 6, flow: 'stack' },
+  { id: 'sidebar', region: 'side', band: 0, span: 12, flow: 'stack' }
+]
+
 /** The layout that describes the page exactly as it ships, before any dragging. */
-export function defaultStatusDashboardLayout(specs: readonly StatusDashboardCardSpec[]): StatusDashboardLayout {
+export function defaultStatusDashboardLayout(
+  specs: readonly StatusDashboardCardSpec[]
+): StatusDashboardLayout {
   return {
     version: STATUS_DASHBOARD_LAYOUT_VERSION,
-    cards: specs.map((spec) => ({ id: spec.id, zone: spec.zone }))
+    columns: DEFAULT_STATUS_DASHBOARD_COLUMNS.map((column) => ({ ...column })),
+    cards: specs.map((spec) => ({ id: spec.id, column: spec.column }))
   }
+}
+
+function isColumnFlow(value: unknown): value is StatusDashboardColumnFlow {
+  return value === 'stack' || value === 'shelf'
 }
 
 /**
  * Parse a stored layout defensively. Anything we cannot fully trust — bad JSON,
- * a different version, a non-array `cards`, an entry without a string id —
- * returns undefined so the caller falls back to the default. A corrupt value in
- * localStorage must never be able to white-screen the Status page.
+ * a different version, a non-array `columns`/`cards`, an entry without a string
+ * id — returns undefined so the caller falls back to the default. A corrupt
+ * value in localStorage must never be able to white-screen the Status page.
  */
 export function parseStoredStatusDashboardLayout(raw: string | null): StatusDashboardLayout | undefined {
   if (!raw) {
@@ -117,36 +207,61 @@ export function parseStoredStatusDashboardLayout(raw: string | null): StatusDash
   if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
     return undefined
   }
-  const candidate = parsed as { version?: unknown; cards?: unknown }
+  const candidate = parsed as { version?: unknown; columns?: unknown; cards?: unknown }
   if (candidate.version !== STATUS_DASHBOARD_LAYOUT_VERSION) {
     return undefined
   }
-  if (!Array.isArray(candidate.cards)) {
+  if (!Array.isArray(candidate.columns) || !Array.isArray(candidate.cards)) {
     return undefined
   }
+
+  const columns: StatusDashboardColumn[] = []
+  const seenColumns = new Set<string>()
+  for (const entry of candidate.columns) {
+    if (!entry || typeof entry !== 'object') {
+      continue
+    }
+    const record = entry as { id?: unknown; region?: unknown; band?: unknown; span?: unknown; flow?: unknown }
+    if (typeof record.id !== 'string' || record.id.length === 0 || seenColumns.has(record.id)) {
+      continue
+    }
+    seenColumns.add(record.id)
+    columns.push({
+      id: record.id,
+      region: isStatusDashboardRegionId(record.region) ? record.region : 'main',
+      band: typeof record.band === 'number' && Number.isFinite(record.band) ? Math.max(0, Math.round(record.band)) : 0,
+      span: clampSpan(typeof record.span === 'number' ? record.span : STATUS_DASHBOARD_GRID_COLUMNS),
+      flow: isColumnFlow(record.flow) ? record.flow : 'stack'
+    })
+  }
+  // No columns at all means nothing can be rendered — treat as untrusted.
+  if (columns.length === 0) {
+    return undefined
+  }
+
   const cards: StatusDashboardPlacement[] = []
-  const seen = new Set<string>()
+  const seenCards = new Set<string>()
   for (const entry of candidate.cards) {
     if (!entry || typeof entry !== 'object') {
       continue
     }
-    const record = entry as { id?: unknown; zone?: unknown; heightRows?: unknown }
-    if (typeof record.id !== 'string' || record.id.length === 0 || seen.has(record.id)) {
+    const record = entry as { id?: unknown; column?: unknown; heightRows?: unknown }
+    if (typeof record.id !== 'string' || record.id.length === 0 || seenCards.has(record.id)) {
       continue
     }
-    seen.add(record.id)
+    seenCards.add(record.id)
     const placement: StatusDashboardPlacement = {
       id: record.id,
-      // An unknown zone (a zone we removed in a later release) is not fatal:
-      // the reconcile pass below puts the card back where it belongs.
-      zone: isStatusDashboardZoneId(record.zone) ? record.zone : 'sensors'
+      // An unknown column is not fatal: reconcile puts the card somewhere real.
+      column: typeof record.column === 'string' && seenColumns.has(record.column) ? record.column : columns[0]!.id
     }
     if (typeof record.heightRows === 'number' && Number.isFinite(record.heightRows)) {
       placement.heightRows = clampHeightRows(record.heightRows)
     }
     cards.push(placement)
   }
-  return { version: STATUS_DASHBOARD_LAYOUT_VERSION, cards }
+
+  return { version: STATUS_DASHBOARD_LAYOUT_VERSION, columns, cards }
 }
 
 /**
@@ -158,13 +273,21 @@ export function parseStoredStatusDashboardLayout(raw: string | null): StatusDash
  * cards that are gone, and routinely lacks cards that just appeared:
  *
  *  - a placement for a card that is NOT present is dropped;
- *  - a present card with NO placement is inserted at its DEFAULT position,
- *    immediately after the nearest earlier default-neighbour that the operator
- *    still has on screen — so a rangefinder card that appears mid-session lands
- *    beside GPS in the sensor row where it belongs, not orphaned at the bottom
- *    of a zone.
+ *  - a present card with NO placement is inserted next to the nearest earlier
+ *    default-neighbour that the operator still has on screen — so a
+ *    rangefinder card that appears mid-session lands beside GPS wherever the
+ *    operator has since dragged GPS to, not orphaned at the bottom of the page;
+ *  - a card whose DEFAULT column the operator has deleted falls back to that
+ *    column being recreated only if nothing better exists; otherwise it joins
+ *    the neighbour's column.
  *
- * The result always contains exactly the present cards, exactly once.
+ * Empty columns are kept, not pruned: an operator who deliberately made room
+ * for a card that is only sometimes present should still have that room when
+ * it disappears and comes back. `tidy` is where emptiness gets cleaned up, on
+ * request.
+ *
+ * The result always contains exactly the present cards, exactly once, each in
+ * a column that exists.
  */
 export function reconcileStatusDashboardLayout(
   layout: StatusDashboardLayout | undefined,
@@ -174,16 +297,24 @@ export function reconcileStatusDashboardLayout(
     return defaultStatusDashboardLayout(specs)
   }
   const specById = new Map(specs.map((spec) => [spec.id, spec]))
-  const cards = layout.cards.filter((placement) => specById.has(placement.id))
-  const placed = new Set(cards.map((placement) => placement.id))
+  const columns = layout.columns.map((column) => ({ ...column }))
+  const columnIds = new Set(columns.map((column) => column.id))
+  const cards = layout.cards
+    .filter((placement) => specById.has(placement.id))
+    .map((placement) =>
+      columnIds.has(placement.column) ? placement : { ...placement, column: columns[0]!.id }
+    )
+  const placed = new Map(cards.map((placement) => [placement.id, placement]))
 
   for (const [index, spec] of specs.entries()) {
     if (placed.has(spec.id)) {
       continue
     }
-    // Find the nearest earlier card in DEFAULT order that survived, and land
-    // directly after it. Falls back to the end of the list.
+    // Land directly after the nearest earlier card in DEFAULT order that
+    // survived — that is what keeps a re-appearing sensor card beside its
+    // neighbours instead of at the end of the page.
     let insertAt = cards.length
+    let column = columnIds.has(spec.column) ? spec.column : undefined
     for (let back = index - 1; back >= 0; back -= 1) {
       const anchor = specs[back]
       if (!anchor) {
@@ -192,19 +323,26 @@ export function reconcileStatusDashboardLayout(
       const anchorIndex = cards.findIndex((placement) => placement.id === anchor.id)
       if (anchorIndex >= 0) {
         insertAt = anchorIndex + 1
+        // Only follow the neighbour into ITS column when this card's own
+        // default column is gone; otherwise the default column wins.
+        column = column ?? cards[anchorIndex]!.column
+        if (anchor.column === spec.column) {
+          column = cards[anchorIndex]!.column
+        }
         break
       }
     }
-    cards.splice(insertAt, 0, { id: spec.id, zone: spec.zone })
-    placed.add(spec.id)
+    const placement: StatusDashboardPlacement = { id: spec.id, column: column ?? columns[0]!.id }
+    cards.splice(insertAt, 0, placement)
+    placed.set(spec.id, placement)
   }
 
-  return { version: STATUS_DASHBOARD_LAYOUT_VERSION, cards }
+  return { version: STATUS_DASHBOARD_LAYOUT_VERSION, columns, cards }
 }
 
-/** The ids in one zone, in render order. */
-export function zoneCardIds(layout: StatusDashboardLayout, zone: StatusDashboardZoneId): string[] {
-  return layout.cards.filter((placement) => placement.zone === zone).map((placement) => placement.id)
+/** The ids in one column, in render order. */
+export function columnCardIds(layout: StatusDashboardLayout, columnId: string): string[] {
+  return layout.cards.filter((placement) => placement.column === columnId).map((placement) => placement.id)
 }
 
 export function findPlacement(
@@ -214,54 +352,302 @@ export function findPlacement(
   return layout.cards.find((placement) => placement.id === id)
 }
 
+export function findColumn(layout: StatusDashboardLayout, columnId: string): StatusDashboardColumn | undefined {
+  return layout.columns.find((column) => column.id === columnId)
+}
+
+/** One band: the columns on one horizontal shelf, left to right. */
+export interface StatusDashboardBand {
+  band: number
+  columns: StatusDashboardColumn[]
+}
+
 /**
- * Move `id` into `zone` at `index` (index counted within that zone, after the
- * card has been removed). Returns the same object when nothing would change, so
- * callers can skip a re-render and a localStorage write.
+ * The bands of a region, in render order, each with its columns left to right
+ * and their explicit grid start lines resolved.
+ *
+ * Start lines are explicit rather than auto-placed so that a band whose spans
+ * do not add up to 12 leaves its free space at the RIGHT, deterministically,
+ * instead of the grid quietly repacking the row.
+ */
+export function regionBands(
+  layout: StatusDashboardLayout,
+  region: StatusDashboardRegionId
+): StatusDashboardBand[] {
+  const byBand = new Map<number, StatusDashboardColumn[]>()
+  for (const column of layout.columns) {
+    if (column.region !== region) {
+      continue
+    }
+    const list = byBand.get(column.band)
+    if (list) {
+      list.push(column)
+    } else {
+      byBand.set(column.band, [column])
+    }
+  }
+  return [...byBand.entries()]
+    .sort((a, b) => a[0] - b[0])
+    .map(([band, columns]) => ({ band, columns }))
+}
+
+/** The 1-based grid column this column starts at, given its band neighbours. */
+export function columnStartLine(band: StatusDashboardBand, columnId: string): number {
+  let start = 1
+  for (const column of band.columns) {
+    if (column.id === columnId) {
+      return Math.min(start, STATUS_DASHBOARD_GRID_COLUMNS)
+    }
+    start += column.span
+  }
+  return Math.min(start, STATUS_DASHBOARD_GRID_COLUMNS)
+}
+
+/** Spare grid columns at the right-hand end of a band. Never negative. */
+export function bandFreeSpan(band: StatusDashboardBand): number {
+  const used = band.columns.reduce((total, column) => total + column.span, 0)
+  return Math.max(0, STATUS_DASHBOARD_GRID_COLUMNS - used)
+}
+
+/**
+ * Move `id` into `columnId` at `index` (index counted within that column, after
+ * the card has been removed). Returns the same object when nothing would
+ * change, so callers can skip a re-render and a localStorage write.
  */
 export function moveStatusDashboardCard(
   layout: StatusDashboardLayout,
   id: string,
-  zone: StatusDashboardZoneId,
+  columnId: string,
   index: number
 ): StatusDashboardLayout {
   const moving = findPlacement(layout, id)
-  if (!moving) {
+  if (!moving || !findColumn(layout, columnId)) {
     return layout
   }
   const rest = layout.cards.filter((placement) => placement.id !== id)
-  const zoneIds = rest.filter((placement) => placement.zone === zone)
-  const clampedIndex = Math.min(Math.max(index, 0), zoneIds.length)
+  const inColumn = rest.filter((placement) => placement.column === columnId)
+  const clampedIndex = Math.min(Math.max(index, 0), inColumn.length)
 
-  if (moving.zone === zone) {
-    const currentIndex = zoneCardIds(layout, zone).indexOf(id)
+  if (moving.column === columnId) {
+    const currentIndex = columnCardIds(layout, columnId).indexOf(id)
     if (currentIndex === clampedIndex) {
       return layout
     }
   }
 
   const next: StatusDashboardPlacement[] = []
-  let zoneSeen = 0
+  let seen = 0
   let inserted = false
-  const relocated: StatusDashboardPlacement = { ...moving, zone }
+  const relocated: StatusDashboardPlacement = { ...moving, column: columnId }
 
   for (const placement of rest) {
-    if (placement.zone === zone) {
-      if (zoneSeen === clampedIndex && !inserted) {
+    if (placement.column === columnId) {
+      if (seen === clampedIndex && !inserted) {
         next.push(relocated)
         inserted = true
       }
-      zoneSeen += 1
+      seen += 1
     }
     next.push(placement)
   }
   if (!inserted) {
     next.push(relocated)
   }
-  return { version: layout.version, cards: next }
+  return { version: layout.version, columns: layout.columns, cards: next }
 }
 
-/** Step a card one slot earlier/later inside its own zone. The keyboard path. */
+let columnIdCounter = 0
+
+function mintColumnId(layout: StatusDashboardLayout): string {
+  let candidate: string
+  do {
+    columnIdCounter += 1
+    candidate = `col-${columnIdCounter}`
+  } while (layout.columns.some((column) => column.id === candidate))
+  return candidate
+}
+
+/**
+ * Split a new column into `band` at position `at` (counted in that band's
+ * column list) and move `id` into it.
+ *
+ * The new column takes its width from the band's free space where there is
+ * any, and otherwise halves its right-hand neighbour — the neighbour is the
+ * column the operator just dropped a card next to, so it is the one they are
+ * looking at and the one whose change they will understand.
+ */
+export function splitStatusDashboardColumn(
+  layout: StatusDashboardLayout,
+  id: string,
+  region: StatusDashboardRegionId,
+  band: number,
+  at: number
+): StatusDashboardLayout {
+  if (!findPlacement(layout, id)) {
+    return layout
+  }
+  const bands = regionBands(layout, region)
+  const target = bands.find((entry) => entry.band === band)
+  const siblings = target?.columns ?? []
+  const clampedAt = Math.min(Math.max(at, 0), siblings.length)
+  const free = target ? bandFreeSpan(target) : STATUS_DASHBOARD_GRID_COLUMNS
+
+  let span = free
+  const columns = layout.columns.map((column) => ({ ...column }))
+  if (span < 2) {
+    // No room: take half of the widest sibling that can afford to give.
+    const donor = [...siblings].sort((a, b) => b.span - a.span)[0]
+    if (!donor || donor.span < 2) {
+      return layout
+    }
+    const donated = Math.floor(donor.span / 2)
+    span = donated
+    const donorEntry = columns.find((column) => column.id === donor.id)
+    if (donorEntry) {
+      donorEntry.span = donor.span - donated
+    }
+  }
+
+  const newColumn: StatusDashboardColumn = {
+    id: mintColumnId(layout),
+    region,
+    band,
+    span: clampSpan(span),
+    flow: 'stack'
+  }
+
+  // Splice into the layout's column array so the band's left-to-right order
+  // matches where the operator dropped.
+  const anchor = siblings[clampedAt]
+  const insertIndex = anchor
+    ? columns.findIndex((column) => column.id === anchor.id)
+    : columns.length
+  columns.splice(insertIndex < 0 ? columns.length : insertIndex, 0, newColumn)
+
+  const next: StatusDashboardLayout = { version: layout.version, columns, cards: layout.cards }
+  return moveStatusDashboardCard(next, id, newColumn.id, 0)
+}
+
+/**
+ * Open a brand new band at `band` in `region`, pushing every band at or below
+ * it down one, and move `id` into a full-width column on it.
+ */
+export function insertStatusDashboardBand(
+  layout: StatusDashboardLayout,
+  id: string,
+  region: StatusDashboardRegionId,
+  band: number
+): StatusDashboardLayout {
+  if (!findPlacement(layout, id)) {
+    return layout
+  }
+  const columns = layout.columns.map((column) =>
+    column.region === region && column.band >= band ? { ...column, band: column.band + 1 } : { ...column }
+  )
+  const newColumn: StatusDashboardColumn = {
+    id: mintColumnId(layout),
+    region,
+    band,
+    span: STATUS_DASHBOARD_GRID_COLUMNS,
+    flow: 'stack'
+  }
+  columns.push(newColumn)
+  const next: StatusDashboardLayout = { version: layout.version, columns, cards: layout.cards }
+  return moveStatusDashboardCard(next, id, newColumn.id, 0)
+}
+
+/**
+ * Set a column's width. Growing steals from the band's free space first and
+ * then from the next column along; shrinking simply hands the space back and
+ * is allowed to leave a gap — that is the point of "place them how I please".
+ */
+export function resizeStatusDashboardColumn(
+  layout: StatusDashboardLayout,
+  columnId: string,
+  span: number
+): StatusDashboardLayout {
+  const column = findColumn(layout, columnId)
+  if (!column) {
+    return layout
+  }
+  const band = regionBands(layout, column.region).find((entry) => entry.band === column.band)
+  if (!band) {
+    return layout
+  }
+  const others = band.columns.filter((entry) => entry.id !== columnId)
+  const otherTotal = others.reduce((total, entry) => total + entry.span, 0)
+  // Never let a band overflow 12 — a wrapped band is a broken-looking page,
+  // and it is the one arrangement the operator cannot see themselves making.
+  const maxSpan = Math.max(1, STATUS_DASHBOARD_GRID_COLUMNS - otherTotal)
+  const wanted = Math.min(clampSpan(span), STATUS_DASHBOARD_GRID_COLUMNS)
+
+  if (wanted <= maxSpan) {
+    if (wanted === column.span) {
+      return layout
+    }
+    return {
+      version: layout.version,
+      columns: layout.columns.map((entry) => (entry.id === columnId ? { ...entry, span: wanted } : entry)),
+      cards: layout.cards
+    }
+  }
+
+  // Growing past the free space: take the difference off the next column along
+  // (wrapping to the previous one for the last column in the band).
+  const position = band.columns.findIndex((entry) => entry.id === columnId)
+  const neighbour = band.columns[position + 1] ?? band.columns[position - 1]
+  if (!neighbour) {
+    return layout
+  }
+  const take = Math.min(wanted - maxSpan, neighbour.span - 1)
+  if (take <= 0) {
+    return layout
+  }
+  const finalSpan = maxSpan + take
+  if (finalSpan === column.span) {
+    return layout
+  }
+  return {
+    version: layout.version,
+    columns: layout.columns.map((entry) => {
+      if (entry.id === columnId) {
+        return { ...entry, span: finalSpan }
+      }
+      if (entry.id === neighbour.id) {
+        return { ...entry, span: entry.span - take }
+      }
+      return entry
+    }),
+    cards: layout.cards
+  }
+}
+
+/** Flip a column between stacking its cards and shelving them side by side. */
+export function toggleStatusDashboardColumnFlow(
+  layout: StatusDashboardLayout,
+  columnId: string
+): StatusDashboardLayout {
+  const column = findColumn(layout, columnId)
+  if (!column) {
+    return layout
+  }
+  return {
+    version: layout.version,
+    columns: layout.columns.map((entry) =>
+      entry.id === columnId ? { ...entry, flow: entry.flow === 'stack' ? 'shelf' : 'stack' } : entry
+    ),
+    cards: layout.cards
+  }
+}
+
+/** Every column of a region in visual order: band by band, left to right. */
+export function orderedColumns(layout: StatusDashboardLayout): StatusDashboardColumn[] {
+  return STATUS_DASHBOARD_REGION_IDS.flatMap((region) =>
+    regionBands(layout, region).flatMap((band) => band.columns)
+  )
+}
+
+/** Step a card one slot earlier/later inside its own column. The keyboard path. */
 export function nudgeStatusDashboardCard(
   layout: StatusDashboardLayout,
   id: string,
@@ -271,12 +657,16 @@ export function nudgeStatusDashboardCard(
   if (!placement) {
     return layout
   }
-  const index = zoneCardIds(layout, placement.zone).indexOf(id)
-  return moveStatusDashboardCard(layout, id, placement.zone, index + delta)
+  const index = columnCardIds(layout, placement.column).indexOf(id)
+  return moveStatusDashboardCard(layout, id, placement.column, index + delta)
 }
 
-/** Move a card to the neighbouring zone, keeping roughly its vertical slot. */
-export function shiftStatusDashboardCardZone(
+/**
+ * Move a card to the neighbouring column in visual order, keeping roughly its
+ * vertical slot. Walks across bands and into the sidebar, so the keyboard can
+ * reach every column the pointer can.
+ */
+export function shiftStatusDashboardCardColumn(
   layout: StatusDashboardLayout,
   id: string,
   delta: -1 | 1
@@ -285,13 +675,31 @@ export function shiftStatusDashboardCardZone(
   if (!placement) {
     return layout
   }
-  const zoneIndex = STATUS_DASHBOARD_ZONE_IDS.indexOf(placement.zone)
-  const targetZone = STATUS_DASHBOARD_ZONE_IDS[zoneIndex + delta]
-  if (!targetZone) {
+  const order = orderedColumns(layout)
+  const position = order.findIndex((column) => column.id === placement.column)
+  const target = order[position + delta]
+  if (!target) {
     return layout
   }
-  const index = zoneCardIds(layout, placement.zone).indexOf(id)
-  return moveStatusDashboardCard(layout, id, targetZone, index)
+  const index = columnCardIds(layout, placement.column).indexOf(id)
+  return moveStatusDashboardCard(layout, id, target.id, index)
+}
+
+/** Widen/narrow the column a card lives in. The keyboard path for width. */
+export function nudgeStatusDashboardCardWidth(
+  layout: StatusDashboardLayout,
+  id: string,
+  delta: -1 | 1
+): StatusDashboardLayout {
+  const placement = findPlacement(layout, id)
+  if (!placement) {
+    return layout
+  }
+  const column = findColumn(layout, placement.column)
+  if (!column) {
+    return layout
+  }
+  return resizeStatusDashboardColumn(layout, column.id, column.span + delta)
 }
 
 /** Set (or, with undefined, clear) a card's height cap. Always snapped+clamped. */
@@ -310,10 +718,58 @@ export function resizeStatusDashboardCard(
   }
   return {
     version: layout.version,
+    columns: layout.columns,
     cards: layout.cards.map((entry) =>
-      entry.id === id ? (next === undefined ? { id: entry.id, zone: entry.zone } : { ...entry, heightRows: next }) : entry
+      entry.id === id
+        ? next === undefined
+          ? { id: entry.id, column: entry.column }
+          : { ...entry, heightRows: next }
+        : entry
     )
   }
+}
+
+/**
+ * Tidy up: the way out of a mess that is not a full Reset.
+ *
+ * Drops empty columns, closes the gaps that leaves in the band numbering, and
+ * spreads each band's columns evenly across the full 12 so no band is left
+ * with a ragged right edge. Card ORDER and which-card-is-with-which is
+ * untouched — the operator keeps the arrangement they built, it just stops
+ * looking accidental.
+ */
+export function tidyStatusDashboardLayout(layout: StatusDashboardLayout): StatusDashboardLayout {
+  const occupied = new Set(layout.cards.map((placement) => placement.column))
+  const kept = layout.columns.filter((column) => occupied.has(column.id))
+  if (kept.length === 0) {
+    return layout
+  }
+
+  const columns: StatusDashboardColumn[] = []
+  for (const region of STATUS_DASHBOARD_REGION_IDS) {
+    const bands = regionBands({ ...layout, columns: kept }, region)
+    for (const [bandIndex, band] of bands.entries()) {
+      const count = band.columns.length
+      const base = Math.floor(STATUS_DASHBOARD_GRID_COLUMNS / count)
+      // The remainder goes to the leftmost columns, so a 5-column band reads
+      // 3/3/2/2/2 rather than trailing a 2 the operator did not ask for.
+      const remainder = STATUS_DASHBOARD_GRID_COLUMNS - base * count
+      for (const [index, column] of band.columns.entries()) {
+        columns.push({ ...column, band: bandIndex, span: clampSpan(base + (index < remainder ? 1 : 0)) })
+      }
+    }
+  }
+
+  const same =
+    columns.length === layout.columns.length &&
+    columns.every((column) => {
+      const before = layout.columns.find((entry) => entry.id === column.id)
+      return before && before.band === column.band && before.span === column.span
+    })
+  if (same) {
+    return layout
+  }
+  return { version: layout.version, columns, cards: layout.cards }
 }
 
 /** True when the layout is the shipped default — used to hide "Reset layout". */
@@ -321,7 +777,21 @@ export function isDefaultStatusDashboardLayout(
   layout: StatusDashboardLayout,
   specs: readonly StatusDashboardCardSpec[]
 ): boolean {
-  if (layout.cards.length !== specs.length) {
+  if (layout.columns.length !== DEFAULT_STATUS_DASHBOARD_COLUMNS.length) {
+    return false
+  }
+  const columnsMatch = layout.columns.every((column, index) => {
+    const expected = DEFAULT_STATUS_DASHBOARD_COLUMNS[index]
+    return (
+      expected !== undefined &&
+      expected.id === column.id &&
+      expected.region === column.region &&
+      expected.band === column.band &&
+      expected.span === column.span &&
+      expected.flow === column.flow
+    )
+  })
+  if (!columnsMatch || layout.cards.length !== specs.length) {
     return false
   }
   return layout.cards.every((placement, index) => {
@@ -329,8 +799,197 @@ export function isDefaultStatusDashboardLayout(
     return (
       spec !== undefined &&
       spec.id === placement.id &&
-      spec.zone === placement.zone &&
+      spec.column === placement.column &&
       placement.heightRows === undefined
     )
   })
+}
+
+// ── Drop-target hit testing ───────────────────────────────────────────────
+//
+// Hit testing is a PURE function over a geometry SNAPSHOT taken once, at
+// pointer-down. That is the whole clunkiness fix in one sentence: v1 called
+// `document.elementFromPoint` plus `getBoundingClientRect` on every pointermove
+// and inserted a real element to show the drop position, so the page reflowed
+// under the cursor and the geometry it had just measured went stale. Here the
+// drag never changes layout, so a single snapshot stays true for the whole
+// gesture — and the hit test becomes arithmetic, testable off the DOM.
+
+export interface StatusDashboardRect {
+  left: number
+  top: number
+  right: number
+  bottom: number
+}
+
+export interface StatusDashboardColumnGeometry {
+  id: string
+  region: StatusDashboardRegionId
+  band: number
+  rect: StatusDashboardRect
+  /** Rects of the cards in this column, in render order, with their ids. */
+  cards: { id: string; rect: StatusDashboardRect }[]
+}
+
+export interface StatusDashboardGeometry {
+  regions: { region: StatusDashboardRegionId; rect: StatusDashboardRect }[]
+  columns: StatusDashboardColumnGeometry[]
+}
+
+export type StatusDashboardDropTarget =
+  | { kind: 'column'; columnId: string; index: number }
+  | { kind: 'new-column'; region: StatusDashboardRegionId; band: number; at: number }
+  | { kind: 'new-band'; region: StatusDashboardRegionId; band: number }
+
+/**
+ * How far OUTSIDE a column edge still counts as "make a new column here", in
+ * px — the gutter between two columns is 14px, so this widens it to a target
+ * you can actually hit.
+ */
+export const STATUS_DASHBOARD_GUTTER_PX = 16
+/**
+ * How far INSIDE a column edge counts as the gutter. Deliberately tiny: an
+ * earlier version used the full gutter width on both sides, which turned the
+ * last 16px of every card into a new-column zone and made dropping onto the
+ * right-hand card of a shelf nearly impossible.
+ */
+export const STATUS_DASHBOARD_GUTTER_INSET_PX = 6
+/** How close to a band edge counts as "make a new band here", in px. */
+export const STATUS_DASHBOARD_BAND_EDGE_PX = 16
+
+function contains(rect: StatusDashboardRect, x: number, y: number): boolean {
+  return x >= rect.left && x <= rect.right && y >= rect.top && y <= rect.bottom
+}
+
+function distanceTo(rect: StatusDashboardRect, x: number, y: number): number {
+  const dx = Math.max(rect.left - x, 0, x - rect.right)
+  const dy = Math.max(rect.top - y, 0, y - rect.bottom)
+  return Math.hypot(dx, dy)
+}
+
+/**
+ * Where a card dropped at (x, y) would land.
+ *
+ * Deliberately never returns undefined for a pointer that is anywhere near the
+ * dashboard: a drag that ends slightly outside a column should still do the
+ * obvious thing rather than silently snap back, which is a large part of what
+ * made v1 feel unresponsive. Only a pointer with no region at all — a drag off
+ * the top of the page — yields undefined, and the caller treats that as cancel.
+ */
+export function resolveStatusDashboardDrop(
+  geometry: StatusDashboardGeometry,
+  x: number,
+  y: number,
+  draggedId: string
+): StatusDashboardDropTarget | undefined {
+  if (geometry.regions.length === 0) {
+    return undefined
+  }
+  const region =
+    geometry.regions.find((entry) => contains(entry.rect, x, y)) ??
+    [...geometry.regions].sort((a, b) => distanceTo(a.rect, x, y) - distanceTo(b.rect, x, y))[0]
+  if (!region) {
+    return undefined
+  }
+
+  const columns = geometry.columns.filter((column) => column.region === region.region)
+  if (columns.length === 0) {
+    return { kind: 'new-band', region: region.region, band: 0 }
+  }
+
+  // Group into bands, top to bottom.
+  const bandNumbers = [...new Set(columns.map((column) => column.band))].sort((a, b) => a - b)
+  const bands = bandNumbers.map((band) => {
+    const inBand = columns
+      .filter((column) => column.band === band)
+      .sort((a, b) => a.rect.left - b.rect.left)
+    return {
+      band,
+      columns: inBand,
+      top: Math.min(...inBand.map((column) => column.rect.top)),
+      bottom: Math.max(...inBand.map((column) => column.rect.bottom))
+    }
+  })
+
+  // Above the first band, below the last, or in the gap between two: a new
+  // full-width band. The threshold is small so the common case — dropping into
+  // a column — stays easy to hit.
+  const first = bands[0]!
+  const last = bands[bands.length - 1]!
+  if (y < first.top - STATUS_DASHBOARD_BAND_EDGE_PX) {
+    return { kind: 'new-band', region: region.region, band: first.band }
+  }
+  if (y > last.bottom + STATUS_DASHBOARD_BAND_EDGE_PX) {
+    return { kind: 'new-band', region: region.region, band: last.band + 1 }
+  }
+  for (let index = 0; index < bands.length - 1; index += 1) {
+    const above = bands[index]!
+    const below = bands[index + 1]!
+    if (y > above.bottom + STATUS_DASHBOARD_BAND_EDGE_PX && y < below.top - STATUS_DASHBOARD_BAND_EDGE_PX) {
+      return { kind: 'new-band', region: region.region, band: below.band }
+    }
+  }
+
+  // Pick the band the pointer is in, or the nearest one vertically.
+  const band =
+    bands.find((entry) => y >= entry.top - STATUS_DASHBOARD_BAND_EDGE_PX && y <= entry.bottom + STATUS_DASHBOARD_BAND_EDGE_PX) ??
+    [...bands].sort(
+      (a, b) =>
+        Math.min(Math.abs(y - a.top), Math.abs(y - a.bottom)) -
+        Math.min(Math.abs(y - b.top), Math.abs(y - b.bottom))
+    )[0]!
+
+  // Gutters: in the space between two columns — or just off either end of the
+  // band — means "open a new column here".
+  for (const [index, column] of band.columns.entries()) {
+    if (
+      x >= column.rect.left - STATUS_DASHBOARD_GUTTER_PX &&
+      x <= column.rect.left + STATUS_DASHBOARD_GUTTER_INSET_PX
+    ) {
+      return { kind: 'new-column', region: region.region, band: band.band, at: index }
+    }
+  }
+  const rightmost = band.columns[band.columns.length - 1]!
+  if (x >= rightmost.rect.right - STATUS_DASHBOARD_GUTTER_INSET_PX) {
+    return { kind: 'new-column', region: region.region, band: band.band, at: band.columns.length }
+  }
+
+  const column =
+    band.columns.find((entry) => x >= entry.rect.left && x <= entry.rect.right) ??
+    [...band.columns].sort(
+      (a, b) =>
+        Math.min(Math.abs(x - a.rect.left), Math.abs(x - a.rect.right)) -
+        Math.min(Math.abs(x - b.rect.left), Math.abs(x - b.rect.right))
+    )[0]!
+
+  // Index within the column: how many of the OTHER cards have their midpoint
+  // above the pointer. A shelf column compares horizontally instead, because
+  // its cards sit side by side.
+  const others = column.cards.filter((card) => card.id !== draggedId)
+  let index = 0
+  for (const card of others) {
+    const shelf = others.length > 1 && others.some((other) => other !== card && Math.abs(other.rect.top - card.rect.top) < 8)
+    const midpoint = shelf
+      ? (card.rect.left + card.rect.right) / 2
+      : (card.rect.top + card.rect.bottom) / 2
+    if ((shelf ? x : y) > midpoint) {
+      index += 1
+    }
+  }
+  return { kind: 'column', columnId: column.id, index }
+}
+
+/** Apply a resolved drop target to a layout. */
+export function applyStatusDashboardDrop(
+  layout: StatusDashboardLayout,
+  id: string,
+  target: StatusDashboardDropTarget
+): StatusDashboardLayout {
+  if (target.kind === 'column') {
+    return moveStatusDashboardCard(layout, id, target.columnId, target.index)
+  }
+  if (target.kind === 'new-column') {
+    return splitStatusDashboardColumn(layout, id, target.region, target.band, target.at)
+  }
+  return insertStatusDashboardBand(layout, id, target.region, target.band)
 }

--- a/apps/web/src/views/StatusDashboard.tsx
+++ b/apps/web/src/views/StatusDashboard.tsx
@@ -5,18 +5,52 @@
 // dashboard, so the sensor-availability gate, the telemetry requests and every
 // value on the page behave exactly as they did before.
 //
-// LIBRARY vs HAND-ROLLED. react-grid-layout (MIT, which is GPL-3.0 compatible,
-// so licensing was not the deciding factor) solves free 2-D placement by
-// absolutely positioning every card at an explicit pixel size. That is the
-// wrong shape for this page twice over: the Status cards are natural-height
-// (a pre-arm card grows with the number of issues), and free placement is
-// exactly what lets a user produce the broken-looking, hole-riddled page we
-// have to avoid. The model here — named zones, order within a zone, optional
-// height cap — cannot overlap, cannot leave a hole, needs no collision solver,
-// and is ~250 lines of pointer handling. So: hand-rolled, no dependency added.
+// ── WHY v1 FELT CLUNKY, AND WHAT CHANGED ──────────────────────────────────
+//
+// The verdict on the shipped version was "fairly clunky". It was, and the
+// cause was structural rather than a missing polish pass: v1 previewed a drop
+// by inserting a REAL element into the target column. Every pointermove that
+// crossed a slot boundary therefore relaid out the page — cards below the
+// indicator moved down by its height, the column changed height, and the whole
+// grid reflowed under a cursor that had barely moved. On top of that, the move
+// handler called `document.elementFromPoint` and `getBoundingClientRect` on
+// every single event, which forces a synchronous style+layout flush, so the
+// browser was laying the page out twice per pointer event at pointer rate.
+// The known symptom — a drop landing in a different column than the indicator
+// promised, because releasing re-hit-tested coordinates the indicator had
+// shifted by 56px — was that reflow showing through, not a one-off bug.
+//
+// Three changes, in order of how much they matter:
+//
+//  1. THE DRAG NEVER CHANGES LAYOUT. The dragged card keeps its slot in the
+//     flow and is moved by a `transform` — a composited property, zero layout
+//     cost. The drop position is shown by an absolutely-positioned indicator
+//     that is out of flow and pushes nothing. Nothing on the page moves during
+//     a drag except the card under the finger.
+//  2. GEOMETRY IS SNAPSHOTTED ONCE, at pointer-down, in one batched read. Hit
+//     testing is then pure arithmetic against that snapshot
+//     (`resolveStatusDashboardDrop`, unit-tested off the DOM). Because (1)
+//     guarantees the page does not move, the snapshot stays true for the whole
+//     gesture. There is not one layout read in the move handler.
+//  3. MOVES ARE rAF-COALESCED. Pointer events land at up to 240Hz on a good
+//     trackpad; only the newest position matters. The handler stores it and
+//     schedules one animation frame, which writes the transform directly to
+//     the node and only calls setState when the drop TARGET actually changed —
+//     so a drag across a column is a handful of React renders, not hundreds.
+//
+// Pointer capture, `touch-action: none` and `user-select: none` are set on the
+// handles so a drag cannot be stolen by scrolling, text selection, or the
+// pointer leaving the element.
 //
 // Pointer events, not HTML5 drag-and-drop: HTML5 DnD has no touch story, no
-// keyboard story, and drags a browser-drawn ghost we cannot style.
+// keyboard story, and drags a browser-drawn ghost we cannot style. Because
+// these are unified pointer events, a touch or pen drag on a landscape tablet
+// works exactly like a mouse drag; below 1025px the page is one column and
+// customisation is off entirely.
+//
+// The placement model — regions, bands, columns, spans — and the honest
+// re-evaluation of react-grid-layout live in
+// `../view-models/status-dashboard-layout`.
 
 import {
   createContext,
@@ -26,6 +60,7 @@ import {
   useMemo,
   useRef,
   useState,
+  type CSSProperties,
   type KeyboardEvent as ReactKeyboardEvent,
   type PointerEvent as ReactPointerEvent,
   type ReactElement,
@@ -34,13 +69,19 @@ import {
 
 import type { StatusDashboardLayoutController } from '../hooks/use-status-dashboard-layout'
 import {
+  STATUS_DASHBOARD_GRID_COLUMNS,
   STATUS_DASHBOARD_MIN_ROWS,
   STATUS_DASHBOARD_ROW_PX,
-  STATUS_DASHBOARD_ZONE_LABELS,
+  bandFreeSpan,
+  columnCardIds,
+  columnStartLine,
   findPlacement,
-  isStatusDashboardZoneId,
-  zoneCardIds,
-  type StatusDashboardZoneId
+  regionBands,
+  resolveStatusDashboardDrop,
+  type StatusDashboardColumn,
+  type StatusDashboardDropTarget,
+  type StatusDashboardGeometry,
+  type StatusDashboardRegionId
 } from '../view-models/status-dashboard-layout'
 
 /** One card as the dashboard sees it: an id, a name for screen readers, a node. */
@@ -50,23 +91,88 @@ export interface StatusDashboardCardEntry {
   node: ReactNode
 }
 
-interface DragState {
+/** Where the drop indicator should be painted, in viewport coordinates. */
+interface Indicator {
+  left: number
+  top: number
+  width: number
+  height: number
+  orientation: 'horizontal' | 'vertical'
+}
+
+interface DragMutable {
   id: string
   pointerId: number
-  zone: StatusDashboardZoneId
-  index: number
+  originX: number
+  originY: number
+  pointerX: number
+  pointerY: number
+  scrollX: number
+  scrollY: number
+  geometry: StatusDashboardGeometry
+  node: HTMLElement | undefined
+  frame: number | undefined
+  target: StatusDashboardDropTarget | undefined
 }
 
 interface DashboardContextValue {
   controller: StatusDashboardLayoutController
   cardsById: Map<string, StatusDashboardCardEntry>
-  drag: DragState | undefined
-  beginDrag: (id: string, pointerId: number, zone: StatusDashboardZoneId, index: number) => void
+  draggingId: string | undefined
+  beginDrag: (id: string, event: ReactPointerEvent<HTMLElement>) => void
   resizePreview: { id: string; rows: number } | undefined
   setResizePreview: (preview: { id: string; rows: number } | undefined) => void
 }
 
 const DashboardContext = createContext<DashboardContextValue | undefined>(undefined)
+
+function useDashboard(): DashboardContextValue {
+  const context = useContext(DashboardContext)
+  if (!context) {
+    throw new Error('Status dashboard parts must be rendered inside StatusDashboardProvider')
+  }
+  return context
+}
+
+function toRect(element: Element): { left: number; top: number; right: number; bottom: number } {
+  const rect = element.getBoundingClientRect()
+  return { left: rect.left, top: rect.top, right: rect.right, bottom: rect.bottom }
+}
+
+/**
+ * Read every region, column and card rect in one pass.
+ *
+ * Called exactly once per drag, before anything has moved. Every
+ * `getBoundingClientRect` in a drag happens here, in one batch, so the browser
+ * flushes layout once rather than once per pointer event.
+ */
+function collectGeometry(): StatusDashboardGeometry {
+  const regions: StatusDashboardGeometry['regions'] = []
+  for (const element of document.querySelectorAll('[data-status-dash-region]')) {
+    const region = element.getAttribute('data-status-dash-region')
+    if (region === 'main' || region === 'side') {
+      regions.push({ region, rect: toRect(element) })
+    }
+  }
+  const columns: StatusDashboardGeometry['columns'] = []
+  for (const element of document.querySelectorAll('[data-status-dash-col]')) {
+    const id = element.getAttribute('data-status-dash-col')
+    const region = element.getAttribute('data-status-dash-col-region')
+    const band = Number(element.getAttribute('data-status-dash-col-band'))
+    if (!id || (region !== 'main' && region !== 'side') || !Number.isFinite(band)) {
+      continue
+    }
+    const cards: StatusDashboardGeometry['columns'][number]['cards'] = []
+    for (const cardElement of element.querySelectorAll('[data-status-dash-card]')) {
+      const cardId = cardElement.getAttribute('data-status-dash-card')
+      if (cardId) {
+        cards.push({ id: cardId, rect: toRect(cardElement) })
+      }
+    }
+    columns.push({ id, region, band, rect: toRect(element), cards })
+  }
+  return { regions, columns }
+}
 
 export interface StatusDashboardProviderProps {
   controller: StatusDashboardLayoutController
@@ -79,203 +185,437 @@ export function StatusDashboardProvider({
   cards,
   children
 }: StatusDashboardProviderProps): ReactElement {
-  const [drag, setDrag] = useState<DragState | undefined>(undefined)
+  const [draggingId, setDraggingId] = useState<string | undefined>(undefined)
+  const [indicator, setIndicator] = useState<Indicator | undefined>(undefined)
   const [resizePreview, setResizePreview] = useState<{ id: string; rows: number } | undefined>(undefined)
   const cardsById = useMemo(() => new Map(cards.map((card) => [card.id, card])), [cards])
+  const drag = useRef<DragMutable | undefined>(undefined)
 
-  const { moveCard } = controller
-  const layout = controller.layout
+  // `dropCard` is read through a ref so the pointer listeners below can be
+  // registered ONCE per gesture instead of being torn down and re-attached
+  // every time the drop target changes — which is what v1 did, on every move.
+  const dropCardRef = useRef(controller.dropCard)
+  dropCardRef.current = controller.dropCard
 
-  // Start with the card's own slot as the "drop target" so nothing jumps before
-  // the pointer has actually moved anywhere.
-  const beginDrag = useCallback(
-    (id: string, pointerId: number, zone: StatusDashboardZoneId, index: number) => {
-      setDrag({ id, pointerId, zone, index })
+  /** Turn a resolved drop target back into a line to paint, from the snapshot. */
+  const indicatorFor = useCallback(
+    (state: DragMutable, target: StatusDashboardDropTarget | undefined): Indicator | undefined => {
+      if (!target) {
+        return undefined
+      }
+      // The page can still be scrolled mid-drag (a wheel, a trackpad flick).
+      // The snapshot is in viewport coordinates, so correct it by the scroll
+      // delta rather than re-measuring anything.
+      const dx = state.scrollX - window.scrollX
+      const dy = state.scrollY - window.scrollY
+      const geometry = state.geometry
+
+      if (target.kind === 'column') {
+        const column = geometry.columns.find((entry) => entry.id === target.columnId)
+        if (!column) {
+          return undefined
+        }
+        const others = column.cards.filter((card) => card.id !== state.id)
+        const shelf =
+          others.length > 1 && others.some((card, index) => index > 0 && Math.abs(card.rect.top - others[0]!.rect.top) < 8)
+        if (shelf) {
+          const before = others[target.index]
+          const after = others[target.index - 1]
+          const x = before ? before.rect.left - 7 : after ? after.rect.right + 7 : column.rect.left
+          return {
+            left: x + dx - 2,
+            top: column.rect.top + dy,
+            width: 4,
+            height: Math.max(column.rect.bottom - column.rect.top, 24),
+            orientation: 'vertical'
+          }
+        }
+        const before = others[target.index]
+        const after = others[target.index - 1]
+        const y = before ? before.rect.top - 7 : after ? after.rect.bottom + 7 : column.rect.top
+        return {
+          left: column.rect.left + dx,
+          top: y + dy - 2,
+          width: Math.max(column.rect.right - column.rect.left, 24),
+          height: 4,
+          orientation: 'horizontal'
+        }
+      }
+
+      const inRegion = geometry.columns.filter((entry) => entry.region === target.region)
+      if (inRegion.length === 0) {
+        return undefined
+      }
+
+      if (target.kind === 'new-column') {
+        const inBand = inRegion
+          .filter((entry) => entry.band === target.band)
+          .sort((a, b) => a.rect.left - b.rect.left)
+        if (inBand.length === 0) {
+          return undefined
+        }
+        const before = inBand[target.at]
+        const after = inBand[target.at - 1]
+        const x = before ? before.rect.left - 7 : after ? after.rect.right + 7 : inBand[0]!.rect.left
+        const top = Math.min(...inBand.map((entry) => entry.rect.top))
+        const bottom = Math.max(...inBand.map((entry) => entry.rect.bottom))
+        return { left: x + dx - 2, top: top + dy, width: 4, height: Math.max(bottom - top, 24), orientation: 'vertical' }
+      }
+
+      const above = inRegion.filter((entry) => entry.band < target.band)
+      const below = inRegion.filter((entry) => entry.band >= target.band)
+      const y =
+        below.length > 0
+          ? Math.min(...below.map((entry) => entry.rect.top)) - 7
+          : Math.max(...above.map((entry) => entry.rect.bottom)) + 7
+      const left = Math.min(...inRegion.map((entry) => entry.rect.left))
+      const right = Math.max(...inRegion.map((entry) => entry.rect.right))
+      return { left: left + dx, top: y + dy - 2, width: Math.max(right - left, 24), height: 4, orientation: 'horizontal' }
     },
     []
   )
 
-  // Resolve where the pointer currently is: which zone, and which slot in it.
-  // Computed against the zone list with the dragged card already removed, so
-  // the index we hand to `moveCard` is the final index.
-  const resolveDropTarget = useCallback(
-    (id: string, clientX: number, clientY: number): { zone: StatusDashboardZoneId; index: number } | undefined => {
-      const element = document.elementFromPoint(clientX, clientY)
-      if (!element) {
-        return undefined
+  const finishDrag = useCallback((commit: boolean) => {
+    const state = drag.current
+    drag.current = undefined
+    if (!state) {
+      return
+    }
+    if (state.frame !== undefined) {
+      cancelAnimationFrame(state.frame)
+    }
+    if (state.node) {
+      state.node.style.transform = ''
+      state.node.style.willChange = ''
+    }
+    document.body.classList.remove('is-status-dash-dragging')
+    setDraggingId(undefined)
+    setIndicator(undefined)
+    // Commit the target the operator was LAST SHOWN. Because the drag never
+    // reflows the page, a fresh hit-test at release would now agree with it —
+    // but honouring the shown target is still the only version that cannot
+    // drift, and it costs nothing.
+    if (commit && state.target) {
+      dropCardRef.current(state.id, state.target)
+    }
+  }, [])
+
+  const beginDrag = useCallback(
+    (id: string, event: ReactPointerEvent<HTMLElement>) => {
+      const node = (event.currentTarget.closest('[data-status-dash-card]') as HTMLElement | null) ?? undefined
+      drag.current = {
+        id,
+        pointerId: event.pointerId,
+        originX: event.clientX,
+        originY: event.clientY,
+        pointerX: event.clientX,
+        pointerY: event.clientY,
+        scrollX: window.scrollX,
+        scrollY: window.scrollY,
+        geometry: collectGeometry(),
+        node,
+        frame: undefined,
+        // Start on the card's own slot, so a click that never moves is a no-op.
+        target: undefined
       }
-      const zoneElement = element.closest('[data-status-dash-zone]')
-      const zoneId = zoneElement?.getAttribute('data-status-dash-zone')
-      if (!isStatusDashboardZoneId(zoneId)) {
-        return undefined
+      try {
+        event.currentTarget.setPointerCapture(event.pointerId)
+      } catch {
+        // Synthetic events and exotic pointer devices can refuse capture; the
+        // window-level listeners below still track the gesture.
       }
-      const remaining = zoneCardIds(layout, zoneId).filter((cardId) => cardId !== id)
-      const cardElement = element.closest('[data-status-dash-card]')
-      const cardId = cardElement?.getAttribute('data-status-dash-card')
-      if (cardElement && cardId && cardId !== id) {
-        const position = remaining.indexOf(cardId)
-        if (position >= 0) {
-          const rect = cardElement.getBoundingClientRect()
-          return { zone: zoneId, index: clientY < rect.top + rect.height / 2 ? position : position + 1 }
-        }
-      }
-      // Empty space in the zone: land at the end (or the start, if the pointer
-      // is above every card in it).
-      const firstCard = zoneElement?.querySelector('[data-status-dash-card]')
-      if (firstCard && clientY < firstCard.getBoundingClientRect().top) {
-        return { zone: zoneId, index: 0 }
-      }
-      return { zone: zoneId, index: remaining.length }
+      document.body.classList.add('is-status-dash-dragging')
+      setDraggingId(id)
     },
-    [layout]
+    []
   )
 
   useEffect(() => {
-    if (!drag) {
+    if (!draggingId) {
       return
     }
+
+    const render = (): void => {
+      const state = drag.current
+      if (!state) {
+        return
+      }
+      state.frame = undefined
+      // Composited transform: the card follows the pointer without the page
+      // laying out even once.
+      if (state.node) {
+        const dx = state.pointerX - state.originX
+        const dy = state.pointerY - state.originY
+        state.node.style.transform = `translate3d(${dx}px, ${dy}px, 0)`
+      }
+      const target = resolveStatusDashboardDrop(state.geometry, state.pointerX, state.pointerY, state.id)
+      const changed =
+        JSON.stringify(target ?? null) !== JSON.stringify(state.target ?? null)
+      state.target = target
+      if (changed) {
+        setIndicator(indicatorFor(state, target))
+      }
+    }
+
+    const schedule = (): void => {
+      const state = drag.current
+      if (!state || state.frame !== undefined) {
+        return
+      }
+      state.frame = requestAnimationFrame(render)
+    }
+
     const onMove = (event: PointerEvent): void => {
-      if (event.pointerId !== drag.pointerId) {
+      const state = drag.current
+      if (!state || event.pointerId !== state.pointerId) {
         return
       }
       event.preventDefault()
-      const target = resolveDropTarget(drag.id, event.clientX, event.clientY)
-      if (!target) {
-        return
-      }
-      setDrag((current) =>
-        current && (current.zone !== target.zone || current.index !== target.index)
-          ? { ...current, ...target }
-          : current
-      )
+      // Only the newest position matters; coalesced intermediate points would
+      // just be thrown away by the next frame.
+      state.pointerX = event.clientX
+      state.pointerY = event.clientY
+      schedule()
     }
     const onUp = (event: PointerEvent): void => {
-      if (event.pointerId !== drag.pointerId) {
+      const state = drag.current
+      if (!state || event.pointerId !== state.pointerId) {
         return
       }
-      // Commit the slot the operator was LAST SHOWN, not a fresh hit-test of the
-      // release coordinates. Re-resolving here looks equivalent and is not: the
-      // drop indicator is a real element, so inserting it reflows the target
-      // zone and pushes the cards below it down — measured at 56px dropping GPS
-      // onto Pre-arm. That slides the zone the pointer is over out from under a
-      // pointer that never moved, and the release then hit-tests a DIFFERENT
-      // zone than the indicator was promising. The card landed back in the
-      // sensor row while the line said column 1.
-      //
-      // `drag` is the state that rendered the indicator (the effect re-subscribes
-      // whenever it changes), so honouring it makes the drop land exactly where
-      // the line was. A drag that never moved still carries the card's own slot
-      // from `beginDrag`, which `moveStatusDashboardCard` recognises as a no-op.
-      moveCard(drag.id, drag.zone, drag.index)
-      setDrag(undefined)
+      state.pointerX = event.clientX
+      state.pointerY = event.clientY
+      state.target = resolveStatusDashboardDrop(state.geometry, state.pointerX, state.pointerY, state.id)
+      finishDrag(true)
     }
-    const onCancel = (): void => setDrag(undefined)
+    const onCancel = (): void => finishDrag(false)
     const onKey = (event: KeyboardEvent): void => {
       if (event.key === 'Escape') {
-        setDrag(undefined)
+        finishDrag(false)
       }
     }
+    const onScroll = (): void => schedule()
+
     window.addEventListener('pointermove', onMove, { passive: false })
     window.addEventListener('pointerup', onUp)
     window.addEventListener('pointercancel', onCancel)
     window.addEventListener('keydown', onKey)
-    document.body.classList.add('is-status-dash-dragging')
+    window.addEventListener('scroll', onScroll, { passive: true })
     return () => {
       window.removeEventListener('pointermove', onMove)
       window.removeEventListener('pointerup', onUp)
       window.removeEventListener('pointercancel', onCancel)
       window.removeEventListener('keydown', onKey)
-      document.body.classList.remove('is-status-dash-dragging')
+      window.removeEventListener('scroll', onScroll)
     }
-  }, [drag, moveCard, resolveDropTarget])
+    // Registered once per gesture: the handlers read mutable drag state from a
+    // ref, so a changing drop target does not re-subscribe them.
+  }, [draggingId, finishDrag, indicatorFor])
 
   const value = useMemo<DashboardContextValue>(
-    () => ({ controller, cardsById, drag, beginDrag, resizePreview, setResizePreview }),
-    [controller, cardsById, drag, beginDrag, resizePreview]
+    () => ({ controller, cardsById, draggingId, beginDrag, resizePreview, setResizePreview }),
+    [controller, cardsById, draggingId, beginDrag, resizePreview]
   )
 
-  return <DashboardContext.Provider value={value}>{children}</DashboardContext.Provider>
+  return (
+    <DashboardContext.Provider value={value}>
+      {children}
+      {indicator ? (
+        <div
+          className={`status-dash-drop status-dash-drop--${indicator.orientation}`}
+          data-testid="status-dash-drop-indicator"
+          aria-hidden="true"
+          style={{
+            left: `${indicator.left}px`,
+            top: `${indicator.top}px`,
+            width: `${indicator.width}px`,
+            height: `${indicator.height}px`
+          }}
+        />
+      ) : null}
+    </DashboardContext.Provider>
+  )
 }
 
-export interface StatusDashboardZoneProps {
-  zone: StatusDashboardZoneId
-  /** The existing container class, so the zone keeps the layout it always had. */
+export interface StatusDashboardRegionProps {
+  region: StatusDashboardRegionId
+  /** The container class the region's element had before the dashboard existed. */
   className: string
-  /**
-   * The container's existing `data-testid`, where it had one. A zone replaces a
-   * plain `<div>` that tests already reach for by name — the sensor row is
-   * asserted on as `setup-sensor-group` — so the zone has to answer to that name
-   * rather than mint a new one and quietly break those tests.
-   */
   testId?: string
-  children?: ReactNode
 }
 
 /**
- * A drop zone. It renders whichever cards the layout currently assigns to it,
- * in layout order, and keeps the class name the container always had — the
- * default arrangement is therefore pixel-identical to the page without this
- * feature.
+ * One region: a 12-column CSS grid with AUTO rows, holding bands of columns.
+ *
+ * Auto rows are the whole reason this can be free without clipping anything —
+ * every card is exactly as tall as its content, decided by the layout engine,
+ * and a card that grows a row simply makes its column taller.
  */
-export function StatusDashboardZone({ zone, className, testId, children }: StatusDashboardZoneProps): ReactElement {
-  const context = useContext(DashboardContext)
-  if (!context) {
-    throw new Error('StatusDashboardZone must be rendered inside StatusDashboardProvider')
-  }
-  const { controller, cardsById, drag } = context
-  const ids = zoneCardIds(controller.layout, zone)
-  const isDropTarget = drag?.zone === zone
-
-  // The dragged card stays MOUNTED (ghosted) rather than being pulled out of
-  // the tree: several cards own expensive children — the GPS card hosts a
-  // Leaflet map — and unmounting them mid-drag would tear the map down and
-  // rebuild it on every drop. `slot` counts only the cards that are not being
-  // dragged, which is the index space `moveCard` expects.
-  const rendered: ReactNode[] = []
-  let slot = 0
-  for (const id of ids) {
-    const dragged = drag?.id === id
-    if (!dragged) {
-      if (isDropTarget && drag && drag.index === slot) {
-        rendered.push(<div key={`drop:${slot}`} className="status-dash-drop" aria-hidden="true" />)
-      }
-      slot += 1
-    }
-    const card = cardsById.get(id)
-    if (card) {
-      rendered.push(<StatusDashboardCard key={id} entry={card} zone={zone} index={ids.indexOf(id)} />)
-    }
-  }
-  if (isDropTarget && drag && drag.index >= slot) {
-    rendered.push(<div key="drop:end" className="status-dash-drop" aria-hidden="true" />)
-  }
+export function StatusDashboardRegion({ region, className, testId }: StatusDashboardRegionProps): ReactElement {
+  const { controller } = useDashboard()
+  const bands = regionBands(controller.layout, region)
 
   return (
     <div
-      className={`${className} status-dash-zone${
-        controller.customisable ? ' status-dash-zone--live' : ''
-      }${drag ? ' status-dash-zone--armed' : ''}${isDropTarget ? ' is-drop-target' : ''}`}
-      data-status-dash-zone={zone}
-      data-testid={testId ?? `status-dash-zone-${zone}`}
+      className={`${className} status-dash-region${controller.customisable ? ' status-dash-region--live' : ''}`}
+      data-status-dash-region={region}
+      data-testid={testId ?? `status-dash-region-${region}`}
     >
-      {rendered}
-      {children}
+      {bands.map((band) =>
+        band.columns.map((column) => (
+          <StatusDashboardColumnView
+            key={column.id}
+            column={column}
+            startLine={columnStartLine(band, column.id)}
+            canGrow={bandFreeSpan(band) > 0 || band.columns.length > 1}
+            bandIndex={band.band}
+          />
+        ))
+      )}
+    </div>
+  )
+}
+
+interface StatusDashboardColumnViewProps {
+  column: StatusDashboardColumn
+  startLine: number
+  canGrow: boolean
+  bandIndex: number
+}
+
+function StatusDashboardColumnView({
+  column,
+  startLine,
+  canGrow,
+  bandIndex
+}: StatusDashboardColumnViewProps): ReactElement {
+  const { controller, cardsById } = useDashboard()
+  const ids = columnCardIds(controller.layout, column.id)
+  const resizeStart = useRef<{ pointerId: number; x: number; span: number; step: number } | undefined>(undefined)
+
+  const onWidthPointerDown = (event: ReactPointerEvent<HTMLButtonElement>): void => {
+    if (event.button !== 0) {
+      return
+    }
+    event.preventDefault()
+    event.stopPropagation()
+    const region = event.currentTarget.closest('[data-status-dash-region]')
+    const width = region?.getBoundingClientRect().width ?? 0
+    const gap = 14
+    // One grid column plus its gutter — the distance the pointer must travel
+    // to earn one more twelfth.
+    const step = Math.max(1, (width - gap * (STATUS_DASHBOARD_GRID_COLUMNS - 1)) / STATUS_DASHBOARD_GRID_COLUMNS + gap)
+    resizeStart.current = { pointerId: event.pointerId, x: event.clientX, span: column.span, step }
+    try {
+      event.currentTarget.setPointerCapture(event.pointerId)
+    } catch {
+      // See the card resize handle — capture is best-effort.
+    }
+  }
+
+  const onWidthPointerMove = (event: ReactPointerEvent<HTMLButtonElement>): void => {
+    const start = resizeStart.current
+    if (!start || start.pointerId !== event.pointerId) {
+      return
+    }
+    // Snapping to a whole twelfth is also the throttle: the layout changes at
+    // most eleven times across the whole gesture, however fast the pointer moves.
+    const next = start.span + Math.round((event.clientX - start.x) / start.step)
+    if (next !== column.span) {
+      controller.resizeColumn(column.id, next)
+    }
+  }
+
+  const endWidthResize = (event: ReactPointerEvent<HTMLButtonElement>): void => {
+    if (resizeStart.current?.pointerId === event.pointerId) {
+      resizeStart.current = undefined
+    }
+  }
+
+  const onWidthKeyDown = (event: ReactKeyboardEvent<HTMLButtonElement>): void => {
+    if (event.key !== 'ArrowLeft' && event.key !== 'ArrowRight') {
+      return
+    }
+    event.preventDefault()
+    controller.resizeColumn(column.id, column.span + (event.key === 'ArrowLeft' ? -1 : 1))
+  }
+
+  const style: CSSProperties = {
+    gridColumn: `${startLine} / span ${column.span}`,
+    gridRow: bandIndex + 1
+  }
+
+  // The sensor shelf answers to `setup-sensor-group`, the name tests have
+  // reached for since before the dashboard existed. A column that minted a new
+  // name and quietly broke those tests would be worse than one special case.
+  const testId = column.id === 'sensors' ? 'setup-sensor-group' : `status-dash-col-${column.id}`
+
+  // A shelf column keeps the `setup-status-sensors` class it always had: the
+  // GPS map's whole `@container` compaction ruleset is scoped under it,
+  // including the `> .status-dash-card` rule that puts `container-type` on the
+  // WRAPPER — the card is one level too deep for `>` once the dashboard wraps
+  // it. Dropping the class here would silently kill the compaction, and the
+  // GPS card would render its full-size map inside a 276px column.
+  return (
+    <div
+      className={`status-dash-col status-dash-col--${column.flow}${
+        column.flow === 'shelf' ? ' setup-status-sensors' : ''
+      }${ids.length === 0 ? ' status-dash-col--empty' : ''}`}
+      style={style}
+      data-status-dash-col={column.id}
+      data-status-dash-col-region={column.region}
+      data-status-dash-col-band={column.band}
+      data-status-dash-col-span={column.span}
+      data-testid={testId}
+    >
+      {ids.map((id) => {
+        const card = cardsById.get(id)
+        return card ? <StatusDashboardCard key={id} entry={card} columnSpan={column.span} /> : null
+      })}
+      {controller.customisable ? (
+        <div className="status-dash-col__chrome">
+          <button
+            type="button"
+            className="status-dash-col__flow"
+            data-testid={`status-dash-flow-${column.id}`}
+            aria-label={`${column.flow === 'stack' ? 'Lay this column out side by side' : 'Stack this column top to bottom'}`}
+            title={column.flow === 'stack' ? 'Side by side' : 'Stack'}
+            onClick={() => controller.toggleColumnFlow(column.id)}
+          >
+            <span aria-hidden="true">{column.flow === 'stack' ? '⇄' : '⇅'}</span>
+          </button>
+          <button
+            type="button"
+            className="status-dash-col__width"
+            data-testid={`status-dash-width-${column.id}`}
+            aria-label={`Column width, currently ${column.span} of ${STATUS_DASHBOARD_GRID_COLUMNS}. Drag, or use the left and right arrow keys.`}
+            title={`Drag to set the column width (${column.span}/${STATUS_DASHBOARD_GRID_COLUMNS})`}
+            aria-valuenow={column.span}
+            aria-valuemin={1}
+            aria-valuemax={STATUS_DASHBOARD_GRID_COLUMNS}
+            role="slider"
+            onPointerDown={onWidthPointerDown}
+            onPointerMove={onWidthPointerMove}
+            onPointerUp={endWidthResize}
+            onPointerCancel={endWidthResize}
+            onKeyDown={onWidthKeyDown}
+            disabled={!canGrow && column.span === STATUS_DASHBOARD_GRID_COLUMNS}
+          >
+            <span aria-hidden="true" />
+          </button>
+        </div>
+      ) : null}
     </div>
   )
 }
 
 interface StatusDashboardCardProps {
   entry: StatusDashboardCardEntry
-  zone: StatusDashboardZoneId
-  index: number
+  /** Its column's width, announced on the handle so width is discoverable. */
+  columnSpan: number
 }
 
-function StatusDashboardCard({ entry, zone, index }: StatusDashboardCardProps): ReactElement {
-  const context = useContext(DashboardContext)
-  if (!context) {
-    throw new Error('StatusDashboardCard must be rendered inside StatusDashboardProvider')
-  }
-  const { controller, drag, beginDrag, resizePreview, setResizePreview } = context
+function StatusDashboardCard({ entry, columnSpan }: StatusDashboardCardProps): ReactElement {
+  const { controller, draggingId, beginDrag, resizePreview, setResizePreview } = useDashboard()
   const { customisable } = controller
   const contentRef = useRef<HTMLDivElement | null>(null)
   const resizeStart = useRef<{ pointerId: number; y: number; rows: number } | undefined>(undefined)
@@ -283,7 +623,7 @@ function StatusDashboardCard({ entry, zone, index }: StatusDashboardCardProps): 
   const placement = findPlacement(controller.layout, entry.id)
   const previewRows = resizePreview?.id === entry.id ? resizePreview.rows : undefined
   const rows = previewRows ?? placement?.heightRows
-  const isDragging = drag?.id === entry.id
+  const isDragging = draggingId === entry.id
 
   const onResizePointerDown = (event: ReactPointerEvent<HTMLButtonElement>): void => {
     event.preventDefault()
@@ -323,9 +663,11 @@ function StatusDashboardCard({ entry, zone, index }: StatusDashboardCardProps): 
   }
 
   const onHandleKeyDown = (event: ReactKeyboardEvent<HTMLButtonElement>): void => {
-    // The keyboard path. Drag-only reordering is unusable without a pointer, so
-    // the handle is a real button: up/down reorders inside the column, left/
-    // right walks the card across columns.
+    // The keyboard path. Drag-only rearranging is unusable without a pointer,
+    // so the handle is a real button: up/down reorders inside the column,
+    // left/right walks the card across every column in visual order — bands
+    // and the sidebar included — and shift+left/right changes the width of the
+    // column it is in, which is the keyboard equivalent of the width handle.
     const handled = ['ArrowUp', 'ArrowDown', 'ArrowLeft', 'ArrowRight'].includes(event.key)
     if (!handled) {
       return
@@ -335,10 +677,10 @@ function StatusDashboardCard({ entry, zone, index }: StatusDashboardCardProps): 
       controller.nudgeCard(entry.id, -1)
     } else if (event.key === 'ArrowDown') {
       controller.nudgeCard(entry.id, 1)
-    } else if (event.key === 'ArrowLeft') {
-      controller.shiftCardZone(entry.id, -1)
+    } else if (event.shiftKey) {
+      controller.nudgeCardWidth(entry.id, event.key === 'ArrowLeft' ? -1 : 1)
     } else {
-      controller.shiftCardZone(entry.id, 1)
+      controller.shiftCardColumn(entry.id, event.key === 'ArrowLeft' ? -1 : 1)
     }
   }
 
@@ -354,13 +696,12 @@ function StatusDashboardCard({ entry, zone, index }: StatusDashboardCardProps): 
     }
   }
 
-  const style = rows === undefined ? undefined : { ['--status-dash-height' as string]: `${rows * STATUS_DASHBOARD_ROW_PX}px` }
+  const style =
+    rows === undefined ? undefined : { ['--status-dash-height' as string]: `${rows * STATUS_DASHBOARD_ROW_PX}px` }
 
   return (
     <div
-      className={`status-dash-card${isDragging ? ' is-dragging' : ''}${
-        rows === undefined ? '' : ' is-capped'
-      }`}
+      className={`status-dash-card${isDragging ? ' is-dragging' : ''}${rows === undefined ? '' : ' is-capped'}`}
       data-status-dash-card={entry.id}
       data-testid={`status-dash-card-${entry.id}`}
       style={style}
@@ -374,14 +715,14 @@ function StatusDashboardCard({ entry, zone, index }: StatusDashboardCardProps): 
             type="button"
             className="status-dash-card__handle"
             data-testid={`status-dash-handle-${entry.id}`}
-            aria-label={`Move ${entry.label} card. Currently in ${STATUS_DASHBOARD_ZONE_LABELS[zone]}. Drag, or use the arrow keys to move it up, down, left or right.`}
+            aria-label={`Move ${entry.label} card. Its column is ${columnSpan} of ${STATUS_DASHBOARD_GRID_COLUMNS} wide. Drag it anywhere, or use the arrow keys to move it up, down, or into the next column — hold shift with left and right to change the column width.`}
             title={`Drag to move ${entry.label} — or focus and use the arrow keys`}
             onPointerDown={(event) => {
               if (event.button !== 0) {
                 return
               }
               event.preventDefault()
-              beginDrag(entry.id, event.pointerId, zone, index)
+              beginDrag(entry.id, event)
             }}
             onKeyDown={onHandleKeyDown}
           >

--- a/tests/e2e/views.spec.ts
+++ b/tests/e2e/views.spec.ts
@@ -5035,7 +5035,11 @@ test.describe('Status & Info advanced sensor cards', () => {
 
     const tops = await page.evaluate(() => {
       const group = document.querySelector('[data-testid="setup-sensor-group"]')!
-      return [...group.children].map((child) => Math.round(child.getBoundingClientRect().top))
+      // The cards specifically: the shelf column also carries its own
+      // (absolutely positioned, out-of-flow) width/flow chrome as a child.
+      return [...group.querySelectorAll('[data-status-dash-card]')].map((child) =>
+        Math.round(child.getBoundingClientRect().top)
+      )
     })
     expect(tops).toHaveLength(3)
     // Every card starts on the same line — no wrap onto a second row, which is
@@ -5059,15 +5063,19 @@ test.describe('Status & Info advanced sensor cards', () => {
 })
 
 test.describe('Status & Info dashboard layout', () => {
-  // The ask: "can we just make all the various boxes click and drag and
-  // resizable so users can click and drag them around how they want it?"
+  // The ask, after the first cut shipped: "pretty good, but its fairly clunky.
+  // can we make that more responsive and free so i can drag and drop how i
+  // please". So the arrangement is now a real 12-column grid with auto rows —
+  // free columns, free widths, new bands — and the drag never relays the page
+  // out while it is in flight.
   //
-  // The mechanism is chrome AROUND the existing cards — no card content, gate
-  // or telemetry changed — so these tests assert ARRANGEMENT: where a card
-  // sits, that a move sticks, that a reload keeps it, that Reset puts it back,
-  // and that a stale saved arrangement can never render a broken page.
+  // The mechanism is still chrome AROUND the existing cards — no card content,
+  // gate or telemetry changed — so these tests assert ARRANGEMENT: where a card
+  // sits, how wide its column is, that a move sticks, that a reload keeps it,
+  // that Reset and Tidy do what they say, and that a stale saved arrangement
+  // can never render a broken page.
 
-  const STORAGE_KEY = 'arduconfig.status-dashboard.v1'
+  const STORAGE_KEY = 'arduconfig.status-dashboard.v2'
 
   async function connectDemo(page: Page): Promise<void> {
     await page.goto('/')
@@ -5077,8 +5085,8 @@ test.describe('Status & Info dashboard layout', () => {
     await expect(page.getByTestId('status-dash-card-system-info')).toBeVisible({ timeout: VEHICLE_CONNECT_TIMEOUT })
   }
 
-  async function zoneIds(page: Page, zone: string): Promise<string[]> {
-    return page.$$eval(`[data-status-dash-zone="${zone}"] [data-status-dash-card]`, (nodes) =>
+  async function columnIds(page: Page, column: string): Promise<string[]> {
+    return page.$$eval(`[data-status-dash-col="${column}"] [data-status-dash-card]`, (nodes) =>
       nodes.map((node) => node.getAttribute('data-status-dash-card') ?? '')
     )
   }
@@ -5090,13 +5098,39 @@ test.describe('Status & Info dashboard layout', () => {
     await connectDemo(page)
     // Poll: the two advanced sensor cards appear only once RNGFND1_TYPE /
     // FLOW_TYPE have arrived, which is later than the unconditional cards.
-    await expect.poll(() => zoneIds(page, 'sensors')).toEqual(['gps', 'rangefinder', 'optical-flow'])
-    expect(await zoneIds(page, 'midcol')).toEqual(['prearm', 'statistics'])
-    expect(await zoneIds(page, 'noticecol')).toEqual(['notices'])
-    expect(await zoneIds(page, 'sidebar')).toEqual(['system-info', 'instruments', 'guided-setup'])
+    await expect.poll(() => columnIds(page, 'sensors')).toEqual(['gps', 'rangefinder', 'optical-flow'])
+    expect(await columnIds(page, 'midcol')).toEqual(['prearm', 'statistics'])
+    expect(await columnIds(page, 'noticecol')).toEqual(['notices'])
+    expect(await columnIds(page, 'sidebar')).toEqual(['system-info', 'instruments', 'guided-setup'])
     // Reset only appears once there is something to reset — an always-on
     // "Reset Layout" on a page nobody has customised is just noise.
     await expect(page.getByTestId('status-dash-reset-layout')).toHaveCount(0)
+    await expect(page.getByTestId('status-dash-tidy-layout')).toHaveCount(0)
+  })
+
+  test('the default columns are the widths the page shipped with', async ({ page }) => {
+    // The guarantee that survived the model change: the two status columns are
+    // half the main area each, exactly as the `auto-fit` pair they replaced
+    // were, and the sensor shelf spans it all. Six twelfths with a uniform
+    // 14px gutter IS half — this asserts the arithmetic actually holds in a
+    // browser rather than only on paper.
+    await page.setViewportSize({ width: 1440, height: 900 })
+    await connectDemo(page)
+    await expect.poll(() => columnIds(page, 'sensors')).toEqual(['gps', 'rangefinder', 'optical-flow'])
+
+    const widths = await page.evaluate(() => {
+      const read = (id: string): { left: number; width: number } => {
+        const rect = document.querySelector(`[data-status-dash-col="${id}"]`)!.getBoundingClientRect()
+        return { left: Math.round(rect.left), width: Math.round(rect.width) }
+      }
+      return { sensors: read('sensors'), midcol: read('midcol'), noticecol: read('noticecol') }
+    })
+
+    expect(widths.midcol.left).toBe(widths.sensors.left)
+    expect(widths.midcol.width).toBe(widths.noticecol.width)
+    // The pair plus one 14px gutter fills the shelf above them.
+    expect(widths.midcol.width + 14 + widths.noticecol.width).toBe(widths.sensors.width)
+    expect(widths.noticecol.left).toBe(widths.midcol.left + widths.midcol.width + 14)
   })
 
   test('a card can be moved with the keyboard alone, and Reset puts it back', async ({ page }) => {
@@ -5105,18 +5139,18 @@ test.describe('Status & Info dashboard layout', () => {
     await connectDemo(page)
     await page.getByTestId('status-dash-handle-guided-setup').focus()
     await page.keyboard.press('ArrowLeft')
-    await expect.poll(() => zoneIds(page, 'noticecol')).toEqual(['notices', 'guided-setup'])
-    expect(await zoneIds(page, 'sidebar')).toEqual(['system-info', 'instruments'])
+    await expect.poll(() => columnIds(page, 'noticecol')).toEqual(['notices', 'guided-setup'])
+    expect(await columnIds(page, 'sidebar')).toEqual(['system-info', 'instruments'])
 
     // The move is saved, so it survives a reload.
     await page.reload()
     await page.getByTestId('connect-button').click()
     await expect(page.getByTestId('session-vehicle-name')).toHaveText('ArduCopter', { timeout: VEHICLE_CONNECT_TIMEOUT })
     await expect(page.getByTestId('status-dash-card-guided-setup')).toBeVisible({ timeout: VEHICLE_CONNECT_TIMEOUT })
-    expect(await zoneIds(page, 'noticecol')).toEqual(['notices', 'guided-setup'])
+    expect(await columnIds(page, 'noticecol')).toEqual(['notices', 'guided-setup'])
 
     await page.getByTestId('status-dash-reset-layout').click()
-    await expect.poll(() => zoneIds(page, 'sidebar')).toEqual(['system-info', 'instruments', 'guided-setup'])
+    await expect.poll(() => columnIds(page, 'sidebar')).toEqual(['system-info', 'instruments', 'guided-setup'])
     await expect(page.getByTestId('status-dash-reset-layout')).toHaveCount(0)
     // Reset CLEARS the saved arrangement rather than saving a copy of today's
     // default, so a later default change still reaches the operator.
@@ -5145,10 +5179,10 @@ test.describe('Status & Info dashboard layout', () => {
     // optical-flow cards only exist when the sensor is configured, so a saved
     // arrangement routinely names cards that are not there.
     await connectDemo(page)
-    await expect.poll(() => zoneIds(page, 'sensors')).toEqual(['gps', 'rangefinder', 'optical-flow'])
+    await expect.poll(() => columnIds(page, 'sensors')).toEqual(['gps', 'rangefinder', 'optical-flow'])
     await page.getByTestId('status-dash-handle-rangefinder').focus()
     await page.keyboard.press('ArrowRight')
-    await expect.poll(() => zoneIds(page, 'midcol')).toContain('rangefinder')
+    await expect.poll(() => columnIds(page, 'midcol')).toContain('rangefinder')
 
     await page.goto('/?demoParamOverrides=RNGFND1_TYPE:0,FLOW_TYPE:0')
     await page.getByTestId('connect-button').click()
@@ -5156,33 +5190,169 @@ test.describe('Status & Info dashboard layout', () => {
     await expect(page.getByTestId('status-dash-card-system-info')).toBeVisible({ timeout: VEHICLE_CONNECT_TIMEOUT })
 
     // The absent cards are simply not placed; every card that IS present is.
-    expect(await zoneIds(page, 'sensors')).toEqual(['gps'])
-    expect(await zoneIds(page, 'midcol')).toEqual(['prearm', 'statistics'])
-    expect(await zoneIds(page, 'sidebar')).toEqual(['system-info', 'instruments', 'guided-setup'])
+    expect(await columnIds(page, 'sensors')).toEqual(['gps'])
+    expect(await columnIds(page, 'midcol')).toEqual(['prearm', 'statistics'])
+    expect(await columnIds(page, 'sidebar')).toEqual(['system-info', 'instruments', 'guided-setup'])
+  })
+
+  test('a column can be widened, and the width is saved', async ({ page }) => {
+    // The horizontal resize the zone model did not have: width was a property
+    // of the zone, so moving a card between columns WAS the only way to change
+    // it. Now a column has a span, and the space comes off its neighbour.
+    await page.setViewportSize({ width: 1440, height: 900 })
+    await connectDemo(page)
+    const before = await page.evaluate(
+      () => document.querySelector('[data-status-dash-col="midcol"]')!.getBoundingClientRect().width
+    )
+
+    await page.getByTestId('status-dash-width-midcol').focus()
+    await page.keyboard.press('ArrowRight')
+    await page.keyboard.press('ArrowRight')
+
+    await expect(page.getByTestId('status-dash-col-midcol')).toHaveAttribute('data-status-dash-col-span', '8')
+    await expect(page.getByTestId('status-dash-col-noticecol')).toHaveAttribute('data-status-dash-col-span', '4')
+    const after = await page.evaluate(
+      () => document.querySelector('[data-status-dash-col="midcol"]')!.getBoundingClientRect().width
+    )
+    expect(after).toBeGreaterThan(before)
+
+    expect(await page.evaluate((key) => window.localStorage.getItem(key), STORAGE_KEY)).toContain('"span":8')
+  })
+
+  test('a card dragged into a gutter opens a new column, and Tidy closes the mess up', async ({ page }) => {
+    // The freedom the operator asked for: a card can go somewhere there was no
+    // column at all. Tidy is the way back out without a full Reset.
+    await page.setViewportSize({ width: 1440, height: 900 })
+    await connectDemo(page)
+    await expect.poll(() => columnIds(page, 'sensors')).toEqual(['gps', 'rangefinder', 'optical-flow'])
+
+    const handle = page.getByTestId('status-dash-handle-optical-flow')
+    const box = (await handle.boundingBox())!
+    // Drop it just past the right-hand edge of the midcol column — the gutter
+    // between the two status columns.
+    const midcol = (await page.getByTestId('status-dash-col-midcol').boundingBox())!
+    await page.mouse.move(box.x + box.width / 2, box.y + box.height / 2)
+    await page.mouse.down()
+    await page.mouse.move(midcol.x + midcol.width + 4, midcol.y + 40, { steps: 12 })
+    await page.mouse.up()
+
+    // A brand new column exists, holding exactly the dragged card, and the
+    // sensor shelf has given it up.
+    await expect.poll(() => columnIds(page, 'sensors')).toEqual(['gps', 'rangefinder'])
+    const created = await page.$$eval('[data-status-dash-col]', (nodes) =>
+      nodes
+        .map((node) => node.getAttribute('data-status-dash-col') ?? '')
+        .filter((id) => !['sensors', 'midcol', 'noticecol', 'sidebar'].includes(id))
+    )
+    expect(created).toHaveLength(1)
+    expect(await columnIds(page, created[0]!)).toEqual(['optical-flow'])
+
+    // Tidy keeps the arrangement but evens the widths back out to fill the row.
+    await page.getByTestId('status-dash-tidy-layout').click()
+    const spans = await page.$$eval('[data-status-dash-col-band="1"][data-status-dash-col-region="main"]', (nodes) =>
+      nodes.map((node) => Number(node.getAttribute('data-status-dash-col-span')))
+    )
+    expect(spans.reduce((total, span) => total + span, 0)).toBe(12)
+    // The card the operator placed is still where they put it.
+    expect(await columnIds(page, created[0]!)).toEqual(['optical-flow'])
+  })
+
+  test('a drag does not relayout the page under the pointer', async ({ page }) => {
+    // The clunkiness fix, asserted rather than asserted-about. v1 previewed a
+    // drop by inserting a real element into the target column, so every card
+    // below it moved — measured at 56px — and the page reflowed on every
+    // pointer move. The indicator is now fixed-position and out of flow, and
+    // the dragged card moves on a transform, so NOTHING that is not being
+    // dragged may change position mid-gesture.
+    await page.setViewportSize({ width: 1440, height: 900 })
+    await connectDemo(page)
+    await expect.poll(() => columnIds(page, 'sensors')).toEqual(['gps', 'rangefinder', 'optical-flow'])
+
+    const positions = async (): Promise<Record<string, number[]>> =>
+      page.$$eval('[data-status-dash-card]', (nodes) =>
+        Object.fromEntries(
+          nodes.map((node) => {
+            const rect = node.getBoundingClientRect()
+            return [node.getAttribute('data-status-dash-card') ?? '', [Math.round(rect.left), Math.round(rect.top)]]
+          })
+        )
+      )
+
+    const before = await positions()
+    const handle = page.getByTestId('status-dash-handle-gps')
+    const box = (await handle.boundingBox())!
+    await page.mouse.move(box.x + box.width / 2, box.y + box.height / 2)
+    await page.mouse.down()
+    const midcol = (await page.getByTestId('status-dash-col-midcol').boundingBox())!
+    await page.mouse.move(midcol.x + midcol.width / 2, midcol.y + 30, { steps: 20 })
+
+    // Mid-drag: the indicator is up, and every card except the lifted one is
+    // exactly where it was.
+    await expect(page.getByTestId('status-dash-drop-indicator')).toBeVisible()
+    const during = await positions()
+    for (const [id, position] of Object.entries(before)) {
+      if (id === 'gps') {
+        continue
+      }
+      expect(during[id], `${id} moved during the drag`).toEqual(position)
+    }
+
+    await page.keyboard.press('Escape')
+    await page.mouse.up()
+    // Escape cancels: nothing moved at all.
+    await expect.poll(() => columnIds(page, 'sensors')).toEqual(['gps', 'rangefinder', 'optical-flow'])
   })
 
   test('an unreadable saved layout falls back to the default silently', async ({ page }) => {
     await page.goto('/')
     await page.evaluate(
       ([key, value]) => window.localStorage.setItem(key, value),
-      [STORAGE_KEY, '{"version":1,"cards":[{"id":"gho'] as const
+      [STORAGE_KEY, '{"version":2,"columns":[{"id":"gho'] as const
     )
     await page.getByTestId('transport-mode-select').selectOption('demo')
     await page.getByTestId('connect-button').click()
     await expect(page.getByTestId('session-vehicle-name')).toHaveText('ArduCopter', { timeout: VEHICLE_CONNECT_TIMEOUT })
     await expect(page.getByTestId('status-dash-card-system-info')).toBeVisible({ timeout: VEHICLE_CONNECT_TIMEOUT })
-    expect(await zoneIds(page, 'sidebar')).toEqual(['system-info', 'instruments', 'guided-setup'])
+    expect(await columnIds(page, 'sidebar')).toEqual(['system-info', 'instruments', 'guided-setup'])
+  })
+
+  test('a layout saved by the zone model is dropped, not half-read', async ({ page }) => {
+    // v1 stored `{version:1, cards:[{id, zone}]}` under its own key. There are
+    // no columns in it to migrate, so the version bump means those operators
+    // get the (unchanged) default back rather than a broken page.
+    await page.goto('/')
+    await page.evaluate(() => {
+      window.localStorage.setItem(
+        'arduconfig.status-dashboard.v1',
+        JSON.stringify({ version: 1, cards: [{ id: 'gps', zone: 'sidebar', heightRows: 6 }] })
+      )
+    })
+    await page.getByTestId('transport-mode-select').selectOption('demo')
+    await page.getByTestId('connect-button').click()
+    await expect(page.getByTestId('session-vehicle-name')).toHaveText('ArduCopter', { timeout: VEHICLE_CONNECT_TIMEOUT })
+    await expect(page.getByTestId('status-dash-card-system-info')).toBeVisible({ timeout: VEHICLE_CONNECT_TIMEOUT })
+    await expect.poll(() => columnIds(page, 'sensors')).toEqual(['gps', 'rangefinder', 'optical-flow'])
+    expect(await columnIds(page, 'sidebar')).toEqual(['system-info', 'instruments', 'guided-setup'])
+    await expect(page.getByTestId('status-dash-reset-layout')).toHaveCount(0)
   })
 
   test('phone width drops the drag affordances and keeps the default order', async ({ page }) => {
-    // Dragging a card on a phone fights the scroll gesture, and a four-zone
+    // Dragging a card on a phone fights the scroll gesture, and a multi-column
     // arrangement means nothing in a single column. Below the breakpoint the
-    // controls are gone and a saved arrangement is ignored.
+    // controls are gone, a saved arrangement is ignored, and every column
+    // spans the full width so the bands simply stack in order.
     await page.setViewportSize({ width: 390, height: 844 })
     await page.goto('/')
     await page.evaluate(
       ([key, value]) => window.localStorage.setItem(key, value),
-      [STORAGE_KEY, JSON.stringify({ version: 1, cards: [{ id: 'gps', zone: 'sidebar', heightRows: 6 }] })] as const
+      [
+        STORAGE_KEY,
+        JSON.stringify({
+          version: 2,
+          columns: [{ id: 'sidebar', region: 'side', band: 0, span: 12, flow: 'stack' }],
+          cards: [{ id: 'gps', column: 'sidebar', heightRows: 6 }]
+        })
+      ] as const
     )
     await page.getByTestId('transport-mode-select').selectOption('demo')
     await page.getByTestId('connect-button').click()
@@ -5191,7 +5361,13 @@ test.describe('Status & Info dashboard layout', () => {
 
     await expect(page.getByTestId('status-dash-toolbar')).toHaveCount(0)
     await expect(page.locator('.status-dash-card__handle')).toHaveCount(0)
-    expect(await zoneIds(page, 'sidebar')).toEqual(['system-info', 'instruments', 'guided-setup'])
+    await expect(page.locator('.status-dash-col__width')).toHaveCount(0)
+    expect(await columnIds(page, 'sidebar')).toEqual(['system-info', 'instruments', 'guided-setup'])
+    // Every column is full width, so nothing sits beside anything else.
+    const lefts = await page.$$eval('[data-status-dash-col-region="main"]', (nodes) =>
+      nodes.map((node) => Math.round(node.getBoundingClientRect().left))
+    )
+    expect(new Set(lefts).size).toBe(1)
 
     const overflow = await page.evaluate(
       () => document.documentElement.scrollWidth - document.documentElement.clientWidth


### PR DESCRIPTION
> "pretty good, but its fairly clunky. can we make that more responsive and free so i can drag and drop how i please"

Two separate problems, diagnosed separately.

## 1. Clunky — it was the drag model, not polish

v1 previewed a drop by **inserting a real element into the target column**, so every pointermove crossing a slot boundary relaid out the page under the cursor. On top of that the move handler called `document.elementFromPoint` + `getBoundingClientRect` on *every* event, forcing a synchronous layout flush at pointer rate.

The bug fixed just before #163 merged — "drop lands 56px from where the indicator promised" — was that same reflow showing through. The model was the root cause, not a one-off.

Fixed in order of impact:
1. **The drag never changes layout.** The card keeps its slot and moves on a composited `transform`; the indicator is `position: fixed` and out of flow.
2. **Geometry is snapshotted once** at pointer-down in a single batched read, and hit testing is pure arithmetic over it (`resolveStatusDashboardDrop`, unit-tested off the DOM).
3. rAF-coalesced moves; listeners registered once per gesture instead of re-subscribed on every target change. Plus pointer capture and `touch-action: none`.

**Measured** — identical 60-move drag, main vs branch, with a no-drag control run to subtract the live feed's own drift:

| | main | branch |
|---|---|---|
| `elementFromPoint` calls | 60 | **0** |
| cards displaced mid-drag | 3 (Pre-arm, Statistics, Notices, +18px) | **0** |
| forced layout reads | 21 | 24 (all from the one snapshot) |
| median frame / frames >32ms | 8 ms / 0 | 8 ms / 0 |

## 2. Free — the placement model

A real CSS grid: **12 columns, auto rows**, per region (`main` under the craft model, `side` for the sidebar — two grids because the sidebar is a sibling of the viewer and must stay beside the craft preview). Inside a region: **bands** (horizontal shelves) of **columns**, each with a `span` — the horizontal resize v1 lacked.

**The key decision: a column is a stack, not a grid cell.** A flat card-per-cell grid cannot pack tightly, because grid rows share a height — a tall Recent Notices would shove Statistics below its bottom edge and leave a hole, which would have *changed the default page*. Stacks keep two cards adjacent regardless of the neighbouring column's height. Auto rows are what make freedom possible without absolute pixel positioning.

Gained: any number of columns and bands, per-column width (drag or arrow keys), new columns/bands created by dropping into a gutter, gaps permitted rather than forbidden, and **Tidy Up** to recover without a full Reset.

**react-grid-layout, re-evaluated from scratch rather than inheriting the earlier verdict:** MIT is GPL-3.0 compatible, so licensing is not the objection. The objection is its data model — it positions items absolutely at `h * rowHeight` px; `autoSize` sizes the *container*, not items, and the ResizeObserver workaround fights the user's own resize and re-runs the collision solver every time a STATUSTEXT lands. CSS grid gets content-driven heights from the layout engine for free. Hand-rolled again, but for a different reason than last time.

## Default unchanged — proved

Captured all 9 cards' x/width on main and on the branch at 1440x900: **identical, all 9**. Span 6-of-12 with a uniform 14 px gutter is arithmetically the same width as one `auto-fit minmax(220px, 1fr)` track; an e2e test now asserts that in a browser.

The `@container` trap that nearly broke #161's GPS-map compaction is handled — shelf columns keep `setup-status-sensors`; verified `container-type: inline-size` on the wrapper, map header `display: none`, frame 132 px.

Schema bumped **v1 → v2**. A v1 layout has no columns to migrate, so it is discarded in favour of the default rather than half-restored.

## Validation

typecheck clean · `npm run test` **855 pass / 0 fail** · web vitest **701 pass** (40 in this file, up from 16) · **full** `npm run test:e2e` **260 pass, 1 fail** — exactly the known popout flake, not chased.

Hand-verified in a real browser: free placement into a new band and a new column; width 421 → 638 px (span 6 → 9, neighbour → 3); height cap 354 → 250 px; reload; Tidy → 6/6 and Reset clears the key; conditional sensors with `RNGFND1_TYPE:0,FLOW_TYPE:0`; Notices expand 330 → 527 px **and** popout from inside the grid; 390 px with 0 overflow.

## Known limits and caveats

- **Verification ran through headless Playwright, not the Chrome extension.** The demo connect never completes through the MCP tab here — it reports `visibilityState: 'hidden'`, which throttles the mock's timers. Confirmed reproducing on unmodified main, so environmental. The checks above are real browser runs, just not through the extension.
- Between 1025–1300 px the sensor shelf no longer wraps to 2 columns the way `auto-fit minmax(260px, 1fr)` would; cards just get narrower and the `@container` compaction handles it. Verified at 1440 and 390, not exhaustively in that band.
- **Touch:** drags work from the handle at ≥1025 px (landscape tablet), since pointer events are unified and `touch-action: none` is set. No long-press-to-lift; phone widths remain non-customisable.