### PR TITLE
test(e2e): stop the notices popout test racing the live feed

### DIFF
--- a/tests/e2e/views.spec.ts
+++ b/tests/e2e/views.spec.ts
@@ -4285,11 +4285,41 @@ test('Recent Notices pops out into its own styled, live window', async ({ page, 
   expect(background).not.toBe('rgba(0, 0, 0, 0)')
   expect(background).not.toBe('transparent')
 
-  // Live: the window is a portal into the opener's tree, so clearing the feed
-  // from the main window empties the popped-out copy in the same render.
+  // Live: the window is a portal into the opener's tree, so opener state
+  // reaches it in the same render with no reload and no second session.
+  // Asserted on Expert mode rather than on the feed itself: the feed never
+  // settles (the runtime appends its own notices — the post-connect
+  // "Fetched @SYS/uarts.txt via MAVFTP." lands seconds after connect — and the
+  // demo state machine emits STATUSTEXT on a 7s cadence), so anything that
+  // asserts an *emptied* feed is racing a live stream it cannot win.
+  const noticeRows = popout.locator('.setup-gui-box__status-entry[data-testid^="notices-popout-notice-"]')
   await expect(popout.getByTestId('notices-popout-list')).toBeVisible()
+  await expect(noticeRows.first()).toBeVisible({ timeout: 15_000 })
+  await expect(popout.getByTestId('notices-popout-search')).toHaveCount(0)
+  await page.getByTestId('product-mode-expert').click()
+  await expect(popout.getByTestId('notices-popout-search')).toBeVisible()
+
+  // …and the filter typed in the window filters the window: a term nothing can
+  // match empties the list deterministically, which is the only way to assert
+  // the empty state against a feed that keeps producing.
+  await popout.getByTestId('notices-popout-search').fill('zzz-no-such-notice')
+  await expect(popout.getByText('No status text yet')).toBeVisible()
+  await expect(noticeRows).toHaveCount(0)
+  await popout.getByTestId('notices-popout-search').fill('')
+  await expect(noticeRows.first()).toBeVisible()
+
+  // Clear all in the main window drops the popped-out rows in the same render.
+  // Asserted as "the rows that were there are gone" rather than "the list is
+  // empty": every notice text the demo produces is one-shot, so a cleared row
+  // never comes back, while a *new* row may land at any moment.
+  const clearedTexts = await popout
+    .locator('.setup-gui-box__status-entry .setup-gui-box__status-text')
+    .allTextContents()
+  expect(clearedTexts.length).toBeGreaterThan(0)
   await page.getByTestId('setup-notices-clear-all').click()
-  await expect(popout.getByText('No status text yet')).toBeVisible({ timeout: 10_000 })
+  for (const text of clearedTexts) {
+    await expect(popout.getByText(text, { exact: true })).toHaveCount(0)
+  }
 
   // The inline panel says where the feed went, and the button closes it again.
   await expect(page.getByTestId('setup-notices-popped-out')).toBeVisible()


### PR DESCRIPTION
The `Recent Notices pops out into its own styled, live window` e2e failed **deterministically** on developer machines and intermittently on CI, across three independent sessions — including on unmodified `main` with all local work stashed.

## Root cause — not what we assumed

The working theory was the demo scenario's STATUSTEXT cadence. It is more specific than that: the failure dump shows the popped-out list holding exactly one row after Clear all — **"Fetched @SYS/uarts.txt via MAVFTP."**

That notice comes from the **app itself** (`packages/ardupilot-core/src/runtime.ts:2013`), emitted when the post-connect `@SYS/uarts.txt` MAVFTP probe resolves, landing a second or two after connect — i.e. right when the test clicks Clear all. The demo state machine (`dynamicCadenceMs: 7000`) then piles on more at 21 s / 28 s / 35 s.

So the test was asserting **a state the product never guarantees.** Clearing is local-display-only by design, and the feed is supposed to keep producing. **No app bug** — the test was wrong, not the app.

## The fix (test-only, no feature code)

- **Live portal proved without the feed:** toggling Expert in the opener makes `notices-popout-search` appear inside the popped-out window — same render, no reload, no second session. That is the real contract.
- **Empty state kept, made deterministic:** a filter term nothing can match (`zzz-no-such-notice`) empties the list and *keeps* it empty regardless of what arrives.
- **Clear all kept, reframed:** capture the rows present, click Clear all, assert **those exact rows are gone** rather than that the list is empty. Every demo notice text is one-shot, so a cleared row never returns while a new row may land at any moment.

Timeouts unchanged — the assertions no longer need them. Test not deleted.

## Proof

Single test, fresh server each run:

| | pass | fail |
|---|---|---|
| before | **0** | **10** |
| after | **12** | **0** |

Every "before" failure was `getByText('No status text yet')` not found.

Full `npx playwright test` on the fix: **258 passed, 6 skipped, 0 failed** (8.0 m) — which also exercises the test under an aged bridge mid-suite.

## The cascade was a different problem — diagnosed, not fixed

A single failing test does **not** kill the preview server. Running all of `views.spec.ts` with the *old* failing test in place: 207 tests, 1 failed (this one), **206 passed, zero `ERR_CONNECTION_REFUSED`**, servers healthy throughout.

The real cause is **fixed ports**. `playwright.config.ts` pins 4173 (`--strictPort`) and 14550, and 14550 is additionally baked into the web app's default WebSocket URL (asserted in `tests/e2e/app.spec.ts:777`), so two e2e runs cannot coexist on one machine. With `ARDUCONFIG_E2E_REUSE_EXISTING=1` a second run silently attaches to the first run's servers, and every remaining test dies the moment the first run tears them down. That is exactly the "~21 tests cascade, all pass in isolation" signature — and it matches the port contention between concurrent agents seen repeatedly today.

Making the preview port configurable is easy. Making the bridge port configurable means changing the app's default URL and its assertion — app-surface work, deliberately left alone here rather than restructuring the harness in passing.