### PR TITLE
fix(can): do not offer online firmware lookup before the node reports its hardware version

### DIFF
--- a/apps/web/src/views/CanDeviceInspector.test.ts
+++ b/apps/web/src/views/CanDeviceInspector.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest'
+
+import { canLookUpFirmwareOnline } from './CanDeviceInspector'
+
+// A DroneCAN node shows up in the device list the moment its first NodeStatus
+// broadcast arrives — seconds before its GetNodeInfo answer on a busy bus. The
+// online firmware lookup is matched purely on the APJ board id reconstructed
+// from that answer's hardware_version, so offering it in that gap can only
+// produce "this node hasn't reported its hardware version yet". This gate keeps
+// the affordance closed until the identity is genuinely in hand; it guards a
+// path that ends in flashing a peripheral, so it stays covered off the DOM.
+describe('canLookUpFirmwareOnline', () => {
+  it('stays closed until the node has answered GetNodeInfo', () => {
+    expect(canLookUpFirmwareOnline({ hwVersion: undefined })).toBe(false)
+  })
+
+  it('opens once a hardware version is in hand', () => {
+    expect(canLookUpFirmwareOnline({ hwVersion: { major: 2, minor: 1 } })).toBe(true)
+  })
+
+  it('treats a zero hardware version as reported (board id 0 is still an answer)', () => {
+    expect(canLookUpFirmwareOnline({ hwVersion: { major: 0, minor: 0 } })).toBe(true)
+  })
+})

--- a/apps/web/src/views/CanDeviceInspector.tsx
+++ b/apps/web/src/views/CanDeviceInspector.tsx
@@ -51,6 +51,15 @@ export interface DronecanFirmwareCandidate {
   latest: boolean
 }
 
+/** Whether a node can be matched against the firmware server yet. A node row
+ *  appears on its first uavcan.protocol.NodeStatus broadcast, but the online
+ *  lookup is matched on the APJ board id reconstructed from the hardware_version
+ *  in its GetNodeInfo answer — which lands later. Until it does, there is
+ *  nothing to look up, so the affordance stays closed rather than failing. */
+export function canLookUpFirmwareOnline(node: Pick<DronecanInspectedNode, 'hwVersion'>): boolean {
+  return node.hwVersion !== undefined
+}
+
 /** Online firmware lookup capability, injected by the host. Only reachable in
  *  the desktop shell (the browser can't fetch firmware.ardupilot.org — no CORS),
  *  so the browser build passes `available: false` and the UI degrades to the
@@ -241,6 +250,12 @@ function NodeFirmwareUpdate(props: {
   }
 
   const disabled = busy || anotherUpdateActive
+  // A node row appears as soon as its first NodeStatus broadcast lands, which is
+  // BEFORE its GetNodeInfo answer — and the online lookup is matched purely on
+  // the APJ board id reconstructed from that answer's hardware_version. Offering
+  // the button in that gap only ever produced "hasn't reported its hardware
+  // version yet", so hold it closed until the identity is actually in hand.
+  const identified = canLookUpFirmwareOnline(node)
 
   const pickFile = (selected: File | undefined): void => {
     setAcknowledged(false)
@@ -322,7 +337,12 @@ function NodeFirmwareUpdate(props: {
             <button
               type="button"
               style={buttonStyle()}
-              disabled={disabled || onlineBusy || downloadingUrl !== null}
+              disabled={disabled || onlineBusy || downloadingUrl !== null || !identified}
+              title={
+                identified
+                  ? undefined
+                  : 'Waiting for this device to answer GetNodeInfo — its hardware version is the match key for the firmware server.'
+              }
               onClick={findOnline}
               data-testid={`dronecan-fwupdate-online-find-${nodeId}`}
             >
@@ -331,6 +351,12 @@ function NodeFirmwareUpdate(props: {
             <span className="dronecan-inspector__fwupdate-online-id">
               {node.name ? node.name : `node #${nodeId}`}
             </span>
+            {identified ? null : (
+              <p className="telemetry-note" data-testid={`dronecan-fwupdate-online-waiting-${nodeId}`}>
+                Waiting for this device’s identity (<code>GetNodeInfo</code>) — the firmware server is matched on the
+                hardware version it reports, so the lookup can’t run until it arrives.
+              </p>
+            )}
             {onlineError ? (
               <p
                 className="dronecan-inspector__fwupdate-error"

--- a/tests/e2e/views.spec.ts
+++ b/tests/e2e/views.spec.ts
@@ -4728,9 +4728,22 @@ test.describe('Inspectors (expert-only)', () => {
     await expect(toggle).toBeVisible({ timeout: 12000 })
     await toggle.click()
 
+    // A node row appears on its first NodeStatus broadcast, which is BEFORE its
+    // GetNodeInfo answer — and the online lookup matches on the board id
+    // reconstructed from that answer's hardware_version. Wait for the identity
+    // (HW x.y in the row) before asking for a lookup that depends on it; the
+    // button is held disabled until then, and clicking in that gap is what a
+    // contended runner used to do.
+    await expect(page.getByTestId('can-bus-node-50')).toContainText('HW 2.1', { timeout: COMMAND_ACK_TIMEOUT })
+
     // Find firmware online -> the matched AP_Periph build appears.
+    await expect(page.getByTestId('dronecan-fwupdate-online-waiting-50')).toHaveCount(0)
     await page.getByTestId('dronecan-fwupdate-online-find-50').click()
     await expect(page.getByTestId('dronecan-fwupdate-online-list-50')).toBeVisible({ timeout: COMMAND_ACK_TIMEOUT })
+    // The lookup must actually have matched — never silently fall through to the
+    // "couldn't look it up" note on a path that ends in a flash.
+    await expect(page.getByTestId('dronecan-fwupdate-online-error-50')).toHaveCount(0)
+    await expect(page.getByTestId('dronecan-fwupdate-online-empty-50')).toHaveCount(0)
     await expect(page.getByTestId('dronecan-fwupdate-online-list-50')).toContainText('1.7.0')
 
     // Use the build: it downloads + decodes, then stages the image for the


### PR DESCRIPTION
CI failed on `CAN tab finds firmware online, downloads + decodes it, and updates the node`. **It is a real app defect, not a stale test** — proved from the failing run's own artifacts, not inferred.

## The proof

Pulled `playwright-results` from the failing private-repo run. Both the initial attempt and retry #1 captured the same device-row DOM:

```
- button "Find firmware online"
- text: org.ardupilot.ap_periph
- paragraph: This node hasn't reported its hardware version yet — wait for its
  identity to fill in, then try again.
```

The click landed, the lookup ran, and it **rejected**. The error paragraph rendered exactly where the test was waiting for the list — "element not found" was the list never existing because the error took its place.

## The mechanism

A node row appears on its first `uavcan.protocol.NodeStatus` broadcast. But the online lookup matches on the APJ board id reconstructed from `hardware_version`, which arrives later in the node's **GetNodeInfo** answer (`dronecanNodeBoardId(node.hwVersion)`, `App.tsx:2416`, which throws that exact string).

So there is a window where the row — and its enabled "Find firmware online" button — exists before the identity needed to use it. On a contended CI runner the click fell in that gap.

Locally the mock answers GetNodeInfo ~4 ms after the row appears, so it never reproduces — **including at 20× CDP CPU throttle**, which slows the click as much as the response. That is why the CI artifact was the only usable reproduction.

Not #154's expert-gating, not the manifest seam, not the download path.

## The fix

**Do not offer an action that cannot yet succeed.** "Find firmware online" is disabled until the node has reported a hardware version, with a `title` and a short `dronecan-fwupdate-online-waiting-<id>` note explaining it is waiting on GetNodeInfo. The existing throw stays as a backstop.

The gate is extracted as a pure exported `canLookUpFirmwareOnline(node)` with 3 unit tests (absent identity, present, zero-valued).

## The test was strengthened, not loosened

It now waits for the row to show `HW 2.1` — i.e. identity actually arrived — before clicking Find, asserts the waiting note is gone, and after the list appears asserts `online-error-50` and `online-empty-50` both have **count 0**, so the flash path can never silently proceed off a failed or empty match.

That last part matters: this is a brick-risk path, and this project has a known, deliberately-deferred DroneCAN false-success issue. Nothing was removed or relaxed.

## ArduCopter byte-identical

UI affordance only — no parameter path, no write path, no DroneCAN transfer path touched.

## Validation

- Affected test **10× before**: 10/10 locally (expected — the race needs a contended runner)
- **After: 30/30** — 10 runs each of all three CAN firmware e2e tests (online lookup, local-file update, browser degrade), `--workers=1 --retries=0`
- Full `npm run test:e2e`: **267 passed, 6 skipped, 0 failed** (8.5 m)
- `npm run test` 855 pass / 0 fail · `apps/web` vitest 744 pass · typecheck clean