### PR TITLE
feat(parameters): create a reusable preset from selected parameters

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -389,6 +389,13 @@ import {
   tcpSupported
 } from './hooks/use-transport-selection'
 import { useLibraries } from './hooks/use-libraries'
+import {
+  createUserPresetId,
+  isUserPresetId,
+  sortUserPresets,
+  type UserPresetDraft,
+  type UserPresetRecord
+} from './user-preset-library'
 import { useParameterDrafts } from './hooks/use-parameter-drafts'
 import { useTuningProfiles } from './hooks/use-tuning-profiles'
 import { useParameterBackupIo } from './hooks/use-parameter-backup-io'
@@ -2244,9 +2251,16 @@ export function App() {
     tuningMasterPitchRatio,
     tuningMasterFilterStrength
   })
+  // Serial-port remap targets for saved presets, keyed by preset id. Session
+  // state only — a remap is a decision about the aircraft in front of you, not
+  // a property of the preset, so it must not persist into the next connection.
+  const [presetSerialRemapTargets, setPresetSerialRemapTargets] = useState<Record<string, number>>({})
   const {
     presetDefinitions,
+    presetsByGroup,
     presetGroups,
+    selectedPresetSerialRemap,
+    selectedPresetDependencyLabels,
     presetPreviewById,
     selectedPresets,
     selectedPresetDraftValues,
@@ -2258,7 +2272,50 @@ export function App() {
     selectedPresetChangedEntries,
     selectedPresetInvalidEntries,
     selectedPresetDiffSignature
-  } = usePresetCatalog({ snapshot, metadataCatalog, selectedPresetIds })
+  } = usePresetCatalog({
+    snapshot,
+    metadataCatalog,
+    selectedPresetIds,
+    userPresets: libraries.savedUserPresets,
+    serialRemapTargets: presetSerialRemapTargets
+  })
+
+  // Create / delete of operator-authored presets. Creating is read-only — it
+  // captures values already synced from the aircraft — and applying one runs the
+  // existing preset apply path (verified setParameters with rollback, pre-apply
+  // auto-backup), so there is no new write path anywhere in this feature.
+  const sourceFirmwareForPresets = snapshot.vehicle?.firmware
+  const handleCreateUserPreset = useCallback(
+    (draft: UserPresetDraft) => {
+      const record: UserPresetRecord = {
+        id: createUserPresetId(draft.label),
+        label: draft.label,
+        description: draft.description || `${draft.values.length} parameter(s) saved from the Parameter Editor.`,
+        createdAt: new Date().toISOString(),
+        sourceFirmware: sourceFirmwareForPresets,
+        tags: ['user'],
+        values: draft.values,
+        dependencies: draft.dependencies
+      }
+      libraries.setSavedUserPresets((current) => sortUserPresets([...current, record]))
+      setParameterNotice({
+        tone: 'success',
+        text: `Saved preset "${record.label}" (${record.values.length} parameters). Apply it from the Presets tab.`
+      })
+    },
+    [libraries, setParameterNotice, sourceFirmwareForPresets]
+  )
+
+  const handleDeleteUserPreset = useCallback(
+    (presetId: string) => {
+      if (!isUserPresetId(presetId)) {
+        return
+      }
+      libraries.setSavedUserPresets((current) => current.filter((record) => record.id !== presetId))
+      setSelectedPresetIds((current) => current.filter((id) => id !== presetId))
+    },
+    [libraries]
+  )
   // The preset changes that will actually be written — the combined diff minus
   // any params the operator dropped in the review list.
   const effectivePresetChangedEntries = selectedPresetChangedEntries.filter(
@@ -8716,13 +8773,22 @@ export function App() {
       {activeViewId === 'presets' ? (
         <PresetsSection
           snapshot={snapshot}
-          metadataCatalog={metadataCatalog}
           busyAction={busyAction}
           canApplyDraftParameters={canApplyDraftParameters}
           parameterFollowUp={parameterFollowUp}
           presetNotice={presetNotice}
           presetDefinitions={presetDefinitions}
           presetGroups={presetGroups}
+          presetsByGroup={presetsByGroup}
+          selectedPresetSerialRemap={selectedPresetSerialRemap}
+          selectedPresetDependencyLabels={selectedPresetDependencyLabels}
+          onSerialRemapChange={(port) => {
+            const presetId = selectedPresetSerialRemap?.presetId
+            if (presetId) {
+              setPresetSerialRemapTargets((current) => ({ ...current, [presetId]: port }))
+            }
+          }}
+          onDeleteUserPreset={handleDeleteUserPreset}
           presetPreviewById={presetPreviewById}
           selectedPresets={selectedPresets}
           selectedPresetConflicts={selectedPresetConflicts}
@@ -9232,6 +9298,7 @@ export function App() {
           }}
           onFetchParamDefaults={handleFetchParamDefaults}
           fetchDefaultsBusy={fetchDefaultsBusy}
+          onCreateUserPreset={handleCreateUserPreset}
         />
       ) : null}
         </div>

--- a/apps/web/src/hooks/use-libraries.ts
+++ b/apps/web/src/hooks/use-libraries.ts
@@ -24,6 +24,12 @@ import {
   type SavedTuningProfile,
   type TuningProfileStorageLoadResult
 } from '../tuning-profile-library'
+import {
+  loadStoredUserPresets,
+  persistUserPresets,
+  type UserPresetRecord,
+  type UserPresetStorageLoadResult
+} from '../user-preset-library'
 
 /**
  * A storage-warning banner. Structurally compatible with App's
@@ -55,6 +61,11 @@ export interface Libraries {
   selectedTuningProfileId: string | undefined
   setSelectedTuningProfileId: Dispatch<SetStateAction<string | undefined>>
   tuningProfileStorageNotice: LibraryStorageNotice
+
+  /** Operator-authored parameter-group presets — see user-preset-library.ts. */
+  savedUserPresets: UserPresetRecord[]
+  setSavedUserPresets: Dispatch<SetStateAction<UserPresetRecord[]>>
+  userPresetStorageNotice: LibraryStorageNotice
 }
 
 /**
@@ -104,6 +115,17 @@ export function useLibraries(): Libraries {
     warningNotice(initialTuningProfileStorage.warning)
   )
 
+  const initialUserPresetStorage = useMemo<UserPresetStorageLoadResult>(() => loadStoredUserPresets(), [])
+  const [savedUserPresets, setSavedUserPresets] = useState<UserPresetRecord[]>(initialUserPresetStorage.presets)
+  const [userPresetStorageNotice, setUserPresetStorageNotice] = useState<LibraryStorageNotice>(() =>
+    warningNotice(initialUserPresetStorage.warning)
+  )
+
+  useEffect(() => {
+    const persistence = persistUserPresets(savedUserPresets)
+    setUserPresetStorageNotice(warningNotice(persistence.warning))
+  }, [savedUserPresets])
+
   useEffect(() => {
     const persistence = persistSnapshots(savedSnapshots)
     setSnapshotStorageNotice(warningNotice(persistence.warning))
@@ -134,6 +156,9 @@ export function useLibraries(): Libraries {
     setSavedTuningProfiles,
     selectedTuningProfileId,
     setSelectedTuningProfileId,
-    tuningProfileStorageNotice
+    tuningProfileStorageNotice,
+    savedUserPresets,
+    setSavedUserPresets,
+    userPresetStorageNotice
   }
 }

--- a/apps/web/src/hooks/use-preset-catalog.ts
+++ b/apps/web/src/hooks/use-preset-catalog.ts
@@ -6,7 +6,7 @@
 // through selectEntityDiff for the grouped/changed/invalid/signature bag, plus a
 // combined applicability (worst status + per-preset reasons).
 
-import { useMemo } from 'react'
+import { useCallback, useMemo } from 'react'
 
 import {
   type ConfiguratorSnapshot,
@@ -14,11 +14,38 @@ import {
   deriveDraftValuesFromParameterPreset,
   evaluateParameterPresetApplicability
 } from '@arduconfig/ardupilot-core'
-import type { NormalizedFirmwareMetadataBundle, NormalizedPresetDefinition } from '@arduconfig/param-metadata'
+import type {
+  NormalizedFirmwareMetadataBundle,
+  NormalizedPresetDefinition,
+  PresetGroupDefinition
+} from '@arduconfig/param-metadata'
 
 import { selectEntityDiff } from '../selectors/entity-diff'
+import {
+  evaluatePresetDependencies,
+  presetDependencyClass,
+  remapPresetSerialPort,
+  serialPortIndexOf,
+  type PresetDependencyRecord
+} from '../view-models/preset-dependencies'
+import { USER_PRESET_GROUP, type UserPresetRecord, toPresetDefinition } from '../user-preset-library'
 
 const APPLICABILITY_RANK = { ready: 0, caution: 1, blocked: 2 } as const
+
+/** Chosen target SERIALn index per preset id — see selectedPresetSerialRemap. */
+export type PresetSerialRemapTargets = Readonly<Record<string, number>>
+
+export interface PresetSerialRemapState {
+  presetId: string
+  /** Port the preset's values were captured on. */
+  savedPort: number
+  /** SERIALn indices this aircraft actually has, ascending. */
+  availablePorts: number[]
+  /** Currently chosen target (equals savedPort when no remap is active). */
+  selectedPort: number
+  /** Remapped ids that do not exist on this aircraft — the remap is a no-op for these. */
+  missingOnTarget: string[]
+}
 
 /** A preset's diff against the live snapshot, narrowed to what the merge needs. */
 interface PresetDraftPreview {
@@ -65,26 +92,124 @@ export function usePresetCatalog(input: {
   snapshot: ConfiguratorSnapshot
   metadataCatalog: NormalizedFirmwareMetadataBundle
   selectedPresetIds: readonly string[]
+  /** Operator-authored presets from browser storage, merged in as a group. */
+  userPresets?: readonly UserPresetRecord[]
+  serialRemapTargets?: PresetSerialRemapTargets
 }) {
-  const { snapshot, metadataCatalog, selectedPresetIds } = input
+  const { snapshot, metadataCatalog, selectedPresetIds, userPresets, serialRemapTargets } = input
 
-  const presetDefinitions = useMemo(() => metadataCatalog.presets, [metadataCatalog.presets])
-  const presetGroups = useMemo(
-    () => metadataCatalog.presetGroups.filter((group) => (metadataCatalog.presetsByGroup[group.id] ?? []).length > 0),
-    [metadataCatalog.presetGroups, metadataCatalog.presetsByGroup]
+  // Deliberately a linear scan rather than a Map built per snapshot: dependency
+  // evaluation reads a handful of named params (MOT_BAT_VOLT_MAX, FRAME_CLASS)
+  // and only for presets that declared a dependency, so indexing all ~590
+  // parameters on every telemetry tick would cost far more than it saves.
+  const readLiveParameter = useCallback(
+    (paramId: string) => snapshot.parameters.find((parameter) => parameter.id === paramId)?.value,
+    [snapshot.parameters]
+  )
+
+  // Dependency answers, keyed by preset id. Only user presets have them —
+  // curated bundle presets carry a hand-written `compatibility` block instead.
+  const dependenciesByPresetId = useMemo(
+    () => new Map((userPresets ?? []).map((record) => [record.id, record.dependencies as readonly PresetDependencyRecord[]])),
+    [userPresets]
+  )
+
+  /**
+   * Present saved presets in the exact shape the curated ones have, so the
+   * whole downstream pipeline (diff, applicability, cards, apply) is shared and
+   * this feature adds no second code path.
+   *
+   * The serial remap is applied HERE, before the diff is taken, which is what
+   * makes it honest: the operator sees the remapped SERIALn ids in the review
+   * list and applies exactly what is on screen.
+   *
+   * The dependency list deliberately does NOT include anything derived from the
+   * live parameters. Everything downstream of `presetDefinitions` — the merged
+   * draft values, selectEntityDiff over the whole parameter tree, the draft
+   * entry derivation — is memoised on this array's identity, and on main that
+   * identity was `metadataCatalog.presets`, i.e. constant across a session. An
+   * earlier revision of this feature threaded the aircraft's known param ids in
+   * here for the remap's missing-on-target check, which quietly broke that
+   * stability and re-ran the whole preset diff pipeline on every telemetry tick.
+   * The missing-on-target report lives on `selectedPresetSerialRemap` instead,
+   * where it is computed once for the one preset the operator is looking at.
+   */
+  const userPresetDefinitions = useMemo<NormalizedPresetDefinition[]>(
+    () =>
+      (userPresets ?? []).map((record, index) => {
+        const base = toPresetDefinition(record, index)
+        const savedPort = record.dependencies.find((entry) => entry.classId === 'serial-port')?.context?.serialPorts?.[0]
+        const targetPort = serialRemapTargets?.[record.id]
+        const remap =
+          savedPort !== undefined && targetPort !== undefined && targetPort !== savedPort
+            ? remapPresetSerialPort(base.values, savedPort, targetPort)
+            : undefined
+
+        return {
+          ...base,
+          values: remap?.values ?? base.values,
+          tags: base.tags ?? [],
+          groupDefinition: USER_PRESET_GROUP,
+          // The dependency labels double as a plain-language contents list on
+          // the card ("Serial port position, Battery pack") — cheaper to read
+          // than the raw param list and it is the thing that decides whether
+          // this preset belongs on this aircraft.
+          cautions:
+            remap && remap.remapped.length > 0
+              ? [`Remapped ${remap.remapped.length} value(s) from SERIAL${savedPort} to SERIAL${targetPort}.`]
+              : []
+        }
+      }),
+    [userPresets, serialRemapTargets]
+  )
+
+  const presetDefinitions = useMemo(
+    () => [...metadataCatalog.presets, ...userPresetDefinitions],
+    [metadataCatalog.presets, userPresetDefinitions]
+  )
+  const presetsByGroup = useMemo<Record<string, readonly NormalizedPresetDefinition[]>>(
+    () => ({ ...metadataCatalog.presetsByGroup, [USER_PRESET_GROUP.id]: userPresetDefinitions }),
+    [metadataCatalog.presetsByGroup, userPresetDefinitions]
+  )
+  const presetGroups = useMemo<PresetGroupDefinition[]>(
+    () =>
+      [...metadataCatalog.presetGroups, USER_PRESET_GROUP]
+        .filter((group) => (presetsByGroup[group.id] ?? []).length > 0)
+        .sort((left, right) => left.order - right.order),
+    [metadataCatalog.presetGroups, presetsByGroup]
   )
   const presetPreviewById = useMemo(
     () =>
       new Map(
-        presetDefinitions.map((preset) => [
-          preset.id,
-          {
-            diff: deriveDraftValuesFromParameterPreset(snapshot.parameters, preset),
-            applicability: evaluateParameterPresetApplicability(snapshot, preset)
-          }
-        ])
+        presetDefinitions.map((preset) => {
+          const applicability = evaluateParameterPresetApplicability(snapshot, preset)
+          const dependencies = dependenciesByPresetId.get(preset.id)
+          // Dependency warnings only ever raise 'ready' to 'caution' (see
+          // preset-dependencies.ts — they never block), so a curated preset's
+          // 'blocked' frame-class verdict still wins.
+          const dependencyResult = dependencies?.length ? evaluatePresetDependencies(dependencies, readLiveParameter) : undefined
+          return [
+            preset.id,
+            {
+              diff: deriveDraftValuesFromParameterPreset(snapshot.parameters, preset),
+              applicability: dependencyResult
+                ? {
+                    status:
+                      APPLICABILITY_RANK[dependencyResult.status] > APPLICABILITY_RANK[applicability.status]
+                        ? dependencyResult.status
+                        : applicability.status,
+                    reasons: [...applicability.reasons, ...dependencyResult.reasons]
+                  }
+                : applicability
+            }
+          ]
+        })
       ),
-    [presetDefinitions, snapshot.parameters, snapshot.vehicle?.vehicle]
+    // Deliberately narrow: `snapshot` itself changes on every telemetry tick,
+    // and re-diffing every preset at telemetry rate is pure waste. Applicability
+    // and the diff read only the parameter list and the vehicle type.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [presetDefinitions, snapshot.parameters, snapshot.vehicle?.vehicle, dependenciesByPresetId, readLiveParameter]
   )
 
   // Resolve the selected ids into preset definitions, preserving the order in
@@ -140,9 +265,63 @@ export function usePresetCatalog(input: {
     return { status, reasons }
   }, [selectedPresets, presetPreviewById])
 
+  // The port-remap control only makes sense for ONE user preset at a time: the
+  // remap rewrites that preset's own ids, and offering it over a merged
+  // multi-preset diff would be ambiguous about which preset's ports move.
+  const selectedPresetSerialRemap = useMemo<PresetSerialRemapState | undefined>(() => {
+    if (selectedPresets.length !== 1) {
+      return undefined
+    }
+    const preset = selectedPresets[0]
+    const savedPort = dependenciesByPresetId
+      .get(preset.id)
+      ?.find((entry) => entry.classId === 'serial-port')?.context?.serialPorts?.[0]
+    if (savedPort === undefined) {
+      return undefined
+    }
+    // Built here and not at hook scope so it costs nothing on the overwhelmingly
+    // common path (no user preset selected, or one with no port dependency) —
+    // and so it never becomes a per-tick dependency of `presetDefinitions`.
+    const knownParamIds = new Set(snapshot.parameters.map((parameter) => parameter.id))
+    // Offer only ports this aircraft actually reports, so the operator cannot
+    // pick a UART the board does not have.
+    const availablePorts = [
+      ...new Set(
+        [...knownParamIds].map((paramId) => serialPortIndexOf(paramId)).filter((port): port is number => port !== undefined)
+      )
+    ].sort((left, right) => left - right)
+    const selectedPort = serialRemapTargets?.[preset.id] ?? savedPort
+    // `preset.values` has ALREADY been remapped above, so the check is simply
+    // "which of the remapped ids does this board not have" — re-running the
+    // remap here would find nothing left to move and report a falsely clean bill.
+    const missingOnTarget =
+      selectedPort === savedPort
+        ? []
+        : preset.values
+            .map((entry) => entry.paramId)
+            .filter((paramId) => serialPortIndexOf(paramId) === selectedPort && !knownParamIds.has(paramId))
+    return { presetId: preset.id, savedPort, availablePorts, selectedPort, missingOnTarget }
+  }, [selectedPresets, dependenciesByPresetId, snapshot.parameters, serialRemapTargets])
+
+  /** Plain-language list of what the selected preset declared it depends on. */
+  const selectedPresetDependencyLabels = useMemo(
+    () =>
+      [
+        ...new Set(
+          selectedPresets.flatMap((preset) =>
+            (dependenciesByPresetId.get(preset.id) ?? []).map((entry) => presetDependencyClass(entry.classId).label)
+          )
+        )
+      ],
+    [selectedPresets, dependenciesByPresetId]
+  )
+
   return {
     presetDefinitions,
+    presetsByGroup,
     presetGroups,
+    selectedPresetSerialRemap,
+    selectedPresetDependencyLabels,
     presetPreviewById,
     selectedPresets,
     selectedPresetDraftValues: mergedDraftValues,

--- a/apps/web/src/sections/ParametersSection.tsx
+++ b/apps/web/src/sections/ParametersSection.tsx
@@ -19,6 +19,17 @@ import {
 } from '../view-models/parameter-diff-actions'
 import { ParameterDiffGroupActions } from '../views/ParameterDiffGroupActions'
 import { ParameterDiffIdentity, ParameterDiffInvalidRow } from '../views/ParameterDiffRow'
+import { applyDraftSelectionClick } from '../view-models/draft-selection'
+import {
+  detectPresetDependencies,
+  inferBatteryCellCount,
+  presetDependencyClass,
+  type PresetDependencyClassId,
+  type PresetDependencyContext,
+  type PresetDependencyRecord
+} from '../view-models/preset-dependencies'
+import { CreatePresetDialog, type CreatePresetParam, type CreatePresetQuestion } from '../views/CreatePresetDialog'
+import type { UserPresetDraft } from '../user-preset-library'
 
 import {
   formatParameterDelta,
@@ -118,6 +129,9 @@ export interface ParametersSectionProps {
   onFetchParamDefaults: () => void | Promise<void>
   /** True while the defaults fetch is in flight. */
   fetchDefaultsBusy: boolean
+  /** Save a group of selected parameters as a reusable preset. Read-only —
+   *  nothing is written to the aircraft. Omitting it hides the whole control. */
+  onCreateUserPreset?: (draft: UserPresetDraft) => void
 }
 
 export function ParametersSection(props: ParametersSectionProps): ReactElement {
@@ -176,7 +190,8 @@ export function ParametersSection(props: ParametersSectionProps): ReactElement {
     onDismissPendingParameterImport,
     recentlyWrittenParamIds,
     onToggleShowOnlyNonDefault: handleToggleShowOnlyNonDefault,
-    fetchDefaultsBusy
+    fetchDefaultsBusy,
+    onCreateUserPreset
   } = props
 
   // Bulk-drop selection over the staged review rows — dropping unwanted
@@ -308,6 +323,229 @@ export function ParametersSection(props: ParametersSectionProps): ReactElement {
     // eslint-disable-next-line react-hooks/exhaustive-deps
     [filteredParameters, categoryFilter, metadataCatalog, showOnlyNonDefault, nonDefaultParamIds]
   )
+  // ---------------------------------------------------------------------
+  // "Create preset" — row selection over the parameter TABLE
+  // ---------------------------------------------------------------------
+  // A second selection set, distinct from the staged-review bulk-drop one below
+  // because it selects live parameters rather than pending drafts. It shares the
+  // shift-click RULE (applyDraftSelectionClick) but deliberately not
+  // useDraftSelection: that hook prunes any selected id missing from the ordered
+  // list, which is right when a row leaves by being dropped and wrong here,
+  // where rows leave because the operator typed in the search box. Pruning on a
+  // filter change would silently empty a selection built across two categories.
+  //
+  // The visible-rows-only rule from bulk drop still holds, and is stated in the
+  // UI: Select all and Create preset act on what is on screen, so a filtered
+  // action can never reach into rows the filter is hiding. Ids selected and then
+  // filtered away are kept, counted separately, and come back with the filter.
+  const [presetSelection, setPresetSelection] = useState<ReadonlySet<string>>(() => new Set())
+  const presetSelectionAnchorRef = useRef<string | null>(null)
+  const displayedParameterIds = useMemo(() => displayedParameters.map((parameter) => parameter.id), [displayedParameters])
+  const visibleSelectedParamIds = useMemo(
+    () => displayedParameterIds.filter((id) => presetSelection.has(id)),
+    [displayedParameterIds, presetSelection]
+  )
+  const hiddenSelectedCount = presetSelection.size - visibleSelectedParamIds.length
+  const allVisibleSelected = displayedParameterIds.length > 0 && visibleSelectedParamIds.length === displayedParameterIds.length
+
+  const handlePresetSelectionClick = useCallback(
+    (paramId: string, shiftKey: boolean) => {
+      setPresetSelection((current) =>
+        applyDraftSelectionClick(current, displayedParameterIds, paramId, {
+          shiftKey,
+          anchorId: presetSelectionAnchorRef.current
+        })
+      )
+      presetSelectionAnchorRef.current = paramId
+    },
+    [displayedParameterIds]
+  )
+
+  const handleSelectAllVisible = useCallback(
+    (selected: boolean) => {
+      setPresetSelection((current) => {
+        const next = new Set(current)
+        displayedParameterIds.forEach((id) => (selected ? next.add(id) : next.delete(id)))
+        return next
+      })
+      presetSelectionAnchorRef.current = null
+    },
+    [displayedParameterIds]
+  )
+
+  // Live values + metadata, looked up often enough while the dialog is open to
+  // be worth a map rather than a linear scan per parameter.
+  const liveValueById = useMemo(
+    () => new Map(snapshot.parameters.map((parameter) => [parameter.id, parameter.value])),
+    [snapshot.parameters]
+  )
+  const readLiveParameter = useCallback((paramId: string) => liveValueById.get(paramId), [liveValueById])
+  const definitionOf = useCallback(
+    (paramId: string) =>
+      metadataCatalog.parameters[paramId] ?? snapshot.parameters.find((parameter) => parameter.id === paramId)?.definition,
+    [metadataCatalog, snapshot.parameters]
+  )
+
+  // Dialog state. `presetDraftIds` is a snapshot of the selection taken when the
+  // dialog opens: the table underneath stays live, and a filter change (or an
+  // auto-refresh dropping a row) must not silently change what is about to be
+  // saved.
+  const [createPresetOpen, setCreatePresetOpen] = useState(false)
+  const [presetDraftIds, setPresetDraftIds] = useState<readonly string[]>([])
+  const [presetName, setPresetName] = useState('')
+  const [presetDescription, setPresetDescription] = useState('')
+  const [presetExcludedIds, setPresetExcludedIds] = useState<ReadonlySet<string>>(() => new Set())
+  const [presetAnsweredClasses, setPresetAnsweredClasses] = useState<ReadonlySet<string>>(() => new Set())
+  const [presetCellCount, setPresetCellCount] = useState('')
+
+  const presetKeptIds = useMemo(
+    () => presetDraftIds.filter((id) => !presetExcludedIds.has(id)),
+    [presetDraftIds, presetExcludedIds]
+  )
+  // Re-detect over what is actually KEPT, so dropping the last SERIAL3 row also
+  // removes the serial-port question instead of leaving a dependency recorded
+  // against parameters the preset no longer contains.
+  const presetDetection = useMemo(
+    () =>
+      detectPresetDependencies({
+        paramIds: presetKeptIds,
+        readParameter: readLiveParameter,
+        isRebootRequired: (paramId) => definitionOf(paramId)?.rebootRequired === true
+      }),
+    [presetKeptIds, readLiveParameter, definitionOf]
+  )
+
+  // Calibration ids come from the FULL selection, not from presetDetection:
+  // they are excluded by default, so by the time detection runs over the kept
+  // set the class has disappeared — and the warning explaining why they were
+  // dropped would disappear with it.
+  const presetCalibrationParamIds = useMemo(
+    () =>
+      detectPresetDependencies({ paramIds: presetDraftIds, readParameter: readLiveParameter }).dependencies.find(
+        (entry) => entry.classId === 'calibration'
+      )?.paramIds ?? [],
+    [presetDraftIds, readLiveParameter]
+  )
+
+  const handleOpenCreatePreset = useCallback(() => {
+    const ids = visibleSelectedParamIds
+    const initial = detectPresetDependencies({ paramIds: ids, readParameter: readLiveParameter })
+    setPresetDraftIds(ids)
+    // Per-board calibration is excluded BY DEFAULT rather than merely flagged:
+    // a compass offset is never valid on another board, so the safe default is
+    // to leave it out. Fully reversible per row ("Keep"), and the dialog says
+    // so in a warning banner, so this is a default and not a decision taken
+    // away from the operator.
+    setPresetExcludedIds(
+      new Set(initial.dependencies.find((entry) => entry.classId === 'calibration')?.paramIds ?? [])
+    )
+    setPresetAnsweredClasses(new Set(initial.dependencies.map((entry) => entry.classId)))
+    setPresetCellCount(String(inferBatteryCellCount(readLiveParameter) ?? ''))
+    setPresetName('')
+    setPresetDescription('')
+    setCreatePresetOpen(true)
+  }, [visibleSelectedParamIds, readLiveParameter])
+
+  const handleToggleDependencyAnswer = useCallback((classId: string) => {
+    setPresetAnsweredClasses((current) => {
+      const next = new Set(current)
+      if (next.has(classId)) {
+        next.delete(classId)
+      } else {
+        next.add(classId)
+      }
+      return next
+    })
+  }, [])
+
+  const handleTogglePresetParamExcluded = useCallback((paramId: string) => {
+    setPresetExcludedIds((current) => {
+      const next = new Set(current)
+      if (next.has(paramId)) {
+        next.delete(paramId)
+      } else {
+        next.add(paramId)
+      }
+      return next
+    })
+  }, [])
+
+  const handleSaveUserPreset = useCallback(() => {
+    if (!onCreateUserPreset) {
+      return
+    }
+    const values = presetKeptIds
+      .map((paramId) => ({ paramId, value: liveValueById.get(paramId) }))
+      .filter((entry): entry is { paramId: string; value: number } => entry.value !== undefined && Number.isFinite(entry.value))
+
+    const typedCells = Number.parseInt(presetCellCount, 10)
+    const dependencies: PresetDependencyRecord[] = presetDetection.dependencies
+      .filter((entry) => presetAnsweredClasses.has(entry.classId))
+      .map((entry) => {
+        const context: PresetDependencyContext = { ...entry.context }
+        // The operator's typed cell count wins over the MOT_BAT_VOLT_MAX
+        // inference — they know the pack, the inference only guessed at it.
+        if (entry.classId === 'battery-pack') {
+          if (Number.isFinite(typedCells) && typedCells >= 2 && typedCells <= 14) {
+            context.batteryCells = typedCells
+          } else {
+            delete context.batteryCells
+          }
+        }
+        return { classId: entry.classId, paramIds: entry.paramIds, context }
+      })
+
+    onCreateUserPreset({
+      label: presetName.trim(),
+      description: presetDescription.trim(),
+      values,
+      dependencies
+    })
+    setCreatePresetOpen(false)
+    setPresetSelection(new Set())
+    presetSelectionAnchorRef.current = null
+  }, [
+    onCreateUserPreset,
+    presetKeptIds,
+    liveValueById,
+    presetCellCount,
+    presetDetection,
+    presetAnsweredClasses,
+    presetName,
+    presetDescription
+  ])
+
+  const createPresetParams = useMemo<CreatePresetParam[]>(
+    () =>
+      presetDraftIds.map((paramId) => {
+        const definition = definitionOf(paramId)
+        return {
+          id: paramId,
+          label: definition?.label ?? paramId,
+          description: definition?.description,
+          valueText: formatParameterValue(liveValueById.get(paramId) ?? Number.NaN, definition?.unit),
+          excluded: presetExcludedIds.has(paramId)
+        }
+      }),
+    [presetDraftIds, presetExcludedIds, definitionOf, liveValueById]
+  )
+
+  const createPresetQuestions = useMemo<CreatePresetQuestion[]>(
+    () =>
+      presetDetection.dependencies.map((entry) => {
+        const descriptor = presetDependencyClass(entry.classId as PresetDependencyClassId)
+        return {
+          classId: entry.classId,
+          label: descriptor.label,
+          question: descriptor.question,
+          rationale: descriptor.rationale,
+          detail: entry.detail,
+          checked: presetAnsweredClasses.has(entry.classId)
+        }
+      }),
+    [presetDetection, presetAnsweredClasses]
+  )
+
   const visibleStagedGroups = useMemo(() => {
     if (!searchPredicate) {
       return stagedParameterGroups
@@ -1076,6 +1314,59 @@ export function ParametersSection(props: ParametersSectionProps): ReactElement {
           ) : null}
         </div>
 
+        {/* Group-to-preset selection. Sits directly above the table because it
+          * acts on the table's rows, and states the visible-rows-only rule
+          * inline — the same rule the staged bulk drop follows. */}
+        {onCreateUserPreset ? (
+          <div className="parameter-preset-bulk" data-testid="parameter-preset-bulk">
+            <label className="parameter-diff-bulk__all">
+              <input
+                type="checkbox"
+                data-testid="parameter-preset-select-all"
+                checked={allVisibleSelected}
+                onChange={(event) => handleSelectAllVisible(event.target.checked)}
+                disabled={busyAction !== undefined || displayedParameterIds.length === 0}
+              />
+              <span>Select all visible ({displayedParameterIds.length})</span>
+            </label>
+            <button
+              type="button"
+              data-testid="parameter-create-preset"
+              style={buttonStyle('primary')}
+              onClick={handleOpenCreatePreset}
+              disabled={busyAction !== undefined || visibleSelectedParamIds.length === 0}
+              title="Save the selected parameters' current values as a reusable preset. Reads only — nothing is written to the aircraft."
+            >
+              Create preset ({visibleSelectedParamIds.length})
+            </button>
+            <button
+              type="button"
+              data-testid="parameter-preset-clear-selection"
+              style={buttonStyle()}
+              onClick={() => {
+                setPresetSelection(new Set())
+                presetSelectionAnchorRef.current = null
+              }}
+              disabled={presetSelection.size === 0}
+            >
+              Clear selection
+            </button>
+            <small>
+              Tick rows to build a preset. Shift-click selects a range. Select all and Create preset act on the rows currently visible,
+              so the search and category filters can never pull in a row you cannot see.
+              {hiddenSelectedCount > 0 ? (
+                <>
+                  {' '}
+                  <strong data-testid="parameter-preset-hidden-count">
+                    {hiddenSelectedCount} selected row{hiddenSelectedCount === 1 ? '' : 's'} hidden by the current filter
+                  </strong>{' '}
+                  — they stay selected and return when you clear it.
+                </>
+              ) : null}
+            </small>
+          </div>
+        ) : null}
+
         <div className="parameter-table">
           <div className="parameter-row parameter-row--header">
             <span>Parameter</span>
@@ -1120,6 +1411,26 @@ export function ParametersSection(props: ParametersSectionProps): ReactElement {
                 onClick={() => setSelectedParameterId(isExpanded ? undefined : parameter.id)}
               >
                 <span className="parameter-row__name">
+                  {/* Lives inside the name cell rather than as a seventh grid
+                    * column so the table's column template (and every surface
+                    * that styles it) is untouched. stopPropagation keeps a
+                    * selection click from also expanding the row detail. */}
+                  {onCreateUserPreset ? (
+                    <input
+                      type="checkbox"
+                      className="parameter-row__select"
+                      data-testid={`parameter-preset-select-${parameter.id}`}
+                      checked={presetSelection.has(parameter.id)}
+                      aria-label={`Select ${parameter.id} for a preset`}
+                      title="Select for Create preset. Shift-click selects a range."
+                      disabled={busyAction !== undefined}
+                      onClick={(event) => {
+                        event.stopPropagation()
+                        handlePresetSelectionClick(parameter.id, event.shiftKey)
+                      }}
+                      onChange={() => {}}
+                    />
+                  ) : null}
                   <span className="parameter-row__caret" aria-hidden="true">{isExpanded ? '▾' : '▸'}</span>
                   <span>
                     <strong>{parameter.id}</strong>
@@ -1258,6 +1569,28 @@ export function ParametersSection(props: ParametersSectionProps): ReactElement {
           })}
         </div>
         {displayedParameters.length === 0 ? <p className="parameter-empty-state">No parameters match the current filter.</p> : null}
+
+        {createPresetOpen && onCreateUserPreset ? (
+          <CreatePresetDialog
+            params={createPresetParams}
+            savedCount={presetKeptIds.length}
+            name={presetName}
+            onNameChange={setPresetName}
+            description={presetDescription}
+            onDescriptionChange={setPresetDescription}
+            questions={createPresetQuestions}
+            onToggleQuestion={handleToggleDependencyAnswer}
+            showCellCount={presetAnsweredClasses.has('battery-pack')}
+            cellCount={presetCellCount}
+            onCellCountChange={setPresetCellCount}
+            calibrationParamIds={presetCalibrationParamIds}
+            rebootRequiredParamIds={presetDetection.rebootRequiredParamIds}
+            unclassifiedCount={presetDetection.unclassifiedParamIds.length}
+            onToggleParamExcluded={handleTogglePresetParamExcluded}
+            onSave={handleSaveUserPreset}
+            onCancel={() => setCreatePresetOpen(false)}
+          />
+        ) : null}
       </Panel>
 
   )

--- a/apps/web/src/sections/PresetsSection.tsx
+++ b/apps/web/src/sections/PresetsSection.tsx
@@ -12,9 +12,11 @@ import type {
   ParameterPresetDiffResult
 } from '@arduconfig/ardupilot-core'
 import { deriveParameterDraftEntries } from '@arduconfig/ardupilot-core'
-import type { NormalizedFirmwareMetadataBundle, NormalizedPresetDefinition, PresetGroupDefinition } from '@arduconfig/param-metadata'
+import type { NormalizedPresetDefinition, PresetGroupDefinition } from '@arduconfig/param-metadata'
 
 import type { ParameterFollowUp, ParameterNotice } from '../hooks/use-parameter-feedback'
+import type { PresetSerialRemapState } from '../hooks/use-preset-catalog'
+import { isUserPresetId } from '../user-preset-library'
 import { formatParameterDelta, formatParameterValue } from '../parameter-format'
 import type { SavedParameterSnapshot } from '../snapshot-library'
 import { statusToneLabel } from '../status-tone'
@@ -28,13 +30,19 @@ interface PresetPreview {
 
 export interface PresetsSectionProps {
   snapshot: ConfiguratorSnapshot
-  metadataCatalog: NormalizedFirmwareMetadataBundle
   busyAction: string | undefined
   canApplyDraftParameters: boolean
   parameterFollowUp: ParameterFollowUp | undefined
   presetNotice: ParameterNotice | undefined
   presetDefinitions: readonly NormalizedPresetDefinition[]
   presetGroups: readonly PresetGroupDefinition[]
+  /** Group -> presets, already merged with the operator's saved presets. */
+  presetsByGroup: Record<string, readonly NormalizedPresetDefinition[]>
+  /** Present when exactly one saved preset with a serial dependency is selected. */
+  selectedPresetSerialRemap: PresetSerialRemapState | undefined
+  onSerialRemapChange: (port: number) => void
+  selectedPresetDependencyLabels: readonly string[]
+  onDeleteUserPreset: (presetId: string) => void
   presetPreviewById: ReadonlyMap<string, PresetPreview>
   selectedPresets: readonly NormalizedPresetDefinition[]
   selectedPresetConflicts: readonly string[]
@@ -61,13 +69,17 @@ export interface PresetsSectionProps {
 export function PresetsSection(props: PresetsSectionProps): ReactElement {
   const {
     snapshot,
-    metadataCatalog,
     busyAction,
     canApplyDraftParameters,
     parameterFollowUp,
     presetNotice,
     presetDefinitions,
     presetGroups,
+    presetsByGroup,
+    selectedPresetSerialRemap,
+    onSerialRemapChange,
+    selectedPresetDependencyLabels,
+    onDeleteUserPreset,
     presetPreviewById,
     selectedPresets,
     selectedPresetConflicts,
@@ -140,7 +152,19 @@ export function PresetsSection(props: PresetsSectionProps): ReactElement {
           label: draft.label,
           rawValue: draft.rawValue,
           reason: draft.reason ?? 'Invalid value'
-        }))
+        })),
+        dependencyLabels: selectedPresetDependencyLabels,
+        // Only the operator's own presets can be deleted — the curated bundle
+        // ones ship with the app and are not the library's to remove.
+        deletable: single !== undefined && isUserPresetId(single.id),
+        serialRemap: selectedPresetSerialRemap
+          ? {
+              savedPort: selectedPresetSerialRemap.savedPort,
+              availablePorts: selectedPresetSerialRemap.availablePorts,
+              selectedPort: selectedPresetSerialRemap.selectedPort,
+              missingOnTarget: selectedPresetSerialRemap.missingOnTarget
+            }
+          : null
       }
     : null
 
@@ -164,8 +188,8 @@ export function PresetsSection(props: PresetsSectionProps): ReactElement {
         id: group.id,
         label: group.label,
         description: group.description,
-        cardCount: metadataCatalog.presetsByGroup[group.id]?.length ?? 0,
-        cards: (metadataCatalog.presetsByGroup[group.id] ?? []).map((preset): PresetsCard => {
+        cardCount: presetsByGroup[group.id]?.length ?? 0,
+        cards: (presetsByGroup[group.id] ?? []).map((preset): PresetsCard => {
           const preview = presetPreviewById.get(preset.id)
           const isActive = selectedPresets.some((selected) => selected.id === preset.id)
           const cardChangedCount = preview?.diff.changedCount ?? 0
@@ -201,6 +225,8 @@ export function PresetsSection(props: PresetsSectionProps): ReactElement {
       }))}
       selected={selectedPanel}
       onToggleDropParam={onTogglePresetParamDrop}
+      onSerialRemapChange={onSerialRemapChange}
+      onDeleteSelectedPreset={single ? () => onDeleteUserPreset(single.id) : undefined}
       applyAcknowledged={presetApplyAcknowledged}
       onAcknowledgedChange={setPresetApplyAcknowledged}
       onSelectPreset={onTogglePreset}

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -11941,6 +11941,233 @@ details.metadata-settings-section:not([open]) > summary::after {
   align-items: center;
 }
 
+/* Group-to-preset selection strip above the parameter table. Wraps rather than
+   scrolling so the visible-rows-only explanation stays readable at 390px. */
+.parameter-preset-bulk {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px 12px;
+  align-items: center;
+  margin: 12px 0;
+  padding: 10px 12px;
+  border: 1px solid var(--surface-400);
+  border-radius: 8px;
+  background: var(--surface-200);
+}
+
+.parameter-preset-bulk > small {
+  flex: 1 1 220px;
+  min-width: 0;
+  font-size: 12px;
+  color: var(--text-muted);
+}
+
+/* Row-select checkbox, inside the name cell so the table's column template is
+   untouched. */
+.parameter-row__select {
+  flex: 0 0 auto;
+  margin: 0 6px 0 0;
+  cursor: pointer;
+}
+
+/* ---- Create preset dialog ---- */
+.create-preset {
+  width: min(760px, 100%);
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  padding: 18px;
+  border: 1px solid var(--surface-400);
+  border-radius: 12px;
+  background: var(--surface-100);
+  box-shadow: 0 18px 48px rgba(0, 0, 0, 0.4);
+}
+
+.create-preset__header {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  align-items: flex-start;
+  justify-content: space-between;
+}
+
+.create-preset__header h3 {
+  margin: 0 0 4px;
+}
+
+.create-preset__header p {
+  margin: 0;
+  font-size: 13px;
+  color: var(--text-muted);
+}
+
+.create-preset__field {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  font-size: 13px;
+}
+
+.create-preset__field > span {
+  color: var(--text-muted);
+}
+
+.create-preset__field input {
+  width: 100%;
+  min-width: 0;
+}
+
+.create-preset__questions {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.create-preset__hint {
+  margin: 0;
+  font-size: 12px;
+  color: var(--text-muted);
+}
+
+.create-preset__question {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  padding: 10px;
+  border: 1px solid var(--surface-400);
+  border-radius: 8px;
+  background: var(--surface-200);
+}
+
+.create-preset__question > label {
+  display: flex;
+  gap: 8px;
+  align-items: flex-start;
+  cursor: pointer;
+}
+
+.create-preset__question > label > span {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+}
+
+.create-preset__question-detail {
+  font-size: 12px;
+  color: var(--text-dim);
+}
+
+.create-preset__question-rationale {
+  font-size: 12px;
+  color: var(--text-muted);
+}
+
+.create-preset__cells {
+  display: inline-flex;
+  gap: 8px;
+  align-items: center;
+  font-size: 12px;
+  color: var(--text-muted);
+}
+
+.create-preset__cells input {
+  width: 84px;
+}
+
+.create-preset__params > header {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  align-items: baseline;
+  justify-content: space-between;
+  margin-bottom: 6px;
+  font-size: 12px;
+  color: var(--text-muted);
+}
+
+.create-preset__param-list {
+  max-height: 260px;
+  overflow-y: auto;
+  border: 1px solid var(--surface-400);
+  border-radius: 8px;
+}
+
+.create-preset__param {
+  display: grid;
+  grid-template-columns: minmax(0, 1.2fr) minmax(0, 1.4fr) minmax(0, 0.8fr) auto;
+  gap: 8px;
+  align-items: center;
+  padding: 6px 10px;
+  font-size: 12px;
+  border-bottom: 1px solid rgba(var(--edge-rgb), 0.08);
+}
+
+.create-preset__param:last-child {
+  border-bottom: none;
+}
+
+.create-preset__param--excluded {
+  opacity: 0.5;
+  text-decoration: line-through;
+}
+
+.create-preset__param-id {
+  display: inline-flex;
+  gap: 4px;
+  align-items: center;
+  min-width: 0;
+}
+
+.create-preset__param-label,
+.create-preset__param-value {
+  min-width: 0;
+  overflow-wrap: anywhere;
+  color: var(--text-muted);
+}
+
+.create-preset__actions {
+  justify-content: flex-end;
+}
+
+/* Serial-port remap control in the selected-preset panel. */
+.preset-serial-remap {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px 12px;
+  align-items: center;
+  padding: 10px 12px;
+  border: 1px solid var(--surface-400);
+  border-radius: 8px;
+  background: var(--surface-200);
+}
+
+.preset-serial-remap > label {
+  display: inline-flex;
+  gap: 8px;
+  align-items: center;
+  font-size: 13px;
+  color: var(--text-muted);
+}
+
+.preset-serial-remap > small {
+  flex: 1 1 240px;
+  min-width: 0;
+  font-size: 12px;
+  color: var(--text-muted);
+}
+
+/* Phone: the four-column param row is unreadable under ~520px, so it stacks. */
+@media (max-width: 640px) {
+  .create-preset__param {
+    grid-template-columns: minmax(0, 1fr) auto;
+  }
+
+  .create-preset__param-label {
+    grid-column: 1 / -1;
+  }
+}
+
 .parameter-diff-bulk__all {
   display: inline-flex;
   gap: 6px;

--- a/apps/web/src/user-preset-library.ts
+++ b/apps/web/src/user-preset-library.ts
@@ -1,0 +1,221 @@
+// Browser-local storage for operator-authored parameter-group presets.
+//
+// Why a fifth storage key rather than a fifth CONCEPT: this is deliberately not
+// a new save/restore mechanism. A user preset is a `PresetDefinition` — the
+// same sparse `{paramId, value}[]` shape the curated metadata presets already
+// use — plus provenance and the dependency answers. `toPresetDefinition()`
+// below hands it straight to `deriveDraftValuesFromParameterPreset` /
+// `evaluateParameterPresetApplicability` / the Presets tab's existing apply
+// path, so nothing about diffing, reviewing, auto-backup, or writing is new
+// code. The other three libraries (snapshots, provisioning profiles, tuning
+// profiles) all store a whole-vehicle `ParameterBackupFile`, which is the wrong
+// shape entirely for "one tab's worth of params".
+//
+// Envelope + key convention matches snapshot-library.ts / provisioning-library.ts:
+// a versioned, `kind`-discriminated wrapper, and a silent fall back to an empty
+// library on anything stale or corrupt (a broken blob must never take out the
+// Presets tab).
+
+import type { ParameterPresetValue, PresetDefinition, PresetGroupDefinition } from '@arduconfig/param-metadata'
+
+import type { PresetDependencyRecord } from './view-models/preset-dependencies'
+
+export interface UserPresetRecord {
+  /** Always `user:`-prefixed — see USER_PRESET_ID_PREFIX. */
+  id: string
+  label: string
+  description: string
+  createdAt: string
+  /** Firmware the preset was captured from, e.g. `ArduCopter`. */
+  sourceFirmware?: string
+  /** Free-text note the operator typed at create time. */
+  note?: string
+  tags: string[]
+  values: ParameterPresetValue[]
+  /** The operator's answers to the dependency questions. */
+  dependencies: PresetDependencyRecord[]
+}
+
+/** What the create dialog hands back — the host adds id/timestamp/provenance. */
+export interface UserPresetDraft {
+  label: string
+  description: string
+  values: ParameterPresetValue[]
+  dependencies: PresetDependencyRecord[]
+}
+
+export interface UserPresetLibraryFile {
+  schemaVersion: 1
+  application: 'ArduConfigurator'
+  kind: 'parameter-user-preset-library'
+  name: string
+  updatedAt: string
+  presets: UserPresetRecord[]
+}
+
+export interface UserPresetStorageLoadResult {
+  presets: UserPresetRecord[]
+  warning?: string
+}
+
+export interface UserPresetStoragePersistResult {
+  ok: boolean
+  warning?: string
+}
+
+const USER_PRESET_STORAGE_KEY = 'arduconfig:user-presets'
+const USER_PRESET_STORAGE_WARNING =
+  'Browser preset storage is unavailable. Presets you create will stay in memory for this session only until browser storage works again.'
+
+/**
+ * Namespace for user preset ids. Curated preset ids are plain slugs
+ * (`starter-quad-x`), so the prefix guarantees a saved preset can never shadow
+ * or be shadowed by one that ships in the metadata bundle — the two live in the
+ * same `presetDefinitions` list once merged, and a collision would silently
+ * swap one for the other.
+ */
+export const USER_PRESET_ID_PREFIX = 'user:'
+
+/** The synthetic preset group user presets are filed under in the Presets tab. */
+export const USER_PRESET_GROUP: PresetGroupDefinition = {
+  id: 'user-presets',
+  label: 'Your presets',
+  description:
+    'Parameter groups you saved from the Parameter Editor. Each records what it depends on, and warns before applying to an aircraft that differs.',
+  // Sorted after every curated group: the curated ones are the safe, vetted
+  // starting points and should stay at the top of the tab.
+  order: 900
+}
+
+export function isUserPresetId(presetId: string): boolean {
+  return presetId.startsWith(USER_PRESET_ID_PREFIX)
+}
+
+export function createUserPresetId(label: string): string {
+  const slug = label
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 40)
+  // The random suffix, not the slug, is what makes the id unique — two presets
+  // called "6S OSD" must not overwrite each other.
+  return `${USER_PRESET_ID_PREFIX}${slug || 'preset'}-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`
+}
+
+/** Newest first, then by label — same ordering rule as the other libraries. */
+export function sortUserPresets(presets: readonly UserPresetRecord[]): UserPresetRecord[] {
+  return [...presets].sort((left, right) => {
+    const leftTime = Date.parse(left.createdAt)
+    const rightTime = Date.parse(right.createdAt)
+    if (!Number.isNaN(leftTime) && !Number.isNaN(rightTime) && leftTime !== rightTime) {
+      return rightTime - leftTime
+    }
+    return left.label.localeCompare(right.label)
+  })
+}
+
+/**
+ * Present a saved record as a `PresetDefinition` so every existing preset
+ * code path — diff, applicability, card rendering, apply — consumes it without
+ * knowing it came from localStorage.
+ *
+ * The dependency answers surface as `cautions`, which the Presets tab already
+ * renders in its "Cautions" list; the sharper, comparison-based warnings are
+ * added at apply time by `evaluatePresetDependencies` in use-preset-catalog.
+ */
+export function toPresetDefinition(record: UserPresetRecord, index: number): PresetDefinition {
+  return {
+    id: record.id,
+    label: record.label,
+    description: record.description,
+    groupId: USER_PRESET_GROUP.id,
+    order: index,
+    values: record.values,
+    note: record.note,
+    tags: record.tags,
+    // Deliberately no `compatibility` block: that field can BLOCK an apply, and
+    // it is meant to carry a human author's assertion. Everything this module
+    // knows came from pattern-matching parameter names, which earns a warning,
+    // not a veto.
+    cautions: []
+  }
+}
+
+export function loadStoredUserPresets(): UserPresetStorageLoadResult {
+  if (typeof window === 'undefined') {
+    return { presets: [] }
+  }
+
+  let raw: string | null
+  try {
+    raw = window.localStorage.getItem(USER_PRESET_STORAGE_KEY)
+  } catch {
+    return { presets: [], warning: USER_PRESET_STORAGE_WARNING }
+  }
+
+  if (!raw) {
+    return { presets: [] }
+  }
+
+  try {
+    const parsed = JSON.parse(raw) as Partial<UserPresetLibraryFile>
+    if (
+      parsed.schemaVersion !== 1 ||
+      parsed.application !== 'ArduConfigurator' ||
+      parsed.kind !== 'parameter-user-preset-library' ||
+      !Array.isArray(parsed.presets)
+    ) {
+      return { presets: [] }
+    }
+    return { presets: sortUserPresets(parsed.presets.filter(isUserPresetRecord)) }
+  } catch {
+    return { presets: [] }
+  }
+}
+
+export function persistUserPresets(presets: readonly UserPresetRecord[]): UserPresetStoragePersistResult {
+  if (typeof window === 'undefined') {
+    return { ok: true }
+  }
+
+  const library: UserPresetLibraryFile = {
+    schemaVersion: 1,
+    application: 'ArduConfigurator',
+    kind: 'parameter-user-preset-library',
+    name: 'Browser Local Preset Library',
+    updatedAt: new Date().toISOString(),
+    presets: sortUserPresets(presets)
+  }
+
+  try {
+    window.localStorage.setItem(USER_PRESET_STORAGE_KEY, JSON.stringify(library, null, 2))
+    return { ok: true }
+  } catch {
+    return { ok: false, warning: USER_PRESET_STORAGE_WARNING }
+  }
+}
+
+function isUserPresetRecord(value: unknown): value is UserPresetRecord {
+  if (typeof value !== 'object' || value === null) {
+    return false
+  }
+  const candidate = value as Partial<UserPresetRecord>
+  return (
+    typeof candidate.id === 'string' &&
+    typeof candidate.label === 'string' &&
+    typeof candidate.createdAt === 'string' &&
+    Array.isArray(candidate.tags) &&
+    Array.isArray(candidate.dependencies) &&
+    Array.isArray(candidate.values) &&
+    // A preset with a malformed value list would produce NaN drafts that the
+    // draft validator rejects one by one, which reads as a mysterious wall of
+    // invalid rows. Reject the record instead.
+    candidate.values.every(
+      (entry) =>
+        typeof entry === 'object' &&
+        entry !== null &&
+        typeof (entry as ParameterPresetValue).paramId === 'string' &&
+        Number.isFinite((entry as ParameterPresetValue).value)
+    )
+  )
+}

--- a/apps/web/src/view-models/preset-dependencies.test.ts
+++ b/apps/web/src/view-models/preset-dependencies.test.ts
@@ -1,0 +1,287 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  PRESET_DEPENDENCY_CLASSES,
+  detectPresetDependencies,
+  evaluatePresetDependencies,
+  inferBatteryCellCount,
+  presetDependencyClass,
+  remapPresetSerialPort,
+  serialPortIndexOf,
+  type PresetDependencyRecord
+} from './preset-dependencies'
+
+/** Convenience: a value reader over a plain object. */
+const reader = (values: Record<string, number>) => (paramId: string) => values[paramId]
+
+const detect = (paramIds: string[], values: Record<string, number> = {}) =>
+  detectPresetDependencies({ paramIds, readParameter: reader(values) })
+
+const classIds = (paramIds: string[], values: Record<string, number> = {}) =>
+  detect(paramIds, values).dependencies.map((entry) => entry.classId)
+
+describe('serialPortIndexOf', () => {
+  it('reads the index out of a SERIALn param', () => {
+    expect(serialPortIndexOf('SERIAL3_PROTOCOL')).toBe(3)
+    expect(serialPortIndexOf('SERIAL10_BAUD')).toBe(10)
+  })
+
+  it('does not claim the SERIAL_PASS debug bridge', () => {
+    // SERIAL_PASS1/PASS2/PASSTIMO are a USB<->UART passthrough, not a port
+    // configuration. Treating them as port params would drag the whole
+    // remap question onto an ELRS-flashing preset that has no port dependency.
+    expect(serialPortIndexOf('SERIAL_PASS1')).toBeUndefined()
+    expect(serialPortIndexOf('SERIAL_PASS2')).toBeUndefined()
+    expect(serialPortIndexOf('SERIAL_PASSTIMO')).toBeUndefined()
+  })
+
+  it('does not claim unrelated params that merely start with SERIAL', () => {
+    expect(serialPortIndexOf('SERIALMANAGER')).toBeUndefined()
+    expect(serialPortIndexOf('BATT_SERIAL_NUM')).toBeUndefined()
+  })
+})
+
+describe('detectPresetDependencies — classification', () => {
+  it('classifies serial port params and records which UART they came from', () => {
+    const result = detect(['SERIAL3_PROTOCOL', 'SERIAL3_BAUD', 'SERIAL3_OPTIONS'])
+    expect(result.dependencies).toHaveLength(1)
+    expect(result.dependencies[0].classId).toBe('serial-port')
+    expect(result.dependencies[0].context.serialPorts).toEqual([3])
+    expect(result.dependencies[0].detail).toContain('SERIAL3')
+  })
+
+  it('records every distinct port, ascending', () => {
+    const result = detect(['SERIAL5_PROTOCOL', 'SERIAL1_BAUD', 'SERIAL5_BAUD'])
+    expect(result.dependencies[0].context.serialPorts).toEqual([1, 5])
+  })
+
+  it('classifies battery voltage and capacity params together', () => {
+    expect(classIds(['BATT_LOW_VOLT', 'BATT_CRT_VOLT', 'BATT_CAPACITY', 'MOT_BAT_VOLT_MAX'])).toEqual(['battery-pack'])
+  })
+
+  it('keeps battery MONITOR and pin wiring in the sensor-hardware class, not battery-pack', () => {
+    // BATT_MONITOR names a device; BATT_VOLT_PIN names a board pin. Neither
+    // changes with the pack, so grouping them under "4S or 6S?" would ask the
+    // wrong question about them.
+    expect(classIds(['BATT_MONITOR', 'BATT_VOLT_PIN', 'BATT2_CURR_PIN'])).toEqual(['sensor-hardware'])
+  })
+
+  it('separates the frame layout from the tune measured on it', () => {
+    expect(classIds(['FRAME_CLASS', 'FRAME_TYPE'])).toEqual(['frame'])
+    expect(classIds(['ATC_RAT_RLL_P', 'ATC_ANG_PIT_P', 'MOT_THST_EXPO', 'MOT_THST_HOVER', 'PSC_POSXY_P'])).toEqual([
+      'airframe-tune'
+    ])
+  })
+
+  it('classifies output mapping and CAN', () => {
+    expect(classIds(['SERVO1_FUNCTION', 'SERVO_BLH_MASK', 'MOT_PWM_TYPE'])).toEqual(['output-mapping'])
+    expect(classIds(['CAN_P1_DRIVER', 'CAN_D1_PROTOCOL'])).toEqual(['can-bus'])
+  })
+
+  it('classifies the sensor families the operator named', () => {
+    expect(classIds(['RNGFND1_TYPE', 'FLOW_TYPE', 'GPS_TYPE', 'PRX1_TYPE'])).toEqual(['sensor-hardware'])
+  })
+
+  it('claims per-board calibration first, whatever else it looks like', () => {
+    // COMPASS_OFS_X is a calibration value; nothing else may claim it.
+    const result = detect(['COMPASS_OFS_X', 'INS_ACCOFFS_X', 'AHRS_TRIM_X'])
+    expect(result.dependencies.map((entry) => entry.classId)).toEqual(['calibration'])
+    expect(result.dependencies[0].paramIds).toHaveLength(3)
+  })
+
+  it('assigns each param to exactly one class so the counts do not double up', () => {
+    const paramIds = ['SERIAL3_PROTOCOL', 'BATT_LOW_VOLT', 'MOT_BAT_VOLT_MAX', 'MOT_THST_EXPO', 'SERVO1_FUNCTION']
+    const result = detect(paramIds)
+    const claimed = result.dependencies.flatMap((entry) => entry.paramIds)
+    expect(claimed).toHaveLength(new Set(claimed).size)
+    expect(claimed.length + result.unclassifiedParamIds.length).toBe(paramIds.length)
+  })
+
+  it('reports params no rule claims rather than silently swallowing them', () => {
+    const result = detect(['OSD1_ALTITUDE_EN', 'LOG_BITMASK'])
+    expect(result.dependencies).toEqual([])
+    expect(result.unclassifiedParamIds).toEqual(['OSD1_ALTITUDE_EN', 'LOG_BITMASK'])
+  })
+
+  it('asks the most consequential questions first regardless of selection order', () => {
+    const order = classIds(['CAN_P1_DRIVER', 'SERVO1_FUNCTION', 'BATT_LOW_VOLT', 'SERIAL3_BAUD'])
+    const canonical = PRESET_DEPENDENCY_CLASSES.map((entry) => entry.id).filter((id) => order.includes(id))
+    expect(order).toEqual(canonical)
+  })
+
+  it('surfaces reboot-required params as a note, not a question', () => {
+    const result = detectPresetDependencies({
+      paramIds: ['SERIAL3_PROTOCOL', 'BATT_LOW_VOLT'],
+      readParameter: reader({}),
+      isRebootRequired: (paramId) => paramId === 'SERIAL3_PROTOCOL'
+    })
+    expect(result.rebootRequiredParamIds).toEqual(['SERIAL3_PROTOCOL'])
+    expect(result.dependencies.map((entry) => entry.classId)).not.toContain('reboot')
+  })
+
+  it('records the source frame alongside a tune', () => {
+    const result = detect(['ATC_RAT_RLL_P'], { FRAME_CLASS: 1, FRAME_TYPE: 3 })
+    expect(result.dependencies[0].context).toEqual({ frameClass: 1, frameType: 3 })
+  })
+})
+
+describe('inferBatteryCellCount', () => {
+  it('reads a clean multiple off MOT_BAT_VOLT_MAX', () => {
+    expect(inferBatteryCellCount(reader({ MOT_BAT_VOLT_MAX: 25.2 }))).toBe(6)
+    expect(inferBatteryCellCount(reader({ MOT_BAT_VOLT_MAX: 16.8 }))).toBe(4)
+  })
+
+  it('tolerates the round numbers operators actually type', () => {
+    expect(inferBatteryCellCount(reader({ MOT_BAT_VOLT_MAX: 25.0 }))).toBe(6)
+  })
+
+  it('gives up rather than guessing when the param is unset', () => {
+    // MOT_BAT_VOLT_MAX defaults to 0 (compensation disabled) and plenty of
+    // aircraft never set it. Silence here is what makes the dialog ASK.
+    expect(inferBatteryCellCount(reader({}))).toBeUndefined()
+    expect(inferBatteryCellCount(reader({ MOT_BAT_VOLT_MAX: 0 }))).toBeUndefined()
+  })
+
+  it('gives up on a value that sits between two cell counts', () => {
+    expect(inferBatteryCellCount(reader({ MOT_BAT_VOLT_MAX: 19.0 }))).toBeUndefined()
+  })
+
+  it('rejects implausible pack sizes', () => {
+    expect(inferBatteryCellCount(reader({ MOT_BAT_VOLT_MAX: 4.2 }))).toBeUndefined()
+    expect(inferBatteryCellCount(reader({ MOT_BAT_VOLT_MAX: 210 }))).toBeUndefined()
+  })
+})
+
+describe('evaluatePresetDependencies', () => {
+  const ready = { status: 'ready', reasons: [] }
+
+  it('is ready when a preset declares nothing', () => {
+    expect(evaluatePresetDependencies([], reader({}))).toEqual(ready)
+  })
+
+  it('never blocks, only cautions', () => {
+    const dependencies: PresetDependencyRecord[] = PRESET_DEPENDENCY_CLASSES.map((descriptor) => ({
+      classId: descriptor.id,
+      paramIds: ['X']
+    }))
+    const result = evaluatePresetDependencies(dependencies, reader({}))
+    expect(result.status).toBe('caution')
+    expect(result.reasons).toHaveLength(PRESET_DEPENDENCY_CLASSES.length)
+  })
+
+  it('names both cell counts when the packs differ', () => {
+    const result = evaluatePresetDependencies(
+      [{ classId: 'battery-pack', paramIds: ['BATT_LOW_VOLT'], context: { batteryCells: 6 } }],
+      reader({ MOT_BAT_VOLT_MAX: 16.8 })
+    )
+    expect(result.status).toBe('caution')
+    expect(result.reasons[0]).toContain('6S')
+    expect(result.reasons[0]).toContain('4S')
+  })
+
+  it('says the cell count could not be checked rather than implying a match', () => {
+    const result = evaluatePresetDependencies(
+      [{ classId: 'battery-pack', paramIds: ['BATT_LOW_VOLT'], context: { batteryCells: 6 } }],
+      reader({})
+    )
+    expect(result.reasons[0]).toContain('cannot be checked')
+  })
+
+  it('still warns when the packs match, because the thresholds are worth a look', () => {
+    const result = evaluatePresetDependencies(
+      [{ classId: 'battery-pack', paramIds: ['BATT_LOW_VOLT'], context: { batteryCells: 6 } }],
+      reader({ MOT_BAT_VOLT_MAX: 25.2 })
+    )
+    // Matching packs produce no per-pack complaint at all — the class was
+    // declared, so the operator still gets a line, but it must not claim a
+    // mismatch that does not exist.
+    expect(result.reasons.join(' ')).not.toContain('will be wrong')
+  })
+
+  it('names the frame classes when a tune moved airframe', () => {
+    const result = evaluatePresetDependencies(
+      [{ classId: 'airframe-tune', paramIds: ['ATC_RAT_RLL_P'], context: { frameClass: 1 } }],
+      reader({ FRAME_CLASS: 2 })
+    )
+    expect(result.reasons[0]).toContain('FRAME_CLASS 1')
+    expect(result.reasons[0]).toContain('FRAME_CLASS 2')
+  })
+
+  it('names the saved UART so the operator knows what to remap', () => {
+    const result = evaluatePresetDependencies(
+      [{ classId: 'serial-port', paramIds: ['SERIAL3_BAUD'], context: { serialPorts: [3] } }],
+      reader({})
+    )
+    expect(result.reasons[0]).toContain('SERIAL3')
+  })
+
+  it('degrades gracefully on a dependency class this build does not know', () => {
+    const result = evaluatePresetDependencies(
+      [{ classId: 'from-the-future' as never, paramIds: ['X'] }],
+      reader({})
+    )
+    expect(result.status).toBe('caution')
+    expect(result.reasons[0]).toContain('from-the-future')
+  })
+})
+
+describe('presetDependencyClass', () => {
+  it('returns a usable descriptor for an unknown class rather than throwing', () => {
+    const descriptor = presetDependencyClass('made-up' as never)
+    expect(descriptor.label).toBe('made-up')
+    expect(descriptor.question).toContain('made-up')
+  })
+})
+
+describe('remapPresetSerialPort', () => {
+  const values = [
+    { paramId: 'SERIAL3_PROTOCOL', value: 23 },
+    { paramId: 'SERIAL3_BAUD', value: 115 },
+    { paramId: 'RC_OPTIONS', value: 32 }
+  ]
+
+  it('is a no-op when the target is the saved port', () => {
+    const result = remapPresetSerialPort(values, 3, 3)
+    expect(result.values).toEqual(values)
+    expect(result.remapped).toEqual([])
+  })
+
+  it('rewrites only the matching port and leaves everything else alone', () => {
+    const result = remapPresetSerialPort(values, 3, 4)
+    expect(result.values.map((entry) => entry.paramId)).toEqual(['SERIAL4_PROTOCOL', 'SERIAL4_BAUD', 'RC_OPTIONS'])
+    expect(result.remapped).toEqual([
+      { from: 'SERIAL3_PROTOCOL', to: 'SERIAL4_PROTOCOL' },
+      { from: 'SERIAL3_BAUD', to: 'SERIAL4_BAUD' }
+    ])
+  })
+
+  it('preserves the values it moves', () => {
+    const result = remapPresetSerialPort(values, 3, 4)
+    expect(result.values[0].value).toBe(23)
+    expect(result.values[1].value).toBe(115)
+  })
+
+  it('does not touch a different port that happens to be in the same preset', () => {
+    const mixed = [{ paramId: 'SERIAL1_BAUD', value: 57 }, { paramId: 'SERIAL3_BAUD', value: 115 }]
+    const result = remapPresetSerialPort(mixed, 3, 4)
+    expect(result.values.map((entry) => entry.paramId)).toEqual(['SERIAL1_BAUD', 'SERIAL4_BAUD'])
+  })
+
+  it('reports remapped ids the target board does not have', () => {
+    // A four-UART board has no SERIAL6_*. Silently producing writes to a
+    // nonexistent param would look like the remap worked.
+    const result = remapPresetSerialPort(values, 3, 6, new Set(['SERIAL1_BAUD', 'SERIAL3_BAUD', 'RC_OPTIONS']))
+    expect(result.missingOnTarget).toEqual(['SERIAL6_PROTOCOL', 'SERIAL6_BAUD'])
+  })
+
+  it('reports nothing missing when the target ids all exist', () => {
+    const result = remapPresetSerialPort(values, 3, 4, new Set(['SERIAL4_PROTOCOL', 'SERIAL4_BAUD']))
+    expect(result.missingOnTarget).toEqual([])
+  })
+
+  it('does not mutate the input', () => {
+    const input = [{ paramId: 'SERIAL3_BAUD', value: 115 }]
+    remapPresetSerialPort(input, 3, 4)
+    expect(input[0].paramId).toBe('SERIAL3_BAUD')
+  })
+})

--- a/apps/web/src/view-models/preset-dependencies.ts
+++ b/apps/web/src/view-models/preset-dependencies.ts
@@ -1,0 +1,516 @@
+// Dependency classification for operator-authored parameter-group presets.
+//
+// A preset lifted off one aircraft is a footgun on another: SERIAL3_PROTOCOL=23
+// is correct only while the receiver is on UART3, BATT_LOW_VOLT=21.0 is a 6S
+// number that will fly a 4S pack into the ground, and ATC_RAT_RLL_P is a
+// statement about one airframe's mass and props. The Presets library shipped in
+// param-metadata never had this problem — every curated preset was hand-written
+// with a `compatibility` block by someone who knew what it touched. User presets
+// are captured off a live aircraft in one click, so the knowledge has to be
+// recovered from the parameter ids instead.
+//
+// This module is the recovery step. It is deliberately pure and has no React,
+// no runtime, and no storage in it, because it is the part that stands between
+// a careless preset and somebody's aircraft; it needs to be unit-testable to
+// death (see preset-dependencies.test.ts).
+//
+// Two halves:
+//   - detectPresetDependencies() runs at CREATE time against the selection and
+//     the source aircraft's live values. It produces pre-ticked questions plus
+//     the context worth recording (which UART, how many cells, which frame).
+//   - evaluatePresetDependencies() runs at APPLY time against the target
+//     aircraft and turns the recorded context into concrete warnings.
+//
+// Deliberate non-goal: nothing here ever returns 'blocked'. Every rule below is
+// a heuristic over parameter names, and a heuristic must not be able to veto a
+// write the operator has reviewed. 'blocked' stays reserved for the curated
+// metadata presets' explicit `compatibility.frameClasses` gate, which is an
+// assertion by a human author rather than a guess. Warnings that are wrong are
+// annoying; blocks that are wrong make the feature unusable and teach operators
+// to route around it.
+
+import { parameterImportExclusionCategory } from '@arduconfig/ardupilot-core'
+
+export type PresetDependencyClassId =
+  | 'serial-port'
+  | 'battery-pack'
+  | 'frame'
+  | 'airframe-tune'
+  | 'output-mapping'
+  | 'sensor-hardware'
+  | 'can-bus'
+  | 'calibration'
+
+/** What a preset recorded about the aircraft it was captured from. */
+export interface PresetDependencyContext {
+  /** SERIALn indices the captured values belong to, ascending. */
+  serialPorts?: number[]
+  /** Cell count of the pack the voltage thresholds were set for. */
+  batteryCells?: number
+  /** FRAME_CLASS on the source aircraft. */
+  frameClass?: number
+  /** FRAME_TYPE on the source aircraft. */
+  frameType?: number
+}
+
+export interface PresetDependencyClassDescriptor {
+  id: PresetDependencyClassId
+  label: string
+  /** The question put to the operator in the create dialog. */
+  question: string
+  /** Why the answer matters — rendered under the question. */
+  rationale: string
+}
+
+/**
+ * The questions the create dialog can ask, in the order it asks them. Ordered
+ * by how badly a wrong answer ends: port position and pack voltage first (they
+ * silently break a link or over-discharge a pack), cosmetic-ish classes last.
+ */
+export const PRESET_DEPENDENCY_CLASSES: readonly PresetDependencyClassDescriptor[] = [
+  {
+    id: 'serial-port',
+    label: 'Serial port position',
+    question: 'Does this preset depend on which serial port the device is wired to?',
+    rationale:
+      'SERIALn values only mean anything while the device stays on UART n. On a board where it is wired to a different UART, applying these writes configures the wrong port and leaves the real one untouched.'
+  },
+  {
+    id: 'battery-pack',
+    label: 'Battery pack (4S / 6S, capacity)',
+    question: 'Does this preset depend on the battery pack (cell count or capacity)?',
+    rationale:
+      'Voltage failsafe thresholds and capacity limits are per-pack. A 6S set of thresholds on a 4S pack never triggers; a 4S set on a 6S pack triggers immediately.'
+  },
+  {
+    id: 'frame',
+    label: 'Frame class / type',
+    question: 'Does this preset set the airframe layout itself?',
+    rationale:
+      'FRAME_CLASS / FRAME_TYPE rewrite the motor mixer. Applying them to a differently-shaped aircraft changes which motor spins which way.'
+  },
+  {
+    id: 'airframe-tune',
+    label: 'Airframe size / props',
+    question: 'Is this tune specific to the airframe size, weight, or props?',
+    rationale:
+      'Rate and angle gains, thrust expo, and hover throttle are measurements of one physical aircraft. They do not transfer to a different size or prop.'
+  },
+  {
+    id: 'output-mapping',
+    label: 'Motor / servo output mapping',
+    question: 'Does this preset depend on how the outputs are wired?',
+    rationale:
+      'SERVOn_FUNCTION and the output protocol settings describe one board’s wiring loom. Applying another aircraft’s mapping can send a motor signal to a servo pin.'
+  },
+  {
+    id: 'sensor-hardware',
+    label: 'Specific sensor hardware',
+    question: 'Does this preset assume specific sensor hardware is fitted?',
+    rationale:
+      'Rangefinder, optical-flow, GPS, proximity, and battery-monitor settings name a particular device and, for analog monitors, a particular board pin. An ARK Flow preset is wrong on a different flow sensor.'
+  },
+  {
+    id: 'can-bus',
+    label: 'CAN bus configuration',
+    question: 'Does this preset depend on the CAN bus setup?',
+    rationale:
+      'CAN driver/protocol assignments are per-board and per-peripheral. Applying them where no CAN peripheral is fitted enables a bus with nothing on it.'
+  },
+  {
+    id: 'calibration',
+    label: 'Per-airframe calibration',
+    question: 'This selection contains calibration values. Keep them?',
+    rationale:
+      'Compass offsets, accel scale/offsets, thermal calibration, and AHRS trims are measured on one physical board. They are never valid on another and are almost never wanted in a preset.'
+  }
+]
+
+const CLASS_BY_ID = new Map(PRESET_DEPENDENCY_CLASSES.map((entry) => [entry.id, entry]))
+
+export function presetDependencyClass(id: PresetDependencyClassId): PresetDependencyClassDescriptor {
+  const descriptor = CLASS_BY_ID.get(id)
+  if (!descriptor) {
+    // Unreachable for the union above, but a stored preset from a future
+    // version could carry a class this build does not know. Degrade to a
+    // generic question rather than crashing the Presets tab.
+    return { id, label: id, question: `Does this preset depend on ${id}?`, rationale: '' }
+  }
+  return descriptor
+}
+
+const SERIAL_PORT_PATTERN = /^SERIAL(\d+)_/
+
+/** The SERIALn index a param belongs to, or undefined if it is not a port param. */
+export function serialPortIndexOf(paramId: string): number | undefined {
+  const match = SERIAL_PORT_PATTERN.exec(paramId)
+  return match ? Number(match[1]) : undefined
+}
+
+// One param belongs to exactly one class: the rules are evaluated in order and
+// the first match wins. Overlaps are real (MOT_BAT_VOLT_MAX is both a MOT_ and
+// a battery param), and counting a param twice would make the dialog's "(n
+// params)" counts lie about how much of the selection each answer covers.
+const CLASS_MATCHERS: readonly { id: PresetDependencyClassId; matches: (paramId: string) => boolean }[] = [
+  // Calibration first and unconditionally: whatever else a per-board offset
+  // looks like, it is a calibration value and belongs in the class whose
+  // recommended answer is "take it out".
+  { id: 'calibration', matches: (id) => parameterImportExclusionCategory(id) === 'calibration' },
+  // SERIALn_ only — SERIAL_PASS1/PASS2/PASSTIMO have no digit after SERIAL and
+  // are a debug bridge, not a port configuration, so they must not drag the
+  // whole port-remap question in.
+  { id: 'serial-port', matches: (id) => SERIAL_PORT_PATTERN.test(id) },
+  {
+    id: 'battery-pack',
+    matches: (id) =>
+      /^BATT\d*_(LOW_VOLT|CRT_VOLT|ARM_VOLT|CAPACITY|LOW_MAH|CRT_MAH|ARM_MAH)$/.test(id) ||
+      /^MOT_BAT_(VOLT_MAX|VOLT_MIN|CURR_MAX|CURR_TC)$/.test(id)
+  },
+  { id: 'frame', matches: (id) => id === 'FRAME_CLASS' || id === 'FRAME_TYPE' },
+  {
+    id: 'airframe-tune',
+    matches: (id) =>
+      /^ATC_(RAT_(RLL|PIT|YAW)_|ANG_(RLL|PIT|YAW)_|ACCEL_[RPY]_MAX$|INPUT_TC$|THR_MIX_)/.test(id) ||
+      /^MOT_(THST_EXPO|THST_HOVER|SPIN_MIN|SPIN_ARM|SPIN_MAX|HOVER_LEARN)$/.test(id) ||
+      /^INS_(GYRO_FILTER|ACCEL_FILTER)$/.test(id) ||
+      /^PSC_/.test(id)
+  },
+  {
+    id: 'output-mapping',
+    matches: (id) =>
+      /^SERVO\d+_/.test(id) || /^SERVO_(BLH_|DSHOT_|RATE$|32_ENABLE$)/.test(id) || /^MOT_PWM_/.test(id)
+  },
+  {
+    id: 'sensor-hardware',
+    matches: (id) =>
+      /^RNGFND\d+_/.test(id) ||
+      /^FLOW_/.test(id) ||
+      /^GPS\d*_/.test(id) ||
+      /^PRX\d*_/.test(id) ||
+      /^ARSPD\d*_/.test(id) ||
+      /^EFI\d*_/.test(id) ||
+      /^BARO\d*_(PROBE_EXT|EXT_BUS|PRIMARY)$/.test(id) ||
+      /^BATT\d*_(MONITOR|VOLT_PIN|CURR_PIN|VOLT_MULT|AMP_PERVLT|AMP_OFFSET|I2C_ADDR|I2C_BUS|SERIAL_NUM)$/.test(id) ||
+      /^COMPASS_(TYPEMASK|DISBLMSK|DEV_ID\d*|PRIO\d_ID|EXTERN\w*)$/.test(id)
+  },
+  { id: 'can-bus', matches: (id) => /^CAN_/.test(id) }
+]
+
+export interface DetectedPresetDependency {
+  classId: PresetDependencyClassId
+  /** Params from the selection that put this class on the list, in selection order. */
+  paramIds: string[]
+  /** One-line summary the dialog shows beside the question. */
+  detail: string
+  /** What was recovered off the source aircraft. Empty when nothing applies. */
+  context: PresetDependencyContext
+}
+
+export interface DetectPresetDependenciesResult {
+  dependencies: DetectedPresetDependency[]
+  /** Selected params the metadata marks reboot-required. Not a question — a note. */
+  rebootRequiredParamIds: string[]
+  /** Selected params no rule claimed. Reported so the dialog can say how much is unclassified. */
+  unclassifiedParamIds: string[]
+}
+
+export interface DetectPresetDependenciesInput {
+  paramIds: readonly string[]
+  /** Live value on the source aircraft, for context capture. */
+  readParameter: (paramId: string) => number | undefined
+  /** Metadata reboot-required flag, for the note. */
+  isRebootRequired?: (paramId: string) => boolean
+}
+
+/**
+ * Classify a selection into dependency questions.
+ *
+ * Every returned dependency is meant to arrive PRE-TICKED in the dialog. The
+ * operator's job is to untick the ones that do not apply, which is a far
+ * smaller job than filling an empty questionnaire — and, importantly, the
+ * failure mode of not touching the dialog at all is an over-cautious preset
+ * rather than an unlabelled one.
+ */
+export function detectPresetDependencies(input: DetectPresetDependenciesInput): DetectPresetDependenciesResult {
+  const { paramIds, readParameter, isRebootRequired } = input
+
+  const byClass = new Map<PresetDependencyClassId, string[]>()
+  const unclassifiedParamIds: string[] = []
+  for (const paramId of paramIds) {
+    const matcher = CLASS_MATCHERS.find((rule) => rule.matches(paramId))
+    if (!matcher) {
+      unclassifiedParamIds.push(paramId)
+      continue
+    }
+    const bucket = byClass.get(matcher.id)
+    if (bucket) {
+      bucket.push(paramId)
+    } else {
+      byClass.set(matcher.id, [paramId])
+    }
+  }
+
+  // Emit in PRESET_DEPENDENCY_CLASSES order, not selection order, so the dialog
+  // asks the most consequential questions first regardless of how the operator
+  // happened to tick rows.
+  const dependencies = PRESET_DEPENDENCY_CLASSES.flatMap((descriptor): DetectedPresetDependency[] => {
+    const matched = byClass.get(descriptor.id)
+    if (!matched || matched.length === 0) {
+      return []
+    }
+    const context = captureContext(descriptor.id, matched, readParameter)
+    return [{ classId: descriptor.id, paramIds: matched, detail: describeDetection(descriptor.id, matched, context), context }]
+  })
+
+  return {
+    dependencies,
+    rebootRequiredParamIds: isRebootRequired ? paramIds.filter((paramId) => isRebootRequired(paramId)) : [],
+    unclassifiedParamIds
+  }
+}
+
+function captureContext(
+  classId: PresetDependencyClassId,
+  paramIds: readonly string[],
+  readParameter: (paramId: string) => number | undefined
+): PresetDependencyContext {
+  switch (classId) {
+    case 'serial-port': {
+      const ports = [...new Set(paramIds.map(serialPortIndexOf).filter((port): port is number => port !== undefined))]
+      ports.sort((left, right) => left - right)
+      return { serialPorts: ports }
+    }
+    case 'battery-pack': {
+      const cells = inferBatteryCellCount(readParameter)
+      return cells === undefined ? {} : { batteryCells: cells }
+    }
+    case 'frame':
+    case 'airframe-tune': {
+      // A tune is only meaningful next to the airframe it was measured on, so
+      // both the layout class and the tune class record it.
+      const frameClass = roundedParameter(readParameter, 'FRAME_CLASS')
+      const frameType = roundedParameter(readParameter, 'FRAME_TYPE')
+      const context: PresetDependencyContext = {}
+      if (frameClass !== undefined) context.frameClass = frameClass
+      if (frameType !== undefined) context.frameType = frameType
+      return context
+    }
+    default:
+      return {}
+  }
+}
+
+function roundedParameter(readParameter: (paramId: string) => number | undefined, paramId: string): number | undefined {
+  const value = readParameter(paramId)
+  return value === undefined || !Number.isFinite(value) ? undefined : Math.round(value)
+}
+
+const LIPO_CELL_MAX_VOLTS = 4.2
+/**
+ * Widest per-cell error we will still call a clean multiple. 0.15 V/cell is
+ * enough to absorb an operator who set MOT_BAT_VOLT_MAX to a round 25.0 on 6S
+ * (4.167/cell) while still refusing to round 4S and 5S into each other, whose
+ * MOT_BAT_VOLT_MAX values are 4.2 V apart.
+ */
+const CELL_INFERENCE_TOLERANCE_VOLTS = 0.15
+
+/**
+ * Recover the pack's cell count from the parameters, or give up.
+ *
+ * MOT_BAT_VOLT_MAX is the only parameter on a Copter that is conventionally set
+ * to a whole number of cells times the full-charge cell voltage, so it is the
+ * one honest source. It defaults to 0 (thrust compensation disabled), and
+ * plenty of aircraft never set it — hence `undefined` rather than a guess. The
+ * create dialog turns `undefined` into the operator's own answer, which is
+ * exactly the "4S or 6S?" question the feature exists to ask.
+ */
+export function inferBatteryCellCount(readParameter: (paramId: string) => number | undefined): number | undefined {
+  const voltMax = readParameter('MOT_BAT_VOLT_MAX')
+  if (voltMax === undefined || !Number.isFinite(voltMax) || voltMax <= 0) {
+    return undefined
+  }
+  const cells = Math.round(voltMax / LIPO_CELL_MAX_VOLTS)
+  if (cells < 2 || cells > 14) {
+    return undefined
+  }
+  // Refuse anything that is not close to a clean multiple: a value that sits
+  // between two cell counts is more likely a hand-tuned limit than a pack
+  // description, and reporting a confident wrong number is worse than silence.
+  if (Math.abs(voltMax - cells * LIPO_CELL_MAX_VOLTS) > CELL_INFERENCE_TOLERANCE_VOLTS * cells) {
+    return undefined
+  }
+  return cells
+}
+
+function describeDetection(
+  classId: PresetDependencyClassId,
+  paramIds: readonly string[],
+  context: PresetDependencyContext
+): string {
+  const count = `${paramIds.length} parameter${paramIds.length === 1 ? '' : 's'}`
+  switch (classId) {
+    case 'serial-port': {
+      const ports = context.serialPorts ?? []
+      return ports.length === 0
+        ? count
+        : `${count} on ${ports.map((port) => `SERIAL${port}`).join(', ')}`
+    }
+    case 'battery-pack':
+      return context.batteryCells === undefined
+        ? `${count} — cell count could not be read from MOT_BAT_VOLT_MAX, so state it below`
+        : `${count}, captured on a ${context.batteryCells}S pack`
+    case 'frame':
+    case 'airframe-tune':
+      return context.frameClass === undefined
+        ? count
+        : `${count}, captured on FRAME_CLASS ${context.frameClass}${context.frameType === undefined ? '' : ` / FRAME_TYPE ${context.frameType}`}`
+    default:
+      return count
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Apply time
+// ---------------------------------------------------------------------------
+
+/** A dependency as it is stored on a saved preset. */
+export interface PresetDependencyRecord {
+  classId: PresetDependencyClassId
+  paramIds: readonly string[]
+  context?: PresetDependencyContext
+}
+
+export interface PresetDependencyEvaluation {
+  /** Never 'blocked' — see the module header. */
+  status: 'ready' | 'caution'
+  reasons: string[]
+}
+
+/**
+ * Turn a preset's recorded dependencies into warnings about THIS aircraft.
+ *
+ * Where a recorded context can be compared against the target (cell count,
+ * frame class) the warning names both numbers, because "check your battery
+ * settings" is advice an operator learns to click past and "saved on 6S, this
+ * aircraft reads 4S" is not. Where nothing can be compared, the warning states
+ * the dependency plainly and stops — it does not invent a comparison.
+ */
+export function evaluatePresetDependencies(
+  dependencies: readonly PresetDependencyRecord[],
+  readTargetParameter: (paramId: string) => number | undefined
+): PresetDependencyEvaluation {
+  const reasons: string[] = []
+
+  for (const dependency of dependencies) {
+    const context = dependency.context ?? {}
+    switch (dependency.classId) {
+      case 'serial-port': {
+        const ports = context.serialPorts ?? []
+        reasons.push(
+          ports.length === 0
+            ? 'This preset configures serial ports; confirm the device is on the same UART here.'
+            : `Saved for ${ports.map((port) => `SERIAL${port}`).join(', ')}. If the device is on a different UART on this board, remap the port before applying.`
+        )
+        break
+      }
+      case 'battery-pack': {
+        const savedCells = context.batteryCells
+        const targetCells = inferBatteryCellCount(readTargetParameter)
+        if (savedCells !== undefined && targetCells !== undefined && savedCells !== targetCells) {
+          reasons.push(
+            `Saved for a ${savedCells}S pack; this aircraft reads as ${targetCells}S. The voltage thresholds in this preset will be wrong.`
+          )
+        } else if (savedCells !== undefined && targetCells === undefined) {
+          reasons.push(
+            `Saved for a ${savedCells}S pack. This aircraft does not report a cell count (MOT_BAT_VOLT_MAX is unset), so it cannot be checked.`
+          )
+        } else if (savedCells === undefined) {
+          reasons.push('This preset contains battery thresholds and no recorded cell count. Check them against the pack you fly.')
+        }
+        break
+      }
+      case 'frame':
+      case 'airframe-tune': {
+        const savedFrameClass = context.frameClass
+        const targetFrameClass = roundedParameter(readTargetParameter, 'FRAME_CLASS')
+        const noun = dependency.classId === 'frame' ? 'This preset rewrites the frame layout' : 'This tune was measured on one airframe'
+        if (savedFrameClass !== undefined && targetFrameClass !== undefined && savedFrameClass !== targetFrameClass) {
+          reasons.push(`${noun}: saved on FRAME_CLASS ${savedFrameClass}, this aircraft is FRAME_CLASS ${targetFrameClass}.`)
+        } else {
+          reasons.push(`${noun}; it does not transfer to a different size, weight, or prop.`)
+        }
+        break
+      }
+      case 'output-mapping':
+        reasons.push('This preset sets motor/servo output mapping, which follows this board’s wiring. Verify with props off.')
+        break
+      case 'sensor-hardware':
+        reasons.push('This preset assumes specific sensor hardware is fitted and wired the same way.')
+        break
+      case 'can-bus':
+        reasons.push('This preset changes CAN bus configuration; confirm the same peripherals are on the bus here.')
+        break
+      case 'calibration':
+        reasons.push('This preset still contains per-board calibration values, which are never valid on another board.')
+        break
+      default:
+        reasons.push(`This preset declares a dependency on ${dependency.classId}.`)
+        break
+    }
+  }
+
+  return { status: reasons.length === 0 ? 'ready' : 'caution', reasons }
+}
+
+// ---------------------------------------------------------------------------
+// Serial-port remap
+// ---------------------------------------------------------------------------
+
+export interface PresetSerialRemapResult<T extends { paramId: string }> {
+  values: T[]
+  /** Ids that were rewritten, as `from -> to` pairs, for the confirmation copy. */
+  remapped: { from: string; to: string }[]
+  /** Rewritten ids that do not exist on the target — the remap would be a no-op for these. */
+  missingOnTarget: string[]
+}
+
+/**
+ * Rewrite a preset's SERIALn_* ids from one port index to another.
+ *
+ * The transform itself is exact and total: SERIAL3_PROTOCOL -> SERIAL4_PROTOCOL
+ * is a string substitution on ids the preset already owns, so there is no
+ * inference to get wrong. What cannot be inferred is whether the operator WANTS
+ * it, which is why this is driven by an explicit port choice in the UI and
+ * defaults to no remap.
+ *
+ * `knownParamIds` is the target aircraft's parameter set. Ids that would not
+ * exist after the remap are reported rather than silently dropped: a board with
+ * four UARTs has no SERIAL6_PROTOCOL, and a remap that quietly produced writes
+ * to a nonexistent param would look like it worked.
+ */
+export function remapPresetSerialPort<T extends { paramId: string }>(
+  values: readonly T[],
+  fromPort: number,
+  toPort: number,
+  knownParamIds?: ReadonlySet<string>
+): PresetSerialRemapResult<T> {
+  if (fromPort === toPort) {
+    return { values: [...values], remapped: [], missingOnTarget: [] }
+  }
+
+  const remapped: { from: string; to: string }[] = []
+  const missingOnTarget: string[] = []
+  const next = values.map((entry) => {
+    if (serialPortIndexOf(entry.paramId) !== fromPort) {
+      return entry
+    }
+    const paramId = entry.paramId.replace(SERIAL_PORT_PATTERN, `SERIAL${toPort}_`)
+    remapped.push({ from: entry.paramId, to: paramId })
+    if (knownParamIds && !knownParamIds.has(paramId)) {
+      missingOnTarget.push(paramId)
+    }
+    return { ...entry, paramId }
+  })
+
+  return { values: next, remapped, missingOnTarget }
+}

--- a/apps/web/src/views/CreatePresetDialog.tsx
+++ b/apps/web/src/views/CreatePresetDialog.tsx
@@ -1,0 +1,260 @@
+// The "Create preset" dialog raised from the Parameter Editor's row selection.
+//
+// Presentational only: every value it shows and every decision it records is
+// computed by the caller (ParametersSection) from
+// view-models/preset-dependencies.ts. The one thing worth calling out about its
+// shape is that the dependency questions arrive PRE-ANSWERED. An empty
+// questionnaire gets skipped; a list of "we found 6 SERIAL3 params — does this
+// preset depend on the port position? [x]" gets read, because the app has
+// already done the work and is asking the operator to correct it.
+
+import type { ReactElement } from 'react'
+
+import { StatusBadge, buttonStyle } from '@arduconfig/ui-kit'
+
+import { ParamInfoBubble } from './ParamInfoBubble'
+
+export interface CreatePresetParam {
+  id: string
+  label: string
+  description?: string
+  /** Formatted live value that will be baked into the preset. */
+  valueText: string
+  /** Dropped by the operator — kept in the list, struck through, not saved. */
+  excluded: boolean
+}
+
+export interface CreatePresetQuestion {
+  classId: string
+  label: string
+  question: string
+  rationale: string
+  /** e.g. "6 parameters on SERIAL3" — what detection actually found. */
+  detail: string
+  checked: boolean
+}
+
+export interface CreatePresetDialogProps {
+  /** Params that will be saved (selection minus exclusions). */
+  params: readonly CreatePresetParam[]
+  savedCount: number
+  name: string
+  onNameChange: (name: string) => void
+  description: string
+  onDescriptionChange: (description: string) => void
+  questions: readonly CreatePresetQuestion[]
+  onToggleQuestion: (classId: string) => void
+  /**
+   * Cell-count answer, rendered under the battery question. Empty string means
+   * "not stated" — the preset then warns without a number rather than claiming
+   * a cell count it does not have.
+   */
+  showCellCount: boolean
+  cellCount: string
+  onCellCountChange: (value: string) => void
+  /** Params classified as per-board calibration, which are almost never wanted. */
+  calibrationParamIds: readonly string[]
+  rebootRequiredParamIds: readonly string[]
+  /** Params matched by no rule — reported so the count in the header adds up. */
+  unclassifiedCount: number
+  onToggleParamExcluded: (paramId: string) => void
+  onSave: () => void
+  onCancel: () => void
+}
+
+export function CreatePresetDialog(props: CreatePresetDialogProps): ReactElement {
+  const {
+    params,
+    savedCount,
+    name,
+    onNameChange,
+    description,
+    onDescriptionChange,
+    questions,
+    onToggleQuestion,
+    showCellCount,
+    cellCount,
+    onCellCountChange,
+    calibrationParamIds,
+    rebootRequiredParamIds,
+    unclassifiedCount,
+    onToggleParamExcluded,
+    onSave,
+    onCancel
+  } = props
+
+  const canSave = name.trim().length > 0 && savedCount > 0
+
+  return (
+    <div
+      className="app-modal-overlay"
+      data-testid="create-preset-dialog"
+      role="dialog"
+      aria-modal="true"
+      aria-label="Create preset"
+      // Click-outside closes, matching the rest of the app's dismissable
+      // surfaces. Guarded on the target being the overlay itself so a click
+      // that started inside the panel never dismisses it.
+      onClick={(event) => {
+        if (event.target === event.currentTarget) {
+          onCancel()
+        }
+      }}
+    >
+      <div className="create-preset">
+        <header className="create-preset__header">
+          <div>
+            <h3>Create preset</h3>
+            <p>
+              Saves the current value of {savedCount} selected parameter{savedCount === 1 ? '' : 's'} as a reusable preset in the Presets
+              tab. Nothing is written to the aircraft.
+            </p>
+          </div>
+          <StatusBadge tone={savedCount > 0 ? 'neutral' : 'warning'}>{savedCount} params</StatusBadge>
+        </header>
+
+        <label className="create-preset__field">
+          <span>Name</span>
+          <input
+            data-testid="create-preset-name"
+            value={name}
+            onChange={(event) => onNameChange(event.target.value)}
+            placeholder="e.g. ARK Flow + 6S OSD"
+            autoFocus
+          />
+        </label>
+
+        <label className="create-preset__field">
+          <span>What it is for</span>
+          <input
+            data-testid="create-preset-description"
+            value={description}
+            onChange={(event) => onDescriptionChange(event.target.value)}
+            placeholder="e.g. OSD layout and rates for the 5in 6S build"
+          />
+        </label>
+
+        {questions.length > 0 ? (
+          <section className="create-preset__questions" data-testid="create-preset-questions">
+            <strong>Does this preset depend on…</strong>
+            <p className="create-preset__hint">
+              Ticked answers are recorded on the preset and warn you before it is applied to an aircraft that differs. These are
+              pre-answered from what the selection contains — untick anything that does not apply.
+            </p>
+            {questions.map((question) => (
+              <div key={question.classId} className="create-preset__question">
+                <label>
+                  <input
+                    type="checkbox"
+                    data-testid={`create-preset-dependency-${question.classId}`}
+                    checked={question.checked}
+                    onChange={() => onToggleQuestion(question.classId)}
+                  />
+                  <span>
+                    <strong>{question.label}</strong>
+                    <small>{question.question}</small>
+                  </span>
+                </label>
+                <small className="create-preset__question-detail">{question.detail}</small>
+                <small className="create-preset__question-rationale">{question.rationale}</small>
+                {question.classId === 'battery-pack' && showCellCount ? (
+                  <label className="create-preset__cells">
+                    <span>Pack cell count (S)</span>
+                    <input
+                      type="number"
+                      min={2}
+                      max={14}
+                      step={1}
+                      data-testid="create-preset-cell-count"
+                      value={cellCount}
+                      onChange={(event) => onCellCountChange(event.target.value)}
+                      placeholder="e.g. 6"
+                    />
+                  </label>
+                ) : null}
+              </div>
+            ))}
+          </section>
+        ) : null}
+
+        {calibrationParamIds.length > 0 ? (
+          <div className="parameter-follow-up parameter-follow-up--warning" data-testid="create-preset-calibration-warning">
+            <StatusBadge tone="warning">calibration</StatusBadge>
+            <p>
+              {calibrationParamIds.length} selected parameter{calibrationParamIds.length === 1 ? ' is' : 's are'} per-board calibration
+              (compass/accel offsets, thermal calibration, AHRS trims) and {calibrationParamIds.length === 1 ? 'has' : 'have'} been left
+              out of the preset by default. These are measured on one physical board and are never valid on another. Press Keep on a row
+              below if you meant to include it.
+            </p>
+          </div>
+        ) : null}
+
+        {rebootRequiredParamIds.length > 0 ? (
+          <div className="parameter-follow-up" data-testid="create-preset-reboot-note">
+            <StatusBadge tone="neutral">reboot</StatusBadge>
+            <p>
+              {rebootRequiredParamIds.length} parameter{rebootRequiredParamIds.length === 1 ? '' : 's'} in this preset need a reboot to
+              take effect once applied.
+            </p>
+          </div>
+        ) : null}
+
+        <section className="create-preset__params">
+          <header>
+            <strong>Parameters</strong>
+            <span>
+              {savedCount} of {params.length} kept
+              {unclassifiedCount > 0 ? ` · ${unclassifiedCount} matched no dependency rule` : ''}
+            </span>
+          </header>
+          <div className="create-preset__param-list">
+            {params.map((param) => (
+              <div
+                key={param.id}
+                className={`create-preset__param${param.excluded ? ' create-preset__param--excluded' : ''}`}
+              >
+                <span className="create-preset__param-id">
+                  <strong>{param.id}</strong>
+                  <ParamInfoBubble
+                    paramId={param.id}
+                    label={param.label}
+                    description={param.description}
+                    testId={`create-preset-info-${param.id}`}
+                  />
+                </span>
+                <span className="create-preset__param-label">{param.label}</span>
+                <span className="create-preset__param-value">{param.valueText}</span>
+                <button
+                  type="button"
+                  style={buttonStyle()}
+                  data-testid={`create-preset-drop-${param.id}`}
+                  onClick={() => onToggleParamExcluded(param.id)}
+                  aria-pressed={param.excluded}
+                  title={param.excluded ? `Put ${param.id} back in the preset.` : `Leave ${param.id} out of the preset.`}
+                >
+                  {param.excluded ? 'Keep' : 'Drop'}
+                </button>
+              </div>
+            ))}
+          </div>
+        </section>
+
+        <div className="button-row create-preset__actions">
+          <button
+            type="button"
+            style={buttonStyle('primary')}
+            data-testid="create-preset-save"
+            onClick={onSave}
+            disabled={!canSave}
+            title={canSave ? undefined : 'Give the preset a name and keep at least one parameter.'}
+          >
+            Save preset
+          </button>
+          <button type="button" style={buttonStyle()} data-testid="create-preset-cancel" onClick={onCancel}>
+            Cancel
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/apps/web/src/views/Presets.tsx
+++ b/apps/web/src/views/Presets.tsx
@@ -77,6 +77,22 @@ export interface PresetsSelected {
   cautions: readonly string[]
   diffGroups: readonly PresetsDiffGroup[]
   invalidEntries: readonly PresetsInvalidEntry[]
+  /** Dependency classes an operator-authored preset declared, for the pills. */
+  dependencyLabels?: readonly string[]
+  /** Operator-authored — enables the Delete control. Curated presets cannot be deleted. */
+  deletable?: boolean
+  /**
+   * Serial-port remap offer, present only for a saved preset that recorded the
+   * UART its values came from. The transform is exact (SERIAL3_* -> SERIAL4_*);
+   * what cannot be inferred is whether it is wanted, so it is an explicit
+   * choice that defaults to the saved port.
+   */
+  serialRemap?: {
+    savedPort: number
+    availablePorts: readonly number[]
+    selectedPort: number
+    missingOnTarget: readonly string[]
+  } | null
 }
 
 export interface PresetsViewProps {
@@ -91,6 +107,10 @@ export interface PresetsViewProps {
   groups: readonly PresetsGroup[]
   selected: PresetsSelected | null
   onToggleDropParam: (paramId: string) => void
+  /** Re-target a saved preset's SERIALn_* values at a different UART. */
+  onSerialRemapChange?: (port: number) => void
+  /** Delete the selected operator-authored preset. */
+  onDeleteSelectedPreset?: () => void
   applyAcknowledged: boolean
   onAcknowledgedChange: (acknowledged: boolean) => void
   onSelectPreset: (presetId: string) => void
@@ -126,6 +146,8 @@ export function PresetsView(props: PresetsViewProps) {
     groups,
     selected,
     onToggleDropParam,
+    onSerialRemapChange,
+    onDeleteSelectedPreset,
     applyAcknowledged,
     onAcknowledgedChange,
     onSelectPreset,
@@ -340,9 +362,50 @@ export function PresetsView(props: PresetsViewProps) {
                 {selected.tags.map((tag) => (
                   <span key={`selected:tag:${tag}`}>#{tag}</span>
                 ))}
+                {(selected.dependencyLabels ?? []).map((label) => (
+                  <span key={`selected:dep:${label}`} data-testid={`preset-dependency-pill-${label}`}>
+                    depends on: {label}
+                  </span>
+                ))}
               </div>
 
               {selected.note ? <p className="snapshot-selected__note">{selected.note}</p> : null}
+
+              {/* Port remap. Rendered only when the preset recorded which UART
+                * it came from, so it never appears as a mystery control on a
+                * curated preset. Defaults to the saved port — no remap happens
+                * unless the operator asks for one. */}
+              {selected.serialRemap && onSerialRemapChange ? (
+                <div className="preset-serial-remap" data-testid="preset-serial-remap">
+                  <label>
+                    <span>Serial port</span>
+                    <select
+                      data-testid="preset-serial-remap-select"
+                      value={String(selected.serialRemap.selectedPort)}
+                      onChange={(event) => onSerialRemapChange(Number(event.target.value))}
+                    >
+                      {selected.serialRemap.availablePorts.map((port) => (
+                        <option key={port} value={String(port)}>
+                          SERIAL{port}
+                          {port === selected.serialRemap?.savedPort ? ' (as saved)' : ''}
+                        </option>
+                      ))}
+                    </select>
+                  </label>
+                  <small>
+                    This preset was captured with the device on SERIAL{selected.serialRemap.savedPort}. Pick the UART it is wired to on
+                    this board and the diff below is rewritten to match.
+                    {selected.serialRemap.missingOnTarget.length > 0 ? (
+                      <>
+                        {' '}
+                        <strong>
+                          {selected.serialRemap.missingOnTarget.join(', ')} do not exist on this aircraft and will be ignored.
+                        </strong>
+                      </>
+                    ) : null}
+                  </small>
+                </div>
+              ) : null}
 
               {selected.prerequisites.length > 0 ? (
                 <div className="preset-notes">
@@ -477,6 +540,18 @@ export function PresetsView(props: PresetsViewProps) {
                 >
                   Load as Manual Tuning Draft
                 </button>
+                {selected.deletable && onDeleteSelectedPreset ? (
+                  <button
+                    type="button"
+                    style={buttonStyle()}
+                    data-testid="preset-delete-button"
+                    onClick={onDeleteSelectedPreset}
+                    disabled={isBusy}
+                    title="Remove this saved preset from your browser's preset library. Nothing is written to the aircraft."
+                  >
+                    Delete preset
+                  </button>
+                ) : null}
               </div>
             </div>
           ) : null}

--- a/tests/e2e/param-group-presets.spec.ts
+++ b/tests/e2e/param-group-presets.spec.ts
@@ -1,0 +1,126 @@
+import { expect, test, type Page } from '@playwright/test'
+
+// Parameter-group presets: select rows in the Parameter Editor, answer what the
+// group depends on, save, and find it in the Presets tab with those dependencies
+// surfaced as warnings. The dependency CLASSIFIER is unit-tested exhaustively in
+// apps/web/src/view-models/preset-dependencies.test.ts; what only an e2e run can
+// prove is that the selection, the dialog, the storage round-trip, and the
+// Presets tab are actually wired to each other.
+
+const VEHICLE_CONNECT_TIMEOUT = 30_000
+
+async function connectAndOpenParameters(page: Page): Promise<void> {
+  await page.goto('/')
+  await page.getByTestId('transport-mode-select').selectOption('demo')
+  await page.getByTestId('connect-button').click()
+  await expect(page.getByTestId('session-vehicle-name')).toHaveText('ArduCopter', { timeout: VEHICLE_CONNECT_TIMEOUT })
+  // Rows stream in with the param sync; selecting before it finishes races it.
+  await expect(page.getByTestId('session-parameter-summary')).toHaveText(/^(\d+ params|Params \d+)$/, {
+    timeout: VEHICLE_CONNECT_TIMEOUT
+  })
+  await page.getByTestId('product-mode-expert').click()
+  await page.getByTestId('view-button-parameters').click()
+}
+
+test.describe('Parameter-group presets', () => {
+  test('selects a filtered group, records its dependencies, and saves a preset that appears in Presets', async ({ page }) => {
+    await page.setViewportSize({ width: 1280, height: 900 })
+    await connectAndOpenParameters(page)
+
+    // Filter to the battery family, then take every visible row. The
+    // visible-rows-only rule means this can only ever capture BATT_* params.
+    await page.getByTestId('parameter-search-input').fill('BATT_*')
+    await page.getByTestId('parameter-preset-select-all').check()
+    const createButton = page.getByTestId('parameter-create-preset')
+    await expect(createButton).not.toHaveText('Create preset (0)')
+    await createButton.click()
+
+    const dialog = page.getByTestId('create-preset-dialog')
+    await expect(dialog).toBeVisible()
+
+    // The battery-pack question must be present AND pre-ticked — the whole
+    // point is that the operator corrects an answer rather than authoring one.
+    const batteryQuestion = page.getByTestId('create-preset-dependency-battery-pack')
+    await expect(batteryQuestion).toBeChecked()
+
+    // Saving is gated on a name.
+    const save = page.getByTestId('create-preset-save')
+    await expect(save).toBeDisabled()
+    await page.getByTestId('create-preset-name').fill('6S pack thresholds')
+    await page.getByTestId('create-preset-cell-count').fill('6')
+    await expect(save).toBeEnabled()
+    await save.click()
+
+    await expect(dialog).toBeHidden()
+    await expect(page.getByTestId('parameter-notice')).toContainText('6S pack thresholds')
+
+    // The saved preset is a first-class preset: it shows up in the Presets tab's
+    // card grid and selecting it surfaces the recorded dependency.
+    await page.getByTestId('view-button-presets').click()
+    const card = page.locator('[data-testid^="preset-card-user:"]').first()
+    await expect(card).toBeVisible()
+    await expect(card).toContainText('6S pack thresholds')
+    await card.click()
+    await expect(page.getByTestId('preset-dependency-pill-Battery pack (4S / 6S, capacity)')).toBeVisible()
+    // Only operator-authored presets are deletable.
+    await expect(page.getByTestId('preset-delete-button')).toBeVisible()
+  })
+
+  test('offers a serial-port remap for a preset captured on a specific UART', async ({ page }) => {
+    await page.setViewportSize({ width: 1280, height: 900 })
+    await connectAndOpenParameters(page)
+
+    await page.getByTestId('parameter-search-input').fill('SERIAL1_*')
+    await page.getByTestId('parameter-preset-select-all').check()
+    await page.getByTestId('parameter-create-preset').click()
+
+    await expect(page.getByTestId('create-preset-dependency-serial-port')).toBeChecked()
+    await page.getByTestId('create-preset-name').fill('Telemetry on UART1')
+    await page.getByTestId('create-preset-save').click()
+
+    await page.getByTestId('view-button-presets').click()
+    await page.locator('[data-testid^="preset-card-user:"]').first().click()
+
+    const remap = page.getByTestId('preset-serial-remap')
+    await expect(remap).toBeVisible()
+    await expect(remap).toContainText('SERIAL1')
+    // Re-targeting rewrites the diff itself, so the review list the operator
+    // acknowledges is the one that will be written.
+    await page.getByTestId('preset-serial-remap-select').selectOption('2')
+    // `.first()` — the selected panel renders a changed grid and, separately, an
+    // invalid grid; the changed one is what the remap must have rewritten.
+    await expect(page.locator('.preset-selected .parameter-diff-grid').first()).toContainText('SERIAL2_')
+  })
+
+  test('keeps a selection that the filter hides, and never lets a filtered action reach it', async ({ page }) => {
+    await page.setViewportSize({ width: 1280, height: 900 })
+    await connectAndOpenParameters(page)
+
+    await page.getByTestId('parameter-search-input').fill('BATT_LOW_VOLT')
+    await page.getByTestId('parameter-preset-select-BATT_LOW_VOLT').click()
+    await expect(page.getByTestId('parameter-create-preset')).toHaveText('Create preset (1)')
+
+    // Filter it away: the row is gone, Create preset drops to 0 (it acts on
+    // visible rows only), but the selection itself survives and is reported.
+    await page.getByTestId('parameter-search-input').fill('ATC_RAT_RLL_P')
+    await expect(page.getByTestId('parameter-create-preset')).toHaveText('Create preset (0)')
+    await expect(page.getByTestId('parameter-preset-hidden-count')).toContainText('1 selected row')
+
+    // Clearing the filter brings it back.
+    await page.getByTestId('parameter-search-input').fill('BATT_LOW_VOLT')
+    await expect(page.getByTestId('parameter-create-preset')).toHaveText('Create preset (1)')
+  })
+
+  test('the create dialog fits a phone without horizontal overflow', async ({ page }) => {
+    await page.setViewportSize({ width: 390, height: 844 })
+    await connectAndOpenParameters(page)
+
+    await page.getByTestId('parameter-search-input').fill('BATT_*')
+    await page.getByTestId('parameter-preset-select-all').check()
+    await page.getByTestId('parameter-create-preset').click()
+    await expect(page.getByTestId('create-preset-dialog')).toBeVisible()
+
+    const overflow = await page.evaluate(() => document.documentElement.scrollWidth - document.documentElement.clientWidth)
+    expect(overflow).toBeLessThanOrEqual(2)
+  })
+})


### PR DESCRIPTION
> "for groups of params what i'd like to do is add that to param comparison or param editor. And then have a 'create preset button'. So select a bunch of parameters. Ask user do these depend on things likes serial port position, 4S 6S, or other easy options"

Motivation, from earlier: save "a users specified OSD, rates, tune for x type of frame, or x componant (ark flow vs some other flow)" — feeding batch builds.

## What it extends — not a fifth save-params system

This repo already had five overlapping mechanisms. The decision:

| Mechanism | Stored shape | Verdict |
|---|---|---|
| Metadata `presets` | sparse `{paramId, value}[]` + `compatibility`/`cautions` | **extended this** |
| Snapshot library | full `ParameterBackupFile` | wrong shape |
| Provisioning profiles | full backup + overlay | wrong shape |
| Tuning profiles | full backup, no envelope | wrong shape |
| Non-default filter | session-only `Set<string>` | a filter, not a record |

The curated-preset concept was already exactly "a sparse group of params", and already owned the whole apply loop — diff → applicability → per-row-droppable review → auto-backup snapshot → `runtime.setParameters` with rollback.

So **a user preset IS a `PresetDefinition`**. `user-preset-library.ts` persists it, `toPresetDefinition()` feeds the existing pipeline, and saved presets render as a "Your presets" group beside the curated ones. **No new write path.**

## Dependency detection

`view-models/preset-dependencies.ts`, 37 unit tests. Eight classes in one ordered pass, each param claimed by exactly one class so the dialog's counts cannot double-count:

`calibration` · `serial-port` · `battery-pack` · `frame` · `airframe-tune` · `output-mapping` · `sensor-hardware` · `can-bus`

- **Calibration is claimed first and excluded by default** (reversible per row), reusing core's `parameterImportExclusionCategory` so there is one list, not two.
- `serial-port` claims `SERIALn_*` only — `SERIAL_PASS*` deliberately not claimed.
- Reboot-required is a note, not a question.
- **Cell count is inferred from `MOT_BAT_VOLT_MAX / 4.2` only when it divides cleanly, and left blank otherwise.** That refusal to guess is what makes the dialog ask you the literal "4S or 6S?" question rather than quietly assuming.

**What it cannot catch**, stated plainly: params no rule names (reported as unclassified), airframe-specificity the id does not reveal, non-Copter families. It **never blocks** — every rule is a name heuristic, and `blocked` stays reserved for curated presets' human-written compatibility gate.

## The loop

Select rows in the Parameter Editor → **Create preset** → pre-ticked dependency questions plus a cell-count field → save. Apply from the Presets tab through the unchanged verified/rollback path, with the recorded context compared against the target and named concretely: *"Saved for a 6S pack; this aircraft reads as 4S."*

**Serial remap is real, not just a warning.** The transform is exact, so it is offered as an explicit port choice defaulting to the saved port, limited to UARTs the board reports, and applied *before* the diff — so the review list is what actually gets written.

Selection survives filters; Select all and Create preset act on **visible rows only** (matching bulk drop), the strip says so, and it counts hidden selected rows. Shift-click reuses the rule from `draft-selection.ts` — deliberately not `useDraftSelection`, whose pruning would empty a selection the moment you type in the search box.

## ArduCopter byte-identical

Creating a preset is read-only. Applying goes through the existing verified `setParameters` path with rollback — untouched.

## Validation

- `npm run typecheck` — clean, 11 workspaces
- `npm run test` — **855 pass / 0 fail** / 4 skipped
- `apps/web` vitest — **741 pass / 77 files** (37 new)
- `npx playwright test` full suite — **267 passed / 0 failed** / 6 skipped

**A real regression was caught during that run and fixed:** merging user presets made `presetDefinitions` a fresh array every telemetry tick (on main it is the constant `metadataCatalog.presets`), re-running the entire preset diff pipeline at telemetry rate. Found by chasing what turned out to be the unrelated notices race fixed in #166 — the wild goose chase paid for itself.

## Deliberately left out

File import/export, sharing between machines, cross-vehicle translation. All scope-inflating; the create/apply loop is what feeds batch builds. Rungs 4/5 not walked — no runtime or write-path code changed.