### PR TITLE
fix(mavftp): follow the vehicle's sequence number so consecutive reads work

### DIFF
--- a/packages/ardupilot-core/src/runtime-mavftp-service.ts
+++ b/packages/ardupilot-core/src/runtime-mavftp-service.ts
@@ -151,6 +151,13 @@ export class MavftpService {
   private readonly requestTimeoutMs: number
   private readonly waiters = new Set<MavftpWaiter>()
   private activeBurst: BurstOperation | undefined
+  // The seq_number to put on the NEXT request. Not a private counter: MAVFTP's
+  // seq_number is a SHARED, monotonically rising conversation counter that the
+  // server advances too. A burst reply stream bumps the server's copy once per
+  // streamed packet (ArduPilot GCS_FTP.cpp `reply.seq_number++` inside the
+  // BurstReadFile loop) while the client only ever sent one request — so a
+  // client that just counts its own sends falls BEHIND the server. See
+  // adoptServerSequence for what that costs.
   private sequence = 0
   // Per the MAVLink FTP spec the client sends ResetSessions so a stale
   // server-side session doesn't block session-allocating ops. Sent lazily
@@ -286,16 +293,7 @@ export class MavftpService {
     const normalizedPath = normalizeMavftpPath(path)
     const pathBytes = new TextEncoder().encode(normalizedPath)
     await this.clearStaleSessionsOnce()
-    const openResponse = await this.send(
-      {
-        session: 0,
-        opcode: MAV_FTP_OPCODE.OPEN_FILE_RO,
-        size: pathBytes.length,
-        offset: 0,
-        data: pathBytes
-      },
-      timeoutMs
-    )
+    const openResponse = await this.openFileForRead(pathBytes, timeoutMs)
 
     const session = openResponse.session
     // Size the FC declared on OPEN; 0 for `@SYS` virtual files, which are
@@ -415,16 +413,7 @@ export class MavftpService {
     const maxBytes = options.maxBytes ?? MAX_MAVFTP_FILE_BYTES
     await this.clearStaleSessionsOnce()
 
-    const openResponse = await this.send(
-      {
-        session: 0,
-        opcode: MAV_FTP_OPCODE.OPEN_FILE_RO,
-        size: pathBytes.length,
-        offset: 0,
-        data: pathBytes
-      },
-      timeoutMs
-    )
+    const openResponse = await this.openFileForRead(pathBytes, timeoutMs)
     const session = openResponse.session
     const declaredSize =
       openResponse.data.byteLength >= 4
@@ -457,6 +446,9 @@ export class MavftpService {
 
   handleFileTransferProtocol(message: FileTransferProtocolMessage): void {
     const payload = decodeMavftpPayload(message.payload)
+    // Every reply — burst packet or not — carries the server's current
+    // seq_number, so track it before doing anything else with the payload.
+    this.adoptServerSequence(payload.seqNumber)
     // A burst download receives a stream of packets (each with its own
     // seq_number) for a single request, so it can't use the one-waiter-per-
     // seq correlation; route burst responses to the active burst op instead.
@@ -521,8 +513,7 @@ export class MavftpService {
       this.failBurst(new Error('MAVFTP requires an identified vehicle.'))
       return
     }
-    const requestSeq = this.sequence
-    this.sequence = (this.sequence + 1) & 0xffff
+    const requestSeq = this.nextSequence()
     void this.session
       .send({
         type: 'FILE_TRANSFER_PROTOCOL',
@@ -685,8 +676,98 @@ export class MavftpService {
     }).catch(() => {})
   }
 
+  /**
+   * Take the seq_number for the next request and advance the counter.
+   *
+   * Nothing here is new bookkeeping — it is the same `sequence++` the send
+   * paths used to do inline — but routing BOTH senders through one place is
+   * what lets adoptServerSequence's catch-up apply to burst re-requests as
+   * well as ordinary requests.
+   */
+  private nextSequence(): number {
+    const requestSeq = this.sequence
+    this.sequence = (this.sequence + 1) & 0xffff
+    return requestSeq
+  }
+
+  /**
+   * Keep our seq_number at or ahead of the server's.
+   *
+   * ArduPilot treats a request as a DUPLICATE — replaying its last reply
+   * instead of executing the request — when `request.seq_number + 1 ==
+   * reply.seq_number` for the same session (GCS_FTP.cpp:823-829). A burst read
+   * costs us one seq but costs the server one PER STREAMED PACKET, so after a
+   * burst our counter sits below the server's and the next request we send can
+   * land exactly on that equality by accident.
+   *
+   * It is not a rare accident. A file that fits in a single burst packet leaves
+   * the server exactly two ahead, which is precisely the offset that makes our
+   * follow-up TerminateSession look like a re-request of the burst's EOF NAK.
+   * The close is swallowed, the descriptor stays open, and because ArduPilot
+   * allows only one open file per session (GCS_FTP.cpp:341-352) the NEXT open
+   * is refused with Fail until the server's 3s idle sweep reclaims it. Large
+   * logs never showed this — they take far longer than 3s — but two small
+   * files back to back fail every time.
+   *
+   * Adopting the server's seq also stops a late burst packet from satisfying
+   * the waiter for a subsequent request that happened to reuse its seq.
+   *
+   * Wrap-safe: seq_number is 16-bit, so "ahead" is a signed comparison on the
+   * 16-bit difference rather than a plain `>`.
+   */
+  private adoptServerSequence(serverSeq: number): void {
+    const normalized = serverSeq & 0xffff
+    if (((normalized - this.sequence) & 0xffff) < 0x8000) {
+      // The server's own reply seq is a value it has already USED, so sending
+      // our next request with that same number keeps `request + 1` clear of it
+      // while still being the smallest step that does.
+      this.sequence = normalized
+    }
+  }
+
   private asError(error: unknown): Error {
     return error instanceof Error ? error : new Error('Unknown MAVFTP burst error.')
+  }
+
+  /**
+   * OPEN_FILE_RO, retried once through RESET_SESSIONS on a bare `Fail` NAK.
+   *
+   * ArduPilot answers OpenFileRO with plain `Fail` in exactly one case: a
+   * descriptor is still open on this session and it has not yet gone idle long
+   * enough for the server to reclaim it (GCS_FTP.cpp:341-352 — a malformed
+   * request gets InvalidDataSize and a missing file gets FailErrno/FileNotFound
+   * instead). That is a TRANSIENT condition, so failing the caller's download
+   * outright is the wrong answer even though the sequence-number fix above
+   * should stop us from ever creating it.
+   *
+   * RESET_SESSIONS is the recovery to reach for rather than another
+   * TerminateSession: the server handles it at the top of its worker loop and
+   * force-closes every session on our channel BEFORE reaching the duplicate-
+   * request check (GCS_FTP.cpp:760-777), so unlike a close it cannot itself be
+   * swallowed as a replay — which is the failure we are recovering from.
+   *
+   * Exactly one retry. If a fresh open still fails with a descriptor we just
+   * ordered closed, something other than a leaked handle is wrong and the
+   * caller deserves the error rather than a retry loop against a live vehicle.
+   */
+  private async openFileForRead(pathBytes: Uint8Array, timeoutMs?: number): Promise<MavftpPayload> {
+    const request = {
+      session: 0,
+      opcode: MAV_FTP_OPCODE.OPEN_FILE_RO,
+      size: pathBytes.length,
+      offset: 0,
+      data: pathBytes
+    }
+
+    try {
+      return await this.send(request, timeoutMs)
+    } catch (error) {
+      if (!(error instanceof MavftpRequestError) || error.errorCode !== MAV_FTP_ERR.FAIL) {
+        throw error
+      }
+      await this.resetSessions().catch(() => {})
+      return this.send(request, timeoutMs)
+    }
   }
 
   /**
@@ -698,18 +779,23 @@ export class MavftpService {
     }
     this.staleSessionsCleared = true
     try {
-      await this.send({
-        session: 0,
-        opcode: MAV_FTP_OPCODE.RESET_SESSIONS,
-        size: 0,
-        offset: 0,
-        data: new Uint8Array(0)
-      })
+      await this.resetSessions()
     } catch {
       // Best-effort: a NAK / timeout here must not block the actual
       // operation — worst case a stale session NAKs the open and
       // ArduPilot's idle sweep eventually reclaims it.
     }
+  }
+
+  /** RESET_SESSIONS — closes every server-side session on our link. */
+  private async resetSessions(): Promise<void> {
+    await this.send({
+      session: 0,
+      opcode: MAV_FTP_OPCODE.RESET_SESSIONS,
+      size: 0,
+      offset: 0,
+      data: new Uint8Array(0)
+    })
   }
 
   private async send(
@@ -721,8 +807,7 @@ export class MavftpService {
       throw new Error('MAVFTP requires an identified vehicle.')
     }
 
-    const requestSeq = this.sequence
-    this.sequence = (this.sequence + 1) & 0xffff
+    const requestSeq = this.nextSequence()
     // The MAVLink FTP server replies with `seq_number = request seq + 1`,
     // so correlate the waiter to the expected response seq.
     const expectedResponseSeq = (requestSeq + 1) & 0xffff

--- a/tests/mavftp-burst.test.mjs
+++ b/tests/mavftp-burst.test.mjs
@@ -270,3 +270,174 @@ test('a second burst download while one is in flight is rejected', async () => {
   await assert.rejects(() => harness.service.downloadRemoteFileBurst('/APM/LOGS/2.BIN'), /already in progress/)
   await assert.rejects(() => first, /No MAVFTP burst data/)
 })
+
+/*
+  A model of ArduPilot's FTP server for the one rule the seq_number handling
+  turns on. The harness above is deliberately simple — it answers every burst
+  packet with `request seq + 1` — but the real server keeps a single rising
+  conversation counter and bumps it per STREAMED PACKET (GCS_FTP.cpp,
+  `reply.seq_number++` inside the BurstReadFile loop). Two further behaviours
+  follow from that counter and are modelled here:
+
+    - a request whose `seq_number + 1` equals the last reply's seq_number is
+      treated as a re-request and answered with a REPLAY of that last reply,
+      never executed (GCS_FTP.cpp:823-829);
+    - only one file may be open per session, and a second OpenFileRO while a
+      descriptor is still held is NAKed with Fail (GCS_FTP.cpp:341-352).
+
+  Together those turn a swallowed TerminateSession into a REFUSED NEXT
+  DOWNLOAD. Rung 4 (tests/runtime.sitl.test.mjs) is the proof against real
+  firmware; this is the cheap guard that catches a regression in the client's
+  seq handling without needing a SITL to notice.
+*/
+function createArduPilotLikeHarness(fileBytes) {
+  const sent = []
+  let service
+  let lastReply
+  let openSession = -1
+  let nextSessionId = 3
+
+  const push = (frame) => {
+    lastReply = decodeFrame(frame)
+    service.handleFileTransferProtocol({ payload: frame })
+  }
+
+  const respond = (req) => {
+    // The duplicate-request rule, applied before the opcode is even looked at.
+    if (lastReply && ((req.seqNumber + 1) & 0xffff) === lastReply.seqNumber && req.session === lastReply.session) {
+      service.handleFileTransferProtocol({ payload: encodeFrame(lastReply) })
+      return
+    }
+
+    switch (req.opcode) {
+      case MAV_FTP_OPCODE.RESET_SESSIONS:
+        openSession = -1
+        push(ackFrame(req))
+        break
+      case MAV_FTP_OPCODE.OPEN_FILE_RO: {
+        if (openSession !== -1) {
+          push(nakFrame(req, MAV_FTP_ERR.FAIL))
+          break
+        }
+        openSession = nextSessionId
+        nextSessionId += 1
+        const data = new Uint8Array(4)
+        new DataView(data.buffer).setUint32(0, fileBytes.length, true)
+        push(ackFrame(req, { session: openSession, data }))
+        break
+      }
+      case MAV_FTP_OPCODE.TERMINATE_SESSION:
+        openSession = -1
+        push(ackFrame(req, { session: req.session }))
+        break
+      case MAV_FTP_OPCODE.READ_FILE: {
+        const end = Math.min(req.offset + req.size, fileBytes.length)
+        if (req.offset >= fileBytes.length) {
+          push(nakFrame(req, MAV_FTP_ERR.EOF))
+          break
+        }
+        push(ackFrame(req, { session: req.session, offset: req.offset, data: fileBytes.slice(req.offset, end) }))
+        break
+      }
+      case MAV_FTP_OPCODE.BURST_READ_FILE: {
+        // One packet per 239 bytes, then the EOF NAK — each carrying the NEXT
+        // seq_number in the conversation, exactly as the firmware does.
+        let seq = (req.seqNumber + 1) & 0xffff
+        let offset = req.offset
+        while (offset < fileBytes.length) {
+          const end = Math.min(offset + BURST_DATA, fileBytes.length)
+          push(
+            encodeFrame({
+              seqNumber: seq,
+              session: req.session,
+              opcode: ACK,
+              size: end - offset,
+              reqOpcode: req.opcode,
+              burstComplete: end >= fileBytes.length ? 1 : 0,
+              offset,
+              data: fileBytes.slice(offset, end)
+            })
+          )
+          seq = (seq + 1) & 0xffff
+          offset = end
+        }
+        push(
+          encodeFrame({
+            seqNumber: seq,
+            session: req.session,
+            opcode: NAK,
+            size: 1,
+            reqOpcode: req.opcode,
+            burstComplete: 1,
+            offset,
+            data: new Uint8Array([MAV_FTP_ERR.EOF])
+          })
+        )
+        break
+      }
+      default:
+        break
+    }
+  }
+
+  service = new MavftpService({
+    session: {
+      send: async (message) => {
+        sent.push(message)
+        if (message.type === 'FILE_TRANSFER_PROTOCOL') {
+          const req = decodeFrame(message.payload)
+          queueMicrotask(() => respond(req))
+        }
+      }
+    },
+    getVehicle: () => VEHICLE,
+    ensureSupport: async () => {},
+    requestTimeoutMs: 200
+  })
+
+  return {
+    service,
+    sent,
+    get sessionIsOpen() {
+      return openSession !== -1
+    },
+    // Strands a descriptor the way a close lost on the wire would.
+    leakDescriptor() {
+      openSession = nextSessionId
+      nextSessionId += 1
+    }
+  }
+}
+
+test('a single-packet burst still closes its session, so the next download opens', async () => {
+  // Small enough for ONE burst packet: the case that leaves the server exactly
+  // two seq ahead of a client counting only its own sends, which is the offset
+  // that makes the follow-up TerminateSession look like a re-request.
+  const fileBytes = makeBytes(120, 4)
+  const harness = createArduPilotLikeHarness(fileBytes)
+
+  const first = await harness.service.downloadRemoteFileBurst('/logs/small-1.txt')
+  assert.deepEqual(Array.from(first), Array.from(fileBytes))
+  assert.equal(harness.sessionIsOpen, false, 'the TerminateSession was swallowed as a duplicate re-request')
+
+  // Back to back, with no spacing between them — spacing is the workaround
+  // this fix exists to make unnecessary.
+  const second = await harness.service.downloadRemoteFileBurst('/logs/small-2.txt')
+  assert.deepEqual(Array.from(second), Array.from(fileBytes))
+  const third = await harness.service.downloadRemoteFileBurst('/logs/small-3.txt')
+  assert.deepEqual(Array.from(third), Array.from(fileBytes))
+})
+
+test('an open refused with Fail is retried through RESET_SESSIONS instead of failing the download', async () => {
+  const fileBytes = makeBytes(300, 6)
+  const harness = createArduPilotLikeHarness(fileBytes)
+  // A plain (non-burst) read first: it spends the one-shot startup
+  // RESET_SESSIONS, so the leak below cannot be cleared by that instead of by
+  // the safety net, and it keeps this test independent of the sequence fix.
+  await harness.service.downloadRemoteFile('/logs/plain.txt')
+  // Strand a descriptor the way a close lost on the wire would.
+  harness.leakDescriptor()
+
+  const bytes = await harness.service.downloadRemoteFileBurst('/logs/after-leak.BIN')
+  assert.deepEqual(Array.from(bytes), Array.from(fileBytes))
+})

--- a/tests/runtime.sitl.test.mjs
+++ b/tests/runtime.sitl.test.mjs
@@ -167,6 +167,138 @@ test('true SITL: an ArduPlane vehicle is detected and swaps to the Plane catalog
 })
 
 /**
+ * Back-to-back MAVFTP downloads of SMALL files.
+ *
+ * Nothing below rung 4 can prove this. The failure lives in the real
+ * ArduPilot FTP server's duplicate-request suppression: it replays its last
+ * reply instead of executing a request whose `seq_number + 1` equals the
+ * seq_number of that reply (GCS_FTP.cpp:823-829). A burst read advances the
+ * server's seq_number once per STREAMED PACKET while the client only sent one
+ * request, so a client that counts only its own sends falls behind — and for a
+ * file small enough to fit in a single burst packet it falls behind by exactly
+ * the amount that makes the follow-up TerminateSession look like a re-request.
+ * The close is swallowed, the descriptor stays open, and since ArduPilot allows
+ * only one open file per session (GCS_FTP.cpp:341-352) the next open is NAKed
+ * with Fail until the server's 3s idle sweep runs (FTP_SESSION_TIMEOUT). Big
+ * logs always outlast that timeout, which is why the log reader never saw it.
+ *
+ * The mock server replies with request+1 and nothing else, so it cannot
+ * exhibit any of this; only a real autopilot can answer.
+ *
+ * The test uploads its own small files rather than trusting whatever happens to
+ * be on the vehicle, so "small enough to fit one burst packet" — the exact
+ * failing case — is guaranteed rather than hoped for. It also downloads a real
+ * multi-burst log in the same run so a fix for the small-file case cannot quietly
+ * cost us the large-file path it was built for.
+ */
+test('true SITL: consecutive small MAVFTP downloads all succeed', { timeout: 240000 }, async (t) => {
+  const repoPath = process.env.ARDUPILOT_REPO_PATH
+  const attachHost = process.env.ARDUPILOT_SITL_HOST
+  const attachPort = Number(process.env.ARDUPILOT_SITL_PORT ?? '5760')
+  const launchWaitPort = Number(process.env.ARDUPILOT_SITL_LAUNCH_WAIT_PORT ?? '5760')
+
+  if (!repoPath && !attachHost) {
+    t.skip('Set ARDUPILOT_REPO_PATH to launch SITL, or ARDUPILOT_SITL_HOST/PORT to attach to an existing endpoint.')
+    return
+  }
+
+  let sitl
+  if (repoPath) {
+    sitl = await launchArduPilotDirectBinary({
+      repoPath,
+      vehicle: process.env.ARDUPILOT_SITL_VEHICLE ?? 'ArduCopter',
+      frame: process.env.ARDUPILOT_SITL_FRAME ?? 'quad',
+      port: launchWaitPort,
+      launchTimeoutMs: Number(process.env.ARDUPILOT_SITL_LAUNCH_TIMEOUT_MS ?? '120000')
+    })
+  }
+
+  const transport = new TcpTransport('sitl-mavftp-small-files-tcp', {
+    host: attachHost ?? '127.0.0.1',
+    port: attachPort,
+    connectTimeoutMs: 10000
+  })
+  const session = new MavlinkSession(transport, new MavlinkV2Codec())
+  const runtime = new ArduPilotConfiguratorRuntime(session, arducopterMetadata, {})
+
+  // `/logs` is the SITL scratch directory (the hardware equivalent is
+  // `/APM/LOGS`); it is the one writable place every SITL has. Cleaned up in
+  // the finally so a re-run starts from the same state.
+  const smallFiles = [1, 2, 3].map((index) => ({
+    path: `/logs/arduconfig-ftp-small-${index}.txt`,
+    // Well under the 239-byte burst packet payload, so each download is a
+    // single-packet burst — the case that used to wedge the session.
+    text: `arduconfig mavftp consecutive-read probe #${index}\n`
+  }))
+  const uploaded = []
+
+  try {
+    await runtime.connect()
+    await runtime.waitForVehicle({ timeoutMs: 20000 })
+
+    // The runtime issues its own `@SYS/uarts.txt` read on connect. This
+    // service drives every transfer through FTP session 0, so an overlapping
+    // read would contend for the same server-side descriptor and muddy what
+    // this test is actually measuring. Let the connect-time read finish first.
+    await new Promise((resolve) => setTimeout(resolve, 4000))
+
+    for (const file of smallFiles) {
+      await runtime.uploadRemoteFile(file.path, new TextEncoder().encode(file.text), { overwrite: true })
+      uploaded.push(file.path)
+    }
+
+    // The assertion: back to back, with NO spacing between them. Spacing is
+    // what the private monitoring collector had to add to work around this,
+    // and adding it here would hide exactly the bug under test.
+    for (const file of smallFiles) {
+      const bytes = await runtime.downloadMavftpLog(file.path, undefined, { silent: true })
+      assert.equal(
+        new TextDecoder().decode(bytes),
+        file.text,
+        `Consecutive MAVFTP download of ${file.path} did not return the uploaded bytes.`
+      )
+    }
+
+    // Same run, same session: the multi-burst path the log reader depends on
+    // must still work after (and before) the small reads.
+    const logs = await runtime.listMavftpLogs()
+    const bySize = logs
+      .filter((entry) => (entry.sizeBytes ?? 0) > 4096)
+      .sort((left, right) => (left.sizeBytes ?? 0) - (right.sizeBytes ?? 0))
+    // ArduPilot streams at most 2000 packets (~478 KiB at 239 bytes each) per
+    // burst request, so prefer a log past that: it forces the burstComplete
+    // re-request the log reader lives on. Fall back to the largest available
+    // when the SITL has nothing that big, and take the SMALLEST qualifying log
+    // so the test stays quick.
+    const largeLog = bySize.find((entry) => (entry.sizeBytes ?? 0) > 512 * 1024) ?? bySize[bySize.length - 1]
+
+    if (largeLog) {
+      let lastProgress = 0
+      const bytes = await runtime.downloadMavftpLog(largeLog.path, (progress) => {
+        lastProgress = progress.bytesReceived
+      }, { silent: true })
+      assert.equal(bytes.length, largeLog.sizeBytes, `Multi-burst download of ${largeLog.path} came back short.`)
+      assert.ok(lastProgress > 0, 'Multi-burst download reported no progress.')
+      t.diagnostic(`Multi-burst path exercised on ${largeLog.path} (${bytes.length} bytes).`)
+
+      // And a small read still works AFTER a large one, which is the ordering
+      // an operator hits when they grab a log and then a config file.
+      const trailing = await runtime.downloadMavftpLog(smallFiles[0].path, undefined, { silent: true })
+      assert.equal(new TextDecoder().decode(trailing), smallFiles[0].text)
+    } else {
+      t.diagnostic('No onboard log over 4 KiB on this SITL — the multi-burst path was not exercised.')
+    }
+  } finally {
+    for (const path of uploaded) {
+      await runtime.deleteRemotePath(path, 'file').catch(() => {})
+    }
+    await runtime.disconnect().catch(() => {})
+    runtime.destroy()
+    await sitl?.stop().catch(() => {})
+  }
+})
+
+/**
  * The rangefinder / optical-flow Status cards depend on two messages that live
  * in STREAM_EXTRA3 and therefore only ever arrive because the runtime issues a
  * SET_MESSAGE_INTERVAL for them. NOTHING below rung 4 can prove that: the mock


### PR DESCRIPTION
Downloading **two small files back-to-back over MAVFTP fails** — the first succeeds, the second is refused. This affects the operator's own download path, not just background work. It has been latent because logs are large enough to outlast the window that hides it.

## Mechanism, confirmed from source *and* from the wire

Verified in ArduPilot `e080acb225`:

- `GCS_FTP.cpp:341-352` — `OpenFileRO` NAKs with plain `Fail` while `fd != -1`, reclaiming the descriptor only after `FTP_SESSION_TIMEOUT` (3000 ms, `:38`) of inactivity.
- `GCS_FTP.cpp:823-829` — before executing anything, the worker treats a request as a **re-request and replays the last reply** when `request.seq_number + 1 == reply.seq_number`.
- `GCS_FTP.cpp:596-632` — the burst loop does `reply.seq_number++` **per streamed packet**. So one client request costs the server N+1 seq numbers. `seq_number` is a shared conversation counter, and our client was counting only its own sends — falling behind.

For a file that fits in **one** burst packet the server ends exactly two ahead, which is precisely the offset that makes our `TerminateSession` look like a re-request of the burst's EOF NAK.

Wire trace against real SITL, before the fix (`/logs/LASTLOG.TXT`, 4 bytes, three times):

```
TX seq=3 op=15 (burst)    RX seq=4 (data)   RX seq=5 (NAK EOF, burstComplete)
TX seq=4 op=1 (terminate) → RX seq=5 NAK EOF again    ← replay; close never executed
TX seq=6 op=4 (open #2)   → RX NAK err=1 (Fail)
TX seq=7 op=4 (open #3)   → RX NAK err=1 (Fail)
```

The runtime's own connect-time `@SYS/uarts.txt` read hit the same `Fail` when it overlapped a held descriptor.

## The fix — follow the protocol, not a stopwatch

**No blanket delay anywhere.** A sleep between reads would work and would be the wrong answer: it slows every download to dodge a protocol detail.

1. **Primary — adopt the server's sequence number.** `adoptServerSequence()` runs for every inbound FTP payload (burst packet or not) and raises our counter to the highest value the vehicle has used, wrap-safe via a signed 16-bit difference. Both senders go through one `nextSequence()`, so **burst re-requests get the catch-up too** — that path had the same latent hazard, where a stall retry could be swallowed as a duplicate. It also stops a late burst packet from resolving the waiter of a later request that happened to reuse its seq.

   `ResetSessions` as the *primary* fix was rejected: it works (handled at `:760-777`, before the duplicate check) but it is blunt — it closes every session on the link — and it would leave the seq desync, and therefore the waiter-correlation hazard, in place.

2. **Safety net — a refused open is retryable.** `openFileForRead()` (now shared by `readRemoteFile` and `downloadRemoteFileBurst`) retries **once** on a `Fail` NAK via `RESET_SESSIONS`, chosen there precisely because — unlike a close — it cannot itself be swallowed as a replay. One retry only, so we never loop against a live vehicle.

`terminateSession`, `runBurst`, `finishBurst`, `failBurst`, the contiguous-frontier logic and `partialTransferOf` are untouched.

## Proved failing first

**Rung 4** — new `true SITL: consecutive small MAVFTP downloads all succeed`. Uploads three sub-239-byte files, downloads them back to back with **no spacing**, then a real multi-burst log, then a small file again.

- Fix stashed, core rebuilt: **FAIL** — `MavftpRequestError … errorCode: 1` at the second download.
- Fix restored: **PASS** (9.1 s), exercising `/logs/00000002.BIN` at 528 KB — past ArduPilot's 2000-packet burst limit, so the `burstComplete` continuation the log reader depends on is covered, and the trailing small read after the large one passes too.

**Rung 1** — two new guards in `tests/mavftp-burst.test.mjs` against a harness modelling the server's duplicate rule, per-packet burst seq, and one-open-file limit: both **fail without the fix, pass with it**.

## Blast radius, stated honestly

This changes MAVFTP **session/sequence handling** — no parameter, write path or command semantics change. On a server that only ever replies `request+1` (the mock, and every non-burst exchange) the emitted sequence numbers are **byte-for-byte** what they were.

Large-log, abort/cancel and partial-salvage paths pass unchanged across `mavftp-burst`, `mavftp-burst-abort`, `mavftp-partial-recovery`, `mavftp-service-timeout`, `log-download-service`.

## Validation

- `npm run typecheck` clean
- `npm run test` — 862 tests, **857 pass / 0 fail**, 5 skipped
- `npm run test:e2e` — **271 passed**, 6 skipped, 8.7 m
- `npm run test:sitl` — **3 pass**, 1 skipped (ArduPlane opt-in), 0 fail

## Known, pre-existing, untouched

**Concurrency is still broken.** The service drives every transfer through FTP session id 0, so two overlapping readers contend for one server-side descriptor. The first repro hit exactly this by starting downloads while the connect-time `@SYS/uarts.txt` read was in flight; the SITL test waits 4 s for that, with a comment saying why. The safety net's `RESET_SESSIONS` will also close a genuinely concurrent transfer — but that transfer was already doomed by the shared session id, so this is not a new failure mode. Worth a separate look if background reads ever run alongside operator downloads.

No live-FC run; SITL only.