### PR TITLE
feat(motors): advance the identify run as soon as the operator answers

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -264,7 +264,8 @@ import { buildRecentNotices } from './view-models/recent-notices'
 import { deriveExternalChannelClaims, deriveRcLogicChannelClaims } from './view-models/channel-usage'
 import { orderDraftsByEnableGate } from './view-models/enable-gate-write-order'
 import { deriveVtxPowerLevels } from './view-models/vtx-power-levels'
-import { invertGuidedReorderMapping, pickedReorderPositions } from './view-models/motor-reorder-mapping'
+import { invertGuidedReorderMapping } from './view-models/motor-reorder-mapping'
+import { planGuidedIdentifyAdvance } from './view-models/guided-identify-advance'
 import { LiveGpsMapCard } from './live-gps-map'
 import { DisconnectedLanding } from './disconnected-landing'
 import { FirmwareFlasher } from './firmware/FirmwareFlasher'
@@ -885,13 +886,22 @@ export function App() {
   // writes the reorder once the staged drafts have actually landed in state.
   const [pendingMotorReorderSave, setPendingMotorReorderSave] = useState(false)
   // Guided motor-identify auto-spin: after the operator spins the FIRST motor,
-  // automatically spin each subsequent motor once the previous test window has
-  // fully closed, so they only ever click the position that moved. The wait is
-  // gated on the live motor-test status (not a fixed delay) — the old timed
-  // auto-advance fired while the FC was still armed from the prior test and got
-  // rejected with "the vehicle reports armed=true".
+  // automatically spin each subsequent motor. Once the operator has clicked the
+  // position that moved, the spin has served its purpose, so the answer itself
+  // ends it — an explicit zero-throttle DO_MOTOR_TEST abort — and the next motor
+  // starts behind that stop's ACK rather than after the full test window. (The
+  // status-gated fallback below still covers the case where a spin ends without
+  // an answer, e.g. the operator re-spun and let the window lapse; a fixed timed
+  // advance used to fire while the FC was still armed from the prior test and
+  // got rejected with "the vehicle reports armed=true".)
   const [guidedReorderAutoSpin, setGuidedReorderAutoSpin] = useState(true)
   const autoSpunGuidedReorderStepRef = useRef<number | null>(null)
+  // True from the moment a position is picked until the stop+start pair for
+  // that pick has settled. A ref (not state) because the guard must be read and
+  // set synchronously inside the click handler — a re-render round trip is
+  // exactly the window a double-click slips through, and two overlapping starts
+  // would spin a motor the operator is not looking at.
+  const guidedReorderAdvanceInFlightRef = useRef(false)
   // Spin-error banner — when spinGuidedReorderStep or a manual dialog spin
   // fails (FC rejected DO_MOTOR_TEST, eligibility check failed, etc.) we
   // used to swallow the error; surface it inside the dialog so the
@@ -4390,6 +4400,7 @@ export function App() {
   function handleCloseMotorReorderDialog(): void {
     setMotorReorderDialogOpen(false)
     // Cancel any in-flight guided identify state.
+    guidedReorderAdvanceInFlightRef.current = false
     setGuidedReorderActive(false)
     setGuidedReorderStep(0)
     setGuidedReorderMapping({})
@@ -4397,38 +4408,51 @@ export function App() {
     setGuidedReorderCompleted(false)
   }
 
-  // Spin the guided-identify sequence's CURRENT output. Operator-paced
-  // (field feedback): the old flow auto-spun the next motor 400 ms after
-  // each pick, which raced the FC's previous motor-test window (ArduPilot
-  // stays armed through the test, so the rushed follow-up was rejected
-  // with "the vehicle reports armed=true") and forced the operator's
-  // tempo. Now every spin is an explicit click — including the first —
-  // and can be repeated ("Spin again") before picking a position.
-  function spinGuidedReorderStep(index: number): void {
+  // Spin one output of the guided-identify sequence. The FIRST motor is
+  // always an explicit click, and any motor can be re-spun ("Spin again")
+  // before picking a position. History worth keeping: an older flow auto-spun
+  // the next motor on a 400 ms timer after each pick, which raced the FC's
+  // still-running previous test (ArduPilot stays armed through it, so the
+  // rushed follow-up was rejected with "the vehicle reports armed=true").
+  // The advance-on-selection path avoids that by ENDING the previous test
+  // first and waiting for the abort's ACK, not by waiting on a timer.
+  //
+  // Awaitable core of a guided spin, so the advance-on-selection path can
+  // chain it behind a stop inside ONE busy window (the fire-and-forget
+  // wrapper below would clear busyAction out from under the follow-up).
+  // Resolves once the FC has ACKed the DO_MOTOR_TEST, not when the motor
+  // finishes spinning.
+  async function runGuidedReorderSpin(index: number): Promise<void> {
     const output = effectiveMotorOutputs[index]
     if (!output) {
       return
     }
     // Conservative cap — 2.5s window with low throttle so the operator
     // has time to see which motor moved without spinning long enough to
-    // overheat anything bench-mounted with props off.
+    // overheat anything bench-mounted with props off. In practice the
+    // window is now cut short by the operator's answer.
     const request = buildMotorTestRequest(output.channelNumber, 6, 2.5)
+    try {
+      await runtime.runMotorTest(request as MotorTestRequest)
+      setGuidedReorderAwaitingSpin(false)
+    } catch (error) {
+      // Surface the failure in the dialog so the operator sees WHY no
+      // motor moved. MotorTestService also records failure in the
+      // snapshot, but that's invisible from the dialog context.
+      const message = error instanceof Error ? error.message : 'Motor test failed.'
+      setMotorDialogSpinError(`OUT${output.channelNumber}: ${message}`)
+    }
+  }
+
+  function spinGuidedReorderStep(index: number): void {
+    if (!effectiveMotorOutputs[index]) {
+      return
+    }
     setMotorDialogSpinError(undefined)
     setBusyAction('motor-test')
-    void (async () => {
-      try {
-        await runtime.runMotorTest(request as MotorTestRequest)
-        setGuidedReorderAwaitingSpin(false)
-      } catch (error) {
-        // Surface the failure in the dialog so the operator sees WHY no
-        // motor moved. MotorTestService also records failure in the
-        // snapshot, but that's invisible from the dialog context.
-        const message = error instanceof Error ? error.message : 'Motor test failed.'
-        setMotorDialogSpinError(`OUT${output.channelNumber}: ${message}`)
-      } finally {
-        setBusyAction(undefined)
-      }
-    })()
+    void runGuidedReorderSpin(index).finally(() => {
+      setBusyAction(undefined)
+    })
   }
 
   function handleSpinGuidedReorderCurrent(): void {
@@ -4438,11 +4462,16 @@ export function App() {
     spinGuidedReorderStep(guidedReorderStep)
   }
 
-  // Auto-spin the NEXT motor in the guided identify sequence. Only steps after
-  // the first fire automatically (the operator kicks the sequence off with an
-  // explicit Spin), and only once the previous motor test has left the
-  // requested/running window — i.e. the FC has stopped the last motor and will
-  // accept a fresh DO_MOTOR_TEST. Safety acknowledgements are re-checked here,
+  // FALLBACK auto-spin for the NEXT motor in the guided identify sequence.
+  // The normal path is now handlePickGuidedReorderPosition, which stops the
+  // answered motor and starts the next one directly; this effect only covers
+  // an advance that reached 'awaiting spin' WITHOUT going through that path
+  // (e.g. a re-spun window that lapsed unanswered). It fires only for steps
+  // after the first (the operator kicks the sequence off with an explicit
+  // Spin), only once the previous motor test has left the requested/running
+  // window — i.e. the FC has stopped the last motor and will accept a fresh
+  // DO_MOTOR_TEST — and never for a step the direct path already claimed via
+  // autoSpunGuidedReorderStepRef. Safety acknowledgements are re-checked here,
   // so un-ticking props-off / area-clear mid-sequence pauses the auto-spin
   // instead of spinning a motor unattended.
   useEffect(() => {
@@ -4489,6 +4518,8 @@ export function App() {
     if (!propsRemovedAcknowledged || !testAreaAcknowledged) {
       return
     }
+    guidedReorderAdvanceInFlightRef.current = false
+    autoSpunGuidedReorderStepRef.current = null
     setGuidedReorderActive(true)
     setGuidedReorderStep(0)
     setGuidedReorderMapping({})
@@ -4498,6 +4529,7 @@ export function App() {
   }
 
   function handleCancelGuidedReorder(): void {
+    guidedReorderAdvanceInFlightRef.current = false
     setGuidedReorderActive(false)
     setGuidedReorderStep(0)
     setGuidedReorderMapping({})
@@ -4505,36 +4537,52 @@ export function App() {
     void runtime.stopMotorTest().catch(() => {})
   }
 
+  /**
+   * The operator answered "that position moved" — so the motor spinning right
+   * now has done its job and every remaining millisecond of its window is dead
+   * time. Stop it immediately and move on.
+   *
+   * Exact sequence on a selection, in this order and no other:
+   *   1. Record the pick + advance the step (synchronous, so the picked
+   *      position locks before any await and a repeat click can't re-answer).
+   *   2. DO_MOTOR_TEST param1=1, throttle_type=PERCENT, throttle=0, duration=0
+   *      — the same hardware-verified zero-throttle abort the Cancel/Stop path
+   *      sends — and AWAIT its COMMAND_ACK.
+   *   3. Only then start the next output's DO_MOTOR_TEST.
+   *
+   * The stop is awaited rather than fired-and-forgotten because the ACK is the
+   * only evidence the FC took the abort, and the round trip is one link RTT
+   * (bench-measured stop-to-idle: 1150 -> 1000 µs in 19 ms). ArduCopter's motor
+   * test is single-state, so a new start would in fact replace the old one —
+   * but that is a property of one firmware, not a stop, so it is not leaned on.
+   * If the abort goes unacknowledged we start NOTHING and say so: the FC's own
+   * per-motor timeout is still the hard safety net.
+   */
   function handlePickGuidedReorderPosition(clickedMotorNumber: number): void {
-    if (!guidedReorderActive) {
+    const plan = planGuidedIdentifyAdvance({
+      active: guidedReorderActive,
+      advanceInFlight: guidedReorderAdvanceInFlightRef.current,
+      step: guidedReorderStep,
+      outputChannels: effectiveMotorOutputs.map((output) => output.channelNumber),
+      mapping: guidedReorderMapping,
+      clickedMotorPosition: clickedMotorNumber,
+      autoSpin: guidedReorderAutoSpin,
+      // Re-read the acks at answer time: a run whose acknowledgement was
+      // withdrawn mid-sequence stops the current motor but starts nothing.
+      safetyAcknowledged: propsRemovedAcknowledged && testAreaAcknowledged
+    })
+    if (plan.kind === 'ignore') {
       return
     }
-    const currentOutput = effectiveMotorOutputs[guidedReorderStep]
-    if (!currentOutput) {
-      return
-    }
-    // Backstop the UI's already-picked lock: a position claimed by an
-    // earlier output must never be reassigned (it would drop a motor and
-    // silently mis-map the reorder). Ignore the stray click rather than
-    // corrupt the mapping.
-    if (pickedReorderPositions(guidedReorderMapping).has(clickedMotorNumber)) {
-      return
-    }
-    // Record: this output should drive the motor at the physical position
-    // the operator just clicked. mapping[OUTn] = clickedMotorNumber.
-    const nextMapping = {
-      ...guidedReorderMapping,
-      [String(currentOutput.channelNumber)]: clickedMotorNumber
-    }
-    setGuidedReorderMapping(nextMapping)
-    const nextStep = guidedReorderStep + 1
-    if (nextStep >= effectiveMotorOutputs.length) {
+
+    setGuidedReorderMapping(plan.nextMapping)
+    if (plan.kind === 'complete') {
       // All outputs identified. Invert the output→position identify map
       // into the reorder table's motor→output selections (pure + tested
       // in motor-reorder-mapping.ts), so Stage Reorder writes the
       // SERVOn_FUNCTION drafts that make every physical position drive
       // its expected motor number.
-      setMotorReorderSelections(invertGuidedReorderMapping(nextMapping))
+      setMotorReorderSelections(invertGuidedReorderMapping(plan.nextMapping))
       setGuidedReorderActive(false)
       setGuidedReorderStep(0)
       setGuidedReorderAwaitingSpin(false)
@@ -4542,11 +4590,47 @@ export function App() {
       // "no changes needed" note when the order already matches.
       setGuidedReorderCompleted(true)
     } else {
-      // No auto-spin: advance and wait for the operator's explicit Spin
-      // click at their own pace.
-      setGuidedReorderStep(nextStep)
+      setGuidedReorderStep(plan.nextStep)
       setGuidedReorderAwaitingSpin(true)
+      if (plan.startStep !== undefined) {
+        // Claim the step for the direct start so the status-gated auto-spin
+        // effect can never fire a second DO_MOTOR_TEST for it.
+        autoSpunGuidedReorderStepRef.current = plan.startStep
+      }
     }
+
+    const startStep = plan.kind === 'advance' ? plan.startStep : undefined
+    guidedReorderAdvanceInFlightRef.current = true
+    setMotorDialogSpinError(undefined)
+    // One busy window covers stop + start, so nothing else (including the
+    // Spin button) can inject a motor command between the two.
+    setBusyAction('motor-test')
+    void (async () => {
+      try {
+        const stopped = await runtime.stopMotorTest()
+        if (stopped.sent && !stopped.acknowledged) {
+          // Unproven stop — refuse to add a second motor command on top of an
+          // FC state we cannot vouch for. Same surfacing as any other guided
+          // spin failure so the operator sees why the sequence paused.
+          setMotorDialogSpinError(
+            'Stopping the spinning motor was not acknowledged, so the next motor was not started. The autopilot still stops it on its own timeout — check the motor is idle, then click Spin.'
+          )
+          return
+        }
+        if (startStep !== undefined) {
+          await runGuidedReorderSpin(startStep)
+        }
+      } catch (error) {
+        // stopMotorTest swallows a rejected abort into `acknowledged: false`,
+        // so anything thrown here is unexpected — still never chain a start
+        // onto it; report and stop the sequence.
+        const message = error instanceof Error ? error.message : 'Stopping the motor test failed.'
+        setMotorDialogSpinError(`${message} The next motor was not started.`)
+      } finally {
+        setBusyAction(undefined)
+        guidedReorderAdvanceInFlightRef.current = false
+      }
+    })()
   }
 
   /**

--- a/apps/web/src/sections/MotorReorderDialog.tsx
+++ b/apps/web/src/sections/MotorReorderDialog.tsx
@@ -45,11 +45,12 @@ export interface MotorReorderDialogProps {
   guidedReorderStep: number
   guidedReorderMapping: Record<string, number>
   /** True while waiting for a motor to spin. The first motor waits for an
-   *  explicit Spin click; when auto-spin is on, later motors spin themselves
-   *  once the previous test window closes (gated on the live motor-test
-   *  status so it can't race the FC's still-armed test). */
+   *  explicit Spin click; when auto-spin is on, picking a position stops the
+   *  motor that just spun and starts the next one behind that stop's ACK. */
   guidedReorderAwaitingSpin: boolean
-  /** When true, each motor after the first spins automatically on advance. */
+  /** When true, picking a position starts the next motor immediately after
+   *  stopping the answered one. When false the answered motor is still
+   *  stopped — only the follow-up spin waits for a manual click. */
   guidedReorderAutoSpin: boolean
   /** True once an identify sequence finished this dialog session. Gates
    *  the Stage button's primary emphasis and the no-changes note. */
@@ -312,14 +313,14 @@ export function MotorReorderDialog({
                         <strong>OUT{effectiveMotorOutputs[guidedReorderStep]?.channelNumber ?? '?'}</strong>
                         {' '}({guidedReorderStep + 1} / {effectiveMotorOutputs.length}) —{' '}
                         {guidedReorderAutoSpin && guidedReorderStep > 0
-                          ? 'auto-spinning as soon as the previous motor stops (or Spin now).'
+                          ? 'spinning now (or click Spin).'
                           : 'click Spin when ready.'}
                       </>
                     ) : (
                       <>
                         <strong>OUT{effectiveMotorOutputs[guidedReorderStep]?.channelNumber ?? '?'} spun</strong>
                         {' '}({guidedReorderStep + 1} / {effectiveMotorOutputs.length}). Click the position that moved
-                        {guidedReorderAutoSpin ? ' — the next motor then spins automatically.' : ', or Spin again.'}
+                        {guidedReorderAutoSpin ? ' — that stops this motor and spins the next one.' : ', or Spin again.'}
                       </>
                     )}
                   </p>
@@ -354,7 +355,7 @@ export function MotorReorderDialog({
                       checked={guidedReorderAutoSpin}
                       onChange={(event) => onToggleGuidedReorderAutoSpin(event.target.checked)}
                     />
-                    <span>Auto-spin each motor after the first (uncheck to spin every motor by hand)</span>
+                    <span>Spin the next motor as soon as you pick a position (uncheck to spin every motor by hand)</span>
                   </label>
                 </div>
               ) : (

--- a/apps/web/src/view-models/guided-identify-advance.test.ts
+++ b/apps/web/src/view-models/guided-identify-advance.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, it } from 'vitest'
+
+import { planGuidedIdentifyAdvance, type GuidedIdentifyAdvanceInput } from './guided-identify-advance'
+
+// A four-motor quad on OUT1..OUT4, mid-run on the first output, everything
+// acknowledged. Individual cases override only what they are about.
+function input(overrides: Partial<GuidedIdentifyAdvanceInput> = {}): GuidedIdentifyAdvanceInput {
+  return {
+    active: true,
+    advanceInFlight: false,
+    step: 0,
+    outputChannels: [1, 2, 3, 4],
+    mapping: {},
+    clickedMotorPosition: 3,
+    autoSpin: true,
+    safetyAcknowledged: true,
+    ...overrides
+  }
+}
+
+describe('planGuidedIdentifyAdvance', () => {
+  it('records the pick and starts the next output behind the stop', () => {
+    expect(planGuidedIdentifyAdvance(input())).toEqual({
+      kind: 'advance',
+      // OUT1 moved the motor at frame position 3.
+      nextMapping: { 1: 3 },
+      nextStep: 1,
+      startStep: 1
+    })
+  })
+
+  it('carries earlier picks forward without disturbing them', () => {
+    expect(
+      planGuidedIdentifyAdvance(input({ step: 2, mapping: { 1: 3, 2: 1 }, clickedMotorPosition: 4 }))
+    ).toEqual({
+      kind: 'advance',
+      nextMapping: { 1: 3, 2: 1, 3: 4 },
+      nextStep: 3,
+      startStep: 3
+    })
+  })
+
+  it('the LAST output completes the run and starts nothing', () => {
+    // Nothing may spin after the final answer — the plan carries no start.
+    const plan = planGuidedIdentifyAdvance(
+      input({ step: 3, mapping: { 1: 3, 2: 1, 3: 4 }, clickedMotorPosition: 2 })
+    )
+    expect(plan).toEqual({ kind: 'complete', nextMapping: { 1: 3, 2: 1, 3: 4, 4: 2 } })
+    expect('startStep' in plan).toBe(false)
+  })
+
+  it('a single-motor frame completes on the very first pick', () => {
+    expect(planGuidedIdentifyAdvance(input({ outputChannels: [7], clickedMotorPosition: 1 }))).toEqual({
+      kind: 'complete',
+      nextMapping: { 7: 1 }
+    })
+  })
+
+  it('still stops but does not start when auto-spin is off', () => {
+    // The answered spin is pointless either way; only the follow-up start is
+    // the operator's preference.
+    expect(planGuidedIdentifyAdvance(input({ autoSpin: false }))).toEqual({
+      kind: 'advance',
+      nextMapping: { 1: 3 },
+      nextStep: 1,
+      startStep: undefined
+    })
+  })
+
+  it('never starts the next motor once the safety ack is withdrawn', () => {
+    expect(planGuidedIdentifyAdvance(input({ safetyAcknowledged: false }))).toMatchObject({
+      kind: 'advance',
+      startStep: undefined
+    })
+  })
+
+  it('drops a second click while the previous stop/start pair is in flight', () => {
+    // Two starts racing would spin an unexpected motor. This is the
+    // double-click / impatient-repeat guard.
+    expect(planGuidedIdentifyAdvance(input({ advanceInFlight: true }))).toEqual({
+      kind: 'ignore',
+      reason: 'advance-in-flight'
+    })
+  })
+
+  it('ignores clicks when no identify run is active', () => {
+    expect(planGuidedIdentifyAdvance(input({ active: false }))).toEqual({
+      kind: 'ignore',
+      reason: 'inactive'
+    })
+  })
+
+  it('ignores a click when the step has no output (state raced away)', () => {
+    expect(planGuidedIdentifyAdvance(input({ step: 4 }))).toEqual({
+      kind: 'ignore',
+      reason: 'no-current-output'
+    })
+  })
+
+  it('refuses to reassign a position an earlier output already claimed', () => {
+    // Overwriting a claimed position would drop a motor from the permutation.
+    expect(planGuidedIdentifyAdvance(input({ step: 1, mapping: { 1: 3 }, clickedMotorPosition: 3 }))).toEqual({
+      kind: 'ignore',
+      reason: 'position-already-picked'
+    })
+  })
+
+  it('a full run over every output yields a bijective mapping and exactly one completion', () => {
+    // Walk the whole sequence the way App.tsx does, asserting that exactly
+    // the last pick completes and every intermediate pick advances by one.
+    let mapping = {}
+    let step = 0
+    const positions = [3, 1, 4, 2]
+    const completions: number[] = []
+    positions.forEach((clickedMotorPosition, index) => {
+      const plan = planGuidedIdentifyAdvance(input({ step, mapping, clickedMotorPosition }))
+      if (plan.kind === 'complete') {
+        completions.push(index)
+        mapping = plan.nextMapping
+        return
+      }
+      expect(plan.kind).toBe('advance')
+      if (plan.kind !== 'advance') {
+        return
+      }
+      expect(plan.nextStep).toBe(step + 1)
+      expect(plan.startStep).toBe(step + 1)
+      mapping = plan.nextMapping
+      step = plan.nextStep
+    })
+    expect(completions).toEqual([3])
+    expect(mapping).toEqual({ 1: 3, 2: 1, 3: 4, 4: 2 })
+  })
+})

--- a/apps/web/src/view-models/guided-identify-advance.ts
+++ b/apps/web/src/view-models/guided-identify-advance.ts
@@ -1,0 +1,106 @@
+// Guided motor-identify "advance on selection" state machine, kept pure so
+// the ordering it dictates can be unit-tested off the runtime. An ordering
+// bug here spins the WRONG motor (or two at once), so every branch is
+// enumerated and locked by guided-identify-advance.test.ts.
+//
+// WHY this exists: identify used to leave the motor spinning for the whole
+// test window after the operator had already answered "that one moved". The
+// answer ends the spin's usefulness, so the flow now stops the motor the
+// instant the position is picked and starts the next one behind that stop.
+//
+// The plan this returns is deliberately declarative — App.tsx executes it in
+// a fixed order (record mapping -> stop -> await ACK -> start next). Keeping
+// the decision separate from the I/O is what makes the ordering testable.
+
+import { pickedReorderPositions, type GuidedReorderMapping } from './motor-reorder-mapping'
+
+export interface GuidedIdentifyAdvanceInput {
+  /** Is a guided identify run in progress? */
+  active: boolean
+  /** True while a previous selection's stop/start pair is still in flight.
+   *  Double-clicks and impatient repeat clicks land here — two starts racing
+   *  would spin an unexpected motor, so the second click is dropped. */
+  advanceInFlight: boolean
+  /** Index into `outputChannels` of the output currently being identified. */
+  step: number
+  /** Output channel numbers in identify order (effectiveMotorOutputs). */
+  outputChannels: number[]
+  /** Accumulated outputChannel -> clicked motor position map. */
+  mapping: GuidedReorderMapping
+  /** The frame position the operator just clicked. */
+  clickedMotorPosition: number
+  /** Operator's "auto-spin each motor after the first" preference. With it
+   *  off, a selection still STOPS the pointless spin — it just doesn't start
+   *  the next motor, leaving the operator their manual Spin click. */
+  autoSpin: boolean
+  /** Props-off AND area-clear, re-read at selection time. A run that lost its
+   *  acknowledgement mid-sequence stops the current motor but starts nothing. */
+  safetyAcknowledged: boolean
+}
+
+export type GuidedIdentifyAdvanceIgnoreReason =
+  | 'inactive'
+  | 'advance-in-flight'
+  | 'no-current-output'
+  | 'position-already-picked'
+
+export type GuidedIdentifyAdvancePlan =
+  | { kind: 'ignore'; reason: GuidedIdentifyAdvanceIgnoreReason }
+  | {
+      /** More outputs remain: record the pick, stop the spinning motor, and
+       *  (when allowed) start `startStep` once the stop is acknowledged. */
+      kind: 'advance'
+      nextMapping: GuidedReorderMapping
+      nextStep: number
+      /** Index to spin after the stop, or undefined to wait for a manual
+       *  Spin click (auto-spin off, or the safety ack was withdrawn). */
+      startStep: number | undefined
+    }
+  | {
+      /** Last output identified: stop the spinning motor and start NOTHING. */
+      kind: 'complete'
+      nextMapping: GuidedReorderMapping
+    }
+
+/**
+ * Decide what a click on a frame position during guided identify should do.
+ * Pure: no timers, no I/O, no snapshot reads — the caller supplies the live
+ * safety/busy facts as plain booleans.
+ */
+export function planGuidedIdentifyAdvance(input: GuidedIdentifyAdvanceInput): GuidedIdentifyAdvancePlan {
+  const { active, advanceInFlight, step, outputChannels, mapping, clickedMotorPosition } = input
+
+  if (!active) {
+    return { kind: 'ignore', reason: 'inactive' }
+  }
+  // Ordering guard, not a cosmetic debounce: while the stop for the previous
+  // pick is still on the wire, a second pick would queue a second start.
+  if (advanceInFlight) {
+    return { kind: 'ignore', reason: 'advance-in-flight' }
+  }
+  const currentOutputChannel = outputChannels[step]
+  if (currentOutputChannel === undefined) {
+    return { kind: 'ignore', reason: 'no-current-output' }
+  }
+  // Backstop the UI's already-picked lock: reassigning a claimed position
+  // would drop a motor and silently mis-map the reorder.
+  if (pickedReorderPositions(mapping).has(clickedMotorPosition)) {
+    return { kind: 'ignore', reason: 'position-already-picked' }
+  }
+
+  const nextMapping: GuidedReorderMapping = {
+    ...mapping,
+    [String(currentOutputChannel)]: clickedMotorPosition
+  }
+  const nextStep = step + 1
+  if (nextStep >= outputChannels.length) {
+    return { kind: 'complete', nextMapping }
+  }
+
+  return {
+    kind: 'advance',
+    nextMapping,
+    nextStep,
+    startStep: input.autoSpin && input.safetyAcknowledged ? nextStep : undefined
+  }
+}

--- a/packages/ardupilot-core/src/runtime-motor-test-service.ts
+++ b/packages/ardupilot-core/src/runtime-motor-test-service.ts
@@ -12,6 +12,7 @@ import type {
   ConfiguratorSnapshot,
   MotorTestRequest,
   MotorTestState,
+  MotorTestStopResult,
   StatusTextEntry
 } from './types.js'
 
@@ -203,10 +204,18 @@ export class MotorTestService {
    * Operator-initiated early abort via a zero-throttle DO_MOTOR_TEST (the
    * FC's per-motor timeout remains the hard safety net). Best-effort: a
    * failed abort is surfaced rather than thrown.
+   *
+   * Returns whether the abort reached the wire and whether it was ACKed, so
+   * a caller that wants to start ANOTHER motor immediately behind the stop
+   * (guided identify's advance-on-selection) can refuse to do so while the
+   * previous motor's state is unproven. The wire behaviour is unchanged —
+   * this only stops throwing the evidence away.
    */
-  async stop(): Promise<void> {
+  async stop(): Promise<MotorTestStopResult> {
     if (!this.hasActiveTest()) {
-      return
+      // Nothing running: either it never started or the FC's own per-motor
+      // timeout already ended it. No command to send, nothing unproven.
+      return { sent: false, acknowledged: true }
     }
     this.clearCompletionTimer()
     let acknowledged = true
@@ -236,6 +245,7 @@ export class MotorTestService {
         : 'Motor test stop sent but not acknowledged; the autopilot per-motor timeout still applies.'
     )
     this.host.emit()
+    return { sent: true, acknowledged }
   }
 
   private scheduleCompletion(): void {

--- a/packages/ardupilot-core/src/runtime.ts
+++ b/packages/ardupilot-core/src/runtime.ts
@@ -44,6 +44,7 @@ import type {
   ConfiguratorSnapshot,
   GuidedActionState,
   MotorTestRequest,
+  MotorTestStopResult,
   PreArmIssueState,
   PreArmStatusState,
   ParameterBatchWriteResult,
@@ -1427,8 +1428,10 @@ export class ArduPilotConfiguratorRuntime {
     return this.motorTestService.run(request, options)
   }
 
-  /** Operator-initiated early abort of an in-flight motor test. */
-  async stopMotorTest(): Promise<void> {
+  /** Operator-initiated early abort of an in-flight motor test. Resolves
+   *  with whether the zero-throttle abort was sent and ACKed, so callers
+   *  chaining a follow-up spin can refuse to start one on an unproven stop. */
+  async stopMotorTest(): Promise<MotorTestStopResult> {
     return this.motorTestService.stop()
   }
 

--- a/packages/ardupilot-core/src/types.ts
+++ b/packages/ardupilot-core/src/types.ts
@@ -449,6 +449,23 @@ export interface MotorTestState {
   completedAtMs?: number
 }
 
+/**
+ * Outcome of an operator-initiated motor-test abort. Callers that chain
+ * another spin behind the stop (the guided-identify advance) MUST NOT
+ * start the next motor unless the abort was acknowledged — an unACKed
+ * stop means we have no evidence the previous motor was commanded down,
+ * and a fresh DO_MOTOR_TEST would then be racing an unknown FC state.
+ */
+export interface MotorTestStopResult {
+  /** True when an abort command was actually put on the wire. False when
+   *  there was no active test to stop (nothing to prove, nothing racing). */
+  sent: boolean
+  /** True when the autopilot COMMAND_ACKed the zero-throttle abort. Always
+   *  true when `sent` is false, so `sent && !acknowledged` is the single
+   *  "the stop is unproven" condition. */
+  acknowledged: boolean
+}
+
 export interface MotorTestRequest {
   outputChannel?: number
   /** Spin every mapped motor ONE AT A TIME in test-order sequence. */

--- a/tests/e2e/app.spec.ts
+++ b/tests/e2e/app.spec.ts
@@ -374,12 +374,41 @@ test.describe('browser configurator regression flows', () => {
     await page.getByTestId('motor-reorder-guided-spin').click()
     await expect(banner).toContainText(/OUT\d+ spun/, { timeout: COMMAND_ACK_TIMEOUT })
 
-    // Picking a position advances to the next output and — with auto-spin on —
-    // spins it automatically once the previous motor's test window closes, so
-    // the operator never has to click Spin again.
+    // Picking a position is the operator's answer, so the spin has served its
+    // purpose: it is stopped with a zero-throttle abort and the next output
+    // starts behind that stop's ACK — no waiting out the rest of the window.
+    const pickedAtMs = Date.now()
     await page.getByTestId('motor-reorder-pick-1').click()
     await expect(banner).toContainText('2 / 4')
     await expect(banner).toContainText(/OUT\d+ spun/, { timeout: COMMAND_ACK_TIMEOUT })
+    // The old flow could only advance after the full 2.5 s test window closed.
+    // A generous ceiling — this asserts "did not wait out the window", not a
+    // latency budget.
+    expect(Date.now() - pickedAtMs).toBeLessThan(2500)
+
+    // A second click on an already-claimed position is ignored: the run stays
+    // on output 2 rather than re-answering or firing a second spin.
+    await expect(page.getByTestId('motor-reorder-pick-1')).toHaveCount(0)
+    await expect(banner).toContainText('2 / 4')
+
+    // Picking the LAST outputs finishes the run — and nothing spins after the
+    // final answer (the banner is gone, so there is no "spun" state to reach).
+    await page.getByTestId('motor-reorder-pick-2').click()
+    await expect(banner).toContainText('3 / 4')
+    await expect(banner).toContainText(/OUT\d+ spun/, { timeout: COMMAND_ACK_TIMEOUT })
+    await page.getByTestId('motor-reorder-pick-3').click()
+    await expect(banner).toContainText('4 / 4')
+    await expect(banner).toContainText(/OUT\d+ spun/, { timeout: COMMAND_ACK_TIMEOUT })
+    await page.getByTestId('motor-reorder-pick-4').click()
+    await expect(banner).toHaveCount(0)
+    await expect(page.getByTestId('motor-reorder-next-direction')).toBeVisible()
+    await expect(page.getByTestId('motor-reorder-guided-start')).toBeVisible()
+
+    // Re-open a run so the remaining mid-sequence assertions below still have
+    // one in progress.
+    await page.getByTestId('motor-reorder-guided-start').click()
+    await expect(banner).toBeVisible()
+    await expect(banner).toContainText('1 / 4')
 
     // The hand-off to Direction only appears once a run COMPLETES — identifying
     // the order is only half the job (the order can be right while a motor

--- a/tests/runtime.integration.test.mjs
+++ b/tests/runtime.integration.test.mjs
@@ -1809,7 +1809,10 @@ test('stopMotorTest aborts an in-flight test with a zero-throttle command and cl
     await runtime.runMotorTest({ outputChannel: 1, throttlePercent: 5, durationSeconds: 2 })
     assert.equal(runtime.getSnapshot().motorTest.status, 'running')
 
-    await runtime.stopMotorTest()
+    const stopResult = await runtime.stopMotorTest()
+    // The guided-identify advance chains the NEXT motor's start behind this
+    // result, so the ACK evidence must survive the call, not just the summary.
+    assert.deepEqual(stopResult, { sent: true, acknowledged: true })
 
     const motorTestCommands = sentMessages.filter(
       (message) => message.type === 'COMMAND_LONG' && message.command === MAV_CMD.DO_MOTOR_TEST
@@ -1825,6 +1828,37 @@ test('stopMotorTest aborts an in-flight test with a zero-throttle command and cl
     // 2s window the state must NOT flip to 'succeeded'.
     await sleep(2400)
     assert.equal(runtime.getSnapshot().motorTest.status, 'failed', 'no late completion-timer flip after a stop')
+  } finally {
+    await runtime.disconnect().catch(() => {})
+    runtime.destroy()
+  }
+})
+
+test('stopMotorTest with nothing running sends no command and still reports a settled state', async () => {
+  // The guided-identify advance calls stop unconditionally on every pick; when
+  // the FC's own per-motor timeout already ended the spin there is nothing to
+  // abort, and that must NOT read as an unproven stop (which would refuse to
+  // start the next motor) nor put a stray DO_MOTOR_TEST on the wire.
+  const sentMessages = []
+  const runtime = new ArduPilotConfiguratorRuntime(
+    createMotorTestAckSession(
+      { FLTMODE1: 0, FRAME_CLASS: 1, FRAME_TYPE: 12, SERVO1_FUNCTION: 33, SERVO2_FUNCTION: 34, SERVO3_FUNCTION: 35, SERVO4_FUNCTION: 36 },
+      sentMessages
+    ),
+    arducopterMetadata
+  )
+
+  try {
+    await runtime.connect()
+    await runtime.requestParameterList({ timeoutMs: 200 })
+    await runtime.waitForParameterSync({ timeoutMs: 200 })
+
+    const stopResult = await runtime.stopMotorTest()
+    assert.deepEqual(stopResult, { sent: false, acknowledged: true })
+    const motorTestCommands = sentMessages.filter(
+      (message) => message.type === 'COMMAND_LONG' && message.command === MAV_CMD.DO_MOTOR_TEST
+    )
+    assert.equal(motorTestCommands.length, 0, 'no DO_MOTOR_TEST is sent when no test is active')
   } finally {
     await runtime.disconnect().catch(() => {})
     runtime.destroy()

--- a/tests/runtime.sitl.test.mjs
+++ b/tests/runtime.sitl.test.mjs
@@ -269,3 +269,176 @@ test('true SITL: the rangefinder + optical-flow streams are accepted and arrive'
     await sitl?.stop().catch(() => {})
   }
 })
+
+/**
+ * SERVO_OUTPUT_RAW (msgid 36) is not in the configurator's codec, so this
+ * test scans the raw transport frames for it. Enough of the MAVLink v2 frame
+ * to find one message: STX 0xFD, len@1, incompat@2, msgid (3 bytes LE) @7,
+ * payload @10. A wrongly-synced start byte is harmless here — it can only
+ * fail to produce a msgid-36 reading, never fabricate one, because the
+ * payload we read is the one the length field delimited.
+ */
+function observeServoOutputRaw(transport, onSample) {
+  let buffer = new Uint8Array(0)
+  return transport.onFrame((chunk) => {
+    const merged = new Uint8Array(buffer.length + chunk.length)
+    merged.set(buffer)
+    merged.set(chunk, buffer.length)
+    buffer = merged
+
+    let index = 0
+    while (index < buffer.length) {
+      if (buffer[index] !== 0xfd) {
+        index += 1
+        continue
+      }
+      if (buffer.length - index < 12) {
+        break // partial header — wait for more bytes
+      }
+      const payloadLength = buffer[index + 1]
+      const signed = (buffer[index + 2] & 0x01) === 0x01
+      const frameLength = 12 + payloadLength + (signed ? 13 : 0)
+      if (buffer.length - index < frameLength) {
+        break
+      }
+      const messageId = buffer[index + 7] | (buffer[index + 8] << 8) | (buffer[index + 9] << 16)
+      // MAVLink v2 truncates trailing zero bytes, and a quad leaves servo5+
+      // at zero — SITL's SERVO_OUTPUT_RAW arrives as just 12 bytes
+      // (time_usec + servo1..4), which is exactly what this reads.
+      if (messageId === 36 && payloadLength >= 12) {
+        const payload = buffer.subarray(index + 10, index + 10 + payloadLength)
+        const view = new DataView(payload.buffer, payload.byteOffset, payload.byteLength)
+        onSample({
+          atMs: Date.now(),
+          // servo1_raw..servo8_raw are uint16 LE starting at offset 4.
+          servos: [0, 1, 2, 3].map((slot) => view.getUint16(4 + slot * 2, true))
+        })
+      }
+      index += frameLength
+    }
+    buffer = buffer.subarray(index)
+  })
+}
+
+// Rung 4 for the guided-identify "advance on selection" change. The mock
+// runtime can prove the commands are SENT in order; only a real autopilot can
+// prove the STOP takes effect on the outputs before the next motor starts.
+// So: spin OUT1, abort it mid-window with the zero-throttle DO_MOTOR_TEST,
+// watch OUT1 fall back to idle, then start OUT2 and assert OUT1 was already
+// idle before OUT2 ever rose.
+test('true SITL: a zero-throttle abort drops the spinning output before the next motor starts', { timeout: 240000 }, async (t) => {
+  const repoPath = process.env.ARDUPILOT_REPO_PATH
+  const attachHost = process.env.ARDUPILOT_SITL_HOST
+  const attachPort = Number(process.env.ARDUPILOT_SITL_PORT ?? '5760')
+  const launchWaitPort = Number(process.env.ARDUPILOT_SITL_LAUNCH_WAIT_PORT ?? '5760')
+
+  if (!repoPath && !attachHost) {
+    t.skip('Set ARDUPILOT_REPO_PATH to launch SITL, or ARDUPILOT_SITL_HOST/PORT to attach to an existing endpoint.')
+    return
+  }
+
+  let sitl
+  if (repoPath) {
+    sitl = await launchArduPilotDirectBinary({
+      repoPath,
+      vehicle: process.env.ARDUPILOT_SITL_VEHICLE ?? 'ArduCopter',
+      frame: process.env.ARDUPILOT_SITL_FRAME ?? 'quad',
+      port: launchWaitPort,
+      launchTimeoutMs: Number(process.env.ARDUPILOT_SITL_LAUNCH_TIMEOUT_MS ?? '120000')
+    })
+  }
+
+  const transport = new TcpTransport('sitl-motor-advance-tcp', {
+    host: attachHost ?? '127.0.0.1',
+    port: attachPort,
+    connectTimeoutMs: 10000
+  })
+  const session = new MavlinkSession(transport, new MavlinkV2Codec())
+  const runtime = new ArduPilotConfiguratorRuntime(session, arducopterMetadata, {})
+
+  const samples = []
+  let unsubscribe
+  try {
+    await runtime.connect()
+    await runtime.waitForVehicle({ timeoutMs: 20000 })
+    await runtime.requestParameterList({ timeoutMs: 20000 })
+    await runtime.waitForParameterSync({ timeoutMs: 60000 })
+
+    unsubscribe = observeServoOutputRaw(transport, (sample) => samples.push(sample))
+    // 20 Hz, so the gap between "OUT1 still high" and "OUT2 high" is measured
+    // finely enough to be meaningful.
+    await runtime.requestMessageInterval(36, 50000)
+    await new Promise((resolve) => setTimeout(resolve, 1500))
+
+    const baseline = samples.at(-1)
+    assert.ok(baseline, 'No SERVO_OUTPUT_RAW arrived from SITL.')
+    const idleOut1 = baseline.servos[0]
+    const idleOut2 = baseline.servos[1]
+    // Comfortably above PWM jitter, far below the ~1060 µs a 6% test drives.
+    const spinThreshold = 25
+    const isHigh = (sample, slot, idle) => sample.servos[slot] > idle + spinThreshold
+
+    // A deliberately LONG window: if the abort did not take effect, OUT1 would
+    // still be spinning when OUT2 starts, and the ordering assertion below
+    // would fail rather than being masked by a short natural timeout.
+    const durationSeconds = 5
+    await runtime.runMotorTest({ outputChannel: 1, throttlePercent: 6, durationSeconds })
+
+    const waitFor = async (predicate, timeoutMs, description) => {
+      const deadline = Date.now() + timeoutMs
+      while (Date.now() < deadline) {
+        const sample = samples.at(-1)
+        if (sample && predicate(sample)) {
+          return sample
+        }
+        await new Promise((resolve) => setTimeout(resolve, 20))
+      }
+      throw new Error(`Timed out waiting for ${description}.`)
+    }
+
+    const spinning = await waitFor((sample) => isHigh(sample, 0, idleOut1), 5000, 'OUT1 to spin up')
+    t.diagnostic(`OUT1 spun up to ${spinning.servos[0]} µs (idle ${idleOut1} µs).`)
+
+    const stopRequestedAtMs = Date.now()
+    const stopResult = await runtime.stopMotorTest()
+    assert.deepEqual(stopResult, { sent: true, acknowledged: true }, 'SITL did not ACK the zero-throttle abort.')
+    const stoppedAtMs = Date.now()
+
+    const idled = await waitFor((sample) => !isHigh(sample, 0, idleOut1), 3000, 'OUT1 to fall back to idle')
+    const stopLatencyMs = idled.atMs - stopRequestedAtMs
+    t.diagnostic(
+      `OUT1 back to ${idled.servos[0]} µs ${stopLatencyMs} ms after the abort was requested (ACK in ${stoppedAtMs - stopRequestedAtMs} ms).`
+    )
+    // The whole point of the change: the operator does not wait out the window.
+    assert.ok(
+      stopLatencyMs < durationSeconds * 1000 * 0.5,
+      `The abort must drop the output well inside the ${durationSeconds}s window; took ${stopLatencyMs} ms.`
+    )
+
+    // Now the next motor, exactly as the identify advance does it.
+    const nextStartedAtMs = Date.now()
+    await runtime.runMotorTest({ outputChannel: 2, throttlePercent: 6, durationSeconds: 2 })
+    const nextSpinning = await waitFor((sample) => isHigh(sample, 1, idleOut2), 5000, 'OUT2 to spin up')
+    t.diagnostic(`OUT2 spun up to ${nextSpinning.servos[1]} µs ${nextSpinning.atMs - nextStartedAtMs} ms after the start.`)
+
+    // The ordering proof: the last moment OUT1 was above idle is strictly
+    // before the first moment OUT2 was, and the two never overlapped.
+    const lastOut1HighMs = samples.filter((sample) => isHigh(sample, 0, idleOut1)).at(-1)?.atMs
+    const firstOut2HighMs = samples.find((sample) => isHigh(sample, 1, idleOut2))?.atMs
+    assert.ok(lastOut1HighMs !== undefined && firstOut2HighMs !== undefined)
+    assert.ok(
+      lastOut1HighMs < firstOut2HighMs,
+      `OUT1 was still above idle after OUT2 started (last OUT1 high ${lastOut1HighMs}, first OUT2 high ${firstOut2HighMs}).`
+    )
+    const overlapping = samples.filter((sample) => isHigh(sample, 0, idleOut1) && isHigh(sample, 1, idleOut2))
+    assert.deepEqual(overlapping, [], 'OUT1 and OUT2 were driven above idle at the same time.')
+    t.diagnostic(`OUT1 idle for ${firstOut2HighMs - lastOut1HighMs} ms before OUT2 rose.`)
+
+    await runtime.stopMotorTest()
+  } finally {
+    unsubscribe?.()
+    await runtime.disconnect().catch(() => {})
+    runtime.destroy()
+    await sitl?.stop().catch(() => {})
+  }
+})


### PR DESCRIPTION
> "Motor Test: 1:Order — after user selects the spinning motor, stop spinning current motor and move on to next one. currently it waits for 5s default"

Once the operator has clicked the position that moved, the spin has served its purpose. It now stops immediately and the next motor starts, instead of running out its remaining seconds.

## The exact sequence on a selection

1. Record the pick and advance the step **synchronously** — locks the picked position before any await.
2. `DO_MOTOR_TEST param1=1, throttle_type=PERCENT, throttle=0, duration=0` — the existing zero-throttle abort from `MotorTestService.stop()`, byte-for-byte unchanged — and **await its COMMAND_ACK**.
3. Only then the next output's `DO_MOTOR_TEST` (6%, 2.5 s).

That abort is already hardware-proven: a bench session on a real BrotherHobbyH743 measured output 1150 → 1000 in 19 ms with the FC logging "finished motor test". This wires a known-good stop into the flow rather than inventing one.

## Ordering guarantees

- **Awaited, not fire-and-forget.** The ACK is the only evidence the FC took the abort, and it costs one RTT (8 ms on SITL). ArduCopter's motor test being single-state (`motor_test_seq` et al. file-static in `motor_test.cpp`) is noted in a comment but explicitly **not** relied on as the stop.
- **Unproven stop ⇒ nothing starts.** `stop()` now returns `{ sent, acknowledged }` (additive; wire bytes unchanged). `sent && !acknowledged` surfaces in the existing `motor-reorder-spin-error` banner and the sequence pauses. `sent: false` means the FC's own timeout already ended the spin — nothing to prove, so the next motor may start, which covers the operator answering as a spin finishes naturally.
- **Double-click / rapid repeat:** an in-flight ref read *and* set synchronously in the click handler — a re-render round trip is exactly the window two starts would race through — plus the pre-existing already-picked position lock. The status-gated auto-spin effect is demoted to a fallback so it cannot double-fire a step the direct path claimed.
- **Last motor:** stop, start nothing, run completes.
- **Auto-spin unchecked:** the answered motor still stops; only the follow-up spin waits for a click. Withdrawing the props-off / area-clear acknowledgement mid-run stops the current motor and starts nothing.

The decision lives in a pure view-model, `view-models/guided-identify-advance.ts`, with 11 unit tests. Ordering bugs here would spin the wrong motor, so it is tested off the DOM rather than only through the UI.

## Safety gating unchanged

Props-off / area-clear acknowledgements, armed check, connection check and busy-action guard are all untouched. This changes **when a spin ends**, never **whether one may start**.

## SITL evidence (rung 4)

ArduCopter quad, direct binary, scanning raw `SERVO_OUTPUT_RAW` at 20 Hz:

- OUT1 rose 1000 → **1060 µs**
- abort **ACKed in 8 ms**; OUT1 back to **1000 µs, 47 ms** after the abort was requested — against a deliberately long **5 s** window
- OUT2 then rose to 1060 µs, **103 ms after OUT1 went idle**
- **no sample had both outputs above idle**; last-OUT1-high strictly precedes first-OUT2-high

That proves sequencing, not merely that commands were ACKed.

## ArduCopter byte-identical: **no**

Stated honestly. A Copter running guided identify now receives one extra zero-throttle `DO_MOTOR_TEST` per selection, and the next start arrives seconds earlier. Other motor-test surfaces — sliders, all-motors sweep, Direction tab — are unchanged.

## Validation

- `npm run typecheck` clean
- `npm run test` — **856 pass / 0 fail** (861 total, 5 skipped), incl. two new runtime assertions for the stop-result contract
- `apps/web` vitest — **755 pass / 79 files**
- `npm run test:e2e` — **267 passed / 6 skipped**. The guided-identify spec now walks a full 4-motor run, asserts the advance lands well under 2.5 s, that an already-claimed position is ignored, and that the final pick starts nothing.
- `npm run test:sitl` — 3 pass / 1 skip

## Still wanted

**Rung 5 was not walked; no hardware verification is claimed.** A props-off bench re-test is still wanted, specifically to confirm the abort-then-start pair feels instant and that no ESC re-arms on the back-to-back commands.