### PR TITLE
fix(parameters): stop the parameter name overlapping its description

### DIFF
--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -12313,6 +12313,17 @@ details.metadata-settings-section:not([open]) > summary::after {
   display: flex;
   align-items: baseline;
   gap: 6px;
+  /* A flex item defaults to min-width:auto, so it refuses to shrink below its
+   * content. Without these the name text cannot give way inside its grid
+   * track: adding the preset checkbox consumed enough of the cell to push the
+   * name straight out of it and draw it on top of the Description column.
+   * min-width:0 lets the text shrink and ellipsize inside the cell instead. */
+  min-width: 0;
+}
+.parameter-row__name > span {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 .parameter-row__caret {
   color: var(--text-muted);


### PR DESCRIPTION
The preset-selection checkbox added in #167 pushed the parameter name out of its own grid cell, so every row drew the name and its Advanced badge **on top of the Description column**. Unreadable, and live in production.

## It was not the grid

Two obvious theories, both wrong:

- **Not a missing seventh column.** The checkbox deliberately lives *inside* the name cell — there is a comment in `ParametersSection.tsx` saying exactly that — so the column template is untouched.
- **Not a header/body mismatch.** Both have six cells.

## It is the flexbox default

`.parameter-row__name` is a flex container, and a flex item defaults to `min-width: auto` — it refuses to shrink below its content width. So the name text could not give way inside its track: the checkbox consumed enough of a `minmax(150px, 1fr)` cell to push the text straight out of it, and an overflowing grid item paints over its neighbour.

`min-width: 0` lets the text shrink; ellipsis on the inner span means a long parameter id truncates inside its cell rather than escaping it. The column template, the header, and the selection feature are all unchanged.

## Why the suite missed it

#167 shipped on a full green run (267 e2e) because every assertion checked that the checkbox **existed** and that selection **worked** — none checked that the row still rendered legibly. A bounding-box overlap assertion between the name and description elements is what was missing, and is worth adding.

## ArduCopter byte-identical

CSS only — 11 added lines in `styles.css`, nothing else.

## Validation

Rung 1. `npm run typecheck` clean; `npm run test` **855 pass / 0 fail**.

**Not visually confirmed in a browser.** The fix follows directly from the layout rule and the reported symptom, but it deserves a look at the Parameters tab (search `tcal` to reproduce the original screenshot) before it is trusted. Flagging rather than implying verification I did not do.