### PR TITLE
polish(ui): put the app back on its own design tokens, and consolidate what drifted

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -7937,6 +7937,30 @@ export function App() {
 
   const showLanding = (activeViewId === 'setup' || activeViewId === 'guided-setup') && snapshot.connection.kind !== 'connected'
 
+  // The OSD/VTX switcher, handed to whichever section is showing instead of
+  // being rendered above it. Every other view puts its tab strip under the page
+  // title; this one sat above, which read as a different kind of control.
+  const osdVtxNav = (
+    <div className="tab-strip config-category-nav" data-testid="osd-vtx-nav" role="tablist">
+      {([
+        { id: 'osd' as const, label: 'OSD' },
+        { id: 'vtx' as const, label: 'VTX' }
+      ]).map((tab) => (
+        <button
+          key={tab.id}
+          type="button"
+          role="tab"
+          aria-selected={osdVtxTab === tab.id}
+          className={`tab-strip__tab${osdVtxTab === tab.id ? ' is-active' : ''}`}
+          data-testid={`osd-vtx-tab-${tab.id}`}
+          onClick={() => setOsdVtxTab(tab.id)}
+        >
+          {tab.label}
+        </button>
+      ))}
+    </div>
+  )
+
   return (
     <>
       {swUpdate.kind === 'available' ? (
@@ -8795,29 +8819,9 @@ export function App() {
 	      ) : null}
 
 
-        {activeViewId === 'osd' ? (
-          <div className="tab-strip config-category-nav" data-testid="osd-vtx-nav" role="tablist">
-            {([
-              { id: 'osd' as const, label: 'OSD' },
-              { id: 'vtx' as const, label: 'VTX' }
-            ]).map((tab) => (
-              <button
-                key={tab.id}
-                type="button"
-                role="tab"
-                aria-selected={osdVtxTab === tab.id}
-                className={`tab-strip__tab${osdVtxTab === tab.id ? ' is-active' : ''}`}
-                data-testid={`osd-vtx-tab-${tab.id}`}
-                onClick={() => setOsdVtxTab(tab.id)}
-              >
-                {tab.label}
-              </button>
-            ))}
-          </div>
-        ) : null}
-
         {activeViewId === 'osd' && osdVtxTab === 'vtx' ? (
           <VtxSection
+            headerNav={osdVtxNav}
             snapshot={snapshot}
             serialPortViewModels={serialPortViewModels}
             editedValues={editedValues}
@@ -8834,6 +8838,7 @@ export function App() {
 
         {activeViewId === 'osd' && osdVtxTab === 'osd' ? (
           <OsdSection
+            headerNav={osdVtxNav}
             snapshot={snapshot}
             osdParameterById={osdParameterById}
             serialPortViewModels={serialPortViewModels}

--- a/apps/web/src/app-header-logo.tsx
+++ b/apps/web/src/app-header-logo.tsx
@@ -5,7 +5,11 @@
 export function AppHeaderLogo() {
   return (
     <svg viewBox="0 0 48 48" aria-hidden="true" focusable="false">
-      <g fill="none" stroke="rgba(236, 241, 247, 0.18)" strokeLinecap="round" strokeLinejoin="round" strokeWidth="1.8">
+      {/* currentColor, not a baked near-white: .app-header__mark sets color from
+          --text, so the arms and the monogram invert with the theme. Spelled as a
+          literal they survived only on the dark ground, and the light theme showed
+          four rotor dots on an empty tile. */}
+      <g fill="none" stroke="currentColor" strokeOpacity="0.28" strokeLinecap="round" strokeLinejoin="round" strokeWidth="1.8">
         <path d="M16 16 22.5 22.5" />
         <path d="M32 16 25.5 22.5" />
         <path d="M16 32 22.5 25.5" />
@@ -17,7 +21,8 @@ export function AppHeaderLogo() {
       <circle cx="32" cy="32" r="3.4" fill="var(--accent)" />
       <path
         d="M24 12.5 31.4 29h-4.2l-1.55-3.75h-3.25L20.85 29h-4.25Zm0 7.2-1.35 3.35h2.7Z"
-        fill="rgba(244, 247, 250, 0.96)"
+        fill="currentColor"
+        fillOpacity="0.96"
       />
     </svg>
   )

--- a/apps/web/src/mavlink-signing-panel.tsx
+++ b/apps/web/src/mavlink-signing-panel.tsx
@@ -148,7 +148,7 @@ export function MavlinkSigningPanel(props: MavlinkSigningPanelProps) {
   }
 
   return (
-    <div data-testid="mavlink-signing-panel" style={{ marginTop: 24 }}>
+    <div data-testid="mavlink-signing-panel" className="mavlink-signing-panel">
       <Panel
         title="MAVLink signing"
         subtitle="Authenticate the link with a shared MAVLink v2 signing key. The key is derived from a passphrase (SHA-256) or pasted as a 32-byte hex key, kept in memory only, and never logged."
@@ -158,9 +158,9 @@ export function MavlinkSigningPanel(props: MavlinkSigningPanelProps) {
           </StatusBadge>
         }
       >
-        <div style={{ display: 'flex', flexDirection: 'column', gap: 14, maxWidth: 640 }}>
-          <div role="radiogroup" aria-label="Key source" style={{ display: 'flex', gap: 16 }}>
-            <label style={{ display: 'inline-flex', alignItems: 'center', gap: 6 }}>
+        <div className="mavlink-signing">
+          <div role="radiogroup" aria-label="Key source" className="mavlink-signing__modes">
+            <label className="mavlink-signing__mode">
               <input
                 type="radio"
                 name="signing-key-mode"
@@ -170,7 +170,7 @@ export function MavlinkSigningPanel(props: MavlinkSigningPanelProps) {
               />
               <span>Passphrase</span>
             </label>
-            <label style={{ display: 'inline-flex', alignItems: 'center', gap: 6 }}>
+            <label className="mavlink-signing__mode">
               <input
                 type="radio"
                 name="signing-key-mode"
@@ -183,7 +183,7 @@ export function MavlinkSigningPanel(props: MavlinkSigningPanelProps) {
           </div>
 
           {keyMode === 'passphrase' ? (
-            <label style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
+            <label className="mavlink-signing__field">
               <span>Passphrase</span>
               <input
                 type="password"
@@ -196,7 +196,7 @@ export function MavlinkSigningPanel(props: MavlinkSigningPanelProps) {
               />
             </label>
           ) : (
-            <label style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
+            <label className="mavlink-signing__field">
               <span>Hex key</span>
               <input
                 type="text"
@@ -210,7 +210,7 @@ export function MavlinkSigningPanel(props: MavlinkSigningPanelProps) {
             </label>
           )}
 
-          <label style={{ display: 'flex', flexDirection: 'column', gap: 6, maxWidth: 160 }}>
+          <label className="mavlink-signing__field mavlink-signing__field--narrow">
             <span>Link ID</span>
             <input
               type="number"
@@ -225,7 +225,7 @@ export function MavlinkSigningPanel(props: MavlinkSigningPanelProps) {
             />
           </label>
 
-          <div style={{ display: 'flex', gap: 10, flexWrap: 'wrap' }}>
+          <div className="mavlink-signing__actions">
             <button type="button" style={buttonStyle('primary')} data-testid="signing-apply-button" onClick={handleApply}>
               {enabled ? 'Update key' : 'Enable signing'}
             </button>
@@ -250,8 +250,8 @@ export function MavlinkSigningPanel(props: MavlinkSigningPanelProps) {
             </button>
           </div>
 
-          <div style={{ display: 'flex', alignItems: 'center', gap: 12 }}>
-            <span style={{ fontSize: 13, color: 'var(--text-muted, #b3b3b3)' }}>Rejected signed frames</span>
+          <div className="mavlink-signing__counter">
+            <span className="mavlink-signing__field-label">Rejected signed frames</span>
             <StatusBadge tone={rejectionCount > 0 ? 'warning' : 'neutral'}>
               <span data-testid="signing-rejection-count">{rejectionCount}</span>
             </StatusBadge>
@@ -260,22 +260,13 @@ export function MavlinkSigningPanel(props: MavlinkSigningPanelProps) {
           {feedback ? (
             <p
               data-testid="signing-feedback"
-              style={{
-                margin: 0,
-                fontSize: 13,
-                color:
-                  feedback.tone === 'success'
-                    ? 'var(--success, #7fb966)'
-                    : feedback.tone === 'danger'
-                      ? 'var(--danger, #e2123f)'
-                      : 'var(--warning, #ff6600)'
-              }}
+              className={`mavlink-signing__feedback mavlink-signing__feedback--${feedback.tone}`}
             >
               {feedback.text}
             </p>
           ) : null}
 
-          <p style={{ margin: 0, fontSize: 12, color: 'var(--text-dim, #999999)' }}>
+          <p className="mavlink-signing__note">
             The flight controller must hold the same key. Use "Send key to vehicle" over a trusted link (USB / wired) to
             provision it via SETUP_SIGNING, or set a matching passphrase on the FC from another GCS.
           </p>

--- a/apps/web/src/sections/AppHeader.tsx
+++ b/apps/web/src/sections/AppHeader.tsx
@@ -156,7 +156,10 @@ export function AppHeader({
         rel="noopener noreferrer"
         title="Open the ArduConfigurator wiki (opens in a new tab)"
       >
-        <span className="app-header__wiki-icon" aria-hidden="true">📖</span>
+        {/* A letter mark, like every entry in the side nav. The emoji that was
+            here rendered in the system emoji font at a size nothing else in the
+            chrome used. */}
+        <span className="app-header__wiki-icon" aria-hidden="true">WIK</span>
         <span className="app-header__wiki-label">Wiki</span>
       </a>
 

--- a/apps/web/src/sections/OsdSection.tsx
+++ b/apps/web/src/sections/OsdSection.tsx
@@ -6,6 +6,7 @@
 import { ARDUCOPTER_MSP_OPTION_BIT_LABELS, formatArducopterMspOsdCellCount, formatArducopterOsdSwitchMethod, formatArducopterOsdType } from '@arduconfig/param-metadata'
 import type { ConfiguratorSnapshot, ParameterDraftEntry, ParameterState } from '@arduconfig/ardupilot-core'
 import { useMemo } from 'react'
+import type { ReactNode } from 'react'
 
 import type { UseOsdEditorResult } from '../hooks/use-osd-editor'
 import type { UseOsdShorthandResult } from '../hooks/use-osd-shorthand'
@@ -19,6 +20,9 @@ import { isOsdSerialProtocol, type SerialPortViewModel } from '../serial-port-he
 import { OsdView } from '../views/Osd'
 
 export interface OsdSectionProps {
+  /** The OSD/VTX switcher, rendered under the panel title like every other
+   *  view's tab strip. */
+  headerNav?: ReactNode
   snapshot: ConfiguratorSnapshot
   osdParameterById: ReadonlyMap<string, ParameterState>
   serialPortViewModels: readonly SerialPortViewModel[]
@@ -41,6 +45,7 @@ export interface OsdSectionProps {
 
 export function OsdSection(props: OsdSectionProps) {
   const {
+    headerNav,
     snapshot,
     osdParameterById,
     serialPortViewModels,
@@ -98,6 +103,7 @@ export function OsdSection(props: OsdSectionProps) {
 
   return (
     <OsdView
+      headerNav={headerNav}
       linkPorts={osdLinkPorts}
       typeField={osdTypeParameter ? { parameter: osdTypeParameter, liveValue: osdType } : undefined}
       channelField={osdChannelParameter ? { parameter: osdChannelParameter, liveValue: osdChannel } : undefined}

--- a/apps/web/src/sections/VtxSection.tsx
+++ b/apps/web/src/sections/VtxSection.tsx
@@ -7,6 +7,7 @@
 import { formatArducopterVtxEnable } from '@arduconfig/param-metadata'
 import type { ConfiguratorSnapshot, ParameterDraftEntry } from '@arduconfig/ardupilot-core'
 import { useMemo } from 'react'
+import type { ReactNode } from 'react'
 
 import { VTX_PARAM_IDS } from '../param-groups'
 import { isVtxReviewParamId } from '../param-review'
@@ -23,6 +24,9 @@ import type { UseVtxTableResult } from '../hooks/use-vtx-table'
 import { VtxView } from '../views/Vtx'
 
 export interface VtxSectionProps {
+  /** The OSD/VTX switcher, rendered under the panel title like every other
+   *  view's tab strip. */
+  headerNav?: ReactNode
   snapshot: ConfiguratorSnapshot
   serialPortViewModels: readonly SerialPortViewModel[]
   editedValues: Record<string, string>
@@ -42,6 +46,7 @@ export interface VtxSectionProps {
 
 export function VtxSection(props: VtxSectionProps) {
   const {
+    headerNav,
     snapshot,
     serialPortViewModels,
     editedValues,
@@ -99,6 +104,7 @@ export function VtxSection(props: VtxSectionProps) {
 
   return (
     <VtxView
+      headerNav={headerNav}
       linkPorts={vtxLinkPorts}
       enabledLabel={formatArducopterVtxEnable(vtxEnabled)}
       enableField={vtxEnableParameter ? { parameter: vtxEnableParameter, liveValue: vtxEnabled } : undefined}

--- a/apps/web/src/setup-format-helpers.ts
+++ b/apps/web/src/setup-format-helpers.ts
@@ -61,6 +61,13 @@ export function viewMonogram(viewId: AppViewId): string {
   switch (viewId) {
     case 'setup':
       return 'ST'
+    // Both of these used to fall through to the 'APP' default, so two adjacent
+    // nav entries carried the same mark — which is the one thing a mark exists
+    // to prevent.
+    case 'guided-setup':
+      return 'GID'
+    case 'calibration':
+      return 'CAL'
     case 'ports':
       return 'PR'
     case 'vtx':

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -54,6 +54,11 @@
   /* RGB components for the hairline edges/overlays used throughout the app.
      White on the dark theme; flipped to dark ink under [data-theme='light'] so
      every rgba(var(--edge-rgb), a) edge inverts while keeping its opacity. */
+  /* Components of the two colours the app draws washes and glows from. The
+     literal was spelled out 49 times for amber and 26 for the danger red, at a
+     dozen different alphas — none of which a theme could reach. */
+  --primary-rgb: 255, 187, 0;
+  --danger-rgb: 226, 18, 63;
   --edge-rgb: 255, 255, 255;
   /* Neutral dark FILL colour (panels/fields/chips) and near-white INK colour
      (text on those fills). Tokenised so [data-theme='light'] flips both at once.
@@ -117,6 +122,19 @@
    * coded 32px on the Panel <h2> at ui-kit/src/index.tsx so the page
    * title block stops drifting between views. */
   --card-padding: 10px;
+  /* Type scale. These are the sizes the app already used — 520 declarations
+     across nine px values, none of them named. Naming them is what stops the
+     tenth from being 12.5px. */
+  --text-2xs: 9px;
+  --text-xs: 10px;
+  --text-sm: 11px;
+  --text-md: 12px;
+  --text-lg: 13px;
+  --text-xl: 14px;
+  --text-2xl: 15px;
+  --text-3xl: 16px;
+  /* The one tracking value for an uppercase micro-label. Was six values. */
+  --tracking-label: 0.08em;
   --font-title: 18px;
   /* Global density lever (2026-06-10 audit). Ships at 1.0 — the px
    * densification already delivers the target density; calibrate to
@@ -267,7 +285,7 @@
   background:
     linear-gradient(rgba(var(--edge-rgb), 0.06) 1px, transparent 1px),
     linear-gradient(90deg, rgba(var(--edge-rgb), 0.06) 1px, transparent 1px),
-    radial-gradient(circle at top, rgba(255, 187, 0, 0.06), transparent 55%),
+    radial-gradient(circle at top, rgba(var(--primary-rgb), 0.06), transparent 55%),
     #e8ebf1;
 }
 :root[data-theme='light'] .osd-preview-screen__hud,
@@ -282,7 +300,7 @@
   background:
     linear-gradient(rgba(var(--edge-rgb), 0.05) 1px, transparent 1px),
     linear-gradient(90deg, rgba(var(--edge-rgb), 0.05) 1px, transparent 1px),
-    radial-gradient(circle at 50% 42%, rgba(255, 187, 0, 0.06), transparent 42%),
+    radial-gradient(circle at 50% 42%, rgba(var(--primary-rgb), 0.06), transparent 42%),
     #e8ebf1;
 }
 :root[data-theme='light'] .motor-mixer-preview__backdrop {
@@ -315,7 +333,7 @@
   border: 1px solid var(--border);
   background: var(--bg-panel-raised);
   color: var(--text-muted);
-  font-size: 15px;
+  font-size: var(--text-2xl);
   line-height: 1;
   cursor: pointer;
   transition: color 0.15s ease, border-color 0.15s ease, background 0.15s ease;
@@ -339,6 +357,18 @@ html {
   overflow-x: clip;
 }
 
+/* Native checkboxes, radios and ranges render in the platform's own blue
+   unless told otherwise. Only four rules set accent-color, so every other
+   native control in the app — the MAVLink signing key-source radios most
+   visibly — sat in system blue inside an amber UI. One global declaration
+   covers the lot; per-component accent-color rules still win where a surface
+   wants its own. */
+input[type='checkbox'],
+input[type='radio'],
+input[type='range'] {
+  accent-color: var(--accent);
+}
+
 body {
   margin: 0;
   min-width: 320px;
@@ -351,7 +381,7 @@ body {
   text-rendering: optimizeLegibility;
   font-feature-settings: "tnum" 1, "ss01" 1;
   background: var(--bg-app);
-  font-size: 12px;
+  font-size: var(--text-md);
   line-height: 1.42;
   zoom: var(--app-zoom);
 }
@@ -394,7 +424,7 @@ textarea {
   color: var(--text);
   padding: 5px 8px;
   outline: none;
-  font-size: 11px;
+  font-size: var(--text-sm);
 }
 
 option {
@@ -411,7 +441,7 @@ input:focus,
 select:focus,
 textarea:focus {
   border-color: var(--accent);
-  box-shadow: 0 0 0 2px rgba(255, 187, 0, 0.15);
+  box-shadow: 0 0 0 2px rgba(var(--primary-rgb), 0.15);
   outline: none;
 }
 
@@ -451,10 +481,10 @@ textarea:focus {
   padding: 10px 14px;
   background: var(--surface-300);
   border: 1px solid var(--border);
-  border-radius: 10px;
+  border-radius: var(--radius-lg);
   box-shadow: 0 12px 32px rgba(0, 0, 0, 0.45);
   color: var(--surface-950);
-  font-size: 13px;
+  font-size: var(--text-lg);
   max-width: 360px;
 }
 .sw-update-banner__message {
@@ -465,7 +495,7 @@ textarea:focus {
   flex: 0 0 auto;
   padding: 6px 12px;
   border: 1px solid var(--border);
-  border-radius: 6px;
+  border-radius: var(--radius-sm);
   background: var(--surface-500);
   color: var(--surface-950);
   font: inherit;
@@ -493,10 +523,10 @@ textarea:focus {
   max-width: 360px;
   background: var(--surface-300);
   border: 1px solid var(--border);
-  border-radius: 10px;
+  border-radius: var(--radius-lg);
   box-shadow: 0 12px 32px rgba(0, 0, 0, 0.45);
   color: var(--surface-950);
-  font-size: 13px;
+  font-size: var(--text-lg);
 }
 .write-progress-banner__label {
   font-variant-numeric: tabular-nums;
@@ -515,11 +545,11 @@ textarea:focus {
   border-radius: 3px;
 }
 .write-progress-banner__bar::-webkit-progress-value {
-  background: var(--accent, #ffbb00);
+  background: var(--accent, var(--primary-500));
   border-radius: 3px;
 }
 .write-progress-banner__bar::-moz-progress-bar {
-  background: var(--accent, #ffbb00);
+  background: var(--accent, var(--primary-500));
   border-radius: 3px;
 }
 
@@ -564,7 +594,7 @@ textarea:focus {
   max-width: 280px;
   padding: 4px 8px;
   border: 1px solid rgba(var(--edge-rgb), 0.04);
-  border-radius: 12px;
+  border-radius: var(--radius-lg);
   background: rgba(var(--edge-rgb), 0.02);
   cursor: pointer;
   flex-shrink: 0;
@@ -599,11 +629,11 @@ textarea:focus {
   flex-shrink: 0;
   padding: 6px 12px;
   border: 1px solid rgba(var(--edge-rgb), 0.08);
-  border-radius: 10px;
+  border-radius: var(--radius-lg);
   background: rgba(var(--edge-rgb), 0.03);
   color: inherit;
   text-decoration: none;
-  font-size: 0.82rem;
+  font-size: var(--text-lg);
   font-weight: 600;
   line-height: 1;
   white-space: nowrap;
@@ -614,11 +644,11 @@ textarea:focus {
 
 .app-header__wiki:hover {
   background: rgba(var(--edge-rgb), 0.06);
-  border-color: color-mix(in srgb, var(--accent, #ffbb00) 60%, transparent);
+  border-color: color-mix(in srgb, var(--accent, var(--primary-500)) 60%, transparent);
 }
 
 .app-header__wiki-icon {
-  font-size: 1rem;
+  font-size: var(--text-3xl);
 }
 
 .app-header__brand:hover {
@@ -638,10 +668,10 @@ textarea:focus {
   width: 40px;
   height: 40px;
   padding: 0;
-  border-radius: 9px;
+  border-radius: var(--radius-md);
   border: 1px solid rgba(var(--edge-rgb), 0.08);
   background:
-    radial-gradient(circle at top right, rgba(255, 187, 0, 0.18), transparent 46%),
+    radial-gradient(circle at top right, rgba(var(--primary-rgb), 0.18), transparent 46%),
     linear-gradient(180deg, rgba(var(--fill-rgb), 0.98), rgba(var(--fill-rgb), 1));
   color: var(--text);
   box-shadow:
@@ -664,7 +694,7 @@ textarea:focus {
 
 .app-header__brand-copy strong {
   display: block;
-  font-size: 13px;
+  font-size: var(--text-lg);
   font-weight: 600;
   letter-spacing: -0.025em;
 }
@@ -698,7 +728,7 @@ textarea:focus {
 .app-header__connection-input {
   min-width: 0;
   height: 28px;
-  font-size: 12px;
+  font-size: var(--text-md);
 }
 
 .app-header__connection select {
@@ -725,7 +755,7 @@ textarea:focus {
   border: 1px solid var(--surface-400);
   background: var(--surface-300);
   color: var(--text-muted);
-  font-size: 12px;
+  font-size: var(--text-md);
   white-space: nowrap;
 }
 
@@ -763,7 +793,7 @@ textarea:focus {
   gap: 5px;
   min-width: 172px;
   padding: 8px 12px;
-  border-radius: 9px;
+  border-radius: var(--radius-md);
   border: 1px solid var(--surface-400);
   background: var(--surface-300);
 }
@@ -779,7 +809,7 @@ textarea:focus {
   width: 42px;
   height: 27px;
   border: 3px solid var(--surface-800);
-  border-radius: 5px;
+  border-radius: var(--radius-sm);
   flex-shrink: 0;
 }
 
@@ -832,7 +862,7 @@ textarea:focus {
   /* Field feedback: the widget bar can afford to be larger — bumped the
      header height + widget sizes to match (there is free space before
      the params chip reaches the Expert toggle). */
-  font-size: 14px;
+  font-size: var(--text-xl);
   line-height: 1.35;
   white-space: nowrap;
   overflow: hidden;
@@ -842,7 +872,7 @@ textarea:focus {
 .header-quad-status__legend small {
   display: block;
   color: var(--text-muted);
-  font-size: 13px;
+  font-size: var(--text-lg);
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -888,7 +918,7 @@ textarea:focus {
 
 .header-sensor-status {
   display: flex;
-  border-radius: 8px;
+  border-radius: var(--radius-md);
   border: 1px solid var(--surface-400);
   background: var(--surface-300);
   /* User feedback: on 1080p the chip strip's overflow-x:auto scrollbar
@@ -1024,7 +1054,7 @@ textarea:focus {
   display: grid;
   gap: 4px;
   padding: 5px 9px;
-  border-radius: 8px;
+  border-radius: var(--radius-md);
   border: 1px solid var(--surface-400);
   background: var(--surface-300);
 }
@@ -1065,7 +1095,7 @@ textarea:focus {
   align-items: center;
   gap: 8px;
   color: var(--text);
-  font-size: 12px;
+  font-size: var(--text-md);
 }
 
 .expert-mode-toggle input {
@@ -1156,10 +1186,10 @@ textarea:focus {
   height: 28px;
   padding: 0 12px;
   border: 1px solid var(--btn-border);
-  border-radius: 8px;
+  border-radius: var(--radius-md);
   background: var(--btn-bg);
   color: var(--text, #f2f2f2);
-  font-size: 12px;
+  font-size: var(--text-md);
   font-weight: 600;
   letter-spacing: 0.01em;
   cursor: pointer;
@@ -1211,8 +1241,8 @@ textarea:focus {
   margin: 0;
   color: var(--text-dim);
   text-transform: uppercase;
-  letter-spacing: 0.1em;
-  font-size: 10px;
+  letter-spacing: var(--tracking-label);
+  font-size: var(--text-xs);
   font-weight: 700;
 }
 
@@ -1253,7 +1283,7 @@ textarea:focus {
   border-top: 1px solid var(--border);
   box-shadow: none;
   font-family: var(--font-data);
-  font-size: 10px;
+  font-size: var(--text-xs);
   color: var(--text-dim);
   position: sticky;
   bottom: 0;
@@ -1310,8 +1340,8 @@ textarea:focus {
   gap: 12px;
   padding: 6px 12px;
   border-radius: 999px;
-  background: color-mix(in srgb, var(--accent, #ffbb00) 22%, var(--surface-200));
-  border: 1px solid color-mix(in srgb, var(--accent, #ffbb00) 50%, transparent);
+  background: color-mix(in srgb, var(--accent, var(--primary-500)) 22%, var(--surface-200));
+  border: 1px solid color-mix(in srgb, var(--accent, var(--primary-500)) 50%, transparent);
   box-shadow: 0 10px 24px rgba(0, 0, 0, 0.35);
   max-width: calc(100vw - 32px);
 }
@@ -1320,8 +1350,8 @@ textarea:focus {
    so the pill reads as "action needed", since the reboot is now the only
    control and a new operator must not miss it. */
 .parameter-draft-bar--reboot {
-  background: color-mix(in srgb, var(--accent, #ffbb00) 36%, var(--surface-200));
-  border-color: color-mix(in srgb, var(--accent, #ffbb00) 72%, transparent);
+  background: color-mix(in srgb, var(--accent, var(--primary-500)) 36%, var(--surface-200));
+  border-color: color-mix(in srgb, var(--accent, var(--primary-500)) 72%, transparent);
   padding: 8px 14px;
 }
 
@@ -1339,7 +1369,7 @@ textarea:focus {
 }
 
 .parameter-draft-bar__invalid {
-  color: var(--danger, #e2123f);
+  color: var(--danger, var(--danger));
   font-weight: 600;
 }
 
@@ -1407,20 +1437,20 @@ textarea:focus {
 .workspace-tabrail__eyebrow {
   color: var(--text-dim);
   font-family: var(--font-data);
-  font-size: 10px;
+  font-size: var(--text-xs);
   font-weight: 700;
-  letter-spacing: 0.08em;
+  letter-spacing: var(--tracking-label);
   text-transform: uppercase;
 }
 
 .workspace-tabrail__header strong {
-  font-size: 13px;
+  font-size: var(--text-lg);
   line-height: 1.2;
 }
 
 .workspace-tabrail__header small {
   color: var(--text-muted);
-  font-size: 11px;
+  font-size: var(--text-sm);
   line-height: 1.4;
 }
 
@@ -1444,15 +1474,15 @@ textarea:focus {
 
 .baseline-summary__header strong {
   display: block;
-  font-size: 10px;
-  letter-spacing: 0.06em;
+  font-size: var(--text-xs);
+  letter-spacing: var(--tracking-label);
   text-transform: uppercase;
   color: var(--text-dim);
 }
 
 .baseline-summary__header small {
   color: var(--text-dim);
-  font-size: 11px;
+  font-size: var(--text-sm);
 }
 
 /* The Active Baseline box collapses by default — the summary is the title row,
@@ -1494,21 +1524,21 @@ textarea:focus {
 
 .baseline-summary__metrics span {
   color: var(--text-dim);
-  font-size: 9px;
+  font-size: var(--text-2xs);
   text-transform: uppercase;
-  letter-spacing: 0.06em;
+  letter-spacing: var(--tracking-label);
   font-family: var(--font-data);
 }
 
 .baseline-summary__metrics strong {
-  font-size: 13px;
+  font-size: var(--text-lg);
 }
 
 .baseline-strip strong {
   display: block;
   margin-bottom: 4px;
-  font-size: 13px;
-  letter-spacing: 0.04em;
+  font-size: var(--text-lg);
+  letter-spacing: var(--tracking-label);
   text-transform: uppercase;
 }
 
@@ -1529,7 +1559,7 @@ textarea:focus {
 /* Description moved into the collapsible body (the name now lives in the summary). */
 .baseline-summary__desc {
   color: var(--text-dim);
-  font-size: 11px;
+  font-size: var(--text-sm);
 }
 
 .baseline-summary__note {
@@ -1564,14 +1594,14 @@ textarea:focus {
 }
 
 .mode-toggle__option.is-active {
-  border-color: rgba(255, 187, 0, 0.5);
+  border-color: rgba(var(--primary-rgb), 0.5);
   color: var(--text);
-  background: rgba(255, 187, 0, 0.10);
-  box-shadow: inset 0 0 0 1px rgba(255, 187, 0, 0.08);
+  background: rgba(var(--primary-rgb), 0.10);
+  box-shadow: inset 0 0 0 1px rgba(var(--primary-rgb), 0.08);
 }
 
 .mode-toggle__option strong {
-  font-size: 11px;
+  font-size: var(--text-sm);
   font-weight: 600;
 }
 
@@ -1593,7 +1623,7 @@ textarea:focus {
   margin: 0;
   color: var(--text-muted);
   line-height: 1.4;
-  font-size: 11px;
+  font-size: var(--text-sm);
 }
 
 .workspace-mode-summary--muted {
@@ -1606,7 +1636,7 @@ textarea:focus {
 }
 
 .workspace-mode-summary--compact p {
-  font-size: 11px;
+  font-size: var(--text-sm);
   line-height: 1.35;
 }
 
@@ -1636,8 +1666,8 @@ textarea:focus {
 }
 
 .session-follow-up__header strong {
-  font-size: 10px;
-  letter-spacing: 0.06em;
+  font-size: var(--text-xs);
+  letter-spacing: var(--tracking-label);
   text-transform: uppercase;
   color: var(--warning);
 }
@@ -1646,7 +1676,7 @@ textarea:focus {
   margin: 0;
   color: var(--text-muted);
   line-height: 1.4;
-  font-size: 11px;
+  font-size: var(--text-sm);
 }
 
 .workspace-nav {
@@ -1718,7 +1748,7 @@ textarea:focus {
   background: transparent;
   color: var(--text-dim);
   font-family: var(--font-data);
-  font-size: 9px;
+  font-size: var(--text-2xs);
   font-weight: 800;
   letter-spacing: 0.06em;
 }
@@ -1731,7 +1761,7 @@ textarea:focus {
 .workspace-nav__item strong {
   display: block;
   margin: 0;
-  font-size: 13px;
+  font-size: var(--text-lg);
   font-weight: 600;
   /* Never ellipsize a nav label — if a label ever outgrows the sidebar
    * (or the stacked mobile layout squeezes it), wrap to a second line
@@ -1773,16 +1803,16 @@ textarea:focus {
 .workspace-sidebar__summary-row span {
   color: var(--text-dim);
   font-family: var(--font-data);
-  font-size: 10px;
+  font-size: var(--text-xs);
   font-weight: 700;
-  letter-spacing: 0.06em;
+  letter-spacing: var(--tracking-label);
   text-transform: uppercase;
 }
 
 .workspace-sidebar__summary-card strong,
 .workspace-sidebar__next-card strong,
 .workspace-sidebar__alert strong {
-  font-size: 12px;
+  font-size: var(--text-md);
   line-height: 1.35;
 }
 
@@ -1790,7 +1820,7 @@ textarea:focus {
 .workspace-sidebar__next-card small,
 .workspace-sidebar__alert small {
   color: var(--text-muted);
-  font-size: 11px;
+  font-size: var(--text-sm);
   line-height: 1.4;
 }
 
@@ -1804,8 +1834,8 @@ textarea:focus {
 }
 
 .workspace-sidebar__alert--danger {
-  border-color: rgba(226, 18, 63, 0.26);
-  background: rgba(226, 18, 63, 0.08);
+  border-color: rgba(var(--danger-rgb), 0.26);
+  background: rgba(var(--danger-rgb), 0.08);
 }
 
 .workspace-focus-card,
@@ -1827,8 +1857,8 @@ textarea:focus {
 
 .workspace-focus-card__header strong,
 .change-control-dock__item span {
-  font-size: 10px;
-  letter-spacing: 0.06em;
+  font-size: var(--text-xs);
+  letter-spacing: var(--tracking-label);
   text-transform: uppercase;
   color: var(--text-dim);
 }
@@ -1851,7 +1881,7 @@ textarea:focus {
 }
 
 .change-control-dock__item strong {
-  font-size: 15px;
+  font-size: var(--text-2xl);
   line-height: 1.3;
 }
 
@@ -1877,14 +1907,14 @@ textarea:focus {
   display: grid;
   gap: 4px;
   padding: 8px 10px;
-  border-radius: 8px;
+  border-radius: var(--radius-md);
   border: 1px solid var(--primary-500);
   background: var(--primary-transparent-1);
 }
 
 .workspace-note strong {
-  font-size: 11px;
-  letter-spacing: 0.06em;
+  font-size: var(--text-sm);
+  letter-spacing: var(--tracking-label);
   text-transform: uppercase;
 }
 
@@ -1896,7 +1926,7 @@ textarea:focus {
 
 .workspace-note small {
   color: var(--text-muted);
-  font-size: 11px;
+  font-size: var(--text-sm);
   line-height: 1.4;
 }
 
@@ -1910,8 +1940,8 @@ textarea:focus {
 }
 
 .workspace-note--danger {
-  border-color: rgba(226, 18, 63, 0.34);
-  background: rgba(226, 18, 63, 0.08);
+  border-color: rgba(var(--danger-rgb), 0.34);
+  background: rgba(var(--danger-rgb), 0.08);
 }
 
 .workspace-main__header--betaflight {
@@ -1945,9 +1975,9 @@ textarea:focus {
   background: var(--bg-panel);
   color: var(--text-muted);
   font-family: var(--font-data);
-  font-size: 10px;
+  font-size: var(--text-xs);
   font-weight: 700;
-  letter-spacing: 0.06em;
+  letter-spacing: var(--tracking-label);
   text-transform: uppercase;
 }
 
@@ -1966,20 +1996,20 @@ textarea:focus {
 .workspace-main__summary-card span {
   color: var(--text-dim);
   font-family: var(--font-data);
-  font-size: 10px;
-  letter-spacing: 0.06em;
+  font-size: var(--text-xs);
+  letter-spacing: var(--tracking-label);
   text-transform: uppercase;
 }
 
 .workspace-main__summary-card strong {
-  font-size: 13px;
+  font-size: var(--text-lg);
   line-height: 1.2;
 }
 
 .workspace-main__summary-card small {
   color: var(--text-muted);
   line-height: 1.35;
-  font-size: 12px;
+  font-size: var(--text-md);
 }
 
 .button-row {
@@ -2026,8 +2056,8 @@ textarea:focus {
 .setup-flow__banner strong {
   display: block;
   margin-bottom: 6px;
-  font-size: 12px;
-  letter-spacing: 0.04em;
+  font-size: var(--text-md);
+  letter-spacing: var(--tracking-label);
   text-transform: uppercase;
 }
 
@@ -2137,13 +2167,13 @@ textarea:focus {
 .setup-flow-step span {
   font-weight: 700;
   letter-spacing: -0.01em;
-  font-size: 14px;
+  font-size: var(--text-xl);
 }
 
 .setup-flow-step small {
   color: var(--text-muted);
   line-height: 1.35;
-  font-size: 12px;
+  font-size: var(--text-md);
 }
 
 .setup-command-center .setup-flow-step {
@@ -2154,7 +2184,7 @@ textarea:focus {
 .setup-flow-step__eyebrow {
   color: var(--accent-strong);
   text-transform: uppercase;
-  letter-spacing: 0.08em;
+  letter-spacing: var(--tracking-label);
 }
 
 .setup-flow-step__meta {
@@ -2163,7 +2193,7 @@ textarea:focus {
   align-items: center;
   gap: 10px;
   color: var(--text-muted);
-  font-size: 12px;
+  font-size: var(--text-md);
 }
 
 .setup-flow-step.is-active {
@@ -2227,7 +2257,7 @@ textarea:focus {
 .setup-wizard__advanced-disclosure > summary::before {
   content: '▸';
   color: var(--text-muted);
-  font-size: 11px;
+  font-size: var(--text-sm);
   transition: transform 0.15s ease;
 }
 .setup-flow__criteria[open] > summary::before,
@@ -2240,7 +2270,7 @@ textarea:focus {
 .setup-flow__criteria-count {
   margin-left: auto;
   color: var(--text-muted);
-  font-size: 12px;
+  font-size: var(--text-md);
   text-transform: none;
   letter-spacing: 0;
 }
@@ -2250,16 +2280,16 @@ textarea:focus {
   padding: 2px 12px;
 }
 .setup-wizard__advanced-disclosure > summary strong {
-  font-size: 13px;
+  font-size: var(--text-lg);
 }
 .setup-wizard__advanced-disclosure > summary span {
   color: var(--text-muted);
-  font-size: 12px;
+  font-size: var(--text-md);
 }
 
 .setup-flow__criteria strong {
-  font-size: 13px;
-  letter-spacing: 0.08em;
+  font-size: var(--text-lg);
+  letter-spacing: var(--tracking-label);
   text-transform: uppercase;
   color: var(--text-muted);
 }
@@ -2284,7 +2314,7 @@ textarea:focus {
   padding: 4px 2px;
   border-radius: var(--radius-md);
   color: var(--text-muted);
-  font-size: 12.5px;
+  font-size: var(--text-lg);
   line-height: 1.45;
 }
 
@@ -2294,7 +2324,7 @@ textarea:focus {
 
 .setup-flow__criteria-mark {
   color: var(--text-dim);
-  font-size: 12px;
+  font-size: var(--text-md);
   line-height: 1.45;
   text-align: center;
 }
@@ -2313,7 +2343,7 @@ textarea:focus {
   margin: 0;
   padding: 8px 12px;
   border-left: 3px solid var(--warning);
-  border-radius: 4px;
+  border-radius: var(--radius-sm);
   background: color-mix(in srgb, var(--warning) 10%, transparent);
   color: var(--text);
 }
@@ -2390,7 +2420,7 @@ textarea:focus {
   align-items: center;
   gap: 10px;
   margin-top: 10px;
-  font-size: 12px;
+  font-size: var(--text-md);
   color: var(--text-muted);
 }
 
@@ -2419,7 +2449,7 @@ textarea:focus {
 
 .ports-surface__header h3 {
   margin: 0 0 6px;
-  font-size: 15px;
+  font-size: var(--text-2xl);
   line-height: 1.06;
   font-weight: 600;
   letter-spacing: -0.03em;
@@ -2517,7 +2547,7 @@ textarea:focus {
   gap: 8px;
   padding: 8px 14px;
   border: 2px solid var(--border);
-  border-radius: 8px;
+  border-radius: var(--radius-md);
   background: color-mix(in srgb, var(--text) 4%, transparent);
   color: var(--text-muted);
   font: inherit;
@@ -2552,7 +2582,7 @@ textarea:focus {
 .outputs-tabs__detail {
   margin: 0;
   color: var(--text-muted);
-  font-size: 12px;
+  font-size: var(--text-md);
 }
 
 .outputs-tab-body {
@@ -2575,7 +2605,7 @@ textarea:focus {
 }
 .outputs-accordion-card {
   border: 1px solid var(--surface-400);
-  border-radius: var(--radius-md, 8px);
+  border-radius: var(--radius-md);
   background: var(--surface-200);
   overflow: hidden;
 }
@@ -2600,15 +2630,15 @@ textarea:focus {
   background: var(--surface-300);
 }
 .outputs-accordion-card.is-active .outputs-accordion-card__header {
-  background: rgba(255, 187, 0, 0.08);
+  background: rgba(var(--primary-rgb), 0.08);
 }
 .outputs-accordion-card__chevron {
   color: var(--text-muted);
-  font-size: 11px;
+  font-size: var(--text-sm);
   width: 12px;
 }
 .outputs-accordion-card__title {
-  font-size: 13px;
+  font-size: var(--text-lg);
   font-weight: 600;
   overflow-wrap: anywhere;
 }
@@ -2616,7 +2646,7 @@ textarea:focus {
   grid-column: 2 / -1;
   margin: 2px 0 0;
   color: var(--text-muted);
-  font-size: 11px;
+  font-size: var(--text-sm);
   line-height: 1.4;
 }
 .outputs-accordion-card__body {
@@ -2686,7 +2716,7 @@ textarea:focus {
 
 .telemetry-header h3 {
   margin: 0 0 6px;
-  font-size: 15px;
+  font-size: var(--text-2xl);
   line-height: 1.08;
   letter-spacing: -0.025em;
 }
@@ -2736,7 +2766,7 @@ textarea:focus {
 }
 
 .setup-bench-action.is-active {
-  background: rgba(255, 187, 0, 0.06);
+  background: rgba(var(--primary-rgb), 0.06);
 }
 
 .setup-bench-action.is-success {
@@ -2744,7 +2774,7 @@ textarea:focus {
 }
 
 .setup-bench-action.is-danger {
-  background: rgba(226, 18, 63, 0.05);
+  background: rgba(var(--danger-rgb), 0.05);
 }
 
 .setup-bench-action__button {
@@ -2757,8 +2787,8 @@ textarea:focus {
 }
 
 .setup-bench-action__copy strong {
-  font-size: 12px;
-  letter-spacing: 0.08em;
+  font-size: var(--text-md);
+  letter-spacing: var(--tracking-label);
   text-transform: uppercase;
   color: var(--text);
 }
@@ -2772,7 +2802,7 @@ textarea:focus {
 .setup-bench-action__blocked-reason {
   color: var(--warning);
   font-family: var(--font-data);
-  font-size: 10px;
+  font-size: var(--text-xs);
   letter-spacing: 0.04em;
 }
 
@@ -2793,7 +2823,7 @@ textarea:focus {
 .setup-bench-action__progress-label {
   display: flex;
   justify-content: space-between;
-  font-size: 12px;
+  font-size: var(--text-md);
   color: var(--text-muted);
 }
 
@@ -2832,7 +2862,7 @@ textarea:focus {
   display: grid;
   gap: 10px;
   border: 2px solid var(--surface-400);
-  border-radius: 12px;
+  border-radius: var(--radius-lg);
   background: var(--surface-200);
   padding: 10px 12px;
   padding-top: 18px;
@@ -2861,8 +2891,8 @@ textarea:focus {
 }
 
 .setup-bench__viewer-titlebar strong {
-  font-size: 11px;
-  letter-spacing: 0.1em;
+  font-size: var(--text-sm);
+  letter-spacing: var(--tracking-label);
   text-transform: uppercase;
   color: #000;
 }
@@ -2895,7 +2925,7 @@ textarea:focus {
   display: grid;
   gap: 10px;
   border: 2px solid var(--surface-400);
-  border-radius: 12px;
+  border-radius: var(--radius-lg);
   background: var(--surface-200);
   padding: 10px 12px;
   padding-top: 18px;
@@ -2933,8 +2963,8 @@ textarea:focus {
  * stopped"), because a fourth colour would be noise, not information. */
 .setup-gui-box--sensor-silent,
 .setup-gui-box--sensor-stalled {
-  border-color: color-mix(in srgb, var(--danger, #e2123f) 55%, transparent);
-  box-shadow: inset 3px 0 0 0 var(--danger, #e2123f);
+  border-color: color-mix(in srgb, var(--danger, var(--danger)) 55%, transparent);
+  box-shadow: inset 3px 0 0 0 var(--danger, var(--danger));
 }
 
 /* The fault/OK headline, on the face of the card. This is deliberately NOT a
@@ -2942,7 +2972,7 @@ textarea:focus {
  * for the one line that diagnosed their problem. */
 .setup-gui-box__sensor-headline {
   margin: 0;
-  font-size: 0.82rem;
+  font-size: var(--text-lg);
   font-weight: 600;
   line-height: 1.35;
 }
@@ -2956,14 +2986,14 @@ textarea:focus {
 }
 
 .setup-gui-box__sensor-headline--danger {
-  color: var(--danger, #e2123f);
+  color: var(--danger, var(--danger));
 }
 
 /* The headline measurement row — the number the operator actually came for.
  * Slightly larger and tabular so a changing distance doesn't jitter the
  * layout as digits change width. */
 .setup-gui-box__kv-row--measurement strong {
-  font-size: 1.02rem;
+  font-size: var(--text-3xl);
   font-variant-numeric: tabular-nums;
 }
 
@@ -2980,8 +3010,8 @@ textarea:focus {
 }
 
 .setup-gui-box__titlebar strong {
-  font-size: 11px;
-  letter-spacing: 0.1em;
+  font-size: var(--text-sm);
+  letter-spacing: var(--tracking-label);
   text-transform: uppercase;
   color: #000;
 }
@@ -3010,7 +3040,7 @@ textarea:focus {
 .setup-gui-box__notice-filter-input {
   width: 100%;
   padding: 6px 10px;
-  border-radius: 6px;
+  border-radius: var(--radius-sm);
   border: 1px solid var(--border, rgba(var(--edge-rgb), 0.16));
   background: var(--surface-2, rgba(var(--edge-rgb), 0.04));
   color: inherit;
@@ -3249,7 +3279,7 @@ textarea:focus {
 /* An emptied column still has to be a target you can hit. */
 .status-dash-col--empty {
   min-height: 64px;
-  border-radius: 12px;
+  border-radius: var(--radius-lg);
   border: 1px dashed color-mix(in srgb, var(--surface-400) 70%, transparent);
 }
 
@@ -3295,7 +3325,7 @@ textarea:focus {
   border: 1px solid var(--surface-400);
   background: var(--surface-300);
   color: var(--text-muted);
-  font-size: 10px;
+  font-size: var(--text-xs);
   line-height: 1;
   cursor: pointer;
 }
@@ -3325,7 +3355,7 @@ textarea:focus {
 .status-dash-col__flow:focus-visible {
   outline: 2px solid var(--primary-500);
   outline-offset: 2px;
-  border-radius: 6px;
+  border-radius: var(--radius-sm);
 }
 
 .status-dash-col__width:disabled {
@@ -3347,7 +3377,7 @@ textarea:focus {
 
 .status-dash-toolbar__hint {
   color: var(--text-muted);
-  font-size: 12px;
+  font-size: var(--text-md);
 }
 
 .status-dash-card {
@@ -3391,7 +3421,7 @@ textarea:focus {
   border-radius: 999px;
   background: var(--surface-300);
   color: var(--text-muted);
-  font-size: 11px;
+  font-size: var(--text-sm);
   line-height: 1;
   cursor: grab;
   opacity: 0.5;
@@ -3447,7 +3477,7 @@ textarea:focus {
 .status-dash-card__resize:focus-visible {
   outline: 2px solid var(--primary-500);
   outline-offset: 2px;
-  border-radius: 6px;
+  border-radius: var(--radius-sm);
 }
 
 /* Where the card will land.
@@ -3497,7 +3527,7 @@ body.is-status-dash-dragging {
 }
 /* Lifetime stats are secondary to pre-arm — render them smaller/denser. */
 .setup-gui-box--compact .setup-gui-box__body {
-  font-size: 12px;
+  font-size: var(--text-md);
 }
 .setup-gui-box--compact .setup-gui-box__kv-row {
   padding: 3px 0;
@@ -3508,7 +3538,7 @@ body.is-status-dash-dragging {
   display: flex;
   flex-direction: column;
   gap: 3px;
-  font-size: 12px;
+  font-size: var(--text-md);
   color: var(--warning);
   /* Reasons are FC-authored strings of unbounded length; wrapping (rather than
      widening) is what keeps the 390px phone layout from overflowing. */
@@ -3525,7 +3555,7 @@ body.is-status-dash-dragging {
   display: flex;
   justify-content: space-between;
   gap: 12px;
-  font-size: 12px;
+  font-size: var(--text-md);
   padding: 7px 0;
   border-bottom: 1px solid var(--surface-400);
 }
@@ -3555,12 +3585,12 @@ body.is-status-dash-dragging {
 
 .setup-gui-box__inline-select {
   font: inherit;
-  font-size: 11px;
+  font-size: var(--text-sm);
   font-family: var(--font-data);
   color: var(--text);
   background: var(--surface-300);
   border: 1px solid var(--surface-400);
-  border-radius: 6px;
+  border-radius: var(--radius-sm);
   padding: 2px 6px;
   cursor: pointer;
 }
@@ -3628,7 +3658,7 @@ body.is-status-dash-dragging {
 .setup-gui-box__popped-out,
 .setup-gui-box__popout-blocked {
   margin: 0;
-  font-size: 11px;
+  font-size: var(--text-sm);
   color: var(--text-muted);
 }
 
@@ -3638,13 +3668,13 @@ body.is-status-dash-dragging {
 
 .setup-gui-box__icon-button {
   font: inherit;
-  font-size: 10px;
-  letter-spacing: 0.08em;
+  font-size: var(--text-xs);
+  letter-spacing: var(--tracking-label);
   text-transform: uppercase;
   color: var(--text);
   background: var(--surface-300);
   border: 1px solid var(--surface-400);
-  border-radius: 6px;
+  border-radius: var(--radius-sm);
   padding: 2px 8px;
   cursor: pointer;
 }
@@ -3665,21 +3695,21 @@ body.is-status-dash-dragging {
 
 .setup-gui-box__empty {
   color: var(--text-dim);
-  font-size: 11px;
+  font-size: var(--text-sm);
 }
 
 .setup-gui-box__status-entry {
   display: grid;
   gap: 4px;
   padding: 8px 9px;
-  border-radius: 8px;
+  border-radius: var(--radius-md);
   border: 1px solid var(--surface-400);
   background: var(--surface-300);
 }
 
 .setup-gui-box__status-entry strong {
-  font-size: 10px;
-  letter-spacing: 0.08em;
+  font-size: var(--text-xs);
+  letter-spacing: var(--tracking-label);
   text-transform: uppercase;
 }
 
@@ -3693,7 +3723,7 @@ body.is-status-dash-dragging {
 }
 
 .setup-gui-box__status-entry.is-error {
-  border-color: rgba(226, 18, 63, 0.24);
+  border-color: rgba(var(--danger-rgb), 0.24);
 }
 
 /* Severity-grouped Recent Notices — small header strip above each group
@@ -3711,15 +3741,15 @@ body.is-status-dash-dragging {
   display: flex;
   justify-content: space-between;
   align-items: baseline;
-  font-size: 10px;
-  letter-spacing: 0.08em;
+  font-size: var(--text-xs);
+  letter-spacing: var(--tracking-label);
   text-transform: uppercase;
   color: var(--text-dim);
   padding: 0 2px;
 }
 
 .setup-gui-box__status-group--error .setup-gui-box__status-group-header strong {
-  color: rgba(226, 18, 63, 0.95);
+  color: rgba(var(--danger-rgb), 0.95);
 }
 
 .setup-gui-box__status-group--warning .setup-gui-box__status-group-header strong {
@@ -3746,7 +3776,7 @@ body.is-status-dash-dragging {
    * which mangled any note with inline emphasis. */
   display: block;
   padding: 10px 12px;
-  border-radius: 12px;
+  border-radius: var(--radius-lg);
   border: 1px solid var(--primary-600);
   background: var(--primary-transparent-2);
 }
@@ -3758,7 +3788,7 @@ body.is-status-dash-dragging {
 
 .bf-note--danger {
   border-color: var(--danger);
-  background: rgba(226, 18, 63, 0.14);
+  background: rgba(var(--danger-rgb), 0.14);
 }
 
 /* Accent variant used by the motor-reorder guided identify banner —
@@ -3781,7 +3811,7 @@ body.is-status-dash-dragging {
   display: grid;
   gap: 10px;
   border: 2px solid var(--surface-400);
-  border-radius: 12px;
+  border-radius: var(--radius-lg);
   background: var(--surface-200);
   padding: 10px 12px;
   padding-top: 18px;
@@ -3806,8 +3836,8 @@ body.is-status-dash-dragging {
 
 .bf-gui-box__titlebar strong {
   color: #000;
-  font-size: 11px;
-  letter-spacing: 0.1em;
+  font-size: var(--text-sm);
+  letter-spacing: var(--tracking-label);
   text-transform: uppercase;
 }
 
@@ -3827,7 +3857,7 @@ body.is-status-dash-dragging {
   gap: 12px;
   padding: 7px 0;
   border-bottom: 1px solid var(--surface-400);
-  font-size: 12px;
+  font-size: var(--text-md);
 }
 
 .bf-gui-box__kv-row:last-child {
@@ -3878,8 +3908,8 @@ body.is-status-dash-dragging {
   gap: 8px;
   margin-right: 6px;
   color: var(--text-muted);
-  font-size: 11px;
-  letter-spacing: 0.08em;
+  font-size: var(--text-sm);
+  letter-spacing: var(--tracking-label);
   text-transform: uppercase;
 }
 
@@ -3912,7 +3942,7 @@ body.is-status-dash-dragging {
   gap: 8px;
   align-content: start;
   padding: 12px;
-  border-radius: 10px;
+  border-radius: var(--radius-lg);
   border: 1px solid rgba(255, 102, 0, 0.35);
   background: rgba(255, 102, 0, 0.08);
 }
@@ -3935,7 +3965,7 @@ body.is-status-dash-dragging {
 }
 .bf-vtx-table__grid {
   border-collapse: collapse;
-  font-size: 12px;
+  font-size: var(--text-md);
   min-width: 100%;
 }
 .bf-vtx-table__grid th,
@@ -3961,11 +3991,11 @@ body.is-status-dash-dragging {
 .bf-vtx-table__grid input[type='number'] {
   width: 68px;
   font-family: var(--font-data);
-  font-size: 12px;
+  font-size: var(--text-md);
   background: var(--surface-300);
   color: var(--text);
   border: 1px solid var(--surface-400);
-  border-radius: 4px;
+  border-radius: var(--radius-sm);
   padding: 2px 4px;
   text-align: right;
 }
@@ -3982,7 +4012,7 @@ body.is-status-dash-dragging {
 }
 .bf-vtx-table__power-grid {
   border-collapse: collapse;
-  font-size: 12px;
+  font-size: var(--text-md);
 }
 .bf-vtx-table__power-grid th,
 .bf-vtx-table__power-grid td {
@@ -3997,11 +4027,11 @@ body.is-status-dash-dragging {
 .bf-vtx-table__power-grid input[type='number'],
 .bf-vtx-table__power-grid input[type='text'] {
   font-family: var(--font-data);
-  font-size: 12px;
+  font-size: var(--text-md);
   background: var(--surface-300);
   color: var(--text);
   border: 1px solid var(--surface-400);
-  border-radius: 4px;
+  border-radius: var(--radius-sm);
   padding: 2px 4px;
 }
 .bf-vtx-table__power-grid input[type='number'] {
@@ -4033,24 +4063,24 @@ body.is-status-dash-dragging {
   border: 1px solid var(--card-outline);
   background: var(--bg-panel-raised);
   color: var(--text);
-  font-size: 13px;
+  font-size: var(--text-lg);
 }
 .bf-vtx-table__import {
   display: grid;
   gap: 8px;
   padding: 10px;
   border: 1px solid var(--surface-400);
-  border-radius: 8px;
+  border-radius: var(--radius-md);
   background: var(--surface-200);
 }
 .bf-vtx-table__import textarea {
   width: 100%;
   font-family: var(--font-data);
-  font-size: 12px;
+  font-size: var(--text-md);
   background: var(--surface-300);
   color: var(--text);
   border: 1px solid var(--surface-400);
-  border-radius: 6px;
+  border-radius: var(--radius-sm);
   padding: 6px 8px;
   resize: vertical;
 }
@@ -4071,8 +4101,8 @@ body.is-status-dash-dragging {
   flex-wrap: wrap;
   gap: 8px;
   color: var(--text-muted);
-  font-size: 11px;
-  letter-spacing: 0.08em;
+  font-size: var(--text-sm);
+  letter-spacing: var(--tracking-label);
   text-transform: uppercase;
 }
 
@@ -4085,12 +4115,12 @@ body.is-status-dash-dragging {
   max-width: 100%;
   min-width: 0;
   min-height: 140px;
-  border-radius: 12px;
+  border-radius: var(--radius-lg);
   border: 2px solid var(--surface-400);
   background:
     linear-gradient(rgba(var(--edge-rgb), 0.04) 1px, transparent 1px),
     linear-gradient(90deg, rgba(var(--edge-rgb), 0.04) 1px, transparent 1px),
-    radial-gradient(circle at top, rgba(255, 187, 0, 0.08), transparent 55%),
+    radial-gradient(circle at top, rgba(var(--primary-rgb), 0.08), transparent 55%),
     #050708;
   background-size: 20px 20px, 20px 20px, auto, auto;
   overflow: hidden;
@@ -4117,7 +4147,7 @@ body.is-status-dash-dragging {
   position: absolute;
   inset: 0;
   font-family: var(--font-data);
-  font-size: 13px;
+  font-size: var(--text-lg);
   color: #d7dcd1;
   text-shadow: 0 0 10px rgba(255, 243, 189, 0.18);
 }
@@ -4144,14 +4174,14 @@ body.is-status-dash-dragging {
   white-space: nowrap;
   /* Smaller, denser glyphs so elements read like real OSD characters and
      don't crowd the (now layout-aware) preview grid. */
-  font-size: 10px;
+  font-size: var(--text-xs);
   line-height: 1;
   letter-spacing: -0.01em;
 }
 
 .osd-preview-screen__element--center {
   justify-self: center;
-  font-size: 14px;
+  font-size: var(--text-xl);
   opacity: 0.55;
 }
 
@@ -4168,7 +4198,7 @@ body.is-status-dash-dragging {
 .osd-preview-screen__center-marker-horizontal,
 .osd-preview-screen__center-marker-vertical {
   position: absolute;
-  background: rgba(255, 187, 0, 0.45);
+  background: rgba(var(--primary-rgb), 0.45);
 }
 
 .osd-preview-screen__center-marker-horizontal {
@@ -4255,12 +4285,12 @@ body.is-status-dash-dragging {
   display: grid;
   place-items: center;
   min-height: 320px;
-  border-radius: 12px;
+  border-radius: var(--radius-lg);
   border: 2px solid var(--surface-400);
   background:
     linear-gradient(rgba(var(--edge-rgb), 0.04) 1px, transparent 1px),
     linear-gradient(90deg, rgba(var(--edge-rgb), 0.04) 1px, transparent 1px),
-    radial-gradient(circle at 50% 42%, rgba(255, 187, 0, 0.08), transparent 42%),
+    radial-gradient(circle at 50% 42%, rgba(var(--primary-rgb), 0.08), transparent 42%),
     #06090c;
   background-size: 22px 22px, 22px 22px, auto, auto;
   overflow: hidden;
@@ -4311,7 +4341,7 @@ body.is-status-dash-dragging {
   margin: 0;
   max-width: 34ch;
   color: var(--text-muted);
-  font-size: 13px;
+  font-size: var(--text-lg);
   line-height: 1.5;
 }
 
@@ -4331,21 +4361,21 @@ body.is-status-dash-dragging {
 }
 
 .motor-mixer-preview__body {
-  fill: rgba(255, 187, 0, 0.08);
-  stroke: rgba(255, 187, 0, 0.3);
+  fill: rgba(var(--primary-rgb), 0.08);
+  stroke: rgba(var(--primary-rgb), 0.3);
   stroke-width: 1.5;
 }
 
 .motor-mixer-preview__center-label {
   fill: var(--text-muted);
   font-family: var(--font-data);
-  font-size: 12px;
+  font-size: var(--text-md);
   letter-spacing: 0.1em;
 }
 
 .motor-mixer-preview__nose-arrow {
-  fill: rgba(255, 187, 0, 0.74);
-  stroke: rgba(255, 187, 0, 0.74);
+  fill: rgba(var(--primary-rgb), 0.74);
+  stroke: rgba(var(--primary-rgb), 0.74);
   stroke-width: 1.2;
 }
 
@@ -4357,7 +4387,7 @@ body.is-status-dash-dragging {
 
 .motor-mixer-preview__stack {
   fill: rgba(var(--edge-rgb), 0.04);
-  stroke: rgba(255, 187, 0, 0.28);
+  stroke: rgba(var(--primary-rgb), 0.28);
   stroke-width: 1.5;
 }
 
@@ -4375,28 +4405,28 @@ body.is-status-dash-dragging {
 .motor-mixer-preview__motor-number {
   fill: var(--text);
   font-family: var(--font-data);
-  font-size: 17px;
+  font-size: var(--text-3xl);
   font-weight: 700;
 }
 
 .motor-mixer-preview__channel-label {
   fill: var(--text-dim);
   font-family: var(--font-data);
-  font-size: 9px;
+  font-size: var(--text-2xs);
   letter-spacing: 0.08em;
 }
 
 .motor-mixer-preview__stack-label {
   fill: var(--text-muted);
   font-family: var(--font-data);
-  font-size: 9px;
-  letter-spacing: 0.08em;
+  font-size: var(--text-2xs);
+  letter-spacing: var(--tracking-label);
   text-transform: uppercase;
 }
 
 .motor-mixer-preview__node.is-target .motor-mixer-preview__ring {
-  fill: rgba(255, 187, 0, 0.18);
-  stroke: rgba(255, 187, 0, 0.92);
+  fill: rgba(var(--primary-rgb), 0.18);
+  stroke: rgba(var(--primary-rgb), 0.92);
 }
 
 .motor-mixer-preview__node.is-complete .motor-mixer-preview__ring {
@@ -4441,7 +4471,7 @@ body.is-status-dash-dragging {
   gap: 4px;
   min-width: 0;
   padding: 11px 12px;
-  border-radius: 10px;
+  border-radius: var(--radius-lg);
   border: 1px solid var(--surface-400);
   background: rgba(var(--fill-rgb), 0.9);
 }
@@ -4453,8 +4483,8 @@ body.is-status-dash-dragging {
 }
 
 .motor-mixer-summary-card strong {
-  font-size: 12px;
-  letter-spacing: 0.08em;
+  font-size: var(--text-md);
+  letter-spacing: var(--tracking-label);
   text-transform: uppercase;
 }
 
@@ -4488,7 +4518,7 @@ body.is-status-dash-dragging {
 .setup-overview__launch-row small {
   color: var(--text-dim);
   line-height: 1.4;
-  font-size: 11px;
+  font-size: var(--text-sm);
 }
 
 /* Flight Deck command display — dense instrument layout */
@@ -4528,11 +4558,11 @@ body.is-status-dash-dragging {
 }
 
 .flight-deck-command__telemetry-strip .telemetry-metric-card span {
-  font-size: 9px;
+  font-size: var(--text-2xs);
 }
 
 .flight-deck-command__telemetry-strip .telemetry-metric-card strong {
-  font-size: 14px;
+  font-size: var(--text-xl);
 }
 
 .flight-deck-command__signal-strip {
@@ -4550,7 +4580,7 @@ body.is-status-dash-dragging {
   border: 1px solid var(--border-soft);
   background: var(--bg-panel-muted);
   color: var(--text-dim);
-  font-size: 10px;
+  font-size: var(--text-xs);
   font-family: var(--font-data);
   letter-spacing: 0.04em;
 }
@@ -4594,10 +4624,10 @@ body.is-status-dash-dragging {
 }
 
 .flight-deck-command__sidebar-section-title {
-  font-size: 9px;
+  font-size: var(--text-2xs);
   font-weight: 700;
   text-transform: uppercase;
-  letter-spacing: 0.08em;
+  letter-spacing: var(--tracking-label);
   color: var(--text-dim);
   font-family: var(--font-data);
   padding: 0 0 4px;
@@ -4611,7 +4641,7 @@ body.is-status-dash-dragging {
   align-items: center;
   gap: 8px;
   padding: 3px 0;
-  font-size: 11px;
+  font-size: var(--text-sm);
 }
 
 .flight-deck-command__kv-row span {
@@ -4621,7 +4651,7 @@ body.is-status-dash-dragging {
 .flight-deck-command__kv-row strong {
   color: var(--text);
   font-family: var(--font-data);
-  font-size: 11px;
+  font-size: var(--text-sm);
 }
 
 .flight-deck-command__guided-summary {
@@ -4639,22 +4669,22 @@ body.is-status-dash-dragging {
 }
 
 .flight-deck-command__guided-summary strong {
-  font-size: 11px;
+  font-size: var(--text-sm);
   font-weight: 600;
 }
 
 .flight-deck-command__guided-summary p {
   margin: 0;
   color: var(--text-dim);
-  font-size: 11px;
+  font-size: var(--text-sm);
   line-height: 1.4;
 }
 
 .flight-deck-command__guided-summary-notes {
   color: var(--text) !important;
   font-family: var(--font-data);
-  font-size: 10px !important;
-  letter-spacing: 0.05em;
+  font-size: var(--text-xs) !important;
+  letter-spacing: var(--tracking-label);
   text-transform: uppercase;
 }
 
@@ -4668,13 +4698,13 @@ body.is-status-dash-dragging {
 .flight-deck-command__status-log .status-entry {
   padding: 5px 8px;
   border-radius: var(--radius-sm);
-  font-size: 11px;
+  font-size: var(--text-sm);
   gap: 8px;
   grid-template-columns: 52px minmax(0, 1fr);
 }
 
 .flight-deck-command__status-log .status-entry strong {
-  font-size: 9px;
+  font-size: var(--text-2xs);
 }
 
 .setup-command-center__hero {
@@ -4745,8 +4775,8 @@ body.is-status-dash-dragging {
   min-height: 40px;
   min-width: 180px;
   padding: 8px 16px !important;
-  font-size: 13px !important;
-  border-radius: 8px !important;
+  font-size: var(--text-lg) !important;
+  border-radius: var(--radius-md) !important;
 }
 
 .setup-wizard__header {
@@ -4770,7 +4800,7 @@ body.is-status-dash-dragging {
   border: 1px solid var(--good, #3fbf6a);
   background: color-mix(in srgb, var(--good, #3fbf6a) 14%, transparent);
   color: var(--text);
-  font-size: 13px;
+  font-size: var(--text-lg);
 }
 .setup-wizard__complete-banner strong {
   letter-spacing: -0.01em;
@@ -4778,7 +4808,7 @@ body.is-status-dash-dragging {
 .setup-wizard__complete-count {
   margin-left: auto;
   color: var(--text-muted);
-  font-size: 12px;
+  font-size: var(--text-md);
 }
 .setup-wizard__complete-check {
   display: inline-flex;
@@ -4789,14 +4819,14 @@ body.is-status-dash-dragging {
   border-radius: 999px;
   background: var(--good, #3fbf6a);
   color: #04140a;
-  font-size: 13px;
+  font-size: var(--text-lg);
   font-weight: 700;
   flex: none;
 }
 
 .setup-wizard__header h3 {
   margin: 0 0 8px;
-  font-size: 15px;
+  font-size: var(--text-2xl);
   letter-spacing: -0.02em;
 }
 
@@ -4856,15 +4886,15 @@ body.is-status-dash-dragging {
 
 .setup-wizard-step small {
   color: var(--text-dim);
-  font-size: 9px;
+  font-size: var(--text-2xs);
   text-transform: uppercase;
-  letter-spacing: 0.06em;
+  letter-spacing: var(--tracking-label);
   font-family: var(--font-data);
   white-space: nowrap;
 }
 
 .setup-wizard-step span {
-  font-size: 11.5px;
+  font-size: var(--text-md);
   font-weight: 700;
   line-height: 1.25;
   /* One line per chip keeps the rail a fixed height regardless of how long a
@@ -4885,11 +4915,11 @@ body.is-status-dash-dragging {
   clip-path: inset(50%);
   white-space: nowrap;
   color: rgba(230, 194, 108, 0.96);
-  font-size: 10px;
+  font-size: var(--text-xs);
   font-style: normal;
   font-weight: 700;
   text-transform: uppercase;
-  letter-spacing: 0.08em;
+  letter-spacing: var(--tracking-label);
   font-family: var(--font-data);
 }
 
@@ -4914,7 +4944,7 @@ body.is-status-dash-dragging {
   top: 6px;
   right: 7px;
   color: rgba(230, 194, 108, 0.96);
-  font-size: 12px;
+  font-size: var(--text-md);
   font-weight: 700;
   line-height: 1;
 }
@@ -4944,11 +4974,11 @@ body.is-status-dash-dragging {
   width: 100%;
   margin-bottom: 10px;
   padding: 7px 12px;
-  border-radius: 8px;
+  border-radius: var(--radius-md);
   border: 1px solid var(--primary-500);
   background: color-mix(in srgb, var(--primary-500) 12%, transparent);
   color: var(--text-primary);
-  font-size: 13px;
+  font-size: var(--text-lg);
   font-weight: 600;
   cursor: pointer;
   text-align: left;
@@ -4969,7 +4999,7 @@ body.is-status-dash-dragging {
   border: 1px solid var(--border-subtle);
   background: transparent;
   color: var(--text-muted);
-  font-size: 11px;
+  font-size: var(--text-sm);
   cursor: pointer;
 }
 
@@ -5009,9 +5039,9 @@ body.is-status-dash-dragging {
 .setup-wizard__evidence strong,
 .setup-wizard__task-header strong {
   margin: 0;
-  font-size: 12px;
+  font-size: var(--text-md);
   text-transform: uppercase;
-  letter-spacing: 0.08em;
+  letter-spacing: var(--tracking-label);
   color: var(--text-dim);
 }
 
@@ -5051,8 +5081,8 @@ body.is-status-dash-dragging {
 }
 
 .accelerometer-pose-guide__hero--mismatch {
-  border-color: rgba(226, 18, 63, 0.44);
-  box-shadow: inset 0 0 0 1px rgba(226, 18, 63, 0.08);
+  border-color: rgba(var(--danger-rgb), 0.44);
+  box-shadow: inset 0 0 0 1px rgba(var(--danger-rgb), 0.08);
 }
 
 .accelerometer-pose-guide__header {
@@ -5064,15 +5094,15 @@ body.is-status-dash-dragging {
 
 .accelerometer-pose-guide__header strong,
 .accelerometer-pose-guide__step strong {
-  font-size: 12px;
+  font-size: var(--text-md);
   text-transform: uppercase;
-  letter-spacing: 0.08em;
+  letter-spacing: var(--tracking-label);
   color: var(--text-dim);
 }
 
 .accelerometer-pose-guide__header span {
   color: var(--text);
-  font-size: 13px;
+  font-size: var(--text-lg);
   font-weight: 600;
   letter-spacing: -0.02em;
 }
@@ -5081,15 +5111,15 @@ body.is-status-dash-dragging {
   display: grid;
   gap: 4px;
   padding: 10px 12px;
-  border-radius: 10px;
+  border-radius: var(--radius-lg);
   border: 1px solid var(--surface-400);
   background: rgba(var(--fill-rgb), 0.88);
 }
 
 .accelerometer-pose-guide__validation strong {
   font-family: var(--font-data);
-  font-size: 10px;
-  letter-spacing: 0.08em;
+  font-size: var(--text-xs);
+  letter-spacing: var(--tracking-label);
   text-transform: uppercase;
 }
 
@@ -5121,8 +5151,8 @@ body.is-status-dash-dragging {
 }
 
 .accelerometer-pose-guide__validation--mismatch {
-  border-color: rgba(226, 18, 63, 0.38);
-  background: rgba(226, 18, 63, 0.08);
+  border-color: rgba(var(--danger-rgb), 0.38);
+  background: rgba(var(--danger-rgb), 0.08);
 }
 
 .accelerometer-pose-guide__validation--mismatch strong {
@@ -5155,7 +5185,7 @@ body.is-status-dash-dragging {
 }
 
 .accelerometer-pose-guide--compact .accelerometer-pose-guide__header span {
-  font-size: 13px;
+  font-size: var(--text-lg);
 }
 
 .accelerometer-pose-guide--compact .accelerometer-pose-guide__hero-visual {
@@ -5232,10 +5262,10 @@ body.is-status-dash-dragging {
 }
 
 .accelerometer-pose-guide__step.is-current.is-mismatch {
-  border-color: rgba(226, 18, 63, 0.68);
+  border-color: rgba(var(--danger-rgb), 0.68);
   box-shadow:
-    inset 0 0 0 1px rgba(226, 18, 63, 0.14),
-    0 0 0 4px rgba(226, 18, 63, 0.08);
+    inset 0 0 0 1px rgba(var(--danger-rgb), 0.14),
+    0 0 0 4px rgba(var(--danger-rgb), 0.08);
 }
 
 .accelerometer-pose-guide__step.is-complete {
@@ -5253,7 +5283,7 @@ body.is-status-dash-dragging {
   border: 1px solid rgba(88, 111, 140, 0.66);
   color: var(--text-dim);
   font-family: var(--font-data);
-  font-size: 12px;
+  font-size: var(--text-md);
 }
 
 .accelerometer-pose-guide__step.is-current .accelerometer-pose-guide__step-index {
@@ -5267,7 +5297,7 @@ body.is-status-dash-dragging {
 }
 
 .accelerometer-pose-guide__step.is-current.is-mismatch .accelerometer-pose-guide__step-index {
-  border-color: rgba(226, 18, 63, 0.68);
+  border-color: rgba(var(--danger-rgb), 0.68);
   color: rgba(255, 127, 153, 0.96);
 }
 
@@ -5289,7 +5319,7 @@ body.is-status-dash-dragging {
 }
 
 .accelerometer-pose-guide--compact .accelerometer-pose-guide__step strong {
-  font-size: 10px;
+  font-size: var(--text-xs);
 }
 
 .setup-wizard__task-card {
@@ -5374,14 +5404,14 @@ body.is-status-dash-dragging {
 }
 
 .setup-wizard__task-focus span {
-  font-size: 10px;
+  font-size: var(--text-xs);
   text-transform: uppercase;
-  letter-spacing: 0.08em;
+  letter-spacing: var(--tracking-label);
   color: var(--text-dim);
 }
 
 .setup-wizard__task-focus strong {
-  font-size: 13px;
+  font-size: var(--text-lg);
   letter-spacing: -0.03em;
   color: var(--text);
 }
@@ -5411,8 +5441,8 @@ body.is-status-dash-dragging {
   min-height: 40px;
   width: 100%;
   padding: 8px 16px !important;
-  border-radius: 8px !important;
-  font-size: 13px !important;
+  border-radius: var(--radius-md) !important;
+  font-size: var(--text-lg) !important;
   line-height: 1.2;
 }
 
@@ -5431,7 +5461,7 @@ body.is-status-dash-dragging {
 
 .setup-wizard__primary-button > span:first-child {
   font-family: var(--font-data);
-  font-size: 13px;
+  font-size: var(--text-lg);
   font-weight: 700;
   line-height: 1;
 }
@@ -5466,7 +5496,7 @@ body.is-status-dash-dragging {
 .setup-wizard__context-hint {
   margin: -4px 0 0;
   color: var(--text-muted);
-  font-size: 12px;
+  font-size: var(--text-md);
   line-height: 1.5;
 }
 
@@ -5555,7 +5585,7 @@ body.is-status-dash-dragging {
   border: 1px solid rgba(var(--edge-rgb), 0.05);
   background: rgba(var(--edge-rgb), 0.03);
   color: var(--text);
-  font-size: 11px;
+  font-size: var(--text-sm);
   font-family: var(--font-data);
   letter-spacing: 0.08em;
 }
@@ -5585,8 +5615,8 @@ body.is-status-dash-dragging {
 }
 
 .setup-overview__notice strong {
-  font-size: 12px;
-  letter-spacing: 0.04em;
+  font-size: var(--text-md);
+  letter-spacing: var(--tracking-label);
   text-transform: uppercase;
 }
 
@@ -5688,7 +5718,7 @@ body.is-status-dash-dragging {
 
 .flight-deck__model-frame::before {
   background:
-    radial-gradient(circle at center, rgba(255, 187, 0, 0.08), transparent 52%);
+    radial-gradient(circle at center, rgba(var(--primary-rgb), 0.08), transparent 52%);
   opacity: 1;
 }
 
@@ -5750,16 +5780,16 @@ body.is-status-dash-dragging {
 
 .flight-deck__standby span {
   color: var(--text-dim);
-  font-size: 9px;
-  letter-spacing: 0.1em;
+  font-size: var(--text-2xs);
+  letter-spacing: var(--tracking-label);
   text-transform: uppercase;
   font-family: var(--font-data);
 }
 
 .flight-deck__standby strong {
   color: var(--text);
-  font-size: 11px;
-  letter-spacing: 0.08em;
+  font-size: var(--text-sm);
+  letter-spacing: var(--tracking-label);
   text-transform: uppercase;
   font-family: var(--font-data);
 }
@@ -5784,9 +5814,9 @@ body.is-status-dash-dragging {
 .flight-deck__hud span,
 .flight-deck__caption span {
   color: var(--text-muted);
-  font-size: 10px;
+  font-size: var(--text-xs);
   text-transform: uppercase;
-  letter-spacing: 0.06em;
+  letter-spacing: var(--tracking-label);
   font-family: var(--font-data);
 }
 
@@ -5812,7 +5842,7 @@ body.is-status-dash-dragging {
 }
 
 .flight-deck__caption strong {
-  font-size: 14px;
+  font-size: var(--text-xl);
   font-family: var(--font-data);
   letter-spacing: 0.04em;
 }
@@ -5826,9 +5856,9 @@ body.is-status-dash-dragging {
 .flight-deck__heading-reference {
   color: var(--text-dim);
   font-family: var(--font-data);
-  font-size: 10px;
+  font-size: var(--text-xs);
   font-weight: 700;
-  letter-spacing: 0.08em;
+  letter-spacing: var(--tracking-label);
   text-transform: uppercase;
 }
 
@@ -5851,9 +5881,9 @@ body.is-status-dash-dragging {
   color: var(--text);
   cursor: pointer;
   font-family: var(--font-data);
-  font-size: 10px;
+  font-size: var(--text-xs);
   font-weight: 700;
-  letter-spacing: 0.08em;
+  letter-spacing: var(--tracking-label);
   text-transform: uppercase;
 }
 
@@ -5937,9 +5967,9 @@ body.is-status-dash-dragging {
 .flight-deck__heading-mark-label {
   color: var(--text-dim);
   font-family: var(--font-data);
-  font-size: 9px;
+  font-size: var(--text-2xs);
   font-weight: 700;
-  letter-spacing: 0.12em;
+  letter-spacing: var(--tracking-label);
   text-transform: uppercase;
 }
 
@@ -5977,9 +6007,9 @@ body.is-status-dash-dragging {
   background: rgba(var(--fill-rgb), 0.96);
   color: var(--text);
   font-family: var(--font-data);
-  font-size: 11px;
+  font-size: var(--text-sm);
   font-weight: 700;
-  letter-spacing: 0.16em;
+  letter-spacing: var(--tracking-label);
   text-transform: uppercase;
 }
 
@@ -6059,14 +6089,14 @@ body.is-status-dash-dragging {
 .flight-deck__readout-card small {
   color: var(--text-dim);
   font-family: var(--font-data);
-  font-size: 10px;
-  letter-spacing: 0.1em;
+  font-size: var(--text-xs);
+  letter-spacing: var(--tracking-label);
   text-transform: uppercase;
 }
 
 .flight-deck__readout-card strong {
   color: var(--text);
-  font-size: 13px;
+  font-size: var(--text-lg);
   line-height: 1.1;
 }
 
@@ -6099,8 +6129,8 @@ body.is-status-dash-dragging {
 
 .gps-map-card__header strong {
   display: block;
-  font-size: 13px;
-  letter-spacing: 0.08em;
+  font-size: var(--text-lg);
+  letter-spacing: var(--tracking-label);
   text-transform: uppercase;
   font-family: var(--font-data);
 }
@@ -6109,7 +6139,7 @@ body.is-status-dash-dragging {
   margin: 6px 0 0;
   color: var(--text-muted);
   line-height: 1.5;
-  font-size: 13px;
+  font-size: var(--text-lg);
 }
 
 .gps-map-card__frame {
@@ -6161,20 +6191,20 @@ body.is-status-dash-dragging {
   padding: 20px;
   text-align: center;
   background:
-    radial-gradient(circle at center, rgba(255, 187, 0, 0.06), transparent 40%),
+    radial-gradient(circle at center, rgba(var(--primary-rgb), 0.06), transparent 40%),
     rgba(18, 18, 18, 0.94);
 }
 
 .gps-map-card__placeholder span {
   color: var(--text-dim);
-  font-size: 10px;
+  font-size: var(--text-xs);
   text-transform: uppercase;
-  letter-spacing: 0.12em;
+  letter-spacing: var(--tracking-label);
   font-family: var(--font-data);
 }
 
 .gps-map-card__placeholder strong {
-  font-size: 13px;
+  font-size: var(--text-lg);
   line-height: 1.35;
 }
 
@@ -6202,15 +6232,15 @@ body.is-status-dash-dragging {
 
 .gps-map-card__meta span {
   color: var(--text-dim);
-  font-size: 10px;
+  font-size: var(--text-xs);
   text-transform: uppercase;
-  letter-spacing: 0.12em;
+  letter-spacing: var(--tracking-label);
   font-family: var(--font-data);
 }
 
 .gps-map-card__meta strong {
   font-family: var(--font-data);
-  font-size: 13px;
+  font-size: var(--text-lg);
   word-break: break-word;
 }
 
@@ -6229,7 +6259,7 @@ body.is-status-dash-dragging {
 .gps-map-card__footer a {
   color: var(--accent-strong);
   text-decoration: none;
-  font-size: 12px;
+  font-size: var(--text-md);
   white-space: nowrap;
 }
 
@@ -6265,8 +6295,8 @@ body.is-status-dash-dragging {
 }
 
 .mode-estimate-card strong {
-  font-size: 12px;
-  letter-spacing: 0.04em;
+  font-size: var(--text-md);
+  letter-spacing: var(--tracking-label);
   text-transform: uppercase;
   color: var(--accent-strong);
   overflow-wrap: anywhere;
@@ -6293,7 +6323,7 @@ body.is-status-dash-dragging {
   border: 1px solid rgba(var(--edge-rgb), 0.05);
   background: rgba(var(--edge-rgb), 0.03);
   color: var(--text-muted);
-  font-size: 11px;
+  font-size: var(--text-sm);
   font-family: var(--font-data);
   letter-spacing: 0.03em;
   line-height: 1.3;
@@ -6324,8 +6354,8 @@ body.is-status-dash-dragging {
 }
 
 .config-pills span.is-pending {
-  border-color: rgba(255, 187, 0, 0.28);
-  background: rgba(255, 187, 0, 0.06);
+  border-color: rgba(var(--primary-rgb), 0.28);
+  background: rgba(var(--primary-rgb), 0.06);
   color: var(--text);
 }
 
@@ -6389,15 +6419,15 @@ body.is-status-dash-dragging {
 }
 
 .orientation-card__focus-copy span {
-  font-size: 10px;
+  font-size: var(--text-xs);
   text-transform: uppercase;
-  letter-spacing: 0.08em;
+  letter-spacing: var(--tracking-label);
   color: rgba(230, 194, 108, 0.94);
   font-family: var(--font-data);
 }
 
 .orientation-card__focus-copy strong {
-  font-size: 13px;
+  font-size: var(--text-lg);
   letter-spacing: -0.03em;
   color: var(--text);
 }
@@ -6421,15 +6451,15 @@ body.is-status-dash-dragging {
 }
 
 .orientation-card__focus-instruction small {
-  font-size: 10px;
+  font-size: var(--text-xs);
   text-transform: uppercase;
-  letter-spacing: 0.08em;
+  letter-spacing: var(--tracking-label);
   color: rgba(230, 194, 108, 0.92);
   font-family: var(--font-data);
 }
 
 .orientation-card__focus-instruction strong {
-  font-size: 13px;
+  font-size: var(--text-lg);
   letter-spacing: -0.02em;
   color: var(--text);
 }
@@ -6495,14 +6525,14 @@ body.is-status-dash-dragging {
 .rc-mapping-focus__copy span {
   color: rgba(230, 194, 108, 0.94);
   font-family: var(--font-data);
-  font-size: 10px;
+  font-size: var(--text-xs);
   font-weight: 700;
-  letter-spacing: 0.08em;
+  letter-spacing: var(--tracking-label);
   text-transform: uppercase;
 }
 
 .rc-mapping-focus__copy strong {
-  font-size: 13px;
+  font-size: var(--text-lg);
   letter-spacing: -0.03em;
   color: var(--text);
 }
@@ -6533,8 +6563,8 @@ body.is-status-dash-dragging {
 }
 
 .rc-mapping-candidate-panel__header strong {
-  font-size: 11px;
-  letter-spacing: 0.08em;
+  font-size: var(--text-sm);
+  letter-spacing: var(--tracking-label);
   text-transform: uppercase;
   color: var(--text);
 }
@@ -6631,8 +6661,8 @@ body.is-status-dash-dragging {
 .switch-exercise-card__header strong {
   display: block;
   margin-bottom: 6px;
-  font-size: 13px;
-  letter-spacing: 0.05em;
+  font-size: var(--text-lg);
+  letter-spacing: var(--tracking-label);
   text-transform: uppercase;
   color: var(--accent-strong);
 }
@@ -6728,7 +6758,7 @@ body.is-status-dash-dragging {
   border-radius: 50%;
   color: var(--text-muted);
   cursor: default;
-  font-size: 9px;
+  font-size: var(--text-2xs);
   font-style: italic;
   font-weight: 700;
   line-height: 1;
@@ -6750,11 +6780,11 @@ body.is-status-dash-dragging {
   width: max-content;
   max-width: 240px;
   padding: 8px 10px;
-  border-radius: 8px;
+  border-radius: var(--radius-md);
   border: 1px solid var(--border);
   background: var(--surface-300, rgb(var(--fill-rgb)));
   color: var(--text);
-  font-size: 12px;
+  font-size: var(--text-md);
   font-style: normal;
   font-weight: 400;
   letter-spacing: normal;
@@ -6801,7 +6831,7 @@ body.is-status-dash-dragging {
   display: inline-block;
   margin-top: 6px;
   color: var(--accent-strong, var(--accent));
-  font-size: 11px;
+  font-size: var(--text-sm);
   text-decoration: underline;
 }
 /* Multi-point guidance inside a tip: each point on its own line so a card's
@@ -6839,7 +6869,7 @@ body.is-status-dash-dragging {
 .tuning-details > summary {
   cursor: pointer;
   color: var(--text-muted);
-  font-size: 12px;
+  font-size: var(--text-md);
   font-weight: 600;
   list-style: none;
   padding: 2px 0;
@@ -6878,9 +6908,9 @@ body.is-status-dash-dragging {
 .tuning-summary-card__header span {
   color: var(--text);
   font-family: var(--font-data);
-  font-size: 11px;
+  font-size: var(--text-sm);
   font-weight: 700;
-  letter-spacing: 0.08em;
+  letter-spacing: var(--tracking-label);
   text-transform: uppercase;
 }
 
@@ -6941,7 +6971,7 @@ body.is-status-dash-dragging {
   align-items: center;
   gap: 6px 10px;
   padding: 6px 10px;
-  border-radius: 8px;
+  border-radius: var(--radius-md);
   background: color-mix(in srgb, var(--surface-200) 60%, transparent);
 }
 
@@ -6970,11 +7000,11 @@ body.is-status-dash-dragging {
 }
 
 .rc-direction-row--reversed {
-  background: color-mix(in srgb, var(--accent, #ffbb00) 22%, var(--surface-200));
+  background: color-mix(in srgb, var(--accent, var(--primary-500)) 22%, var(--surface-200));
 }
 
 .rc-direction-row--reversed .rc-direction-row__verdict {
-  color: var(--accent, #ffbb00);
+  color: var(--accent, var(--primary-500));
   font-weight: 600;
 }
 
@@ -6997,7 +7027,7 @@ body.is-status-dash-dragging {
   min-width: 0;
   align-self: start;
   border: 1px solid var(--border);
-  border-radius: 10px;
+  border-radius: var(--radius-lg);
   background: color-mix(in srgb, var(--surface-200) 55%, transparent);
   padding: 6px;
 }
@@ -7034,7 +7064,7 @@ body.is-status-dash-dragging {
 /* The axis whose stick is deflected right now — ties the reacting craft to the
    row being tested. Rendered as an outline so it layers over any verdict tint. */
 .rc-direction-row--active {
-  outline: 1.5px solid color-mix(in srgb, var(--accent, #ffbb00) 55%, transparent);
+  outline: 1.5px solid color-mix(in srgb, var(--accent, var(--primary-500)) 55%, transparent);
   outline-offset: -1.5px;
 }
 
@@ -7110,16 +7140,16 @@ body.is-status-dash-dragging {
   flex-wrap: wrap;
   gap: 4px 10px;
   padding: 6px 10px;
-  border-radius: var(--radius-sm, 4px);
+  border-radius: var(--radius-sm);
   border: 1px solid var(--border);
   background: rgba(var(--fill-rgb, 20, 28, 40), 0.5);
-  font-size: 11px;
+  font-size: var(--text-sm);
   color: var(--text-muted);
 }
 .receiver-flight-mode-line strong {
-  font-size: 10px;
+  font-size: var(--text-xs);
   text-transform: uppercase;
-  letter-spacing: 0.04em;
+  letter-spacing: var(--tracking-label);
   color: var(--text);
 }
 .receiver-flight-mode-line__ch {
@@ -7208,8 +7238,8 @@ body.is-status-dash-dragging {
 .tuning-task-deck__header h3 {
   margin: 0;
   color: var(--text);
-  font-size: 13px;
-  letter-spacing: 0.04em;
+  font-size: var(--text-lg);
+  letter-spacing: var(--tracking-label);
   text-transform: uppercase;
 }
 
@@ -7217,9 +7247,9 @@ body.is-status-dash-dragging {
 .receiver-live-card__footer span,
 .receiver-task-stage span {
   color: var(--text-muted);
-  font-size: 11px;
+  font-size: var(--text-sm);
   font-family: var(--font-data);
-  letter-spacing: 0.06em;
+  letter-spacing: var(--tracking-label);
   text-transform: uppercase;
 }
 /* The first footer span is the live PWM value ("1500 µs") — keep it as-is so the
@@ -7278,8 +7308,8 @@ body.is-status-dash-dragging {
   display: block;
   margin-bottom: 4px;
   color: var(--text);
-  font-size: 12px;
-  letter-spacing: 0.05em;
+  font-size: var(--text-md);
+  letter-spacing: var(--tracking-label);
   text-transform: uppercase;
 }
 
@@ -7306,7 +7336,7 @@ body.is-status-dash-dragging {
 .receiver-task-deck__header h3,
 .outputs-task-deck__header h3,
 .tuning-task-deck__header h3 {
-  font-size: 13px;
+  font-size: var(--text-lg);
 }
 
 /* Receiver / Tuning sub-tab nav now uses the shared `.tab-strip` underline
@@ -7373,16 +7403,16 @@ body.is-status-dash-dragging {
   display: block;
   margin-bottom: 4px;
   color: var(--text-muted);
-  font-size: 11px;
+  font-size: var(--text-sm);
   font-family: var(--font-data);
   font-weight: 700;
-  letter-spacing: 0.08em;
+  letter-spacing: var(--tracking-label);
   text-transform: uppercase;
 }
 
 .tuning-control__header strong {
   color: var(--text);
-  font-size: 13px;
+  font-size: var(--text-lg);
 }
 
 /* Config-style "i" info bubble inside the tuning header. The generic bubble
@@ -7399,7 +7429,7 @@ body.is-status-dash-dragging {
   display: none;
   margin: 0;
   color: var(--text);
-  font-size: 12px;
+  font-size: var(--text-md);
   font-weight: 400;
   letter-spacing: normal;
   text-transform: none;
@@ -7411,14 +7441,14 @@ body.is-status-dash-dragging {
   display: block;
   margin-bottom: 0;
   color: var(--text);
-  font-size: 11px;
+  font-size: var(--text-sm);
   letter-spacing: 0.06em;
 }
 .tuning-control__header .config-section__info-text {
   display: block;
   margin: 6px 0 0;
   color: var(--text-muted);
-  font-size: 12px;
+  font-size: var(--text-md);
   font-family: inherit;
   font-weight: 400;
   letter-spacing: normal;
@@ -7538,20 +7568,20 @@ body.is-status-dash-dragging {
 .filters-from-gyro__name small {
   color: var(--text-muted);
   font-family: var(--font-data);
-  font-size: 11px;
+  font-size: var(--text-sm);
 }
 
 .filters-from-gyro__current {
   color: var(--text-muted);
   font-family: var(--font-data);
-  font-size: 11px;
+  font-size: var(--text-sm);
   white-space: nowrap;
 }
 
 .filters-from-gyro__warning {
   grid-column: 1 / -1;
   color: var(--warning, #e0a33a);
-  font-size: 11px;
+  font-size: var(--text-sm);
 }
 
 /* The two documented suggestions are buttons, not a two-up layout: sized to
@@ -7577,16 +7607,16 @@ body.is-status-dash-dragging {
 
 .tuning-axis-card__header strong {
   color: var(--text);
-  font-size: 13px;
-  letter-spacing: 0.05em;
+  font-size: var(--text-lg);
+  letter-spacing: var(--tracking-label);
   text-transform: uppercase;
 }
 
 .tuning-axis-card__header span {
   color: var(--text-muted);
-  font-size: 11px;
+  font-size: var(--text-sm);
   font-family: var(--font-data);
-  letter-spacing: 0.06em;
+  letter-spacing: var(--tracking-label);
   text-transform: uppercase;
 }
 
@@ -7648,8 +7678,8 @@ body.is-status-dash-dragging {
   display: block;
   margin-bottom: 4px;
   color: var(--text);
-  font-size: 13px;
-  letter-spacing: 0.04em;
+  font-size: var(--text-lg);
+  letter-spacing: var(--tracking-label);
   text-transform: uppercase;
 }
 
@@ -7694,8 +7724,8 @@ body.is-status-dash-dragging {
   display: block;
   margin-bottom: 4px;
   color: var(--text);
-  font-size: 13px;
-  letter-spacing: 0.04em;
+  font-size: var(--text-lg);
+  letter-spacing: var(--tracking-label);
   text-transform: uppercase;
 }
 
@@ -7715,7 +7745,7 @@ body.is-status-dash-dragging {
   display: grid;
   gap: 8px;
   padding: 12px;
-  border-radius: 14px;
+  border-radius: var(--radius-xl);
   background: rgba(var(--edge-rgb), 0.025);
   box-shadow: inset 0 0 0 1px rgba(var(--edge-rgb), 0.028);
 }
@@ -7735,7 +7765,7 @@ body.is-status-dash-dragging {
 
 .tuning-master-slider__header strong {
   color: var(--text);
-  font-size: 13px;
+  font-size: var(--text-lg);
 }
 
 .tuning-master-slider__header small {
@@ -7746,7 +7776,7 @@ body.is-status-dash-dragging {
 .tuning-master-slider__header code {
   color: rgba(var(--ink-rgb), 0.9);
   font-family: var(--font-data);
-  font-size: 12px;
+  font-size: var(--text-md);
 }
 
 .tuning-master-slider input[type='range'] {
@@ -7869,7 +7899,7 @@ body.is-status-dash-dragging {
 .modes-mode-channel__rcl-claim {
   display: block;
   margin-top: 4px;
-  font-size: 11px;
+  font-size: var(--text-sm);
   font-weight: 600;
   color: var(--warning, #b8860b);
 }
@@ -7877,7 +7907,7 @@ body.is-status-dash-dragging {
 .rc-channel-card__header span,
 .rc-channel-card__footer span {
   color: var(--text-muted);
-  font-size: 12px;
+  font-size: var(--text-md);
 }
 
 .rc-bar {
@@ -7927,11 +7957,11 @@ body.is-status-dash-dragging {
   display: inline-flex;
   align-items: baseline;
   gap: 6px;
-  font-size: 13px;
+  font-size: var(--text-lg);
 }
 .power-live-strip label {
-  font-size: 10px;
-  letter-spacing: 0.05em;
+  font-size: var(--text-xs);
+  letter-spacing: var(--tracking-label);
   text-transform: uppercase;
   color: var(--text-muted);
 }
@@ -7957,14 +7987,14 @@ body.is-status-dash-dragging {
 
 .telemetry-metric-card span {
   color: var(--text-muted);
-  font-size: 11px;
+  font-size: var(--text-sm);
   text-transform: uppercase;
-  letter-spacing: 0.08em;
+  letter-spacing: var(--tracking-label);
   font-family: var(--font-data);
 }
 
 .telemetry-metric-card strong {
-  font-size: 14px;
+  font-size: var(--text-xl);
   line-height: 1.02;
   font-weight: 600;
   letter-spacing: -0.03em;
@@ -8010,8 +8040,8 @@ body.is-status-dash-dragging {
 
 .output-card__header strong {
   display: block;
-  font-size: 13px;
-  letter-spacing: 0.06em;
+  font-size: var(--text-lg);
+  letter-spacing: var(--tracking-label);
   text-transform: uppercase;
   overflow-wrap: anywhere;
 }
@@ -8024,7 +8054,7 @@ body.is-status-dash-dragging {
 .output-card p {
   margin: 0;
   color: var(--text);
-  font-size: 15px;
+  font-size: var(--text-2xl);
 }
 
 .output-note-list {
@@ -8053,7 +8083,7 @@ body.is-status-dash-dragging {
 .receiver-arm-switch__field {
   display: grid;
   gap: 4px;
-  font-size: 12px;
+  font-size: var(--text-md);
   color: var(--text-muted);
 }
 
@@ -8063,7 +8093,7 @@ body.is-status-dash-dragging {
   background: var(--surface-300);
   color: var(--text);
   border: 1px solid var(--surface-400);
-  border-radius: 5px;
+  border-radius: var(--radius-sm);
   padding: 4px 6px;
 }
 
@@ -8071,7 +8101,7 @@ body.is-status-dash-dragging {
   display: inline-flex;
   align-items: center;
   gap: 8px;
-  font-size: 12px;
+  font-size: var(--text-md);
   color: var(--text-muted);
   cursor: pointer;
 }
@@ -8156,7 +8186,7 @@ body.is-status-dash-dragging {
   gap: 10px;
   margin: 10px 0;
   padding: 12px;
-  border-radius: var(--radius-md, 8px);
+  border-radius: var(--radius-md);
   border: 1px solid var(--primary-500);
   background: rgba(var(--edge-rgb), 0.02);
 }
@@ -8164,13 +8194,13 @@ body.is-status-dash-dragging {
 .preset-editor label {
   display: grid;
   gap: 4px;
-  font-size: 12px;
+  font-size: var(--text-md);
   color: var(--text-muted);
 }
 
 .preset-editor input {
   padding: 6px 8px;
-  border-radius: 6px;
+  border-radius: var(--radius-sm);
   border: 1px solid var(--surface-400);
   background: var(--bg-panel);
   color: var(--text-primary);
@@ -8191,13 +8221,13 @@ body.is-status-dash-dragging {
 }
 
 .preset-editor__row code {
-  font-size: 12px;
+  font-size: var(--text-md);
   overflow-wrap: anywhere;
 }
 
 .preset-editor__empty {
   margin: 0;
-  font-size: 12px;
+  font-size: var(--text-md);
   color: var(--warning-500, var(--text-muted));
 }
 
@@ -8231,12 +8261,12 @@ body.is-status-dash-dragging {
 }
 
 .relay-rc-channel--staged .scoped-editor-field {
-  border-color: color-mix(in srgb, var(--accent, #ffbb00) 55%, var(--border));
+  border-color: color-mix(in srgb, var(--accent, var(--primary-500)) 55%, var(--border));
 }
 
 .relay-rc-channel__hint {
   margin: 6px 2px 0;
-  font-size: 11px;
+  font-size: var(--text-sm);
   line-height: 1.45;
   color: var(--text-muted);
 }
@@ -8357,7 +8387,7 @@ body.is-status-dash-dragging {
   display: block;
   margin-top: 4px;
   color: var(--text-muted);
-  font-size: 11px;
+  font-size: var(--text-sm);
   line-height: 1.4;
 }
 
@@ -8366,15 +8396,15 @@ body.is-status-dash-dragging {
   margin-top: 4px;
   color: rgba(255, 217, 215, 0.78);
   font-family: var(--font-data);
-  font-size: 10px;
+  font-size: var(--text-xs);
   letter-spacing: 0.04em;
 }
 
 .scoped-editor-field span {
   color: var(--text-muted);
-  font-size: 11px;
+  font-size: var(--text-sm);
   text-transform: uppercase;
-  letter-spacing: 0.08em;
+  letter-spacing: var(--tracking-label);
   font-family: var(--font-data);
   overflow-wrap: anywhere;
 }
@@ -8394,7 +8424,7 @@ body.is-status-dash-dragging {
   display: block;
   margin-top: 3px;
   color: var(--accent, var(--text-muted));
-  font-size: 11px;
+  font-size: var(--text-sm);
   line-height: 1.35;
 }
 
@@ -8403,7 +8433,7 @@ body.is-status-dash-dragging {
   margin-top: 1px;
   color: var(--text-dim, var(--text-muted));
   font-family: var(--font-data);
-  font-size: 10px;
+  font-size: var(--text-xs);
   font-weight: 400;
   letter-spacing: 0.02em;
   text-transform: none;
@@ -8498,7 +8528,7 @@ body.is-status-dash-dragging {
   align-items: baseline;
   gap: 4px 12px;
   margin-right: auto;
-  font-size: 12px;
+  font-size: var(--text-md);
   color: var(--text-muted);
 }
 
@@ -8526,9 +8556,9 @@ body.is-status-dash-dragging {
   gap: 8px;
   padding: 6px 8px;
   border: 1px solid var(--surface-400);
-  border-radius: 6px;
+  border-radius: var(--radius-sm);
   background: rgba(var(--edge-rgb), 0.03);
-  font-size: 12px;
+  font-size: var(--text-md);
   list-style: none;
 }
 
@@ -8538,7 +8568,7 @@ body.is-status-dash-dragging {
 
 .scoped-bitmask-popover__summary code {
   color: var(--text-muted);
-  font-size: 11px;
+  font-size: var(--text-sm);
 }
 
 .scoped-bitmask-popover[open] > .scoped-bitmask-popover__summary {
@@ -8551,7 +8581,7 @@ body.is-status-dash-dragging {
   overflow-y: auto;
   padding: 6px;
   border: 1px solid var(--surface-400);
-  border-radius: 6px;
+  border-radius: var(--radius-sm);
   background: var(--bg-panel-muted);
 }
 
@@ -8580,7 +8610,7 @@ body.is-status-dash-dragging {
 }
 
 .scoped-bitmask-raw span {
-  font-size: 0.72rem;
+  font-size: var(--text-sm);
   opacity: 0.7;
 }
 
@@ -8592,7 +8622,7 @@ body.is-status-dash-dragging {
 .scoped-bitmask-bit,
 .scoped-option-chip {
   padding: 3px 8px;
-  border-radius: 6px;
+  border-radius: var(--radius-sm);
   border: 1px solid var(--surface-400);
   background: transparent;
   color: var(--text-muted, rgba(var(--edge-rgb), 0.55));
@@ -8633,7 +8663,7 @@ body.is-status-dash-dragging {
   min-width: 0;
   /* Compact row, not a chunky bordered card. */
   padding: 7px 10px;
-  border-radius: 8px;
+  border-radius: var(--radius-md);
   border: 1px solid transparent;
   background: rgba(var(--edge-rgb), 0.025);
   color: var(--text);
@@ -8667,7 +8697,7 @@ body.is-status-dash-dragging {
 .scoped-checkbox-option span {
   min-width: 0;
   color: var(--text);
-  font-size: 12px;
+  font-size: var(--text-md);
   line-height: 1.25;
   letter-spacing: normal;
   text-transform: none;
@@ -8692,7 +8722,7 @@ body.is-status-dash-dragging {
   gap: 6px;
   min-width: 0;
   color: var(--muted, var(--text));
-  font-size: 12px;
+  font-size: var(--text-md);
   line-height: 1.25;
   letter-spacing: normal;
   text-transform: none;
@@ -8776,7 +8806,7 @@ details.metadata-settings-section:not([open]) > summary::after {
 .ports-matrix {
   display: grid;
   gap: 0;
-  border-radius: 10px;
+  border-radius: var(--radius-lg);
   border: 1px solid var(--surface-400);
   /* The matrix rows are wide multi-column grids (~1070px of minimums). Scroll
      horizontally instead of clipping when the content well is narrower (the
@@ -8804,9 +8834,9 @@ details.metadata-settings-section:not([open]) > summary::after {
 
 .ports-matrix__head span {
   color: var(--text-dim);
-  font-size: 10px;
+  font-size: var(--text-xs);
   text-transform: uppercase;
-  letter-spacing: 0.12em;
+  letter-spacing: var(--tracking-label);
   font-family: var(--font-data);
 }
 
@@ -8821,11 +8851,11 @@ details.metadata-settings-section:not([open]) > summary::after {
 }
 
 .ports-matrix-row.is-staged {
-  border-color: rgba(255, 187, 0, 0.42);
+  border-color: rgba(var(--primary-rgb), 0.42);
 }
 
 .ports-matrix-row.is-invalid {
-  border-color: rgba(226, 18, 63, 0.42);
+  border-color: rgba(var(--danger-rgb), 0.42);
 }
 
 .ports-matrix-row.is-readonly {
@@ -8872,8 +8902,8 @@ details.metadata-settings-section:not([open]) > summary::after {
 
 .ports-matrix-row__title strong {
   display: block;
-  font-size: 13px;
-  letter-spacing: 0.08em;
+  font-size: var(--text-lg);
+  letter-spacing: var(--tracking-label);
   text-transform: uppercase;
   overflow-wrap: anywhere;
 }
@@ -8901,8 +8931,8 @@ details.metadata-settings-section:not([open]) > summary::after {
 }
 
 .ports-matrix-row__options-header strong {
-  font-size: 11px;
-  letter-spacing: 0.08em;
+  font-size: var(--text-sm);
+  letter-spacing: var(--tracking-label);
   text-transform: uppercase;
 }
 
@@ -8952,8 +8982,8 @@ details.metadata-settings-section:not([open]) > summary::after {
 
 .port-row__title strong {
   display: block;
-  font-size: 13px;
-  letter-spacing: 0.06em;
+  font-size: var(--text-lg);
+  letter-spacing: var(--tracking-label);
   text-transform: uppercase;
   overflow-wrap: anywhere;
 }
@@ -8989,8 +9019,8 @@ details.metadata-settings-section:not([open]) > summary::after {
 
 .port-row__options-header strong {
   color: var(--text);
-  font-size: 12px;
-  letter-spacing: 0.08em;
+  font-size: var(--text-md);
+  letter-spacing: var(--tracking-label);
   text-transform: uppercase;
 }
 
@@ -9026,8 +9056,8 @@ details.metadata-settings-section:not([open]) > summary::after {
 
 .port-card__header strong {
   display: block;
-  font-size: 13px;
-  letter-spacing: 0.06em;
+  font-size: var(--text-lg);
+  letter-spacing: var(--tracking-label);
   text-transform: uppercase;
   overflow-wrap: anywhere;
 }
@@ -9059,8 +9089,8 @@ details.metadata-settings-section:not([open]) > summary::after {
 }
 
 .dronecan-peripherals__header strong {
-  font-size: 12px;
-  letter-spacing: 0.08em;
+  font-size: var(--text-md);
+  letter-spacing: var(--tracking-label);
   text-transform: uppercase;
 }
 
@@ -9075,7 +9105,7 @@ details.metadata-settings-section:not([open]) > summary::after {
   align-items: baseline;
   gap: 12px;
   margin: 0;
-  font-size: 11px;
+  font-size: var(--text-sm);
 }
 
 .dronecan-peripherals__uid span {
@@ -9137,7 +9167,7 @@ details.metadata-settings-section:not([open]) > summary::after {
 .rc-mixer-logic__header small {
   display: block;
   color: var(--text-muted);
-  font-size: 11px;
+  font-size: var(--text-sm);
 }
 .rc-mixer-logic__list {
   list-style: none;
@@ -9148,7 +9178,7 @@ details.metadata-settings-section:not([open]) > summary::after {
 }
 .rc-mixer-logic__empty {
   color: var(--text-muted);
-  font-size: 12px;
+  font-size: var(--text-md);
 }
 .rc-mixer-logic-term {
   display: flex;
@@ -9157,12 +9187,12 @@ details.metadata-settings-section:not([open]) > summary::after {
   gap: 8px;
   padding: 8px;
   border: 1px solid var(--border, #2a2f37);
-  border-radius: 8px;
+  border-radius: var(--radius-md);
 }
 .rc-mixer-logic-term label {
   display: grid;
   gap: 2px;
-  font-size: 11px;
+  font-size: var(--text-sm);
   color: var(--text-muted);
 }
 .rc-mixer-logic-term__negate {
@@ -9178,7 +9208,7 @@ details.metadata-settings-section:not([open]) > summary::after {
 }
 .rc-mixer-logic-term__meta small {
   color: var(--text-muted);
-  font-size: 11px;
+  font-size: var(--text-sm);
   max-width: 220px;
 }
 
@@ -9186,7 +9216,7 @@ details.metadata-settings-section:not([open]) > summary::after {
   display: flex;
   align-items: center;
   gap: 8px;
-  font-size: 11px;
+  font-size: var(--text-sm);
   color: var(--warning, #b8860b);
 }
 
@@ -9201,7 +9231,7 @@ details.metadata-settings-section:not([open]) > summary::after {
   align-items: center;
   gap: 8px;
   cursor: pointer;
-  font-size: 13px;
+  font-size: var(--text-lg);
 }
 .rc-mixer-engine__toggle code {
   font-size: 0.9em;
@@ -9253,7 +9283,7 @@ details.metadata-settings-section:not([open]) > summary::after {
   left: 0;
   transform: translateX(-50%);
   color: var(--text-dim);
-  font-size: 9px;
+  font-size: var(--text-2xs);
   font-family: var(--font-data);
   font-style: normal;
 }
@@ -9302,10 +9332,10 @@ details.metadata-settings-section:not([open]) > summary::after {
 
 .rc-mixer-track__band em {
   font-style: normal;
-  font-size: 9px;
+  font-size: var(--text-2xs);
   font-family: var(--font-data);
   color: var(--text);
-  letter-spacing: 0.03em;
+  letter-spacing: var(--tracking-label);
   text-transform: uppercase;
   text-shadow: 0 1px 2px rgba(0, 0, 0, 0.45);
   white-space: nowrap;
@@ -9357,15 +9387,15 @@ details.metadata-settings-section:not([open]) > summary::after {
 }
 
 .rc-mixer-channel__header strong {
-  font-size: 11px;
-  letter-spacing: 0.05em;
+  font-size: var(--text-sm);
+  letter-spacing: var(--tracking-label);
   text-transform: uppercase;
 }
 
 .rc-mixer-channel__header small {
   display: block;
   color: var(--text-muted);
-  font-size: 10px;
+  font-size: var(--text-xs);
 }
 
 .rc-mixer-channel__external-claim {
@@ -9409,17 +9439,17 @@ details.metadata-settings-section:not([open]) > summary::after {
 .rc-mixer-assignment__function select {
   font: inherit;
   font-family: var(--font-data);
-  font-size: 11px;
+  font-size: var(--text-sm);
   background: var(--surface-300);
   color: var(--text);
   border: 1px solid var(--surface-400);
-  border-radius: 5px;
+  border-radius: var(--radius-sm);
   padding: 2px 5px;
 }
 
 .rc-mixer-assignment__function small {
   color: var(--text-muted);
-  font-size: 10px;
+  font-size: var(--text-xs);
   line-height: 1.35;
 }
 
@@ -9431,18 +9461,18 @@ details.metadata-settings-section:not([open]) > summary::after {
 .rc-mixer-assignment__range label {
   display: grid;
   gap: 2px;
-  font-size: 10px;
+  font-size: var(--text-xs);
   color: var(--text-muted);
 }
 
 .rc-mixer-assignment__range input[type='number'] {
   font: inherit;
   font-family: var(--font-data);
-  font-size: 11px;
+  font-size: var(--text-sm);
   background: var(--surface-300);
   color: var(--text);
   border: 1px solid var(--surface-400);
-  border-radius: 5px;
+  border-radius: var(--radius-sm);
   padding: 2px 5px;
   width: 100%;
 }
@@ -9452,7 +9482,7 @@ details.metadata-settings-section:not([open]) > summary::after {
   display: flex;
   align-items: center;
   gap: 6px;
-  font-size: 10px;
+  font-size: var(--text-xs);
 }
 
 /* Reset the padding/border/full-width sizing the global `input` rule
@@ -9474,10 +9504,10 @@ details.metadata-settings-section:not([open]) > summary::after {
   display: flex;
   align-items: center;
   gap: 6px;
-  font-size: 10px;
+  font-size: var(--text-xs);
 }
 .rc-mixer-assignment__position select {
-  font-size: 11px;
+  font-size: var(--text-sm);
 }
 
 .rc-mixer-assignment__status {
@@ -9488,7 +9518,7 @@ details.metadata-settings-section:not([open]) > summary::after {
 
 .rc-mixer-assignment__status small {
   color: var(--text-muted);
-  font-size: 10px;
+  font-size: var(--text-xs);
   line-height: 1.35;
 }
 
@@ -9497,7 +9527,7 @@ details.metadata-settings-section:not([open]) > summary::after {
 }
 
 .rc-mixer-callout p {
-  font-size: 11px;
+  font-size: var(--text-sm);
   line-height: 1.45;
 }
 
@@ -9531,12 +9561,12 @@ details.metadata-settings-section:not([open]) > summary::after {
 .can-bus-enable-prompt__body p {
   margin: 0;
   color: var(--text-muted);
-  font-size: 12.5px;
+  font-size: var(--text-lg);
   line-height: 1.45;
 }
 .can-bus-enable-prompt__body code {
   font-family: var(--font-data);
-  font-size: 11px;
+  font-size: var(--text-sm);
 }
 
 /* 3D board-mounting picture under the Board orientation dropdown. A thin slab
@@ -9569,7 +9599,7 @@ details.metadata-settings-section:not([open]) > summary::after {
   left: 50%;
   transform: translateX(-50%);
   font-family: var(--font-data);
-  font-size: 9px;
+  font-size: var(--text-2xs);
   letter-spacing: 0.16em;
   color: var(--text-dim, var(--text-muted));
   z-index: 1;
@@ -9591,7 +9621,7 @@ details.metadata-settings-section:not([open]) > summary::after {
 .board-orientation-diagram__face {
   position: absolute;
   inset: 0;
-  border-radius: 8px;
+  border-radius: var(--radius-md);
   backface-visibility: hidden;
   border: 1.5px solid rgba(var(--edge-rgb), 0.5);
 }
@@ -9614,7 +9644,7 @@ details.metadata-settings-section:not([open]) > summary::after {
    reads as a shading artifact in a screenshot. */
 .board-orientation-diagram__bottom-label {
   font-family: var(--font-data);
-  font-size: 11px;
+  font-size: var(--text-sm);
   letter-spacing: 0.18em;
   font-weight: 700;
   color: color-mix(in srgb, var(--warning) 35%, #1b1205);
@@ -9649,7 +9679,7 @@ details.metadata-settings-section:not([open]) > summary::after {
 .board-orientation-diagram__axis {
   position: absolute;
   font-family: var(--font-data);
-  font-size: 9px;
+  font-size: var(--text-2xs);
   font-weight: 700;
   color: color-mix(in srgb, var(--success, #4ade80) 80%, var(--ink, #fff));
   opacity: 0.75;
@@ -9695,16 +9725,16 @@ details.metadata-settings-section:not([open]) > summary::after {
 .board-orientation-diagram__note strong {
   display: block;
   margin-bottom: 4px;
-  font-size: 12px;
+  font-size: var(--text-md);
 }
 .board-orientation-diagram__note p {
   margin: 0;
   color: var(--text-muted);
-  font-size: 11px;
+  font-size: var(--text-sm);
   line-height: 1.4;
 }
 .board-orientation-diagram__caption {
-  font-size: 12px;
+  font-size: var(--text-md);
 }
 @media (prefers-reduced-motion: reduce) {
   .board-orientation-diagram__board3d {
@@ -9732,7 +9762,7 @@ details.metadata-settings-section:not([open]) > summary::after {
 
 .can-bus-header__status small {
   color: var(--text-muted);
-  font-size: 11px;
+  font-size: var(--text-sm);
 }
 
 .can-bus-header__error {
@@ -9749,7 +9779,7 @@ details.metadata-settings-section:not([open]) > summary::after {
   display: flex;
   align-items: center;
   gap: 6px;
-  font-size: 11px;
+  font-size: var(--text-sm);
   color: var(--text-muted);
 }
 
@@ -9759,7 +9789,7 @@ details.metadata-settings-section:not([open]) > summary::after {
   background: var(--surface-300);
   color: var(--text);
   border: 1px solid var(--surface-400);
-  border-radius: 6px;
+  border-radius: var(--radius-sm);
   padding: 4px 8px;
 }
 
@@ -9832,8 +9862,8 @@ details.metadata-settings-section:not([open]) > summary::after {
 
 .can-bus-node__label strong {
   display: block;
-  font-size: 13px;
-  letter-spacing: 0.04em;
+  font-size: var(--text-lg);
+  letter-spacing: var(--tracking-label);
   text-transform: uppercase;
 }
 
@@ -9854,8 +9884,8 @@ details.metadata-settings-section:not([open]) > summary::after {
   border: 1px solid var(--border);
   background: var(--surface-200);
   color: var(--text-muted);
-  font-size: 10px;
-  letter-spacing: 0.04em;
+  font-size: var(--text-xs);
+  letter-spacing: var(--tracking-label);
   text-transform: uppercase;
   cursor: pointer;
 }
@@ -9879,7 +9909,7 @@ details.metadata-settings-section:not([open]) > summary::after {
 .can-bus-node__label small {
   display: block;
   color: var(--text-muted);
-  font-size: 11px;
+  font-size: var(--text-sm);
 }
 
 .can-bus-node__status {
@@ -9908,8 +9938,8 @@ details.metadata-settings-section:not([open]) > summary::after {
 .can-bus-staged {
   padding: 10px 12px;
   border: 1px solid var(--warning);
-  border-radius: 8px;
-  background: rgba(255, 187, 0, 0.06);
+  border-radius: var(--radius-md);
+  background: rgba(var(--primary-rgb), 0.06);
 }
 
 .can-bus-staged__header {
@@ -9944,7 +9974,7 @@ details.metadata-settings-section:not([open]) > summary::after {
 
 .can-bus-node__toolbar small {
   color: var(--text-muted);
-  font-size: 11px;
+  font-size: var(--text-sm);
 }
 
 .can-bus-node__toolbar-buttons {
@@ -9956,7 +9986,7 @@ details.metadata-settings-section:not([open]) > summary::after {
 .can-bus-params {
   width: 100%;
   border-collapse: collapse;
-  font-size: 12px;
+  font-size: var(--text-md);
 }
 
 .can-bus-params th,
@@ -9969,9 +9999,9 @@ details.metadata-settings-section:not([open]) > summary::after {
 
 .can-bus-params th {
   color: var(--text-muted);
-  font-size: 10px;
+  font-size: var(--text-xs);
   font-weight: 600;
-  letter-spacing: 0.08em;
+  letter-spacing: var(--tracking-label);
   text-transform: uppercase;
 }
 
@@ -9981,7 +10011,7 @@ details.metadata-settings-section:not([open]) > summary::after {
 
 .can-bus-params td small {
   color: var(--text-muted);
-  font-size: 10px;
+  font-size: var(--text-xs);
   margin-left: 6px;
 }
 /* Catalog-derived friendly label + enum value hint (params metadata enrichment).
@@ -9995,11 +10025,11 @@ details.metadata-settings-section:not([open]) > summary::after {
 .can-bus-params input[type='text'] {
   font: inherit;
   font-family: var(--font-data);
-  font-size: 12px;
+  font-size: var(--text-md);
   background: var(--surface-300);
   color: var(--text);
   border: 1px solid var(--surface-400);
-  border-radius: 6px;
+  border-radius: var(--radius-sm);
   padding: 3px 6px;
   width: 100%;
   min-width: 110px;
@@ -10007,7 +10037,7 @@ details.metadata-settings-section:not([open]) > summary::after {
 
 .can-bus-params__input--invalid {
   border-color: var(--danger) !important;
-  background: rgba(226, 18, 63, 0.10) !important;
+  background: rgba(var(--danger-rgb), 0.10) !important;
 }
 
 .port-board-links {
@@ -10040,8 +10070,8 @@ details.metadata-settings-section:not([open]) > summary::after {
 .port-board-debug summary {
   cursor: pointer;
   color: var(--text);
-  font-size: 12px;
-  letter-spacing: 0.08em;
+  font-size: var(--text-md);
+  letter-spacing: var(--tracking-label);
   text-transform: uppercase;
 }
 
@@ -10049,7 +10079,7 @@ details.metadata-settings-section:not([open]) > summary::after {
   margin: 0;
   padding: 10px 12px;
   overflow: auto;
-  border-radius: 12px;
+  border-radius: var(--radius-lg);
   border: 1px solid rgba(39, 49, 59, 0.74);
   background: rgba(var(--fill-rgb), 0.9);
   color: var(--text-muted);
@@ -10088,8 +10118,8 @@ details.metadata-settings-section:not([open]) > summary::after {
 
 .board-media-lightbox__header strong {
   display: block;
-  font-size: 13px;
-  letter-spacing: 0.06em;
+  font-size: var(--text-lg);
+  letter-spacing: var(--tracking-label);
   text-transform: uppercase;
 }
 
@@ -10121,7 +10151,7 @@ details.metadata-settings-section:not([open]) > summary::after {
   padding: 28px 12px;
   text-align: center;
   color: var(--text-muted);
-  font-size: 14px;
+  font-size: var(--text-xl);
   font-weight: 600;
 }
 
@@ -10195,8 +10225,8 @@ details.metadata-settings-section:not([open]) > summary::after {
   border-bottom: 2px solid transparent;
   color: var(--text-muted);
   font: inherit;
-  font-size: 12px;
-  letter-spacing: 0.08em;
+  font-size: var(--text-md);
+  letter-spacing: var(--tracking-label);
   text-transform: uppercase;
   cursor: pointer;
 }
@@ -10221,7 +10251,7 @@ details.metadata-settings-section:not([open]) > summary::after {
    is the recommended path; manual is an opt-in disclosure. */
 .motor-reorder-manual > summary {
   cursor: pointer;
-  font-size: 13px;
+  font-size: var(--text-lg);
   color: var(--text-muted);
   padding: 4px 0;
   user-select: none;
@@ -10231,7 +10261,7 @@ details.metadata-settings-section:not([open]) > summary::after {
 }
 .motor-reorder-manual__hint {
   margin: 6px 0 10px;
-  font-size: 12px;
+  font-size: var(--text-md);
   color: var(--text-muted);
 }
 
@@ -10240,7 +10270,7 @@ details.metadata-settings-section:not([open]) > summary::after {
   align-items: center;
   gap: 8px;
   margin-top: 8px;
-  font-size: 12px;
+  font-size: var(--text-md);
   color: var(--text-muted);
   cursor: pointer;
 }
@@ -10251,7 +10281,7 @@ details.metadata-settings-section:not([open]) > summary::after {
 .motor-reorder-table {
   display: grid;
   gap: 1px;
-  border-radius: 12px;
+  border-radius: var(--radius-lg);
   border: 1px solid var(--surface-400);
   overflow: hidden;
 }
@@ -10268,8 +10298,8 @@ details.metadata-settings-section:not([open]) > summary::after {
 .motor-reorder-table__row--header {
   background: rgba(var(--fill-rgb), 0.98);
   color: var(--text-dim);
-  font-size: 11px;
-  letter-spacing: 0.08em;
+  font-size: var(--text-sm);
+  letter-spacing: var(--tracking-label);
   text-transform: uppercase;
 }
 
@@ -10353,7 +10383,7 @@ details.metadata-settings-section:not([open]) > summary::after {
 .telemetry-stack--receiver .scoped-review-card,
 .telemetry-stack--outputs .scoped-review-card,
 .telemetry-stack--ports .scoped-review-card {
-  border-radius: 15px;
+  border-radius: var(--radius-xl);
 }
 
 .telemetry-stack--ports .port-card {
@@ -10496,8 +10526,8 @@ details.metadata-settings-section:not([open]) > summary::after {
 .snapshot-card__header strong {
   display: block;
   margin-bottom: 6px;
-  font-size: 13px;
-  letter-spacing: 0.08em;
+  font-size: var(--text-lg);
+  letter-spacing: var(--tracking-label);
   text-transform: uppercase;
 }
 
@@ -10543,8 +10573,8 @@ details.metadata-settings-section:not([open]) > summary::after {
 }
 
 .provisioning-checklist strong {
-  font-size: 13px;
-  letter-spacing: 0.08em;
+  font-size: var(--text-lg);
+  letter-spacing: var(--tracking-label);
   text-transform: uppercase;
 }
 
@@ -10616,7 +10646,7 @@ details.metadata-settings-section:not([open]) > summary::after {
   margin: 0 !important;
   max-width: 60ch;
   color: rgba(var(--ink-rgb), 0.66) !important;
-  font-size: 14px !important;
+  font-size: var(--text-xl) !important;
   line-height: 1.6 !important;
 }
 
@@ -10647,15 +10677,15 @@ details.metadata-settings-section:not([open]) > summary::after {
 
 .snapshots-page__eyebrow {
   color: rgba(var(--ink-rgb), 0.54);
-  font-size: 11px;
+  font-size: var(--text-sm);
   font-weight: 600;
-  letter-spacing: 0.12em;
+  letter-spacing: var(--tracking-label);
   text-transform: uppercase;
 }
 
 .snapshots-page__hero-copy h3 {
   margin: 0;
-  font-size: 19px;
+  font-size: var(--font-title);
   line-height: 1.08;
   font-weight: 600;
   letter-spacing: -0.02em;
@@ -10665,7 +10695,7 @@ details.metadata-settings-section:not([open]) > summary::after {
   margin: 0;
   max-width: 60ch;
   color: rgba(var(--ink-rgb), 0.66);
-  font-size: 13px;
+  font-size: var(--text-lg);
   line-height: 1.68;
 }
 
@@ -10690,14 +10720,14 @@ details.metadata-settings-section:not([open]) > summary::after {
 
 .snapshots-page__hero-metric span {
   color: rgba(var(--ink-rgb), 0.52);
-  font-size: 11px;
+  font-size: var(--text-sm);
   font-weight: 600;
-  letter-spacing: 0.12em;
+  letter-spacing: var(--tracking-label);
   text-transform: uppercase;
 }
 
 .snapshots-page__hero-metric strong {
-  font-size: 16px;
+  font-size: var(--text-3xl);
   line-height: 1;
   font-weight: 600;
   letter-spacing: -0.03em;
@@ -10736,7 +10766,7 @@ details.metadata-settings-section:not([open]) > summary::after {
 .snapshots-section-header h3,
 .snapshots-subsection-header h3 {
   margin: 6px 0 6px;
-  font-size: 15px;
+  font-size: var(--text-2xl);
   line-height: 1.08;
   font-weight: 600;
   letter-spacing: -0.02em;
@@ -10747,7 +10777,7 @@ details.metadata-settings-section:not([open]) > summary::after {
   margin: 0;
   max-width: 58ch;
   color: rgba(var(--ink-rgb), 0.62);
-  font-size: 14px;
+  font-size: var(--text-xl);
   line-height: 1.58;
 }
 
@@ -10766,9 +10796,9 @@ details.metadata-settings-section:not([open]) > summary::after {
   background: rgba(var(--edge-rgb), 0.055);
   color: rgba(var(--ink-rgb), 0.88);
   font-family: var(--snapshots-font-mono);
-  font-size: 11px;
+  font-size: var(--text-sm);
   font-weight: 600;
-  letter-spacing: 0.05em;
+  letter-spacing: var(--tracking-label);
   text-transform: uppercase;
 }
 
@@ -10801,9 +10831,9 @@ details.metadata-settings-section:not([open]) > summary::after {
 
 .snapshots-form-group-heading span {
   color: rgba(var(--ink-rgb), 0.66);
-  font-size: 11px;
+  font-size: var(--text-sm);
   font-weight: 600;
-  letter-spacing: 0.12em;
+  letter-spacing: var(--tracking-label);
   text-transform: uppercase;
 }
 
@@ -10811,7 +10841,7 @@ details.metadata-settings-section:not([open]) > summary::after {
   margin: 0;
   max-width: 58ch;
   color: rgba(var(--ink-rgb), 0.56);
-  font-size: 13px;
+  font-size: var(--text-lg);
   line-height: 1.55;
 }
 
@@ -10841,9 +10871,9 @@ details.metadata-settings-section:not([open]) > summary::after {
 .snapshots-page .snapshots-field span,
 .tuning-page .snapshots-field span {
   color: rgba(var(--ink-rgb), 0.66);
-  font-size: 11px;
+  font-size: var(--text-sm);
   font-weight: 600;
-  letter-spacing: 0.12em;
+  letter-spacing: var(--tracking-label);
   text-transform: uppercase;
   font-family: var(--snapshots-font-ui);
 }
@@ -10861,7 +10891,7 @@ details.metadata-settings-section:not([open]) > summary::after {
   color: rgba(var(--ink-rgb), 0.94);
   -webkit-text-fill-color: rgba(var(--ink-rgb), 0.94);
   padding: 4px 10px;
-  font-size: 12px;
+  font-size: var(--text-md);
   line-height: 1.4;
   transition:
     border-color 140ms ease,
@@ -10907,7 +10937,7 @@ details.metadata-settings-section:not([open]) > summary::after {
 .snapshots-page .snapshots-field small,
 .tuning-page .snapshots-field small {
   color: rgba(var(--ink-rgb), 0.48);
-  font-size: 12px;
+  font-size: var(--text-md);
   line-height: 1.45;
 }
 
@@ -10924,7 +10954,7 @@ details.metadata-settings-section:not([open]) > summary::after {
   gap: 14px;
   align-items: start;
   padding: 14px 16px;
-  border-radius: 14px;
+  border-radius: var(--radius-xl);
   background: rgba(var(--edge-rgb), 0.026);
   box-shadow: inset 0 0 0 1px rgba(var(--edge-rgb), 0.028);
   transition:
@@ -10949,7 +10979,7 @@ details.metadata-settings-section:not([open]) > summary::after {
 }
 
 .snapshots-setting-row strong {
-  font-size: 13px;
+  font-size: var(--text-lg);
   font-weight: 600;
   color: rgba(var(--ink-rgb), 0.94);
 }
@@ -10972,11 +11002,11 @@ details.metadata-settings-section:not([open]) > summary::after {
 
 .snapshots-button {
   appearance: none;
-  border-radius: 8px;
+  border-radius: var(--radius-md);
   min-height: 28px;
   padding: 0 12px;
   font-family: var(--snapshots-font-ui);
-  font-size: 12px;
+  font-size: var(--text-md);
   font-weight: 600;
   letter-spacing: 0.01em;
   cursor: pointer;
@@ -11043,7 +11073,7 @@ details.metadata-settings-section:not([open]) > summary::after {
 .snapshots-inline-note {
   max-width: 66ch;
   color: rgba(var(--ink-rgb), 0.54);
-  font-size: 13px;
+  font-size: var(--text-lg);
 }
 
 .snapshots-feedback-stack {
@@ -11054,7 +11084,7 @@ details.metadata-settings-section:not([open]) > summary::after {
 .snapshots-notice,
 .snapshots-follow-up {
   border: none;
-  border-radius: 16px;
+  border-radius: var(--radius-2xl);
   background:
     linear-gradient(180deg, rgba(var(--fill-rgb), 0.92), rgba(var(--fill-rgb), 0.98));
   box-shadow:
@@ -11084,13 +11114,13 @@ details.metadata-settings-section:not([open]) > summary::after {
 .snapshots-metric-card span {
   color: rgba(var(--ink-rgb), 0.48);
   font-family: var(--snapshots-font-ui);
-  font-size: 11px;
+  font-size: var(--text-sm);
   font-weight: 600;
   letter-spacing: 0.1em;
 }
 
 .snapshots-metric-card strong {
-  font-size: 16px;
+  font-size: var(--text-3xl);
   font-weight: 600;
   letter-spacing: -0.035em;
 }
@@ -11123,7 +11153,7 @@ details.metadata-settings-section:not([open]) > summary::after {
 
 .snapshots-browser-rail__header h4 {
   margin: 6px 0 0;
-  font-size: 15px;
+  font-size: var(--text-2xl);
   font-weight: 600;
   letter-spacing: -0.02em;
 }
@@ -11137,7 +11167,7 @@ details.metadata-settings-section:not([open]) > summary::after {
   gap: 10px;
   padding: 16px 14px;
   border: 1px solid transparent;
-  border-radius: 16px;
+  border-radius: var(--radius-2xl);
   background: transparent;
   box-shadow: none;
   transition:
@@ -11165,7 +11195,7 @@ details.metadata-settings-section:not([open]) > summary::after {
 .snapshots-page .snapshot-card__header strong {
   margin-bottom: 4px;
   font-family: var(--snapshots-font-ui);
-  font-size: 13px;
+  font-size: var(--text-lg);
   font-weight: 600;
   letter-spacing: -0.01em;
   text-transform: none;
@@ -11173,7 +11203,7 @@ details.metadata-settings-section:not([open]) > summary::after {
 
 .snapshots-page .snapshot-card__header small {
   font-family: var(--snapshots-font-mono);
-  font-size: 11px;
+  font-size: var(--text-sm);
   letter-spacing: 0.02em;
 }
 
@@ -11181,7 +11211,7 @@ details.metadata-settings-section:not([open]) > summary::after {
 .snapshots-page .snapshot-card__note,
 .snapshots-page .snapshot-selected__note {
   color: rgba(var(--ink-rgb), 0.58);
-  font-size: 13px;
+  font-size: var(--text-lg);
   line-height: 1.55;
 }
 
@@ -11199,7 +11229,7 @@ details.metadata-settings-section:not([open]) > summary::after {
   border-radius: 999px;
   background: rgba(var(--edge-rgb), 0.045);
   color: rgba(var(--ink-rgb), 0.7);
-  font-size: 11px;
+  font-size: var(--text-sm);
   font-weight: 500;
   letter-spacing: 0.03em;
 }
@@ -11228,7 +11258,7 @@ details.metadata-settings-section:not([open]) > summary::after {
 
 .snapshots-empty-state h4 {
   margin: 0;
-  font-size: 13px;
+  font-size: var(--text-lg);
   font-weight: 600;
   letter-spacing: -0.02em;
 }
@@ -11252,7 +11282,7 @@ details.metadata-settings-section:not([open]) > summary::after {
 }
 
 .snapshots-page .snapshot-selected .telemetry-header h3 {
-  font-size: 15px;
+  font-size: var(--text-2xl);
   line-height: 1.08;
   letter-spacing: -0.02em;
 }
@@ -11266,7 +11296,7 @@ details.metadata-settings-section:not([open]) > summary::after {
   min-height: 20px;
   padding: 2px 8px !important;
   border-radius: 999px !important;
-  font-size: 10px !important;
+  font-size: var(--text-xs) !important;
   letter-spacing: 0.06em !important;
 }
 
@@ -11302,7 +11332,7 @@ details.metadata-settings-section:not([open]) > summary::after {
   gap: 4px;
   margin: 4px 0 8px;
   padding: 8px 10px;
-  border-radius: 6px;
+  border-radius: var(--radius-sm);
   border: 1px solid var(--border);
   background: var(--bg-panel-soft, rgba(var(--edge-rgb), 0.02));
 }
@@ -11315,7 +11345,7 @@ details.metadata-settings-section:not([open]) > summary::after {
 }
 
 .snapshots-compare-picker label > span {
-  font-size: 12px;
+  font-size: var(--text-md);
   color: var(--text-muted);
   font-weight: 600;
 }
@@ -11328,13 +11358,13 @@ details.metadata-settings-section:not([open]) > summary::after {
 
 .snapshots-compare-picker__note {
   color: var(--text-muted);
-  font-size: 11px;
+  font-size: var(--text-sm);
   line-height: 1.4;
 }
 
 .snapshots-detail-section-heading h4 {
   margin: 5px 0 0;
-  font-size: 15px;
+  font-size: var(--text-2xl);
   line-height: 1.12;
   font-weight: 600;
   letter-spacing: -0.02em;
@@ -11362,14 +11392,14 @@ details.metadata-settings-section:not([open]) > summary::after {
 .snapshots-page .parameter-diff-group--invalid {
   padding-left: 16px;
   padding-right: 16px;
-  border-radius: 16px;
+  border-radius: var(--radius-2xl);
   background: rgba(110, 42, 52, 0.14);
   box-shadow: inset 0 0 0 1px rgba(177, 99, 113, 0.14);
   border-top: none;
 }
 
 .snapshots-page .parameter-diff-group header {
-  font-size: 11px;
+  font-size: var(--text-sm);
   color: rgba(var(--ink-rgb), 0.52);
 }
 
@@ -11397,7 +11427,7 @@ details.metadata-settings-section:not([open]) > summary::after {
 
 .snapshots-page .parameter-follow-up {
   border: none;
-  border-radius: 16px;
+  border-radius: var(--radius-2xl);
   background: rgba(var(--edge-rgb), 0.024);
   box-shadow: inset 0 0 0 1px rgba(var(--edge-rgb), 0.028);
 }
@@ -11411,7 +11441,7 @@ details.metadata-settings-section:not([open]) > summary::after {
 .snapshots-page .snapshot-restore-ack {
   gap: 12px;
   padding: 15px 16px;
-  border-radius: 16px;
+  border-radius: var(--radius-2xl);
   background: rgba(var(--edge-rgb), 0.025);
   box-shadow: inset 0 0 0 1px rgba(var(--edge-rgb), 0.028);
   color: rgba(var(--ink-rgb), 0.9);
@@ -11426,7 +11456,7 @@ details.metadata-settings-section:not([open]) > summary::after {
   display: grid;
   gap: 12px;
   padding: 18px 18px 16px;
-  border-radius: 18px;
+  border-radius: var(--radius-2xl);
   background: rgba(var(--edge-rgb), 0.024);
   box-shadow: inset 0 0 0 1px rgba(var(--edge-rgb), 0.028);
 }
@@ -11434,7 +11464,7 @@ details.metadata-settings-section:not([open]) > summary::after {
 .snapshots-page .desktop-snapshot-workspace {
   padding: 12px 14px;
   border: none;
-  border-radius: 20px;
+  border-radius: var(--radius-2xl);
   background:
     radial-gradient(circle at top right, rgba(115, 141, 181, 0.1), transparent 40%),
     linear-gradient(180deg, rgba(var(--fill-rgb), 0.98), rgba(var(--fill-rgb), 1));
@@ -11508,8 +11538,8 @@ details.metadata-settings-section:not([open]) > summary::after {
 .preset-group__header strong {
   display: block;
   margin-bottom: 6px;
-  font-size: 13px;
-  letter-spacing: 0.08em;
+  font-size: var(--text-lg);
+  letter-spacing: var(--tracking-label);
   text-transform: uppercase;
 }
 
@@ -11560,8 +11590,8 @@ details.metadata-settings-section:not([open]) > summary::after {
 .preset-card__header strong {
   display: block;
   margin-bottom: 6px;
-  font-size: 13px;
-  letter-spacing: 0.08em;
+  font-size: var(--text-lg);
+  letter-spacing: var(--tracking-label);
   text-transform: uppercase;
 }
 
@@ -11600,8 +11630,8 @@ details.metadata-settings-section:not([open]) > summary::after {
 }
 
 .preset-notes strong {
-  font-size: 13px;
-  letter-spacing: 0.06em;
+  font-size: var(--text-lg);
+  letter-spacing: var(--tracking-label);
   text-transform: uppercase;
   color: var(--text);
 }
@@ -11624,15 +11654,15 @@ details.metadata-settings-section:not([open]) > summary::after {
   justify-content: space-between;
   gap: 10px;
   color: var(--text-muted);
-  font-size: 11px;
+  font-size: var(--text-sm);
 }
 
 /* The two directional "does not exist" notes list the affected param ids —
    monospace + word-break so a long cross-version list stays readable and never
    overflows the note width. */
 .snapshot-missing-list {
-  font-family: var(--font-mono, ui-monospace, monospace);
-  font-size: 11px;
+  font-family: var(--font-data);
+  font-size: var(--text-sm);
   word-break: break-word;
   color: var(--text-muted);
 }
@@ -11649,10 +11679,10 @@ details.metadata-settings-section:not([open]) > summary::after {
 .motor-test-card--embedded {
   height: 100%;
   padding: 14px;
-  border-radius: 12px;
+  border-radius: var(--radius-lg);
   border-color: var(--surface-400);
   background:
-    radial-gradient(circle at top right, rgba(255, 187, 0, 0.05), transparent 42%),
+    radial-gradient(circle at top right, rgba(var(--primary-rgb), 0.05), transparent 42%),
     linear-gradient(180deg, rgba(var(--fill-rgb), 0.98), rgba(var(--fill-rgb), 1));
 }
 
@@ -11670,9 +11700,9 @@ details.metadata-settings-section:not([open]) > summary::after {
 
 .motor-test-grid span {
   color: var(--text-muted);
-  font-size: 11px;
+  font-size: var(--text-sm);
   text-transform: uppercase;
-  letter-spacing: 0.08em;
+  letter-spacing: var(--tracking-label);
   font-family: var(--font-data);
 }
 
@@ -11712,9 +11742,9 @@ details.metadata-settings-section:not([open]) > summary::after {
   gap: 10px;
   align-items: start;
   padding: 10px 12px;
-  border-radius: 8px;
-  border: 1px solid rgba(226, 18, 63, 0.55);
-  background: linear-gradient(180deg, rgba(226, 18, 63, 0.10), rgba(226, 18, 63, 0.04));
+  border-radius: var(--radius-md);
+  border: 1px solid rgba(var(--danger-rgb), 0.55);
+  background: linear-gradient(180deg, rgba(var(--danger-rgb), 0.10), rgba(var(--danger-rgb), 0.04));
   color: var(--text);
 }
 
@@ -11827,7 +11857,7 @@ details.metadata-settings-section:not([open]) > summary::after {
   border: 1px solid var(--border);
   background: rgba(var(--fill-rgb), 0.94);
   color: var(--text-muted);
-  font-size: 12px;
+  font-size: var(--text-md);
   font-family: var(--font-data);
 }
 
@@ -11839,7 +11869,7 @@ details.metadata-settings-section:not([open]) > summary::after {
 
 .setup-card h3 {
   margin: 0;
-  font-size: 15px;
+  font-size: var(--text-2xl);
 }
 
 .setup-card p {
@@ -11870,8 +11900,8 @@ details.metadata-settings-section:not([open]) > summary::after {
   border: 1px solid var(--border);
   background: rgba(var(--fill-rgb), 0.94);
   color: var(--text-muted);
-  font-size: 11px;
-  letter-spacing: 0.08em;
+  font-size: var(--text-sm);
+  letter-spacing: var(--tracking-label);
   text-transform: uppercase;
   font-family: var(--font-data);
 }
@@ -11997,7 +12027,7 @@ details.metadata-settings-section:not([open]) > summary::after {
   display: inline-flex;
   align-items: center;
   gap: 6px;
-  font-size: 12.5px;
+  font-size: var(--text-lg);
   white-space: nowrap;
   cursor: pointer;
 }
@@ -12016,14 +12046,14 @@ details.metadata-settings-section:not([open]) > summary::after {
   margin: 0;
   padding: 4px 12px 6px;
   border: 1px solid var(--border-subtle, rgba(var(--edge-rgb), 0.12));
-  border-radius: 8px;
+  border-radius: var(--radius-md);
 }
 
 .parameter-import-exclusions legend {
   padding: 0 4px;
-  font-size: 0.72rem;
+  font-size: var(--text-sm);
   text-transform: uppercase;
-  letter-spacing: 0.04em;
+  letter-spacing: var(--tracking-label);
   opacity: 0.7;
 }
 
@@ -12031,7 +12061,7 @@ details.metadata-settings-section:not([open]) > summary::after {
   display: inline-flex;
   align-items: center;
   gap: 5px;
-  font-size: 0.82rem;
+  font-size: var(--text-lg);
   white-space: nowrap;
   cursor: pointer;
 }
@@ -12066,13 +12096,13 @@ details.metadata-settings-section:not([open]) > summary::after {
   gap: 12px;
   color: var(--text-muted);
   text-transform: uppercase;
-  letter-spacing: 0.08em;
-  font-size: 12px;
+  letter-spacing: var(--tracking-label);
+  font-size: var(--text-md);
 }
 
 .parameter-diff-group header strong {
   color: var(--text);
-  font-size: 12px;
+  font-size: var(--text-md);
 }
 
 /* A group header carrying an action switches to centre alignment — a button
@@ -12087,7 +12117,7 @@ details.metadata-settings-section:not([open]) > summary::after {
   letter-spacing: normal;
   min-width: 0;
   padding: 4px 10px;
-  font-size: 11px;
+  font-size: var(--text-sm);
 }
 
 .parameter-diff-item {
@@ -12148,9 +12178,9 @@ details.metadata-settings-section:not([open]) > summary::after {
 }
 .parameter-diff-drop {
   justify-self: end;
-  font-size: 11px;
+  font-size: var(--text-sm);
   padding: 2px 8px;
-  border-radius: 6px;
+  border-radius: var(--radius-sm);
   border: 1px solid var(--surface-400);
   background: transparent;
   color: var(--text-muted);
@@ -12191,14 +12221,14 @@ details.metadata-settings-section:not([open]) > summary::after {
   margin: 12px 0;
   padding: 10px 12px;
   border: 1px solid var(--surface-400);
-  border-radius: 8px;
+  border-radius: var(--radius-md);
   background: var(--surface-200);
 }
 
 .parameter-preset-bulk > small {
   flex: 1 1 220px;
   min-width: 0;
-  font-size: 12px;
+  font-size: var(--text-md);
   color: var(--text-muted);
 }
 
@@ -12231,7 +12261,7 @@ details.metadata-settings-section:not([open]) > summary::after {
   gap: 14px;
   padding: 18px;
   border: 1px solid var(--surface-400);
-  border-radius: 12px;
+  border-radius: var(--radius-lg);
   background: var(--surface-100);
   box-shadow: 0 18px 48px rgba(0, 0, 0, 0.4);
 }
@@ -12250,7 +12280,7 @@ details.metadata-settings-section:not([open]) > summary::after {
 
 .create-preset__header p {
   margin: 0;
-  font-size: 13px;
+  font-size: var(--text-lg);
   color: var(--text-muted);
 }
 
@@ -12258,7 +12288,7 @@ details.metadata-settings-section:not([open]) > summary::after {
   display: flex;
   flex-direction: column;
   gap: 4px;
-  font-size: 13px;
+  font-size: var(--text-lg);
 }
 
 .create-preset__field > span {
@@ -12278,7 +12308,7 @@ details.metadata-settings-section:not([open]) > summary::after {
 
 .create-preset__hint {
   margin: 0;
-  font-size: 12px;
+  font-size: var(--text-md);
   color: var(--text-muted);
 }
 
@@ -12288,7 +12318,7 @@ details.metadata-settings-section:not([open]) > summary::after {
   gap: 4px;
   padding: 10px;
   border: 1px solid var(--surface-400);
-  border-radius: 8px;
+  border-radius: var(--radius-md);
   background: var(--surface-200);
 }
 
@@ -12307,12 +12337,12 @@ details.metadata-settings-section:not([open]) > summary::after {
 }
 
 .create-preset__question-detail {
-  font-size: 12px;
+  font-size: var(--text-md);
   color: var(--text-dim);
 }
 
 .create-preset__question-rationale {
-  font-size: 12px;
+  font-size: var(--text-md);
   color: var(--text-muted);
 }
 
@@ -12320,7 +12350,7 @@ details.metadata-settings-section:not([open]) > summary::after {
   display: inline-flex;
   gap: 8px;
   align-items: center;
-  font-size: 12px;
+  font-size: var(--text-md);
   color: var(--text-muted);
 }
 
@@ -12335,7 +12365,7 @@ details.metadata-settings-section:not([open]) > summary::after {
   align-items: baseline;
   justify-content: space-between;
   margin-bottom: 6px;
-  font-size: 12px;
+  font-size: var(--text-md);
   color: var(--text-muted);
 }
 
@@ -12343,7 +12373,7 @@ details.metadata-settings-section:not([open]) > summary::after {
   max-height: 260px;
   overflow-y: auto;
   border: 1px solid var(--surface-400);
-  border-radius: 8px;
+  border-radius: var(--radius-md);
 }
 
 .create-preset__param {
@@ -12352,7 +12382,7 @@ details.metadata-settings-section:not([open]) > summary::after {
   gap: 8px;
   align-items: center;
   padding: 6px 10px;
-  font-size: 12px;
+  font-size: var(--text-md);
   border-bottom: 1px solid rgba(var(--edge-rgb), 0.08);
 }
 
@@ -12391,7 +12421,7 @@ details.metadata-settings-section:not([open]) > summary::after {
   align-items: center;
   padding: 10px 12px;
   border: 1px solid var(--surface-400);
-  border-radius: 8px;
+  border-radius: var(--radius-md);
   background: var(--surface-200);
 }
 
@@ -12399,14 +12429,14 @@ details.metadata-settings-section:not([open]) > summary::after {
   display: inline-flex;
   gap: 8px;
   align-items: center;
-  font-size: 13px;
+  font-size: var(--text-lg);
   color: var(--text-muted);
 }
 
 .preset-serial-remap > small {
   flex: 1 1 240px;
   min-width: 0;
-  font-size: 12px;
+  font-size: var(--text-md);
   color: var(--text-muted);
 }
 
@@ -12425,7 +12455,7 @@ details.metadata-settings-section:not([open]) > summary::after {
   display: inline-flex;
   gap: 6px;
   align-items: center;
-  font-size: 13px;
+  font-size: var(--text-lg);
   color: var(--text-muted);
   cursor: pointer;
 }
@@ -12448,11 +12478,11 @@ details.metadata-settings-section:not([open]) > summary::after {
   margin-left: 4px;
   padding: 2px 6px;
   border: 1px solid var(--border);
-  border-radius: 4px;
+  border-radius: var(--radius-sm);
   background: var(--bg-panel);
   color: var(--text);
   font: inherit;
-  font-size: 13px;
+  font-size: var(--text-lg);
 }
 
 .parameter-diff-edit:focus {
@@ -12502,7 +12532,7 @@ details.metadata-settings-section:not([open]) > summary::after {
   background: linear-gradient(180deg, rgba(var(--fill-rgb), 0.98), rgba(var(--fill-rgb), 1));
   color: var(--text);
   padding: 5px 10px;
-  font-size: 14px;
+  font-size: var(--text-xl);
 }
 
 /* Matches the 28px control scale so selects sitting inline with
@@ -12540,8 +12570,8 @@ details.metadata-settings-section:not([open]) > summary::after {
   border: 1px solid var(--border);
   background: rgba(var(--fill-rgb), 0.94);
   color: var(--text-muted);
-  font-size: 11px;
-  letter-spacing: 0.08em;
+  font-size: var(--text-sm);
+  letter-spacing: var(--tracking-label);
   text-transform: uppercase;
   font-family: var(--font-data);
 }
@@ -12564,7 +12594,7 @@ details.metadata-settings-section:not([open]) > summary::after {
   background: var(--bg-panel-muted);
   cursor: pointer;
   /* Bumped 12 -> 14px for readability (Parameters is text-dense). */
-  font-size: 14px;
+  font-size: var(--text-xl);
 }
 
 /* Click-to-expand affordance on the first cell. */
@@ -12599,7 +12629,7 @@ details.metadata-settings-section:not([open]) > summary::after {
 }
 .parameter-row__caret {
   color: var(--text-muted);
-  font-size: 10px;
+  font-size: var(--text-xs);
 }
 .parameter-row--expanded {
   background: var(--bg-panel);
@@ -12626,10 +12656,10 @@ details.metadata-settings-section:not([open]) > summary::after {
   flex-wrap: wrap;
 }
 .parameter-detail__head strong {
-  font-size: 15px;
+  font-size: var(--text-2xl);
 }
 .parameter-detail__alias {
-  font-size: 12px;
+  font-size: var(--text-md);
   color: var(--text-muted);
 }
 .parameter-detail__alias code,
@@ -12638,7 +12668,7 @@ details.metadata-settings-section:not([open]) > summary::after {
 }
 .parameter-detail__desc {
   margin: 0;
-  font-size: 13px;
+  font-size: var(--text-lg);
   line-height: 1.5;
   color: var(--text);
 }
@@ -12654,14 +12684,14 @@ details.metadata-settings-section:not([open]) > summary::after {
   gap: 6px;
 }
 .parameter-detail__meta dt {
-  font-size: 10px;
-  letter-spacing: 0.08em;
+  font-size: var(--text-xs);
+  letter-spacing: var(--tracking-label);
   text-transform: uppercase;
   color: var(--text-muted);
 }
 .parameter-detail__meta dd {
   margin: 0;
-  font-size: 13px;
+  font-size: var(--text-lg);
   font-family: var(--font-data);
 }
 .parameter-detail__value-row {
@@ -12676,8 +12706,8 @@ details.metadata-settings-section:not([open]) > summary::after {
   gap: 3px;
 }
 .parameter-detail__field > span {
-  font-size: 10px;
-  letter-spacing: 0.08em;
+  font-size: var(--text-xs);
+  letter-spacing: var(--tracking-label);
   text-transform: uppercase;
   color: var(--text-muted);
 }
@@ -12690,10 +12720,10 @@ details.metadata-settings-section:not([open]) > summary::after {
 .parameter-row--header {
   background: var(--bg-panel);
   color: var(--text-dim);
-  font-size: 12px;
+  font-size: var(--text-md);
   font-weight: 700;
   text-transform: uppercase;
-  letter-spacing: 0.08em;
+  letter-spacing: var(--tracking-label);
   font-family: var(--font-data);
 }
 
@@ -12769,7 +12799,7 @@ details.metadata-settings-section:not([open]) > summary::after {
 
 .parameter-actions__idle {
   color: var(--text-muted);
-  font-size: 12px;
+  font-size: var(--text-md);
 }
 
 .parameter-empty-state {
@@ -13102,7 +13132,7 @@ details.metadata-settings-section:not([open]) > summary::after {
   .bf-toolbar {
     position: static;
     width: 100%;
-    border-radius: 12px;
+    border-radius: var(--radius-lg);
     border-right: 1px solid var(--surface-400);
     justify-self: stretch;
   }
@@ -13212,7 +13242,7 @@ details.metadata-settings-section:not([open]) > summary::after {
   display: grid;
   gap: 12px;
   padding: 14px 16px;
-  border-radius: 14px;
+  border-radius: var(--radius-xl);
   border: 1px solid var(--border-accent);
   background: linear-gradient(180deg, var(--surface-warm-glow), transparent 60%), var(--bg-panel-raised);
 }
@@ -13224,13 +13254,13 @@ details.metadata-settings-section:not([open]) > summary::after {
 
 .landing__connect-copy h2 {
   margin: 0;
-  font-size: 13px;
+  font-size: var(--text-lg);
   color: var(--text);
 }
 
 .landing__connect-copy p {
   margin: 0;
-  font-size: 13px;
+  font-size: var(--text-lg);
   color: var(--text-muted);
 }
 
@@ -13244,7 +13274,7 @@ details.metadata-settings-section:not([open]) > summary::after {
 .landing__field {
   display: grid;
   gap: 6px;
-  font-size: 12px;
+  font-size: var(--text-md);
   color: var(--text-muted);
 }
 
@@ -13254,7 +13284,7 @@ details.metadata-settings-section:not([open]) > summary::after {
 
 .landing__hint {
   margin: 2px 0 0;
-  font-size: 11px;
+  font-size: var(--text-sm);
   line-height: 1.5;
   color: var(--text-muted);
   overflow-wrap: anywhere;
@@ -13262,21 +13292,21 @@ details.metadata-settings-section:not([open]) > summary::after {
 
 .landing__hint code {
   padding: 1px 5px;
-  border-radius: 4px;
+  border-radius: var(--radius-sm);
   border: 1px solid var(--border);
   background: var(--bg-panel);
-  font-size: 11px;
+  font-size: var(--text-sm);
 }
 
 .landing__field select,
 .landing__field input {
   height: 32px;
   padding: 0 10px;
-  border-radius: 8px;
+  border-radius: var(--radius-md);
   border: 1px solid var(--border);
   background: var(--bg-panel);
   color: var(--text);
-  font-size: 13px;
+  font-size: var(--text-lg);
 }
 
 .landing__field select:focus,
@@ -13288,11 +13318,11 @@ details.metadata-settings-section:not([open]) > summary::after {
 .landing__connect-button {
   height: 32px;
   padding: 0 16px;
-  border-radius: 8px;
+  border-radius: var(--radius-md);
   border: 1px solid var(--primary-500);
   background: var(--primary-500);
   color: var(--text-on-light);
-  font-size: 14px;
+  font-size: var(--text-xl);
   font-weight: 600;
   letter-spacing: 0.02em;
   cursor: pointer;
@@ -13311,11 +13341,11 @@ details.metadata-settings-section:not([open]) > summary::after {
 .landing__secondary-button {
   height: 32px;
   padding: 0 12px;
-  border-radius: 8px;
+  border-radius: var(--radius-md);
   border: 1px solid var(--border-strong);
   background: var(--bg-panel-soft);
   color: var(--text);
-  font-size: 12px;
+  font-size: var(--text-md);
   font-weight: 600;
   cursor: pointer;
 }
@@ -13349,7 +13379,7 @@ details.metadata-settings-section:not([open]) > summary::after {
 .dfu-hex-flasher__intro {
   margin: 0 0 12px;
   color: var(--text-muted);
-  font-size: 13px;
+  font-size: var(--text-lg);
   line-height: 1.5;
 }
 .dfu-hex-flasher__activate {
@@ -13360,7 +13390,7 @@ details.metadata-settings-section:not([open]) > summary::after {
 }
 .dfu-hex-flasher__help {
   margin: 0 0 12px;
-  font-size: 12px;
+  font-size: var(--text-md);
   color: var(--text-muted);
 }
 .dfu-hex-flasher__help summary {
@@ -13388,7 +13418,7 @@ details.metadata-settings-section:not([open]) > summary::after {
   grid-template-columns: 1fr auto;
   gap: 4px 10px;
   align-items: center;
-  font-size: 12px;
+  font-size: var(--text-md);
   color: var(--text-muted);
   opacity: 0.5;
 }
@@ -13413,7 +13443,7 @@ details.metadata-settings-section:not([open]) > summary::after {
   align-items: flex-start;
   gap: 8px;
   margin: 12px 0;
-  font-size: 12px;
+  font-size: var(--text-md);
   color: var(--text-muted);
   cursor: pointer;
 }
@@ -13433,15 +13463,15 @@ details.metadata-settings-section:not([open]) > summary::after {
   gap: 2px;
 }
 .dfu-hex-flasher__summary dt {
-  font-size: 10px;
-  letter-spacing: 0.05em;
+  font-size: var(--text-xs);
+  letter-spacing: var(--tracking-label);
   text-transform: uppercase;
   color: var(--text-muted);
 }
 .dfu-hex-flasher__summary dd {
   margin: 0;
   font-family: var(--font-data);
-  font-size: 13px;
+  font-size: var(--text-lg);
 }
 
 /* Hard-stop refusal banner — promoted from a small <p> because the
@@ -13458,11 +13488,11 @@ details.metadata-settings-section:not([open]) > summary::after {
   gap: 14px;
   margin: 18px 0 4px;
   padding: 16px 18px;
-  border-radius: 10px;
-  border: 2px solid rgba(226, 18, 63, 0.65);
-  background: rgba(226, 18, 63, 0.14);
+  border-radius: var(--radius-lg);
+  border: 2px solid rgba(var(--danger-rgb), 0.65);
+  background: rgba(var(--danger-rgb), 0.14);
   color: #ffd6e0;
-  box-shadow: 0 0 0 1px rgba(226, 18, 63, 0.25), 0 6px 18px rgba(226, 18, 63, 0.18);
+  box-shadow: 0 0 0 1px rgba(var(--danger-rgb), 0.25), 0 6px 18px rgba(var(--danger-rgb), 0.18);
 }
 
 .firmware-error-banner__badge {
@@ -13472,10 +13502,10 @@ details.metadata-settings-section:not([open]) > summary::after {
   width: 32px;
   height: 32px;
   border-radius: 50%;
-  background: rgba(226, 18, 63, 0.85);
+  background: rgba(var(--danger-rgb), 0.85);
   color: #fff;
   font-weight: 700;
-  font-size: 18px;
+  font-size: var(--font-title);
   line-height: 1;
 }
 
@@ -13488,14 +13518,14 @@ details.metadata-settings-section:not([open]) > summary::after {
 }
 
 .firmware-error-banner__body strong {
-  font-size: 15px;
+  font-size: var(--text-2xl);
   color: #ff97a9;
   letter-spacing: 0.02em;
 }
 
 .firmware-error-banner__body p {
   margin: 0;
-  font-size: 14px;
+  font-size: var(--text-xl);
   line-height: 1.45;
   color: var(--surface-950);
   word-break: break-word;
@@ -13509,12 +13539,12 @@ details.metadata-settings-section:not([open]) > summary::after {
   padding: 12px 14px;
   border: 1px solid var(--border);
   border-left: 3px solid var(--surface-700);
-  border-radius: 8px;
+  border-radius: var(--radius-md);
   background: var(--surface-200);
 }
 
 .firmware-replug-prompt strong {
-  font-size: 13px;
+  font-size: var(--text-lg);
   color: var(--surface-950);
 }
 .firmware-replug-prompt__steps {
@@ -13523,7 +13553,7 @@ details.metadata-settings-section:not([open]) > summary::after {
   display: flex;
   flex-direction: column;
   gap: 5px;
-  font-size: 12.5px;
+  font-size: var(--text-lg);
   line-height: 1.4;
 }
 .firmware-replug-prompt__steps code {
@@ -13541,7 +13571,7 @@ details.metadata-settings-section:not([open]) > summary::after {
   appearance: none;
   padding: 5px 12px;
   border: 1px solid var(--border);
-  border-radius: 6px;
+  border-radius: var(--radius-sm);
   background: var(--surface-500);
   color: var(--surface-950);
   font: inherit;
@@ -13580,7 +13610,7 @@ details.metadata-settings-section:not([open]) > summary::after {
   gap: 8px;
   padding: 12px 14px;
   border: 1px solid var(--border, #3d3d3d);
-  border-radius: var(--radius-md, 8px);
+  border-radius: var(--radius-md);
   background: var(--bg-panel-soft, rgb(var(--fill-rgb)));
 }
 
@@ -13612,7 +13642,7 @@ details.metadata-settings-section:not([open]) > summary::after {
 
 .firmware-wizard__hint {
   margin: 0;
-  font-size: 12px;
+  font-size: var(--text-md);
   color: var(--text-muted, #b3b3b3);
   line-height: 1.45;
 }
@@ -13625,7 +13655,7 @@ details.metadata-settings-section:not([open]) > summary::after {
   margin: 8px 0;
   /* Plain inline confirm, not a heavy bordered field-card — it was reading as
      obnoxious for a single safety checkbox. */
-  font-size: 12px;
+  font-size: var(--text-md);
   color: var(--text-muted);
   cursor: pointer;
 }
@@ -13657,13 +13687,13 @@ details.metadata-settings-section:not([open]) > summary::after {
 
 .landing__section-header h2 {
   margin: 0;
-  font-size: 15px;
+  font-size: var(--text-2xl);
   color: var(--text);
 }
 
 .landing__section-header p {
   margin: 0;
-  font-size: 13px;
+  font-size: var(--text-lg);
   color: var(--text-muted);
 }
 
@@ -13680,21 +13710,21 @@ details.metadata-settings-section:not([open]) > summary::after {
   display: grid;
   gap: 6px;
   padding: 16px;
-  border-radius: 12px;
+  border-radius: var(--radius-lg);
   border: 1px solid var(--card-outline);
   background: var(--bg-panel-raised);
 }
 
 .landing__capability strong {
   color: var(--text);
-  font-size: 14px;
-  letter-spacing: 0.04em;
+  font-size: var(--text-xl);
+  letter-spacing: var(--tracking-label);
   text-transform: uppercase;
 }
 
 .landing__capability span {
   color: var(--text-muted);
-  font-size: 13px;
+  font-size: var(--text-lg);
   line-height: 1.55;
 }
 
@@ -13759,7 +13789,7 @@ details.metadata-settings-section:not([open]) > summary::after {
 }
 
 .telemetry-stack--receiver .receiver-summary-card p {
-  font-size: 12px;
+  font-size: var(--text-md);
 }
 
 /* Modes view: read-only flight-mode slot table with live indicator. */
@@ -13791,8 +13821,8 @@ details.metadata-settings-section:not([open]) > summary::after {
 .modes-status__card span {
   flex: 0 0 auto;
   font-family: var(--font-data);
-  font-size: 10px;
-  letter-spacing: 0.08em;
+  font-size: var(--text-xs);
+  letter-spacing: var(--tracking-label);
   text-transform: uppercase;
   color: var(--text-muted);
 }
@@ -13800,14 +13830,14 @@ details.metadata-settings-section:not([open]) > summary::after {
 .modes-status__card strong {
   flex: 1 1 auto;
   min-width: 0;
-  font-size: 13px;
+  font-size: var(--text-lg);
   color: var(--text);
 }
 
 .modes-status__card small {
   flex: 1 0 100%;
   color: var(--text-muted);
-  font-size: 11px;
+  font-size: var(--text-sm);
   line-height: 1.3;
 }
 
@@ -13838,7 +13868,7 @@ details.metadata-settings-section:not([open]) > summary::after {
   list-style: none;
   margin: 0;
   padding: 0;
-  font-size: 13px;
+  font-size: var(--text-lg);
 }
 
 .logs-onboard-list li {
@@ -13896,7 +13926,7 @@ details.metadata-settings-section:not([open]) > summary::after {
 .download-bar__label {
   flex: 0 0 auto;
   font-family: var(--font-data);
-  font-size: 11px;
+  font-size: var(--text-sm);
   color: var(--text-muted);
   font-variant-numeric: tabular-nums;
 }
@@ -13904,14 +13934,14 @@ details.metadata-settings-section:not([open]) > summary::after {
 .modes-table__row--head {
   background: var(--bg-panel);
   font-family: var(--font-data);
-  font-size: 11px;
-  letter-spacing: 0.08em;
+  font-size: var(--text-sm);
+  letter-spacing: var(--tracking-label);
   text-transform: uppercase;
   color: var(--text-muted);
 }
 
 .modes-table__row span {
-  font-size: 13px;
+  font-size: var(--text-lg);
   color: var(--text);
 }
 
@@ -13959,7 +13989,7 @@ details.metadata-settings-section:not([open]) > summary::after {
 
 .modes-help p {
   margin: 0;
-  font-size: 13px;
+  font-size: var(--text-lg);
   color: var(--text-muted);
   line-height: 1.5;
 }
@@ -13991,7 +14021,7 @@ details.metadata-settings-section:not([open]) > summary::after {
 }
 
 .telemetry-stack--outputs .outputs-summary-card p {
-  font-size: 12px;
+  font-size: var(--text-md);
 }
 
 
@@ -14012,15 +14042,15 @@ details.metadata-settings-section:not([open]) > summary::after {
 }
 
 .osd-preview-screen__element--draggable:hover {
-  background: rgba(255, 187, 0, 0.12);
-  outline-color: rgba(255, 187, 0, 0.4);
+  background: rgba(var(--primary-rgb), 0.12);
+  outline-color: rgba(var(--primary-rgb), 0.4);
 }
 
 .osd-preview-screen__element--draggable.is-dragging {
   cursor: grabbing;
-  background: rgba(255, 187, 0, 0.22);
+  background: rgba(var(--primary-rgb), 0.22);
   transform: scale(1.05);
-  outline-color: rgba(255, 187, 0, 0.85);
+  outline-color: rgba(var(--primary-rgb), 0.85);
   z-index: 2;
 }
 
@@ -14043,9 +14073,9 @@ details.metadata-settings-section:not([open]) > summary::after {
   left: 0;
   padding: 2px 4px;
   border-radius: 3px;
-  background: rgba(255, 187, 0, 0.92);
+  background: rgba(var(--primary-rgb), 0.92);
   color: #10130a;
-  font-size: 9px;
+  font-size: var(--text-2xs);
   line-height: 1;
   letter-spacing: 0.02em;
   font-variant-numeric: tabular-nums;
@@ -14078,14 +14108,14 @@ details.metadata-settings-section:not([open]) > summary::after {
   width: 100%;
   border-collapse: separate;
   border-spacing: 0;
-  font-size: 12px;
+  font-size: var(--text-md);
 }
 
 .servo-mapping__table thead th {
   text-align: left;
   padding: 8px 10px;
-  font-size: 10px;
-  letter-spacing: 0.08em;
+  font-size: var(--text-xs);
+  letter-spacing: var(--tracking-label);
   text-transform: uppercase;
   color: var(--text-muted);
   border-bottom: 1px solid var(--surface-400);
@@ -14118,13 +14148,13 @@ details.metadata-settings-section:not([open]) > summary::after {
 
 .servo-mapping__channel strong {
   display: block;
-  font-size: 13px;
+  font-size: var(--text-lg);
 }
 
 .servo-mapping__channel small {
   display: block;
   color: var(--text-muted);
-  font-size: 10px;
+  font-size: var(--text-xs);
   margin-top: 2px;
 }
 
@@ -14155,7 +14185,7 @@ details.metadata-settings-section:not([open]) > summary::after {
   gap: 14px;
   margin-right: auto;
   color: var(--text-muted);
-  font-size: 11px;
+  font-size: var(--text-sm);
 }
 
 .servo-mapping__pwm {
@@ -14199,7 +14229,7 @@ details.metadata-settings-section:not([open]) > summary::after {
   align-items: center;
   gap: 6px;
   cursor: pointer;
-  font-size: 11px;
+  font-size: var(--text-sm);
   color: var(--text-muted);
 }
 
@@ -14209,16 +14239,16 @@ details.metadata-settings-section:not([open]) > summary::after {
 
 .servo-mapping__missing {
   color: var(--text-muted);
-  font-size: 11px;
+  font-size: var(--text-sm);
 }
 
 .failsafe-placeholder {
   display: grid;
   gap: 8px;
   padding: var(--card-padding, 12px);
-  border-radius: var(--radius-md, 8px);
+  border-radius: var(--radius-md);
   border: 1px dashed var(--surface-500);
-  background: rgba(255, 187, 0, 0.04);
+  background: rgba(var(--primary-rgb), 0.04);
 }
 
 .failsafe-placeholder__header {
@@ -14230,7 +14260,7 @@ details.metadata-settings-section:not([open]) > summary::after {
 
 .failsafe-placeholder__header strong {
   display: block;
-  font-size: 13px;
+  font-size: var(--text-lg);
   margin-bottom: 4px;
 }
 
@@ -14244,7 +14274,7 @@ details.metadata-settings-section:not([open]) > summary::after {
 .failsafe-placeholder__note {
   margin: 0;
   color: var(--text-muted);
-  font-size: 11px;
+  font-size: var(--text-sm);
   line-height: 1.5;
 }
 
@@ -14287,8 +14317,8 @@ details.metadata-settings-section:not([open]) > summary::after {
   gap: 6px;
   cursor: pointer;
   list-style: none;
-  font-size: 11px;
-  letter-spacing: 0.08em;
+  font-size: var(--text-sm);
+  letter-spacing: var(--tracking-label);
   text-transform: uppercase;
   color: var(--text-muted);
   padding: 2px 0;
@@ -14298,7 +14328,7 @@ details.metadata-settings-section:not([open]) > summary::after {
 }
 .config-section__advanced > summary::before {
   content: '▸';
-  font-size: 9px;
+  font-size: var(--text-2xs);
   transition: transform 0.15s ease;
 }
 .config-section__advanced[open] > summary::before {
@@ -14311,7 +14341,7 @@ details.metadata-settings-section:not([open]) > summary::after {
   border-radius: 999px;
   background: rgba(var(--edge-rgb), 0.12);
   color: var(--text-muted);
-  font-size: 10px;
+  font-size: var(--text-xs);
   line-height: 15px;
   text-align: center;
   letter-spacing: 0;
@@ -14324,7 +14354,7 @@ details.metadata-settings-section:not([open]) > summary::after {
   display: grid;
   gap: var(--space-2, 8px);
   padding: var(--card-padding, 12px);
-  border-radius: var(--radius-md, 8px);
+  border-radius: var(--radius-md);
   border: 1px solid var(--surface-400);
   background: var(--surface-200);
   /* Multicolumn item: keep a card whole and space it from the next one. */
@@ -14354,14 +14384,14 @@ details.metadata-settings-section:not([open]) > summary::after {
 
 .config-section__header strong {
   display: block;
-  font-size: 13px;
+  font-size: var(--text-lg);
   margin-bottom: 4px;
 }
 
 .config-section__header p {
   margin: 0;
   color: var(--text-muted);
-  font-size: 11px;
+  font-size: var(--text-sm);
   line-height: 1.45;
 }
 
@@ -14377,7 +14407,7 @@ details.metadata-settings-section:not([open]) > summary::after {
   gap: 8px;
   padding: 4px 0;
   border-bottom: 1px solid var(--surface-300);
-  font-size: 12px;
+  font-size: var(--text-md);
 }
 
 .config-section__value-row:last-child {
@@ -14394,7 +14424,7 @@ details.metadata-settings-section:not([open]) > summary::after {
 .config-section__value-row dt small {
   color: var(--text-muted);
   font-family: var(--font-data);
-  font-size: 10px;
+  font-size: var(--text-xs);
 }
 
 .config-section__value-row dd {
@@ -14406,13 +14436,13 @@ details.metadata-settings-section:not([open]) > summary::after {
 .config-section__empty {
   margin: 0;
   color: var(--text-muted);
-  font-size: 11px;
+  font-size: var(--text-sm);
 }
 
 .config-grid__footnote {
   margin: var(--space-3, 12px) 0 0;
   color: var(--text-muted);
-  font-size: 11px;
+  font-size: var(--text-sm);
   line-height: 1.5;
 }
 
@@ -14439,9 +14469,9 @@ details.metadata-settings-section:not([open]) > summary::after {
   display: flex;
   justify-content: space-between;
   align-items: baseline;
-  font-size: 11px;
+  font-size: var(--text-sm);
   text-transform: uppercase;
-  letter-spacing: 0.04em;
+  letter-spacing: var(--tracking-label);
   color: var(--text-muted);
 }
 .osd-shorthand__row {
@@ -14452,7 +14482,7 @@ details.metadata-settings-section:not([open]) > summary::after {
 }
 .osd-shorthand__row input {
   min-width: 0;
-  font-family: var(--font-mono, ui-monospace, monospace);
+  font-family: var(--font-data);
 }
 
 /* Searchable message combobox for the "from" field. */
@@ -14475,7 +14505,7 @@ details.metadata-settings-section:not([open]) > summary::after {
   max-height: 260px;
   overflow-y: auto;
   border: 1px solid var(--border);
-  border-radius: var(--radius-sm, 4px);
+  border-radius: var(--radius-sm);
   background: var(--surface, #141c28);
   box-shadow: 0 8px 24px rgba(0, 0, 0, 0.4);
 }
@@ -14485,9 +14515,9 @@ details.metadata-settings-section:not([open]) > summary::after {
   justify-content: space-between;
   gap: 10px;
   padding: 5px 8px;
-  border-radius: var(--radius-sm, 4px);
+  border-radius: var(--radius-sm);
   cursor: pointer;
-  font-size: 12px;
+  font-size: var(--text-md);
 }
 .osd-combobox__option:hover,
 .osd-combobox__option[aria-selected='true'] {
@@ -14501,9 +14531,9 @@ details.metadata-settings-section:not([open]) > summary::after {
 }
 .osd-combobox__from {
   flex: 0 0 auto;
-  font-family: var(--font-mono, ui-monospace, monospace);
+  font-family: var(--font-data);
   color: var(--accent, #dab254);
-  font-size: 11px;
+  font-size: var(--text-sm);
 }
 .osd-shorthand__actions {
   display: flex;
@@ -14519,9 +14549,9 @@ details.metadata-settings-section:not([open]) > summary::after {
 .osd-backend-strip .bf-gui-box__titlebar small {
   /* Dark, slightly subordinate to the strong title but legible on the yellow pill. */
   color: rgba(11, 17, 24, 0.7);
-  font-size: 10px;
+  font-size: var(--text-xs);
   font-family: var(--font-data);
-  letter-spacing: 0.04em;
+  letter-spacing: var(--tracking-label);
   text-transform: uppercase;
 }
 
@@ -14547,7 +14577,7 @@ details.bf-gui-box:not([open]) {
 details.bf-gui-box[open] > summary::after,
 details.bf-gui-box:not([open]) > summary::after {
   margin-left: 6px;
-  font-size: 9px;
+  font-size: var(--text-2xs);
   color: #000;
 }
 
@@ -14592,9 +14622,9 @@ details.bf-gui-box:not([open]) > summary::after {
 .osd-bf-preview .bf-gui-box__titlebar small {
   /* Dark, slightly subordinate to the strong title but legible on the yellow pill. */
   color: rgba(11, 17, 24, 0.7);
-  font-size: 10px;
+  font-size: var(--text-xs);
   font-family: var(--font-data);
-  letter-spacing: 0.04em;
+  letter-spacing: var(--tracking-label);
   text-transform: uppercase;
 }
 
@@ -14645,7 +14675,7 @@ details.bf-gui-box:not([open]) > summary::after {
   border: 1px solid var(--surface-400);
   background: transparent;
   color: var(--text-muted);
-  font-size: 11px;
+  font-size: var(--text-sm);
   font-style: italic;
   line-height: 1;
   cursor: help;
@@ -14668,11 +14698,11 @@ details.bf-gui-box:not([open]) > summary::after {
      run past the left edge of the screen and clip its own text. */
   max-width: min(260px, calc(100vw - 32px));
   padding: 8px 10px;
-  border-radius: 6px;
+  border-radius: var(--radius-sm);
   border: 1px solid var(--surface-400);
   background: var(--bg-panel, rgb(var(--fill-rgb)));
   color: var(--text);
-  font-size: 12px;
+  font-size: var(--text-md);
   font-style: normal;
   line-height: 1.4;
   white-space: normal;
@@ -14712,7 +14742,7 @@ details.bf-gui-box:not([open]) > summary::after {
 .config-section__info-param {
   display: block;
   font-family: var(--font-data);
-  font-size: 11px;
+  font-size: var(--text-sm);
   font-weight: 700;
   letter-spacing: 0.06em;
   color: var(--text);
@@ -14729,7 +14759,7 @@ details.bf-gui-box:not([open]) > summary::after {
   display: inline-block;
   margin-top: 6px;
   color: var(--accent-strong, var(--accent));
-  font-size: 11px;
+  font-size: var(--text-sm);
   text-decoration: underline;
 }
 
@@ -14738,15 +14768,15 @@ details.bf-gui-box:not([open]) > summary::after {
   grid-template-columns: 1fr auto;
   gap: 4px;
   padding: 6px 8px;
-  border-radius: var(--radius-sm, 6px);
+  border-radius: var(--radius-sm);
   border: 1px dashed var(--surface-400);
   color: var(--text-muted);
-  font-size: 11px;
+  font-size: var(--text-sm);
 }
 
 .config-section__missing-row small {
   font-family: var(--font-data);
-  font-size: 10px;
+  font-size: var(--text-xs);
   grid-column: 1 / -1;
   margin-top: 2px;
 }
@@ -14782,7 +14812,7 @@ details.bf-gui-box:not([open]) > summary::after {
   gap: 14px;
   margin-right: auto;
   color: var(--text-muted);
-  font-size: 11px;
+  font-size: var(--text-sm);
 }
 
 .firmware-wizard__quick-actions {
@@ -14833,18 +14863,18 @@ details.bf-gui-box:not([open]) > summary::after {
    as dangerous; theme-safe via the danger token. */
 .files-sanitize-button {
   padding: 5px 12px;
-  border-radius: 8px;
-  border: 1px solid color-mix(in srgb, var(--danger, #e2123f) 55%, transparent);
-  background: color-mix(in srgb, var(--danger, #e2123f) 16%, transparent);
-  color: var(--danger, #e2123f);
-  font-size: 12px;
+  border-radius: var(--radius-md);
+  border: 1px solid color-mix(in srgb, var(--danger, var(--danger)) 55%, transparent);
+  background: color-mix(in srgb, var(--danger, var(--danger)) 16%, transparent);
+  color: var(--danger, var(--danger));
+  font-size: var(--text-md);
   font-weight: 600;
   letter-spacing: 0.01em;
   cursor: pointer;
 }
 
 .files-sanitize-button:hover:not(:disabled) {
-  background: color-mix(in srgb, var(--danger, #e2123f) 28%, transparent);
+  background: color-mix(in srgb, var(--danger, var(--danger)) 28%, transparent);
 }
 
 .files-sanitize-button:disabled {
@@ -14857,28 +14887,28 @@ details.bf-gui-box:not([open]) > summary::after {
 .files-error {
   margin: 0 0 10px;
   padding: 8px 12px;
-  border-radius: 8px;
-  border: 1px solid color-mix(in srgb, var(--danger, #e2123f) 45%, transparent);
-  background: color-mix(in srgb, var(--danger, #e2123f) 12%, transparent);
-  color: var(--danger, #e2123f);
-  font-size: 13px;
+  border-radius: var(--radius-md);
+  border: 1px solid color-mix(in srgb, var(--danger, var(--danger)) 45%, transparent);
+  background: color-mix(in srgb, var(--danger, var(--danger)) 12%, transparent);
+  color: var(--danger, var(--danger));
+  font-size: var(--text-lg);
 }
 
 .files-quick-path {
   padding: 6px 12px;
-  border-radius: var(--radius-md, 8px);
+  border-radius: var(--radius-md);
   border: 1px solid var(--surface-400);
   background: var(--surface-200);
   color: var(--text-muted);
   font-family: var(--font-data);
-  font-size: 11px;
+  font-size: var(--text-sm);
   cursor: pointer;
 }
 
 .files-quick-path.is-active {
   border-color: var(--primary-400);
   color: var(--text);
-  background: rgba(255, 187, 0, 0.12);
+  background: rgba(var(--primary-rgb), 0.12);
 }
 
 .files-quick-path:disabled {
@@ -14895,14 +14925,14 @@ details.bf-gui-box:not([open]) > summary::after {
   display: flex;
   align-items: center;
   gap: 8px;
-  font-size: 12px;
+  font-size: var(--text-md);
 }
 
 .files-path__label {
   color: var(--text-muted);
   text-transform: uppercase;
-  letter-spacing: 0.06em;
-  font-size: 10px;
+  letter-spacing: var(--tracking-label);
+  font-size: var(--text-xs);
 }
 
 .files-path code {
@@ -14921,7 +14951,7 @@ details.bf-gui-box:not([open]) > summary::after {
 .files-table {
   width: 100%;
   border-collapse: collapse;
-  font-size: 12px;
+  font-size: var(--text-md);
 }
 
 .files-table th,
@@ -14946,7 +14976,7 @@ details.bf-gui-box:not([open]) > summary::after {
   border: none;
   color: var(--primary-400);
   font-family: var(--font-data);
-  font-size: 12px;
+  font-size: var(--text-md);
   cursor: pointer;
   padding: 0;
 }
@@ -14984,14 +15014,14 @@ details.bf-gui-box:not([open]) > summary::after {
 
 .vehicle-output-summary__header strong {
   display: block;
-  font-size: 13px;
+  font-size: var(--text-lg);
   margin-bottom: 4px;
 }
 
 .vehicle-output-summary__header p {
   margin: 0;
   color: var(--text-muted);
-  font-size: 12px;
+  font-size: var(--text-md);
   line-height: 1.45;
 }
 
@@ -15001,9 +15031,9 @@ details.bf-gui-box:not([open]) > summary::after {
 }
 
 .vehicle-output-group__header {
-  font-size: 11px;
+  font-size: var(--text-sm);
   text-transform: uppercase;
-  letter-spacing: 0.06em;
+  letter-spacing: var(--tracking-label);
   color: var(--text-muted);
   padding-bottom: 2px;
   border-bottom: 1px solid var(--surface-300);
@@ -15020,10 +15050,10 @@ details.bf-gui-box:not([open]) > summary::after {
   align-items: center;
   gap: 10px;
   padding: 8px 10px;
-  border-radius: var(--radius-md, 8px);
+  border-radius: var(--radius-md);
   border: 1px solid var(--surface-400);
   background: var(--surface-200);
-  font-size: 12px;
+  font-size: var(--text-md);
 }
 
 .vehicle-output-row strong {
@@ -15042,7 +15072,7 @@ details.bf-gui-box:not([open]) > summary::after {
 
 .app-header__build {
   display: block;
-  font-size: 10px;
+  font-size: var(--text-xs);
   line-height: 1.3;
   color: var(--text-muted);
   font-family: var(--font-data);
@@ -15058,12 +15088,12 @@ details.bf-gui-box:not([open]) > summary::after {
 
 .app-header__build--muted {
   color: var(--text-dim);
-  font-size: 9px;
+  font-size: var(--text-2xs);
 }
 
 .firmware-wizard__dfu-button--danger {
-  border-color: var(--danger, #e2123f);
-  color: var(--danger, #e2123f);
+  border-color: var(--danger, var(--danger));
+  color: var(--danger, var(--danger));
 }
 
 .firmware-wizard__dfu-confirm {
@@ -15080,9 +15110,9 @@ details.bf-gui-box:not([open]) > summary::after {
   margin: 10px 0 0;
   padding: 10px 12px;
   border: 1px solid var(--border, #2a2f36);
-  border-radius: 8px;
+  border-radius: var(--radius-md);
   background: color-mix(in srgb, var(--panel, #14171c) 60%, transparent);
-  font-size: 12px;
+  font-size: var(--text-md);
 }
 
 .bootloader-identity__headline {
@@ -15123,7 +15153,7 @@ details.bf-gui-box:not([open]) > summary::after {
 
 .bootloader-identity__row dd code {
   overflow-wrap: anywhere;
-  font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, monospace);
+  font-family: var(--font-data);
 }
 
 .bootloader-identity__size,
@@ -15137,7 +15167,7 @@ details.bf-gui-box:not([open]) > summary::after {
 
 .bootloader-identity__method {
   margin: 6px 0 0;
-  font-size: 11px;
+  font-size: var(--text-sm);
 }
 
 .bootloader-identity__method code { overflow-wrap: anywhere; }
@@ -15171,7 +15201,7 @@ details.bf-gui-box:not([open]) > summary::after {
 .parameter-reference__lede {
   margin: 0 0 4px;
   color: var(--text-muted);
-  font-size: 12px;
+  font-size: var(--text-md);
 }
 
 .parameter-reference__row {
@@ -15200,12 +15230,12 @@ details.bf-gui-box:not([open]) > summary::after {
 .parameter-reference__unit {
   color: var(--text-muted);
   font-family: var(--font-data);
-  font-size: 11px;
+  font-size: var(--text-sm);
 }
 
 .parameter-reference__row p {
   margin: 0;
-  font-size: 12px;
+  font-size: var(--text-md);
   color: var(--text-muted);
 }
 
@@ -15217,14 +15247,14 @@ details.bf-gui-box:not([open]) > summary::after {
   padding: 0;
   list-style: none;
   font-family: var(--font-data);
-  font-size: 11px;
+  font-size: var(--text-sm);
   color: var(--text-muted);
 }
 
 .parameter-reference__more {
   margin: 0;
   color: var(--warning, #e0a33a);
-  font-size: 12px;
+  font-size: var(--text-md);
 }
 
 /* Battery-current calibration, as three numbered steps.
@@ -15260,15 +15290,15 @@ details.bf-gui-box:not([open]) > summary::after {
 }
 
 .guided-current-cal__step-title strong {
-  font-size: 12px;
-  letter-spacing: 0.05em;
+  font-size: var(--text-md);
+  letter-spacing: var(--tracking-label);
   text-transform: uppercase;
 }
 
 /* Hints earn their space while a step is in play and lose it afterwards. */
 .guided-current-cal__step .hint {
   margin: 0;
-  font-size: 11px;
+  font-size: var(--text-sm);
   line-height: 1.4;
 }
 
@@ -15281,7 +15311,7 @@ details.bf-gui-box:not([open]) > summary::after {
 }
 
 .guided-current-cal__step .scoped-editor-field span {
-  font-size: 10px;
+  font-size: var(--text-xs);
 }
 
 /* Load length and throttle are two small numbers set together, so they sit on
@@ -15301,14 +15331,14 @@ details.bf-gui-box:not([open]) > summary::after {
   border: 1px solid rgba(var(--warning-rgb, 224, 163, 58), 0.35);
   color: var(--warning, #e0a33a);
   font-family: var(--font-data);
-  font-size: 12px;
+  font-size: var(--text-md);
 }
 
 .guided-current-cal__captured {
   margin: 0;
   color: var(--text-muted);
   font-family: var(--font-data);
-  font-size: 11px;
+  font-size: var(--text-sm);
 }
 
 /* Why an identical bootloader cannot be forced from here. Sits between the
@@ -15316,7 +15346,7 @@ details.bf-gui-box:not([open]) > summary::after {
    nothing has gone wrong, the firmware simply will not rewrite what matches. */
 .bootloader-identity__forced {
   margin: 8px 0 0;
-  font-size: 12px;
+  font-size: var(--text-md);
   color: var(--warning, #e0a33a);
 }
 
@@ -15332,13 +15362,13 @@ details.bf-gui-box:not([open]) > summary::after {
   justify-content: space-between;
   padding: 12px 14px;
   border: 1px solid var(--border);
-  border-radius: 8px;
+  border-radius: var(--radius-md);
   background: var(--surface-200);
 }
 .presets-share__copy { min-width: 0; flex: 1 1 280px; }
 .presets-share__copy p {
   margin: 4px 0 0 0;
-  font-size: 11px;
+  font-size: var(--text-sm);
   line-height: 1.45;
   color: var(--text-dim);
 }
@@ -15350,25 +15380,25 @@ details.bf-gui-box:not([open]) > summary::after {
   align-items: center;
   justify-content: space-between;
   padding: 12px 14px;
-  border: 1px solid var(--danger, #e2123f);
-  border-radius: 8px;
-  background: color-mix(in srgb, var(--danger, #e2123f) 8%, transparent);
+  border: 1px solid var(--danger, var(--danger));
+  border-radius: var(--radius-md);
+  background: color-mix(in srgb, var(--danger, var(--danger)) 8%, transparent);
 }
 
 .presets-erase__copy { min-width: 0; flex: 1 1 280px; }
-.presets-erase__copy strong { color: var(--danger, #e2123f); }
+.presets-erase__copy strong { color: var(--danger, var(--danger)); }
 
 .presets-erase__danger-btn {
-  border-color: var(--danger, #e2123f);
-  color: var(--danger, #e2123f);
+  border-color: var(--danger, var(--danger));
+  color: var(--danger, var(--danger));
   font-weight: 600;
 }
 
 .motor-test-acknowledgments__usb {
-  border-top: 1px dashed var(--danger, #e2123f);
+  border-top: 1px dashed var(--danger, var(--danger));
   padding-top: 6px;
   margin-top: 2px;
-  color: var(--danger, #e2123f);
+  color: var(--danger, var(--danger));
 }
 
 .rc-range-axis-card__bar {
@@ -15384,7 +15414,7 @@ details.bf-gui-box:not([open]) > summary::after {
   position: absolute;
   top: 0;
   bottom: 0;
-  background: var(--primary-transparent-3, rgba(255, 187, 0, 0.3));
+  background: var(--primary-transparent-3, rgba(var(--primary-rgb), 0.3));
 }
 
 .rc-range-axis-card__marker {
@@ -15394,18 +15424,18 @@ details.bf-gui-box:not([open]) > summary::after {
   height: 12px;
   margin-left: -1.5px;
   border-radius: 2px;
-  background: var(--primary-500, #ffbb00);
+  background: var(--primary-500, var(--primary-500));
 }
 
 .osd-preview-footer__layout {
   display: inline-flex;
   align-items: center;
   gap: 6px;
-  font-size: 11px;
+  font-size: var(--text-sm);
   color: var(--text-muted);
 }
 .osd-preview-footer__layout select {
-  font-size: 11px;
+  font-size: var(--text-sm);
   padding: 2px 6px;
 }
 
@@ -15422,7 +15452,7 @@ details.bf-gui-box:not([open]) > summary::after {
 
 .esc-dshot-footer__warning {
   padding: 6px 10px;
-  border-radius: 6px;
+  border-radius: var(--radius-sm);
   border: 1px solid var(--warning, #ef9b4b);
   background: var(--warning-weak, rgba(255, 102, 0, 0.12));
   color: var(--warning, #ef9b4b);
@@ -15436,19 +15466,19 @@ details.bf-gui-box:not([open]) > summary::after {
   margin-bottom: 8px;
 }
 .osd-preview-screen-select > span {
-  font-size: 11px;
+  font-size: var(--text-sm);
   letter-spacing: 0.03em;
   /* Sits inside the yellow preview titlebar pill — keep it dark, not muted-light. */
   color: rgba(11, 17, 24, 0.7);
 }
 .osd-preview-screen-select select {
   padding: 5px 10px;
-  border-radius: 8px;
+  border-radius: var(--radius-md);
   border: 1px solid var(--surface-400);
   background: var(--surface-200);
   color: var(--text);
   font-family: var(--font-data);
-  font-size: 11px;
+  font-size: var(--text-sm);
   cursor: pointer;
 }
 
@@ -15471,7 +15501,7 @@ details.bf-gui-box:not([open]) > summary::after {
   align-items: center;
   column-gap: 4px;
   padding: 2px 6px;
-  border-radius: 6px;
+  border-radius: var(--radius-sm);
 }
 .osd-matrix__row--head {
   background: var(--surface-100);
@@ -15489,7 +15519,7 @@ details.bf-gui-box:not([open]) > summary::after {
 }
 .osd-matrix__label--clickable {
   cursor: pointer;
-  border-radius: 4px;
+  border-radius: var(--radius-sm);
 }
 .osd-matrix__label--clickable:hover {
   background: var(--surface-200);
@@ -15500,7 +15530,7 @@ details.bf-gui-box:not([open]) > summary::after {
 }
 .osd-matrix__col {
   text-align: center;
-  font-size: 10px;
+  font-size: var(--text-xs);
   letter-spacing: 0.03em;
   color: var(--text-muted);
   font-family: var(--font-data);
@@ -15514,8 +15544,8 @@ details.bf-gui-box:not([open]) > summary::after {
 }
 .osd-matrix__col-toggle {
   font: inherit;
-  font-size: 9px;
-  letter-spacing: 0.04em;
+  font-size: var(--text-2xs);
+  letter-spacing: var(--tracking-label);
   text-transform: uppercase;
   padding: 1px 6px;
   border-radius: 3px;
@@ -15533,24 +15563,24 @@ details.bf-gui-box:not([open]) > summary::after {
   background: rgba(111, 207, 111, 0.12);
 }
 .osd-matrix__col-toggle--off {
-  color: var(--accent, #ffbb00);
-  background: rgba(255, 187, 0, 0.14);
+  color: var(--accent, var(--primary-500));
+  background: rgba(var(--primary-rgb), 0.14);
 }
 .osd-matrix__col-status--na {
-  font-size: 9px;
+  font-size: var(--text-2xs);
   color: var(--text-dim);
   font-style: italic;
 }
 .osd-matrix__row--head .osd-matrix__label {
-  font-size: 10px;
-  letter-spacing: 0.04em;
+  font-size: var(--text-xs);
+  letter-spacing: var(--tracking-label);
   text-transform: uppercase;
   color: var(--text-muted);
 }
 .osd-matrix__col.is-preview {
   color: var(--text);
-  background: rgba(255, 187, 0, 0.14);
-  border-radius: 4px;
+  background: rgba(var(--primary-rgb), 0.14);
+  border-radius: var(--radius-sm);
   padding: 2px 0;
 }
 .osd-matrix__label {
@@ -15559,7 +15589,7 @@ details.bf-gui-box:not([open]) > summary::after {
   min-width: 0;
 }
 .osd-matrix__label strong {
-  font-size: 11px;
+  font-size: var(--text-sm);
   color: var(--text);
   white-space: nowrap;
   overflow: hidden;
@@ -15567,7 +15597,7 @@ details.bf-gui-box:not([open]) > summary::after {
 }
 .osd-matrix__label small {
   font-family: var(--font-data);
-  font-size: 9px;
+  font-size: var(--text-2xs);
   color: var(--text-muted);
 }
 .osd-matrix__cell {
@@ -15581,28 +15611,28 @@ details.bf-gui-box:not([open]) > summary::after {
   margin: 0;
 }
 .osd-matrix__cell.is-preview {
-  background: rgba(255, 187, 0, 0.08);
-  border-radius: 4px;
+  background: rgba(var(--primary-rgb), 0.08);
+  border-radius: var(--radius-sm);
 }
 .osd-matrix__cell--na {
   color: var(--surface-500);
-  font-size: 12px;
+  font-size: var(--text-md);
 }
 .osd-matrix__cell--staged {
   box-shadow: inset 0 0 0 1px var(--primary-400);
-  border-radius: 4px;
+  border-radius: var(--radius-sm);
 }
 .osd-matrix__cell--invalid {
   box-shadow: inset 0 0 0 1px var(--danger);
-  border-radius: 4px;
+  border-radius: var(--radius-sm);
 }
 .osd-matrix__group {
   display: grid;
   gap: 1px;
 }
 .osd-matrix__group-header {
-  font-size: 10px;
-  letter-spacing: 0.05em;
+  font-size: var(--text-xs);
+  letter-spacing: var(--tracking-label);
   text-transform: uppercase;
   color: var(--text-muted);
   padding: 8px 6px 2px;
@@ -15613,7 +15643,7 @@ details.bf-gui-box:not([open]) > summary::after {
   display: inline-flex;
   gap: 6px;
   padding-left: 8px;
-  font-size: 10px;
+  font-size: var(--text-xs);
   color: var(--text-muted);
   white-space: nowrap;
 }
@@ -15624,7 +15654,7 @@ details.bf-gui-box:not([open]) > summary::after {
 }
 .osd-matrix__align input {
   width: 40px;
-  font-size: 10px;
+  font-size: var(--text-xs);
   padding: 1px 4px;
 }
 
@@ -15636,7 +15666,7 @@ details.bf-gui-box:not([open]) > summary::after {
 }
 .receiver-stick-craft small {
   color: var(--text-muted);
-  font-size: 11px;
+  font-size: var(--text-sm);
 }
 
 .calibration-grid {
@@ -15650,7 +15680,7 @@ details.bf-gui-box:not([open]) > summary::after {
   gap: 8px;
   padding: 14px;
   border: 1px solid var(--border);
-  border-radius: 12px;
+  border-radius: var(--radius-lg);
   background: var(--surface-200);
 }
 .calibration-card__header {
@@ -15660,7 +15690,7 @@ details.bf-gui-box:not([open]) > summary::after {
   gap: 8px;
 }
 .calibration-card__blocked {
-  font-size: 11px;
+  font-size: var(--text-sm);
   color: var(--warning, #e8a803);
 }
 /* Live ESC RPM beside the motor-test sliders. */
@@ -15668,9 +15698,9 @@ details.bf-gui-box:not([open]) > summary::after {
   margin-top: 10px;
   padding: 10px;
   border: 1px solid var(--border);
-  border-radius: 10px;
+  border-radius: var(--radius-lg);
   background: var(--surface-200);
-  font-size: 12px;
+  font-size: var(--text-md);
 }
 .esc-rpm-readout__header {
   display: flex;
@@ -15680,7 +15710,7 @@ details.bf-gui-box:not([open]) > summary::after {
 }
 .esc-rpm-readout__summary {
   margin: 4px 0 0 0;
-  font-size: 11px;
+  font-size: var(--text-sm);
   line-height: 1.45;
   color: var(--text-dim);
 }
@@ -15697,9 +15727,9 @@ details.bf-gui-box:not([open]) > summary::after {
   border-bottom: 1px solid var(--border);
 }
 .esc-rpm-readout__table thead th {
-  font-size: 10px;
+  font-size: var(--text-xs);
   text-transform: uppercase;
-  letter-spacing: 0.04em;
+  letter-spacing: var(--tracking-label);
   color: var(--text-dim);
 }
 .esc-rpm-readout__table tbody th {
@@ -15722,7 +15752,7 @@ details.bf-gui-box:not([open]) > summary::after {
  * disclosure treatment as the calibration how-tos — hint copy, not a callout. */
 .motor-pole-reference {
   margin-top: 2px;
-  font-size: 11px;
+  font-size: var(--text-sm);
   color: var(--text-dim);
 }
 .motor-pole-reference > summary {
@@ -15737,7 +15767,7 @@ details.bf-gui-box:not([open]) > summary::after {
   content: '▸';
   display: inline-block;
   margin-right: 4px;
-  font-size: 9px;
+  font-size: var(--text-2xs);
   transition: transform 0.1s ease-out;
 }
 .motor-pole-reference[open] > summary::before {
@@ -15758,9 +15788,9 @@ details.bf-gui-box:not([open]) > summary::after {
   margin-top: 2px;
   padding: 10px;
   border: 1px solid var(--border);
-  border-radius: 8px;
+  border-radius: var(--radius-md);
   background: var(--surface-100, var(--surface-200));
-  font-size: 12px;
+  font-size: var(--text-md);
   line-height: 1.45;
 }
 .calibration-card__reboot.is-required {
@@ -15776,7 +15806,7 @@ details.bf-gui-box:not([open]) > summary::after {
   gap: 8px;
 }
 .calibration-card__reboot-note {
-  font-size: 11px;
+  font-size: var(--text-sm);
   color: var(--text-dim);
 }
 /* Inline, low-key collapsible how-to inside each calibration card. Single
@@ -15784,12 +15814,12 @@ details.bf-gui-box:not([open]) > summary::after {
  * no all-caps shouting summary — it's hint copy, not a callout. */
 .calibration-card__howto {
   margin-top: 2px;
-  font-size: 11px;
+  font-size: var(--text-sm);
   color: var(--text-dim);
 }
 .calibration-card__howto > summary {
   cursor: pointer;
-  font-size: 11px;
+  font-size: var(--text-sm);
   color: var(--text-dim);
   list-style: none;
   opacity: 0.75;
@@ -15801,7 +15831,7 @@ details.bf-gui-box:not([open]) > summary::after {
   content: '▸';
   display: inline-block;
   margin-right: 4px;
-  font-size: 9px;
+  font-size: var(--text-2xs);
   transition: transform 0.1s ease-out;
 }
 .calibration-card__howto[open] > summary::before {
@@ -15811,7 +15841,7 @@ details.bf-gui-box:not([open]) > summary::after {
   margin: 6px 0 0 0;
   padding-left: 18px;
   line-height: 1.4;
-  font-size: 11px;
+  font-size: var(--text-sm);
   color: var(--text-dim);
 }
 .calibration-card__howto ol li + li {
@@ -15819,7 +15849,7 @@ details.bf-gui-box:not([open]) > summary::after {
 }
 .calibration-card__howto code {
   font-family: var(--font-data);
-  font-size: 10px;
+  font-size: var(--text-xs);
   /* Theme-safe tint + readable text. --surface-800 is a light mid-tone in dark
      mode (#7f8aa0), so with the inherited light step text the code read as a
      washed-out solid block ("redacted"). Match the config-pills treatment. */
@@ -15854,7 +15884,7 @@ details.bf-gui-box:not([open]) > summary::after {
 }
 .calibration-card__advanced > summary {
   cursor: pointer;
-  font-size: 11px;
+  font-size: var(--text-sm);
   color: var(--text-dim);
   list-style: none;
   opacity: 0.75;
@@ -15866,7 +15896,7 @@ details.bf-gui-box:not([open]) > summary::after {
   content: '▸';
   display: inline-block;
   margin-right: 4px;
-  font-size: 9px;
+  font-size: var(--text-2xs);
   transition: transform 0.1s ease-out;
 }
 .calibration-card__advanced[open] > summary::before {
@@ -15875,7 +15905,7 @@ details.bf-gui-box:not([open]) > summary::after {
 
 .app-header__connection-hint {
   display: block;
-  font-size: 10px;
+  font-size: var(--text-xs);
   color: var(--text-muted);
   max-width: 280px;
   line-height: 1.3;
@@ -15885,7 +15915,7 @@ details.bf-gui-box:not([open]) > summary::after {
   margin-top: 12px;
   padding: 12px 14px;
   border: 1px solid var(--surface-400);
-  border-radius: 12px;
+  border-radius: var(--radius-lg);
   background: var(--surface-200);
 }
 .motor-reverse-grid {
@@ -15899,10 +15929,10 @@ details.bf-gui-box:not([open]) > summary::after {
   align-items: center;
   gap: 8px;
   padding: 6px 10px;
-  border-radius: 8px;
+  border-radius: var(--radius-md);
   border: 1px solid transparent;
   background: rgba(var(--edge-rgb), 0.025);
-  font-size: 12px;
+  font-size: var(--text-md);
   cursor: pointer;
 }
 .motor-reverse-toggle:has(input:checked) {
@@ -15915,9 +15945,9 @@ details.bf-gui-box:not([open]) > summary::after {
   gap: 10px;
   margin-top: 10px;
   padding: 8px 10px;
-  border-radius: 8px;
+  border-radius: var(--radius-md);
   border: 1px solid transparent;
-  font-size: 12px;
+  font-size: var(--text-md);
 }
 .motor-reverse-esctype span {
   color: var(--text-muted);
@@ -15933,14 +15963,14 @@ details.bf-gui-box:not([open]) > summary::after {
 }
 
 .calibration-card--danger {
-  border-color: var(--danger, #e2123f);
+  border-color: var(--danger, var(--danger));
 }
 
 .firmware-wizard__browse {
   margin-top: 10px;
   padding: 10px 12px;
   border: 1px solid var(--surface-400);
-  border-radius: 10px;
+  border-radius: var(--radius-lg);
   background: rgba(var(--edge-rgb), 0.025);
   display: grid;
   gap: 8px;
@@ -15950,7 +15980,7 @@ details.bf-gui-box:not([open]) > summary::after {
   gap: 2px;
 }
 .firmware-wizard__browse-header span {
-  font-size: 11px;
+  font-size: var(--text-sm);
   color: var(--text-muted);
 }
 .firmware-wizard__browse-controls {
@@ -15974,13 +16004,13 @@ details.bf-gui-box:not([open]) > summary::after {
   justify-content: space-between;
   gap: 10px;
   padding: 6px 8px;
-  border-radius: 7px;
+  border-radius: var(--radius-md);
   background: rgba(var(--edge-rgb), 0.03);
-  font-size: 12px;
+  font-size: var(--text-md);
 }
 .firmware-wizard__browse-error {
-  color: var(--danger, #e2123f);
-  font-size: 12px;
+  color: var(--danger, var(--danger));
+  font-size: var(--text-md);
   margin: 0;
 }
 
@@ -16073,10 +16103,10 @@ details.bf-gui-box:not([open]) > summary::after {
 
 .cal-location__info {
   border: 1px solid var(--border);
-  border-radius: 8px;
+  border-radius: var(--radius-md);
   padding: 10px 12px;
   background: var(--surface-100);
-  font-size: 13px;
+  font-size: var(--text-lg);
 }
 
 .cal-location__info p {
@@ -16089,7 +16119,7 @@ details.bf-gui-box:not([open]) > summary::after {
 
 .cal-location__hint {
   margin: 0;
-  font-size: 12px;
+  font-size: var(--text-md);
   color: var(--text-muted);
 }
 
@@ -16102,7 +16132,7 @@ details.bf-gui-box:not([open]) > summary::after {
 
 .cal-location__notice {
   margin: 0;
-  font-size: 13px;
+  font-size: var(--text-lg);
 }
 
 .cal-location__notice--success {
@@ -16146,7 +16176,7 @@ details.bf-gui-box:not([open]) > summary::after {
 
 .cal-location__modal-header p {
   margin: 4px 0 0;
-  font-size: 12px;
+  font-size: var(--text-md);
   color: var(--text-muted);
 }
 
@@ -16171,9 +16201,9 @@ details.bf-gui-box:not([open]) > summary::after {
   background: var(--surface-100, rgba(var(--edge-rgb), 0.02));
 }
 .mavlink-inspector__request-title {
-  font-size: 11px;
+  font-size: var(--text-sm);
   text-transform: uppercase;
-  letter-spacing: 0.05em;
+  letter-spacing: var(--tracking-label);
   color: var(--text-muted);
   align-self: center;
 }
@@ -16188,15 +16218,15 @@ details.bf-gui-box:not([open]) > summary::after {
   background: var(--surface-100, rgba(var(--edge-rgb), 0.02));
 }
 .mavlink-inspector__export-title {
-  font-size: 11px;
+  font-size: var(--text-sm);
   text-transform: uppercase;
-  letter-spacing: 0.05em;
+  letter-spacing: var(--tracking-label);
   color: var(--text-muted);
 }
 .mavlink-inspector__record-meta {
   margin-left: auto;
   font-family: var(--font-data);
-  font-size: 11px;
+  font-size: var(--text-sm);
   color: var(--text-muted);
 }
 .mavlink-inspector__plot-actions {
@@ -16213,7 +16243,7 @@ details.bf-gui-box:not([open]) > summary::after {
   flex-basis: 100%;
   margin: 2px 0 0;
   font-family: var(--font-data);
-  font-size: 11px;
+  font-size: var(--text-sm);
   color: var(--text-muted);
 }
 .mavlink-inspector__table {
@@ -16255,7 +16285,7 @@ details.bf-gui-box:not([open]) > summary::after {
   opacity: 0.55;
   font-size: 0.78em;
   text-transform: uppercase;
-  letter-spacing: 0.04em;
+  letter-spacing: var(--tracking-label);
 }
 /* Outbound data rows are expandable buttons — reset button chrome so they read
    as rows (matching the inbound .mavlink-inspector__row treatment). */
@@ -16266,7 +16296,7 @@ button.mavlink-inspector__sent-row {
   border: none;
   color: var(--text);
   font-family: var(--font-data);
-  font-size: 12px;
+  font-size: var(--text-md);
   cursor: pointer;
 }
 .mavlink-inspector__row {
@@ -16278,7 +16308,7 @@ button.mavlink-inspector__sent-row {
   text-align: left;
   padding: 6px 12px;
   font-family: var(--font-data);
-  font-size: 12px;
+  font-size: var(--text-md);
   background: transparent;
   border: none;
   color: var(--text);
@@ -16298,27 +16328,27 @@ button.mavlink-inspector__sent-row {
 }
 .mavlink-inspector__source-label {
   font-family: var(--font-data);
-  font-size: 12px;
+  font-size: var(--text-md);
   font-weight: 600;
-  color: var(--accent, #ffbb00);
+  color: var(--accent, var(--primary-500));
   letter-spacing: 0.02em;
 }
 .mavlink-inspector__source-meta {
   font-family: var(--font-data);
-  font-size: 11px;
+  font-size: var(--text-sm);
   color: var(--text-muted);
 }
 .mavlink-inspector__source-health {
   margin-left: auto;
   font-family: var(--font-data);
-  font-size: 11px;
+  font-size: var(--text-sm);
   letter-spacing: 0.02em;
 }
 .mavlink-inspector__source-health--ok {
   color: var(--success, #3ddc84);
 }
 .mavlink-inspector__source-health--warn {
-  color: var(--warning, #ffbb00);
+  color: var(--warning, var(--primary-500));
 }
 .mavlink-inspector__last {
   display: inline-flex;
@@ -16326,16 +16356,16 @@ button.mavlink-inspector__sent-row {
   gap: 6px;
 }
 .mavlink-inspector__tone {
-  font-size: 9px;
+  font-size: var(--text-2xs);
   text-transform: uppercase;
-  letter-spacing: 0.05em;
+  letter-spacing: var(--tracking-label);
   padding: 1px 5px;
   border-radius: 999px;
   line-height: 1.4;
 }
 .mavlink-inspector__tone--slow {
-  color: var(--warning, #ffbb00);
-  background: rgba(255, 187, 0, 0.15);
+  color: var(--warning, var(--primary-500));
+  background: rgba(var(--primary-rgb), 0.15);
 }
 .mavlink-inspector__tone--stale {
   color: var(--danger, #ff5a5a);
@@ -16346,9 +16376,9 @@ button.mavlink-inspector__sent-row {
 }
 .mavlink-inspector__row--head {
   text-transform: uppercase;
-  font-size: 10px;
+  font-size: var(--text-xs);
   color: var(--text-muted);
-  letter-spacing: 0.05em;
+  letter-spacing: var(--tracking-label);
   cursor: default;
   background: var(--surface-200);
 }
@@ -16356,12 +16386,12 @@ button.mavlink-inspector__sent-row {
   border-top: 1px solid var(--surface-300);
 }
 .mavlink-inspector__type {
-  color: var(--accent, #ffbb00);
+  color: var(--accent, var(--primary-500));
 }
 .mavlink-inspector__spark {
   width: 64px;
   height: 16px;
-  color: var(--accent, #ffbb00);
+  color: var(--accent, var(--primary-500));
   opacity: 0.85;
 }
 .mavlink-inspector__spark--empty {
@@ -16376,9 +16406,9 @@ button.mavlink-inspector__sent-row {
   justify-content: space-between;
   gap: 10px;
   padding: 6px 12px;
-  font-size: 11px;
+  font-size: var(--text-sm);
   text-transform: uppercase;
-  letter-spacing: 0.05em;
+  letter-spacing: var(--tracking-label);
   color: var(--text-muted);
 }
 .mavlink-inspector__fields {
@@ -16386,7 +16416,7 @@ button.mavlink-inspector__sent-row {
   padding: 8px 12px;
   background: rgba(0, 0, 0, 0.35);
   font-family: var(--font-data);
-  font-size: 11px;
+  font-size: var(--text-sm);
   color: var(--text-muted);
   word-break: break-word;
   max-height: 280px;
@@ -16401,13 +16431,13 @@ button.mavlink-inspector__sent-row {
   gap: 10px;
   align-items: center;
   padding: 2px 0;
-  border-radius: var(--radius-sm, 4px);
+  border-radius: var(--radius-sm);
 }
 .mavlink-inspector__field-row--head {
   text-transform: uppercase;
-  font-size: 10px;
+  font-size: var(--text-xs);
   color: var(--text-muted);
-  letter-spacing: 0.05em;
+  letter-spacing: var(--tracking-label);
 }
 .mavlink-inspector__field-name {
   color: var(--text-muted);
@@ -16429,10 +16459,10 @@ button.mavlink-inspector__sent-row {
 .mavlink-inspector__field-graph {
   background: transparent;
   border: 1px solid var(--surface-300);
-  border-radius: var(--radius-sm, 4px);
+  border-radius: var(--radius-sm);
   color: var(--text-muted);
   font-family: var(--font-data);
-  font-size: 10px;
+  font-size: var(--text-xs);
   padding: 1px 6px;
   cursor: pointer;
   opacity: 0;
@@ -16446,8 +16476,8 @@ button.mavlink-inspector__sent-row {
 }
 .mavlink-inspector__field-graph[aria-pressed='true'] {
   opacity: 1;
-  border-color: var(--accent, #ffbb00);
-  color: var(--accent, #ffbb00);
+  border-color: var(--accent, var(--primary-500));
+  color: var(--accent, var(--primary-500));
 }
 .mavlink-inspector__plots {
   display: grid;
@@ -16469,14 +16499,14 @@ button.mavlink-inspector__sent-row {
 }
 .mavlink-inspector__plot-title {
   font-family: var(--font-data);
-  font-size: 11px;
-  color: var(--accent, #ffbb00);
+  font-size: var(--text-sm);
+  color: var(--accent, var(--primary-500));
   word-break: break-word;
 }
 .mavlink-inspector__plot-svg {
   width: 100%;
   height: 60px;
-  color: var(--accent, #ffbb00);
+  color: var(--accent, var(--primary-500));
   display: block;
 }
 .mavlink-inspector__plot-meta {
@@ -16485,12 +16515,12 @@ button.mavlink-inspector__sent-row {
   gap: 10px;
   margin-top: 4px;
   font-family: var(--font-data);
-  font-size: 10px;
+  font-size: var(--text-xs);
   color: var(--text-muted);
 }
 @keyframes mavlink-field-flash {
   from {
-    background: var(--accent, #ffbb00);
+    background: var(--accent, var(--primary-500));
     color: #000;
   }
   to {
@@ -16504,7 +16534,7 @@ button.mavlink-inspector__sent-row {
   display: inline-flex;
   align-items: center;
   gap: 6px;
-  font-size: 12px;
+  font-size: var(--text-md);
   color: var(--text-muted);
 }
 .dronecan-inspector__row {
@@ -16514,14 +16544,14 @@ button.mavlink-inspector__sent-row {
   align-items: center;
   padding: 6px 12px;
   font-family: var(--font-data);
-  font-size: 12px;
+  font-size: var(--text-md);
   border-top: 1px solid var(--surface-300);
 }
 .dronecan-inspector__row--head {
   text-transform: uppercase;
-  font-size: 10px;
+  font-size: var(--text-xs);
   color: var(--text-muted);
-  letter-spacing: 0.05em;
+  letter-spacing: var(--tracking-label);
   background: var(--surface-200);
   border-top: none;
 }
@@ -16546,7 +16576,7 @@ button.mavlink-inspector__sent-row {
   align-items: center;
   justify-content: space-between;
   gap: 10px;
-  font-size: 12px;
+  font-size: var(--text-md);
   color: var(--text-muted);
   margin-bottom: 6px;
 }
@@ -16569,7 +16599,7 @@ button.mavlink-inspector__sent-row {
   display: flex;
   flex-direction: column;
   border: 1px solid var(--surface-300);
-  border-radius: 6px;
+  border-radius: var(--radius-sm);
   overflow: hidden;
 }
 .dronecan-inspector__param-row {
@@ -16579,7 +16609,7 @@ button.mavlink-inspector__sent-row {
   align-items: center;
   padding: 5px 10px;
   font-family: var(--font-data);
-  font-size: 12px;
+  font-size: var(--text-md);
   border-top: 1px solid var(--surface-300);
   margin: 0;
 }
@@ -16588,9 +16618,9 @@ button.mavlink-inspector__sent-row {
 }
 .dronecan-inspector__param-row--head {
   text-transform: uppercase;
-  font-size: 10px;
+  font-size: var(--text-xs);
   color: var(--text-muted);
-  letter-spacing: 0.05em;
+  letter-spacing: var(--tracking-label);
   background: var(--surface-200);
 }
 .dronecan-inspector__param-row.is-dirty {
@@ -16599,7 +16629,7 @@ button.mavlink-inspector__sent-row {
 .dronecan-inspector__param-row input {
   width: 100%;
   font-family: var(--font-data);
-  font-size: 12px;
+  font-size: var(--text-md);
 }
 .dronecan-inspector__param-range {
   color: var(--text-muted);
@@ -16618,13 +16648,13 @@ button.mavlink-inspector__sent-row {
   margin-top: 8px;
   padding: 8px 10px;
   border: 1px solid var(--surface-300);
-  border-radius: 6px;
+  border-radius: var(--radius-sm);
   background: var(--surface-100);
 }
 .dronecan-inspector__staged-list {
   margin: 0 0 8px;
   padding-left: 18px;
-  font-size: 12px;
+  font-size: var(--text-md);
 }
 .dronecan-inspector__staged-actions,
 .dronecan-inspector__node-actions {
@@ -16637,7 +16667,7 @@ button.mavlink-inspector__sent-row {
   margin-top: 12px;
 }
 .dronecan-inspector__confirm-text {
-  font-size: 12px;
+  font-size: var(--text-md);
   color: var(--text-muted);
 }
 .dronecan-inspector__fwupdate {
@@ -16647,7 +16677,7 @@ button.mavlink-inspector__sent-row {
   gap: 8px;
   padding: 12px;
   border: 1px solid var(--surface-300);
-  border-radius: 8px;
+  border-radius: var(--radius-md);
   background: var(--surface-100);
 }
 .dronecan-inspector__fwupdate-head {
@@ -16655,25 +16685,25 @@ button.mavlink-inspector__sent-row {
   align-items: center;
   justify-content: space-between;
   gap: 8px;
-  font-size: 13px;
+  font-size: var(--text-lg);
   font-weight: 600;
 }
 .dronecan-inspector__fwupdate-file {
   display: flex;
   flex-direction: column;
   gap: 4px;
-  font-size: 12px;
+  font-size: var(--text-md);
   color: var(--text-muted);
 }
 .dronecan-inspector__fwupdate-selected {
   font-family: var(--font-data);
-  font-size: 12px;
+  font-size: var(--text-md);
 }
 .dronecan-inspector__fwupdate-online {
   display: flex;
   flex-direction: column;
   gap: 6px;
-  font-size: 12px;
+  font-size: var(--text-md);
 }
 .dronecan-inspector__fwupdate-online-id {
   font-family: var(--font-data);
@@ -16697,10 +16727,10 @@ button.mavlink-inspector__sent-row {
   display: flex;
   align-items: flex-start;
   gap: 8px;
-  font-size: 12px;
+  font-size: var(--text-md);
   line-height: 1.4;
   padding: 8px;
-  border-radius: 6px;
+  border-radius: var(--radius-sm);
   background: color-mix(in srgb, var(--danger) 12%, transparent);
   border: 1px solid color-mix(in srgb, var(--danger) 35%, transparent);
 }
@@ -16709,7 +16739,7 @@ button.mavlink-inspector__sent-row {
 }
 .dronecan-inspector__fwupdate-bar {
   height: 10px;
-  border-radius: 5px;
+  border-radius: var(--radius-sm);
   background: var(--surface-300);
   overflow: hidden;
 }
@@ -16726,12 +16756,12 @@ button.mavlink-inspector__sent-row {
 }
 .dronecan-inspector__fwupdate-bytes {
   font-family: var(--font-data);
-  font-size: 12px;
+  font-size: var(--text-md);
   color: var(--text-muted);
   margin: 0;
 }
 .dronecan-inspector__fwupdate-note {
-  font-size: 12px;
+  font-size: var(--text-md);
   color: var(--text-muted);
   margin: 0;
 }
@@ -16746,7 +16776,7 @@ button.mavlink-inspector__sent-row {
   color: var(--warning);
 }
 .dronecan-inspector__fwupdate-error {
-  font-size: 12px;
+  font-size: var(--text-md);
   color: var(--danger);
   margin: 0;
 }
@@ -16765,14 +16795,14 @@ button.mavlink-inspector__sent-row {
   align-items: center;
   padding: 6px 12px;
   font-family: var(--font-data);
-  font-size: 12px;
+  font-size: var(--text-md);
   border-top: 1px solid var(--surface-300);
 }
 .dronecan-inspector__esc-row--head {
   text-transform: uppercase;
-  font-size: 10px;
+  font-size: var(--text-xs);
   color: var(--text-muted);
-  letter-spacing: 0.05em;
+  letter-spacing: var(--tracking-label);
   background: var(--surface-200);
   border-top: none;
 }
@@ -16846,7 +16876,7 @@ button.mavlink-inspector__sent-row {
 
 .lua-card {
   border: 1px solid var(--border);
-  border-radius: 10px;
+  border-radius: var(--radius-lg);
   padding: 10px 12px;
   background: var(--surface-100, transparent);
 }
@@ -16880,7 +16910,7 @@ button.mavlink-inspector__sent-row {
   color: var(--text-muted);
   font-size: 0.72em;
   font-weight: 600;
-  letter-spacing: 0.02em;
+  letter-spacing: var(--tracking-label);
   text-transform: uppercase;
   white-space: nowrap;
 }
@@ -17044,7 +17074,7 @@ button.mavlink-inspector__sent-row {
   margin: auto 0;
 }
 .ai-assistant__turn {
-  border-radius: 10px;
+  border-radius: var(--radius-lg);
   padding: 10px 12px;
   max-width: 90%;
   line-height: 1.55;
@@ -17071,7 +17101,7 @@ button.mavlink-inspector__sent-row {
   margin-top: 8px;
 }
 .ai-assistant__tool-chip {
-  font-family: var(--font-mono, monospace);
+  font-family: var(--font-data);
   font-size: 0.75em;
   padding: 2px 7px;
   border-radius: 999px;
@@ -17109,7 +17139,7 @@ button.mavlink-inspector__sent-row {
    for invalid rows and the applied/error result. */
 .ai-assistant__proposal {
   border: 1px solid var(--border-strong, var(--border));
-  border-radius: 10px;
+  border-radius: var(--radius-lg);
   padding: 12px;
   background: var(--bg-panel-raised);
   display: flex;
@@ -17133,7 +17163,7 @@ button.mavlink-inspector__sent-row {
 }
 .ai-assistant__proposal-row {
   border: 1px solid var(--border-subtle, var(--border));
-  border-radius: 8px;
+  border-radius: var(--radius-md);
   padding: 8px 10px;
   background: var(--bg-panel-soft);
 }
@@ -17148,7 +17178,7 @@ button.mavlink-inspector__sent-row {
   gap: 8px;
 }
 .ai-assistant__proposal-row-head code {
-  font-family: var(--font-mono, monospace);
+  font-family: var(--font-data);
   font-size: 0.85em;
 }
 .ai-assistant__proposal-change {
@@ -17261,9 +17291,9 @@ button.mavlink-inspector__sent-row {
   border: 1px solid rgba(var(--edge-rgb), 0.05);
 }
 .log-tuning__metrics span {
-  font-size: 0.72rem;
+  font-size: var(--text-sm);
   text-transform: uppercase;
-  letter-spacing: 0.05em;
+  letter-spacing: var(--tracking-label);
   color: var(--text-dim);
 }
 .log-tuning__peaks ul {
@@ -17351,7 +17381,7 @@ button.mavlink-inspector__sent-row {
   width: 100%;
   height: 40px;
   display: block;
-  border-radius: var(--radius-sm, 6px);
+  border-radius: var(--radius-sm);
   background: var(--bg-panel-muted);
   border: 1px solid rgba(var(--edge-rgb), 0.05);
 }
@@ -17403,7 +17433,7 @@ button.mavlink-inspector__sent-row {
 }
 
 .workspace-note--stale__headline strong {
-  font-size: 15px;
+  font-size: var(--text-2xl);
   letter-spacing: 0.01em;
 }
 
@@ -17435,7 +17465,7 @@ button.mavlink-inspector__sent-row {
 /* Tool/technique hint inside a calibration card — reads as guidance rather than
    as the procedure itself, so it doesn't compete with the actual steps. */
 .calibration-card__tip {
-  font-size: 12px;
+  font-size: var(--text-md);
   line-height: 1.5;
   color: rgba(var(--ink-rgb), 0.72);
   border-left: 2px solid rgba(var(--edge-rgb), 0.18);
@@ -17473,7 +17503,7 @@ button.mavlink-inspector__sent-row {
   gap: 12px;
   align-items: center;
   padding: 6px 8px;
-  border-radius: 8px;
+  border-radius: var(--radius-md);
   background: rgba(var(--edge-rgb), 0.02);
 }
 
@@ -17489,7 +17519,7 @@ button.mavlink-inspector__sent-row {
 
 .receiver-functions-row__channel small {
   font-family: var(--font-data);
-  font-size: 11px;
+  font-size: var(--text-sm);
   color: var(--text-muted);
 }
 
@@ -17510,7 +17540,7 @@ button.mavlink-inspector__sent-row {
   justify-content: space-between;
   padding: 12px 14px;
   margin-bottom: 12px;
-  border-radius: 8px;
+  border-radius: var(--radius-md);
   border: 1px solid color-mix(in srgb, var(--warning) 55%, transparent);
   background: color-mix(in srgb, var(--warning) 10%, transparent);
 }
@@ -17544,8 +17574,8 @@ button.mavlink-inspector__sent-row {
 }
 
 .reset-defaults-button--danger {
-  border-color: var(--danger, #e2123f);
-  color: var(--danger, #e2123f);
+  border-color: var(--danger, var(--danger));
+  color: var(--danger, var(--danger));
 }
 
 .reset-defaults-confirm {
@@ -17556,8 +17586,8 @@ button.mavlink-inspector__sent-row {
 }
 
 .reset-defaults-confirm__warning {
-  color: var(--danger, #e2123f);
-  font-size: 0.85rem;
+  color: var(--danger, var(--danger));
+  font-size: var(--text-lg);
   /* Keep the warning from pushing the buttons off a phone-width viewport —
    * the 390px e2e fails on horizontal overflow. */
   flex: 1 1 16rem;
@@ -17581,8 +17611,8 @@ button.mavlink-inspector__sent-row {
  * staged/written row colours, which mean something else entirely. */
 .parameter-row__default-differs {
   color: var(--text-muted);
-  font-size: 11px;
-  letter-spacing: 0.04em;
+  font-size: var(--text-sm);
+  letter-spacing: var(--tracking-label);
   text-transform: uppercase;
 }
 
@@ -17668,7 +17698,7 @@ button.mavlink-inspector__sent-row {
 .can-bus-node__popped-out,
 .can-bus-node__popout-blocked {
   margin: 8px 0 0;
-  font-size: 11px;
+  font-size: var(--text-sm);
   color: var(--text-muted);
 }
 
@@ -17694,7 +17724,7 @@ button.mavlink-inspector__sent-row {
 .log-server-panel__copy strong { display: block; }
 .log-server-panel__copy p {
   margin: 4px 0 0 0;
-  font-size: 11px;
+  font-size: var(--text-sm);
   line-height: 1.45;
   color: var(--text-dim);
 }
@@ -17708,26 +17738,26 @@ button.mavlink-inspector__sent-row {
 }
 .log-server-panel__fields label { display: grid; gap: 4px; min-width: 0; }
 .log-server-panel__fields label > span {
-  font-size: 10px;
+  font-size: var(--text-xs);
   text-transform: uppercase;
-  letter-spacing: 0.06em;
+  letter-spacing: var(--tracking-label);
   color: var(--text-dim);
 }
 .log-server-panel__fields input {
   width: 100%;
   min-width: 0;
   padding: 7px 9px;
-  border-radius: 7px;
+  border-radius: var(--radius-md);
   border: 1px solid var(--border);
   background: var(--surface-100, var(--surface-200));
   color: var(--text);
-  font-size: 13px;
+  font-size: var(--text-lg);
 }
 .log-server-panel__error {
   margin: 0;
-  font-size: 11px;
+  font-size: var(--text-sm);
   line-height: 1.45;
-  color: var(--danger, #e2123f);
+  color: var(--danger, var(--danger));
 }
 
 .log-upload-dialog {
@@ -17736,7 +17766,7 @@ button.mavlink-inspector__sent-row {
   margin-top: 12px;
   padding: 12px;
   border: 1px solid var(--border-accent, var(--border));
-  border-radius: 10px;
+  border-radius: var(--radius-lg);
   background: var(--surface-200);
 }
 /* The artifact upload form sits inside an existing row of export buttons.
@@ -17760,14 +17790,14 @@ button.mavlink-inspector__sent-row {
 }
 .log-upload-dialog__file {
   font-family: var(--font-data);
-  font-size: 11px;
+  font-size: var(--text-sm);
   color: var(--text-dim);
 }
 .log-upload-dialog label { display: grid; gap: 4px; min-width: 0; }
 .log-upload-dialog label > span {
-  font-size: 10px;
+  font-size: var(--text-xs);
   text-transform: uppercase;
-  letter-spacing: 0.06em;
+  letter-spacing: var(--tracking-label);
   color: var(--text-dim);
 }
 .log-upload-dialog input,
@@ -17775,30 +17805,30 @@ button.mavlink-inspector__sent-row {
   width: 100%;
   min-width: 0;
   padding: 7px 9px;
-  border-radius: 7px;
+  border-radius: var(--radius-md);
   border: 1px solid var(--border);
   background: var(--surface-100, var(--surface-200));
   color: var(--text);
-  font-size: 13px;
+  font-size: var(--text-lg);
   font-family: inherit;
   resize: vertical;
 }
 .log-upload-dialog__autofill > span {
   display: block;
   margin-bottom: 4px;
-  font-size: 10px;
+  font-size: var(--text-xs);
   text-transform: uppercase;
-  letter-spacing: 0.06em;
+  letter-spacing: var(--tracking-label);
   color: var(--text-dim);
 }
 .log-upload-dialog__progress {
   margin: 0;
-  font-size: 11px;
+  font-size: var(--text-sm);
   color: var(--text-dim);
 }
 .logs-upload-message {
   margin: 10px 0 0 0;
-  font-size: 11px;
+  font-size: var(--text-sm);
   line-height: 1.45;
   color: var(--text-dim);
 }
@@ -17824,7 +17854,7 @@ button.mavlink-inspector__sent-row {
   display: flex;
   flex-direction: column;
   gap: 3px;
-  font-size: 13px;
+  font-size: var(--text-lg);
 }
 .initial-tune__inputs input[type='number'],
 .initial-tune__inputs select {
@@ -17841,7 +17871,7 @@ button.mavlink-inspector__sent-row {
 }
 .initial-tune__table {
   border-collapse: collapse;
-  font-size: 13px;
+  font-size: var(--text-lg);
   /* Only three narrow columns — full width would strand the numbers. */
   min-width: 34ch;
 }
@@ -17910,4 +17940,82 @@ button.mavlink-inspector__sent-row {
   .servo-mapping__live-bar {
     display: none;
   }
+}
+
+/* MAVLink signing. Was styled entirely inline, which put it outside the
+   stylesheet's reach: its own gap scale (14/16/6/10/12), bare font sizes, and
+   var() fallbacks that had drifted away from the tokens they shadowed
+   (--text-muted resolved to #a8b0bf, the fallback still said #b3b3b3). Nothing
+   here is new design — it is the same layout, expressed where the rest of the
+   app is. */
+.mavlink-signing-panel {
+  margin-top: var(--space-5);
+}
+
+.mavlink-signing {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+  max-width: 640px;
+}
+
+.mavlink-signing__modes {
+  display: flex;
+  gap: var(--space-4);
+}
+
+.mavlink-signing__mode {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-1);
+}
+
+.mavlink-signing__field {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+}
+
+.mavlink-signing__field--narrow {
+  max-width: 160px;
+}
+
+.mavlink-signing__actions {
+  display: flex;
+  gap: var(--space-2);
+  flex-wrap: wrap;
+}
+
+.mavlink-signing__counter {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+}
+
+.mavlink-signing__field-label {
+  font-size: var(--text-lg);
+  color: var(--text-muted);
+}
+
+.mavlink-signing__feedback {
+  margin: 0;
+  font-size: var(--text-lg);
+}
+
+.mavlink-signing__feedback--success {
+  color: var(--success);
+}
+
+.mavlink-signing__feedback--danger {
+  color: var(--danger);
+}
+
+.mavlink-signing__feedback--warning {
+  color: var(--warning);
+}
+
+.mavlink-signing__note {
+  margin: 0;
+  font-size: var(--text-md);
+  color: var(--text-dim);
 }

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -1,12 +1,13 @@
 :root {
   color-scheme: dark;
-  font-family:
+  --font-ui:
     "Inter",
     "SF Pro Display",
     "SF Pro Text",
     "Segoe UI",
     system-ui,
     sans-serif;
+  font-family: var(--font-ui);
   --font-data:
     "JetBrains Mono",
     "SFMono-Regular",
@@ -325,15 +326,18 @@
   align-items: center;
   justify-content: center;
   /* Breathing room so it doesn't crowd the Expert-mode toggle. */
-  margin-left: 16px;
-  width: 30px;
-  height: 30px;
+  margin-left: var(--space-4);
+  /* Square, but the same height and the same edge treatment as the Wiki button
+     it sits beside -- it was a different radius, a different border colour and
+     a different size from everything else in the header. */
+  width: 32px;
+  height: 32px;
   padding: 0;
-  border-radius: var(--radius-sm);
-  border: 1px solid var(--border);
-  background: var(--bg-panel-raised);
+  border-radius: var(--radius-lg);
+  border: 1px solid rgba(var(--edge-rgb), 0.08);
+  background: rgba(var(--edge-rgb), 0.03);
   color: var(--text-muted);
-  font-size: var(--text-2xl);
+  font-size: var(--text-xl);
   line-height: 1;
   cursor: pointer;
   transition: color 0.15s ease, border-color 0.15s ease, background 0.15s ease;
@@ -477,7 +481,7 @@ textarea:focus {
   z-index: 200;
   display: flex;
   align-items: center;
-  gap: 12px;
+  gap: var(--space-3);
   padding: 10px 14px;
   background: var(--surface-300);
   border: 1px solid var(--border);
@@ -584,7 +588,7 @@ textarea:focus {
   appearance: none;
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: var(--space-2);
   min-width: 0;
   /* max-width (not a rigid width) so the brand can shrink on narrow headers
      and the telemetry/connection blocks wrap instead of overflowing. Wide
@@ -647,8 +651,14 @@ textarea:focus {
   border-color: color-mix(in srgb, var(--accent, var(--primary-500)) 60%, transparent);
 }
 
+/* Matches .workspace-nav__mark, so the header's one mark is drawn the same way
+   as the fourteen in the side nav. */
 .app-header__wiki-icon {
-  font-size: var(--text-3xl);
+  color: var(--text-dim);
+  font-family: var(--font-data);
+  font-size: var(--text-2xs);
+  font-weight: 800;
+  letter-spacing: var(--tracking-label);
 }
 
 .app-header__brand:hover {
@@ -705,7 +715,7 @@ textarea:focus {
      doesn't widen the header row and crowd the telemetry block. */
   flex-direction: column;
   align-items: flex-start;
-  gap: 4px;
+  gap: var(--space-1);
   min-width: 0;
   flex: 0 1 auto;
 }
@@ -745,18 +755,46 @@ textarea:focus {
    that contributes nothing but takes ~520px of header width. Replace it
    with a thin pill so the header collapses to brand + transport-select
    + connect-button on one row. */
-.app-header__disconnected-pill {
+/* One chip.
+ *
+ * There were five, within a click or two of each other and several inside the
+ * same tab strip: three corner radii, three units of measurement (px, em and
+ * an inherited em), and two casings. The geometry lives here; each component
+ * below keeps only what is genuinely different about it -- an option chip is a
+ * button and stays sentence case, the header pill carries a status dot.
+ *
+ * Declared before the component rules so those still win where they differ. */
+.app-header__disconnected-pill,
+.workspace-main__tab-meta-item,
+.scoped-option-chip,
+.snapshots-counter-chip,
+.ai-assistant__tool-chip {
   display: inline-flex;
   align-items: center;
-  gap: 8px;
-  flex: 0 0 auto;
-  padding: 6px 12px;
+  min-height: 24px;
+  padding: 4px 10px;
   border-radius: 999px;
-  border: 1px solid var(--surface-400);
-  background: var(--surface-300);
+  border: 1px solid var(--border-soft);
+  background: var(--bg-panel);
   color: var(--text-muted);
-  font-size: var(--text-md);
+  font-family: var(--font-data);
+  font-size: var(--text-sm);
+  font-weight: 600;
+  letter-spacing: var(--tracking-label);
+  text-transform: uppercase;
   white-space: nowrap;
+}
+
+.app-header__disconnected-pill {
+  /* Sentence case: it reads "Disconnected", not a label. */
+  gap: var(--space-2);
+  flex: 0 0 auto;
+  background: var(--surface-300);
+  font-family: var(--font-ui);
+  font-size: var(--text-md);
+  font-weight: 400;
+  letter-spacing: normal;
+  text-transform: none;
 }
 
 .app-header__disconnected-dot {
@@ -781,7 +819,7 @@ textarea:focus {
 .app-header__telemetry {
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: var(--space-2);
   flex: 1 1 420px;
   min-width: 0;
   /* Battery + sensor strip stay on one line (the strip scrolls if tight)
@@ -801,7 +839,7 @@ textarea:focus {
 .header-quad-status__battery {
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: var(--space-2);
 }
 
 .header-battery-icon {
@@ -1052,7 +1090,7 @@ textarea:focus {
      of the post-shrink header cards. */
   min-width: 110px;
   display: grid;
-  gap: 4px;
+  gap: var(--space-1);
   padding: 5px 9px;
   border-radius: var(--radius-md);
   border: 1px solid var(--surface-400);
@@ -1093,7 +1131,7 @@ textarea:focus {
   position: relative;
   display: inline-flex;
   align-items: center;
-  gap: 8px;
+  gap: var(--space-2);
   color: var(--text);
   font-size: var(--text-md);
 }
@@ -1154,7 +1192,7 @@ textarea:focus {
      of the primary action row). */
   flex-direction: column;
   align-items: stretch;
-  gap: 8px;
+  gap: var(--space-2);
   flex-shrink: 0;
   /* When the header wraps onto a second row at narrower widths, keep the
      session actions aligned to the right edge instead of stranded at the
@@ -1337,7 +1375,7 @@ textarea:focus {
   display: flex;
   flex-wrap: wrap;
   align-items: center;
-  gap: 12px;
+  gap: var(--space-3);
   padding: 6px 12px;
   border-radius: 999px;
   background: color-mix(in srgb, var(--accent, var(--primary-500)) 22%, var(--surface-200));
@@ -1375,7 +1413,7 @@ textarea:focus {
 
 .parameter-draft-bar__actions {
   display: flex;
-  gap: 8px;
+  gap: var(--space-2);
   flex-shrink: 0;
 }
 
@@ -1400,7 +1438,7 @@ textarea:focus {
 
 .workspace-sidebar__shell {
   display: grid;
-  gap: 8px;
+  gap: var(--space-2);
   padding: 10px 12px;
   height: 100%;
   max-height: 100%;
@@ -1457,7 +1495,7 @@ textarea:focus {
 .baseline-summary,
 .baseline-strip {
   display: grid;
-  gap: 8px;
+  gap: var(--space-2);
   padding: 8px 10px;
   border-radius: var(--radius-md);
   border: 1px solid var(--border-soft);
@@ -1469,7 +1507,7 @@ textarea:focus {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  gap: 8px;
+  gap: var(--space-2);
 }
 
 .baseline-summary__header strong {
@@ -1503,7 +1541,7 @@ textarea:focus {
 }
 .baseline-summary__body {
   display: grid;
-  gap: 8px;
+  gap: var(--space-2);
   margin-top: 8px;
 }
 
@@ -1569,7 +1607,7 @@ textarea:focus {
 .mode-toggle {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 4px;
+  gap: var(--space-1);
 }
 
 .mode-toggle__option {
@@ -1612,7 +1650,7 @@ textarea:focus {
 
 .workspace-mode-summary {
   display: grid;
-  gap: 4px;
+  gap: var(--space-1);
   padding: 6px 8px;
   border-radius: var(--radius-sm);
   border: 1px solid var(--border-soft);
@@ -1662,7 +1700,7 @@ textarea:focus {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  gap: 8px;
+  gap: var(--space-2);
 }
 
 .session-follow-up__header strong {
@@ -1690,7 +1728,7 @@ textarea:focus {
 .workspace-nav__item {
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: var(--space-2);
   padding: 4px 10px;
   border-radius: 999px;
   border: 1px solid transparent;
@@ -1750,7 +1788,7 @@ textarea:focus {
   font-family: var(--font-data);
   font-size: var(--text-2xs);
   font-weight: 800;
-  letter-spacing: 0.06em;
+  letter-spacing: var(--tracking-label);
 }
 
 .workspace-nav__item.is-active .workspace-nav__mark {
@@ -1776,7 +1814,7 @@ textarea:focus {
 
 .workspace-sidebar__footer {
   display: grid;
-  gap: 8px;
+  gap: var(--space-2);
   margin-top: auto;
   padding-top: 10px;
   border-top: 1px solid var(--border-soft);
@@ -1797,7 +1835,7 @@ textarea:focus {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  gap: 8px;
+  gap: var(--space-2);
 }
 
 .workspace-sidebar__summary-row span {
@@ -1852,7 +1890,7 @@ textarea:focus {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  gap: 8px;
+  gap: var(--space-2);
 }
 
 .workspace-focus-card__header strong,
@@ -1893,19 +1931,19 @@ textarea:focus {
   /* 2026-05-20 UI density audit: 20px 20px 36px → 14px 16px 24px.
    * Tabs already manage their own internal gap stack so the previous
    * outer gutter was double-padding the content boundary. */
-  padding: var(--space-3, 14px) var(--space-4, 16px) var(--space-5, 24px);
+  padding: var(--space-3) var(--space-4) var(--space-5);
   background: var(--surface-100);
 }
 
 .workspace-main__notes {
   display: grid;
-  gap: 8px;
+  gap: var(--space-2);
   margin-bottom: 14px;
 }
 
 .workspace-note {
   display: grid;
-  gap: 4px;
+  gap: var(--space-1);
   padding: 8px 10px;
   border-radius: var(--radius-md);
   border: 1px solid var(--primary-500);
@@ -1966,19 +2004,8 @@ textarea:focus {
 }
 
 .workspace-main__tab-meta-item {
-  display: inline-flex;
-  align-items: center;
-  min-height: 24px;
-  padding: 0 8px;
-  border-radius: 999px;
-  border: 1px solid var(--border-soft);
-  background: var(--bg-panel);
-  color: var(--text-muted);
-  font-family: var(--font-data);
   font-size: var(--text-xs);
   font-weight: 700;
-  letter-spacing: var(--tracking-label);
-  text-transform: uppercase;
 }
 
 .workspace-main__tab-meta-item.is-ok {
@@ -2021,7 +2048,7 @@ textarea:focus {
 .tuning-card-grid {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 12px;
+  gap: var(--space-3);
 }
 
 .tuning-card {
@@ -2093,7 +2120,7 @@ textarea:focus {
   display: flex;
   justify-content: space-between;
   align-items: flex-start;
-  gap: 16px;
+  gap: var(--space-4);
   padding: 14px 16px;
   border-radius: var(--radius-lg);
   border: 1px solid var(--border-soft);
@@ -2123,7 +2150,7 @@ textarea:focus {
   display: grid;
   grid-auto-flow: column;
   grid-auto-columns: minmax(160px, 1fr);
-  gap: 8px;
+  gap: var(--space-2);
   overflow-x: auto;
   padding-bottom: 4px;
 }
@@ -2296,7 +2323,7 @@ textarea:focus {
 
 .setup-flow__criteria ul {
   display: grid;
-  gap: 4px;
+  gap: var(--space-1);
   margin: 0;
   padding: 0;
   list-style: none;
@@ -2309,7 +2336,7 @@ textarea:focus {
 .setup-flow__criteria li {
   display: grid;
   grid-template-columns: 14px minmax(0, 1fr);
-  gap: 8px;
+  gap: var(--space-2);
   align-items: baseline;
   padding: 4px 2px;
   border-radius: var(--radius-md);
@@ -2370,20 +2397,20 @@ textarea:focus {
 
 .telemetry-stack {
   display: grid;
-  gap: 12px;
+  gap: var(--space-3);
 }
 
 .ports-workspace {
   display: grid;
   grid-template-columns: minmax(0, 1fr);
-  gap: 12px;
+  gap: var(--space-3);
   align-items: start;
 }
 
 .outputs-workspace {
   display: grid;
   grid-template-columns: minmax(320px, 0.9fr) minmax(0, 1.1fr);
-  gap: 12px;
+  gap: var(--space-3);
   align-items: start;
 }
 
@@ -2426,7 +2453,7 @@ textarea:focus {
 
 .ports-surface {
   display: grid;
-  gap: 12px;
+  gap: var(--space-3);
   padding: 12px 14px;
   border-radius: var(--radius-2xl);
   border: 1px solid rgba(var(--edge-rgb), 0.04);
@@ -2442,7 +2469,7 @@ textarea:focus {
   display: flex;
   justify-content: space-between;
   align-items: flex-start;
-  gap: 16px;
+  gap: var(--space-4);
   padding-bottom: 16px;
   border-bottom: 1px solid rgba(var(--edge-rgb), 0.05);
 }
@@ -2470,14 +2497,14 @@ textarea:focus {
   display: flex;
   flex-wrap: wrap;
   justify-content: flex-end;
-  gap: 8px;
+  gap: var(--space-2);
   align-items: center;
 }
 
 .ports-surface__disclosure {
   display: flex;
   justify-content: space-between;
-  gap: 12px;
+  gap: var(--space-3);
 }
 
 .receiver-workspace__live,
@@ -2500,7 +2527,7 @@ textarea:focus {
   position: sticky;
   top: 16px;
   display: grid;
-  gap: 12px;
+  gap: var(--space-3);
 }
 .outputs-overview__badges {
   display: flex;
@@ -2522,7 +2549,7 @@ textarea:focus {
 /* Top tab selector for the Motors/Servos sub-tabs. */
 .outputs-tabs-layout {
   display: grid;
-  gap: var(--space-3, 12px);
+  gap: var(--space-3);
   align-items: start;
 }
 
@@ -2544,8 +2571,10 @@ textarea:focus {
 .tab-strip__tab {
   display: inline-flex;
   align-items: center;
-  gap: 8px;
+  gap: var(--space-2);
   padding: 8px 14px;
+  /* 2px, where the rest of the app uses 1px: the active tab is signalled by
+     its border colour alone, and at 1px that read as a hover state. */
   border: 2px solid var(--border);
   border-radius: var(--radius-md);
   background: color-mix(in srgb, var(--text) 4%, transparent);
@@ -2592,7 +2621,7 @@ textarea:focus {
 .outputs-accordion-layout {
   display: grid;
   grid-template-columns: minmax(0, 1.65fr) minmax(280px, 0.9fr);
-  gap: var(--space-3, 12px);
+  gap: var(--space-3);
   align-items: start;
 }
 .outputs-accordion-layout--full {
@@ -2600,7 +2629,7 @@ textarea:focus {
 }
 .outputs-accordion {
   display: grid;
-  gap: 8px;
+  gap: var(--space-2);
   min-width: 0;
 }
 .outputs-accordion-card {
@@ -2672,7 +2701,7 @@ textarea:focus {
 .receiver-support-grid,
 .outputs-lab-grid {
   display: grid;
-  gap: 12px;
+  gap: var(--space-3);
 }
 
 .receiver-exercise-grid > *,
@@ -2702,7 +2731,7 @@ textarea:focus {
   display: flex;
   justify-content: space-between;
   align-items: flex-start;
-  gap: 12px;
+  gap: var(--space-3);
   padding-bottom: 10px;
   border-bottom: 1px solid rgba(var(--edge-rgb), 0.05);
   /* Title block + trailing badge wrap instead of overflowing on narrow widths. */
@@ -2737,7 +2766,7 @@ textarea:focus {
 
 .setup-command-center {
   display: grid;
-  gap: 12px;
+  gap: var(--space-3);
 }
 
 .setup-bench {
@@ -2873,7 +2902,7 @@ textarea:focus {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  gap: 12px;
+  gap: var(--space-3);
   padding: 0;
   border: none;
   background: transparent;
@@ -3003,7 +3032,7 @@ textarea:focus {
   left: 10px;
   display: inline-flex;
   align-items: center;
-  gap: 12px;
+  gap: var(--space-3);
   padding: 2px 10px;
   border-radius: 999px;
   background: var(--primary-500);
@@ -3025,7 +3054,7 @@ textarea:focus {
 .setup-gui-box__notice-controls {
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: var(--space-2);
   /* Four controls (filter, Expand, Pop out, Copy/Clear) do not fit on one line
    * at phone width — wrapping is what keeps the 390px layout from scrolling
    * sideways. */
@@ -3554,7 +3583,7 @@ body.is-status-dash-dragging {
 .setup-gui-box__kv-row {
   display: flex;
   justify-content: space-between;
-  gap: 12px;
+  gap: var(--space-3);
   font-size: var(--text-md);
   padding: 7px 0;
   border-bottom: 1px solid var(--surface-400);
@@ -3610,12 +3639,12 @@ body.is-status-dash-dragging {
   display: flex;
   justify-content: flex-start;
   align-items: center;
-  gap: 8px;
+  gap: var(--space-2);
 }
 
 .setup-gui-box__status-list {
   display: grid;
-  gap: 8px;
+  gap: var(--space-2);
 }
 
 .setup-gui-box__status-list--scroll {
@@ -3700,7 +3729,7 @@ body.is-status-dash-dragging {
 
 .setup-gui-box__status-entry {
   display: grid;
-  gap: 4px;
+  gap: var(--space-1);
   padding: 8px 9px;
   border-radius: var(--radius-md);
   border: 1px solid var(--surface-400);
@@ -3761,7 +3790,7 @@ body.is-status-dash-dragging {
 }
 
 .setup-gui-box__map .gps-map-card {
-  gap: 8px;
+  gap: var(--space-2);
 }
 
 .bf-tab-stack {
@@ -3824,7 +3853,7 @@ body.is-status-dash-dragging {
   left: 10px;
   display: inline-flex;
   align-items: center;
-  gap: 8px;
+  gap: var(--space-2);
   padding: 2px 10px;
   border-radius: 999px;
   background: var(--primary-500);
@@ -3843,7 +3872,7 @@ body.is-status-dash-dragging {
 
 .bf-gui-box__body {
   display: grid;
-  gap: 12px;
+  gap: var(--space-3);
 }
 
 .bf-gui-box__kv-list {
@@ -3854,7 +3883,7 @@ body.is-status-dash-dragging {
 .bf-gui-box__kv-row {
   display: flex;
   justify-content: space-between;
-  gap: 12px;
+  gap: var(--space-3);
   padding: 7px 0;
   border-bottom: 1px solid var(--surface-400);
   font-size: var(--text-md);
@@ -3885,38 +3914,39 @@ body.is-status-dash-dragging {
   gap: 10px;
 }
 
+/* The staged-changes bar. There were two: this one floated as a rounded card
+ * at the right, detached from the content and overlapping it, while Config
+ * pinned a full-width bar above the status bar. Same job, two shapes and two
+ * positions -- and this one's counter was uppercase where Config's was not, so
+ * the same two words read differently depending on the view. It now behaves
+ * like .config-toolbar. */
 .bf-toolbar {
-  position: sticky;
-  bottom: 16px;
-  justify-self: end;
   display: flex;
   flex-wrap: wrap;
   align-items: center;
-  gap: 8px;
-  width: fit-content;
-  padding: 10px 12px;
-  border-radius: 18px 0 0 18px;
-  border: 1px solid var(--surface-400);
-  border-right: none;
-  background: var(--surface-300);
-  box-shadow: 0 -10px 28px rgba(0, 0, 0, 0.32);
-  z-index: 5;
+  gap: 10px;
+  margin-top: var(--space-3);
+  padding-top: var(--space-3);
+  padding-bottom: var(--space-2);
+  border-top: 1px solid var(--surface-300);
+  position: sticky;
+  bottom: var(--statusbar-height, 24px);
+  background: var(--bg-panel, var(--surface-100));
+  z-index: 3;
 }
 
 .bf-toolbar__status {
   display: flex;
-  gap: 8px;
-  margin-right: 6px;
+  gap: 14px;
+  margin-right: auto;
   color: var(--text-muted);
   font-size: var(--text-sm);
-  letter-spacing: var(--tracking-label);
-  text-transform: uppercase;
 }
 
 .bf-vtx-grid {
   display: grid;
   grid-template-columns: repeat(4, minmax(0, 1fr));
-  gap: 12px;
+  gap: var(--space-3);
 }
 
 .bf-vtx-grid__config {
@@ -3934,12 +3964,12 @@ body.is-status-dash-dragging {
 .bf-vtx-advanced-grid {
   display: grid;
   grid-template-columns: minmax(260px, 0.9fr) minmax(0, 1.1fr);
-  gap: 12px;
+  gap: var(--space-3);
 }
 
 .bf-vtx-callout {
   display: grid;
-  gap: 8px;
+  gap: var(--space-2);
   align-content: start;
   padding: 12px;
   border-radius: var(--radius-lg);
@@ -3958,7 +3988,7 @@ body.is-status-dash-dragging {
 .bf-vtx-table {
   grid-column: 1 / -1;
   display: grid;
-  gap: 12px;
+  gap: var(--space-3);
 }
 .bf-vtx-table__scroll {
   overflow-x: auto;
@@ -4007,7 +4037,7 @@ body.is-status-dash-dragging {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 8px;
+  gap: var(--space-2);
   flex-wrap: wrap;
 }
 .bf-vtx-table__power-grid {
@@ -4047,13 +4077,13 @@ body.is-status-dash-dragging {
 }
 .bf-vtx-table__actions {
   display: flex;
-  gap: 8px;
+  gap: var(--space-2);
 }
 .bf-vtx-table__io {
   display: flex;
   flex-wrap: wrap;
   align-items: center;
-  gap: 8px;
+  gap: var(--space-2);
 }
 
 .bf-vtx-table__preset-select {
@@ -4067,7 +4097,7 @@ body.is-status-dash-dragging {
 }
 .bf-vtx-table__import {
   display: grid;
-  gap: 8px;
+  gap: var(--space-2);
   padding: 10px;
   border: 1px solid var(--surface-400);
   border-radius: var(--radius-md);
@@ -4086,20 +4116,20 @@ body.is-status-dash-dragging {
 }
 .bf-vtx-table__import-actions {
   display: flex;
-  gap: 8px;
+  gap: var(--space-2);
 }
 
 .osd-grid {
   display: grid;
   grid-template-columns: minmax(0, 1fr) minmax(360px, 1.6fr);
-  gap: 12px;
+  gap: var(--space-3);
   align-items: start;
 }
 
 .osd-preview-toolbar {
   display: flex;
   flex-wrap: wrap;
-  gap: 8px;
+  gap: var(--space-2);
   color: var(--text-muted);
   font-size: var(--text-sm);
   letter-spacing: var(--tracking-label);
@@ -4222,7 +4252,7 @@ body.is-status-dash-dragging {
   flex-direction: column;
   justify-content: center;
   align-items: center;
-  gap: 8px;
+  gap: var(--space-2);
   padding: 20px;
   color: var(--text-muted);
   text-align: center;
@@ -4253,7 +4283,7 @@ body.is-status-dash-dragging {
 .bf-motor-setup-grid {
   display: grid;
   grid-template-columns: minmax(340px, 1.15fr) minmax(300px, 0.85fr);
-  gap: 16px;
+  gap: var(--space-4);
   align-items: start;
 }
 
@@ -4303,7 +4333,7 @@ body.is-status-dash-dragging {
 /* Test tab: throttle sliders + a small read-only motor map, side by side. */
 .motor-test-sliders-row {
   display: flex;
-  gap: 16px;
+  gap: var(--space-4);
   align-items: stretch;
   justify-content: center;
   flex-wrap: wrap;
@@ -4468,7 +4498,7 @@ body.is-status-dash-dragging {
 
 .motor-mixer-summary-card {
   display: grid;
-  gap: 4px;
+  gap: var(--space-1);
   min-width: 0;
   padding: 11px 12px;
   border-radius: var(--radius-lg);
@@ -4500,7 +4530,7 @@ body.is-status-dash-dragging {
 
 .osd-preview-footer {
   display: grid;
-  gap: 8px;
+  gap: var(--space-2);
   margin-top: 10px;
 }
 
@@ -4525,7 +4555,7 @@ body.is-status-dash-dragging {
 .flight-deck-command {
   display: grid;
   grid-template-columns: minmax(0, 1fr) 280px;
-  gap: 12px;
+  gap: var(--space-3);
   align-items: start;
 }
 
@@ -4536,14 +4566,14 @@ body.is-status-dash-dragging {
 
 .flight-deck-command__sidebar {
   display: grid;
-  gap: 8px;
+  gap: var(--space-2);
   align-content: start;
 }
 
 .flight-deck-command__instruments {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 8px;
+  gap: var(--space-2);
 }
 
 .flight-deck-command__telemetry-strip {
@@ -4568,13 +4598,13 @@ body.is-status-dash-dragging {
 .flight-deck-command__signal-strip {
   display: flex;
   flex-wrap: wrap;
-  gap: 4px;
+  gap: var(--space-1);
 }
 
 .flight-deck-command__signal-strip span {
   display: inline-flex;
   align-items: center;
-  gap: 4px;
+  gap: var(--space-1);
   padding: 3px 7px;
   border-radius: var(--radius-sm);
   border: 1px solid var(--border-soft);
@@ -4616,7 +4646,7 @@ body.is-status-dash-dragging {
 
 .flight-deck-command__sidebar-section {
   display: grid;
-  gap: 4px;
+  gap: var(--space-1);
   padding: 8px;
   border-radius: var(--radius-md);
   border: 1px solid var(--border);
@@ -4639,7 +4669,7 @@ body.is-status-dash-dragging {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  gap: 8px;
+  gap: var(--space-2);
   padding: 3px 0;
   font-size: var(--text-sm);
 }
@@ -4699,7 +4729,7 @@ body.is-status-dash-dragging {
   padding: 5px 8px;
   border-radius: var(--radius-sm);
   font-size: var(--text-sm);
-  gap: 8px;
+  gap: var(--space-2);
   grid-template-columns: 52px minmax(0, 1fr);
 }
 
@@ -4756,7 +4786,7 @@ body.is-status-dash-dragging {
 
 .setup-command-center__flow {
   display: grid;
-  gap: 16px;
+  gap: var(--space-4);
 }
 
 .setup-command-center__flow-grid {
@@ -4768,7 +4798,7 @@ body.is-status-dash-dragging {
 
 .setup-wizard {
   display: grid;
-  gap: 16px;
+  gap: var(--space-4);
 }
 
 .setup-launch-button {
@@ -4783,7 +4813,7 @@ body.is-status-dash-dragging {
   display: flex;
   justify-content: space-between;
   align-items: flex-start;
-  gap: 16px;
+  gap: var(--space-4);
   padding: 16px 18px;
   border-radius: var(--radius-xl);
   border: 1px solid var(--border);
@@ -5058,12 +5088,12 @@ body.is-status-dash-dragging {
 }
 
 .accelerometer-pose-guide--compact {
-  gap: 12px;
+  gap: var(--space-3);
 }
 
 .accelerometer-pose-guide__hero {
   display: grid;
-  gap: 12px;
+  gap: var(--space-3);
   padding: 16px;
   border-radius: var(--radius-lg);
   border: 1px solid rgba(104, 144, 202, 0.22);
@@ -5089,7 +5119,7 @@ body.is-status-dash-dragging {
   display: flex;
   justify-content: space-between;
   align-items: baseline;
-  gap: 12px;
+  gap: var(--space-3);
 }
 
 .accelerometer-pose-guide__header strong,
@@ -5109,7 +5139,7 @@ body.is-status-dash-dragging {
 
 .accelerometer-pose-guide__validation {
   display: grid;
-  gap: 4px;
+  gap: var(--space-1);
   padding: 10px 12px;
   border-radius: var(--radius-lg);
   border: 1px solid var(--surface-400);
@@ -5205,13 +5235,13 @@ body.is-status-dash-dragging {
 
 .accelerometer-pose-guide--compact .accelerometer-pose-guide__steps {
   grid-template-columns: repeat(6, minmax(0, 1fr));
-  gap: 8px;
+  gap: var(--space-2);
 }
 
 .accelerometer-pose-guide__step {
   display: grid;
   justify-items: center;
-  gap: 8px;
+  gap: var(--space-2);
   padding: 10px 8px 12px;
   border-radius: var(--radius-lg);
   border: 1px solid rgba(54, 72, 97, 0.8);
@@ -5323,7 +5353,7 @@ body.is-status-dash-dragging {
 }
 
 .setup-wizard__task-card {
-  gap: 12px;
+  gap: var(--space-3);
   padding: 14px 12px;
 }
 
@@ -5385,7 +5415,7 @@ body.is-status-dash-dragging {
 
 .setup-wizard__task-copy {
   display: grid;
-  gap: 12px;
+  gap: var(--space-3);
 }
 
 .setup-wizard__task-note {
@@ -5424,7 +5454,7 @@ body.is-status-dash-dragging {
 .setup-wizard__task-fields {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 12px;
+  gap: var(--space-3);
 }
 
 .setup-wizard__task-acknowledgments {
@@ -5433,7 +5463,7 @@ body.is-status-dash-dragging {
 
 .setup-wizard__task-actions {
   display: grid;
-  gap: 12px;
+  gap: var(--space-3);
 }
 
 .setup-wizard__primary-button,
@@ -5450,7 +5480,7 @@ body.is-status-dash-dragging {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  gap: 12px;
+  gap: var(--space-3);
 }
 
 .setup-wizard__primary-button--target {
@@ -5484,7 +5514,7 @@ body.is-status-dash-dragging {
 .setup-wizard__support-actions {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 8px;
+  gap: var(--space-2);
 }
 
 @media (max-width: 1100px) {
@@ -5504,7 +5534,7 @@ body.is-status-dash-dragging {
    card in the right column so the left column carries only the task — the
    single layout rule every guided step follows. */
 .setup-wizard__status-card {
-  gap: 12px;
+  gap: var(--space-3);
 }
 
 .guided-action-pulse {
@@ -5546,7 +5576,7 @@ body.is-status-dash-dragging {
 .setup-overview__visual,
 .setup-overview__summary {
   display: grid;
-  gap: 16px;
+  gap: var(--space-4);
 }
 
 .setup-overview__facts {
@@ -5568,13 +5598,13 @@ body.is-status-dash-dragging {
 .setup-overview__fact-grid {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 8px;
+  gap: var(--space-2);
 }
 
 .setup-overview__signal-row {
   display: flex;
   flex-wrap: wrap;
-  gap: 8px;
+  gap: var(--space-2);
 }
 
 .setup-overview__signal-row span {
@@ -5629,7 +5659,7 @@ body.is-status-dash-dragging {
 .flight-deck {
   display: grid;
   grid-template-columns: minmax(0, 1fr);
-  gap: 16px;
+  gap: var(--space-4);
   align-items: start;
 }
 
@@ -5650,7 +5680,7 @@ body.is-status-dash-dragging {
 .flight-deck__model-shell,
 .flight-deck__instruments {
   display: grid;
-  gap: 12px;
+  gap: var(--space-3);
   align-content: start;
   align-self: start;
 }
@@ -5807,7 +5837,7 @@ body.is-status-dash-dragging {
   display: flex;
   flex-wrap: wrap;
   justify-content: center;
-  gap: 8px;
+  gap: var(--space-2);
   z-index: 2;
 }
 
@@ -5832,13 +5862,13 @@ body.is-status-dash-dragging {
   justify-content: space-between;
   align-items: flex-end;
   flex-wrap: wrap;
-  gap: 12px;
+  gap: var(--space-3);
   padding: 0 2px;
 }
 
 .flight-deck__caption-copy {
   display: grid;
-  gap: 4px;
+  gap: var(--space-1);
 }
 
 .flight-deck__caption strong {
@@ -6019,7 +6049,7 @@ body.is-status-dash-dragging {
   top: 50%;
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: var(--space-2);
   transform: translate(-50%, -50%);
   z-index: 2;
   pointer-events: none;
@@ -6108,7 +6138,7 @@ body.is-status-dash-dragging {
 
 .gps-map-card {
   display: grid;
-  gap: 12px;
+  gap: var(--space-3);
   padding: 12px;
   border-radius: var(--radius-lg);
   border: 1px solid var(--border);
@@ -6117,14 +6147,14 @@ body.is-status-dash-dragging {
 }
 
 .gps-map-card--compact {
-  gap: 12px;
+  gap: var(--space-3);
 }
 
 .gps-map-card__header {
   display: flex;
   justify-content: space-between;
   align-items: start;
-  gap: 12px;
+  gap: var(--space-3);
 }
 
 .gps-map-card__header strong {
@@ -6187,7 +6217,7 @@ body.is-status-dash-dragging {
   inset: 0;
   display: grid;
   align-content: center;
-  gap: 8px;
+  gap: var(--space-2);
   padding: 20px;
   text-align: center;
   background:
@@ -6248,7 +6278,7 @@ body.is-status-dash-dragging {
   display: flex;
   justify-content: space-between;
   align-items: start;
-  gap: 12px;
+  gap: var(--space-3);
 }
 
 .gps-map-card__footer small {
@@ -6280,7 +6310,7 @@ body.is-status-dash-dragging {
   display: flex;
   justify-content: space-between;
   align-items: flex-start;
-  gap: 12px;
+  gap: var(--space-3);
 }
 
 .mode-estimate-card__header > div,
@@ -6367,7 +6397,7 @@ body.is-status-dash-dragging {
 
 .switch-exercise-card {
   display: grid;
-  gap: 12px;
+  gap: var(--space-3);
   padding: 16px;
   border-radius: var(--radius-lg);
   border: 1px solid rgba(var(--edge-rgb), 0.04);
@@ -6381,7 +6411,7 @@ body.is-status-dash-dragging {
 .esc-review-card,
 .prearm-card {
   display: grid;
-  gap: 12px;
+  gap: var(--space-3);
   padding: 16px;
   border-radius: var(--radius-lg);
   border: 1px solid rgba(var(--edge-rgb), 0.04);
@@ -6440,7 +6470,7 @@ body.is-status-dash-dragging {
 
 .orientation-card__focus-instruction {
   display: grid;
-  gap: 4px;
+  gap: var(--space-1);
   margin-top: 4px;
   padding: 12px 14px;
   border-radius: var(--radius-md);
@@ -6519,7 +6549,7 @@ body.is-status-dash-dragging {
 .rc-mapping-focus__copy,
 .rc-mapping-focus__status {
   display: grid;
-  gap: 8px;
+  gap: var(--space-2);
 }
 
 .rc-mapping-focus__copy span {
@@ -6559,7 +6589,7 @@ body.is-status-dash-dragging {
 
 .rc-mapping-candidate-panel__header {
   display: grid;
-  gap: 4px;
+  gap: var(--space-1);
 }
 
 .rc-mapping-candidate-panel__header strong {
@@ -6598,7 +6628,7 @@ body.is-status-dash-dragging {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  gap: 8px;
+  gap: var(--space-2);
   flex-wrap: wrap;
 }
 
@@ -6613,7 +6643,7 @@ body.is-status-dash-dragging {
 
 .rc-mapping-auto-capture {
   display: grid;
-  gap: 8px;
+  gap: var(--space-2);
   padding: 10px 12px;
   border-radius: var(--radius-md);
   border: 1px solid rgba(218, 178, 84, 0.34);
@@ -6655,7 +6685,7 @@ body.is-status-dash-dragging {
   display: flex;
   justify-content: space-between;
   align-items: flex-start;
-  gap: 16px;
+  gap: var(--space-4);
 }
 
 .switch-exercise-card__header strong {
@@ -6711,7 +6741,7 @@ body.is-status-dash-dragging {
 .tuning-summary-grid {
   display: grid;
   grid-template-columns: repeat(5, minmax(0, 1fr));
-  gap: 12px;
+  gap: var(--space-3);
 }
 
 .receiver-summary-card,
@@ -6947,7 +6977,7 @@ body.is-status-dash-dragging {
 .receiver-bind-action {
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: var(--space-2);
   margin-top: 12px;
 }
 
@@ -7103,7 +7133,7 @@ body.is-status-dash-dragging {
   position: sticky;
   top: 16px;
   display: grid;
-  gap: 12px;
+  gap: var(--space-3);
 }
 
 /* Betaflight-style live monitor: the reactive craft model on the left, RC
@@ -7115,12 +7145,12 @@ body.is-status-dash-dragging {
 .receiver-live-columns {
   display: grid;
   grid-template-columns: minmax(0, 0.85fr) minmax(0, 1.15fr);
-  gap: 12px;
+  gap: var(--space-3);
   align-items: start;
 }
 .receiver-live-columns__channels {
   display: grid;
-  gap: 12px;
+  gap: var(--space-3);
   min-width: 0;
 }
 .receiver-live-columns__craft {
@@ -7173,7 +7203,7 @@ body.is-status-dash-dragging {
   position: sticky;
   top: 16px;
   display: grid;
-  gap: 12px;
+  gap: var(--space-3);
 }
 
 .receiver-live-primary-grid,
@@ -7182,7 +7212,7 @@ body.is-status-dash-dragging {
 .receiver-task-stage-strip {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 12px;
+  gap: var(--space-3);
 }
 /* The endpoints task now holds a single combined calibration card. */
 .receiver-task-two-up--single {
@@ -7196,7 +7226,7 @@ body.is-status-dash-dragging {
 .outputs-inline-toggle,
 .outputs-review-dock {
   display: grid;
-  gap: 8px;
+  gap: var(--space-2);
   padding: 12px;
   border-radius: var(--radius-md);
   border: 1px solid var(--border);
@@ -7223,7 +7253,7 @@ body.is-status-dash-dragging {
 .outputs-inline-toggle__actions {
   display: flex;
   justify-content: space-between;
-  gap: 12px;
+  gap: var(--space-3);
   align-items: flex-start;
 }
 
@@ -7317,7 +7347,7 @@ body.is-status-dash-dragging {
 .outputs-task-deck,
 .tuning-task-deck {
   display: grid;
-  gap: 12px;
+  gap: var(--space-3);
 }
 
 .receiver-task-deck__header,
@@ -7325,7 +7355,7 @@ body.is-status-dash-dragging {
 .tuning-task-deck__header {
   display: flex;
   justify-content: space-between;
-  gap: 16px;
+  gap: var(--space-4);
   align-items: flex-start;
   padding: 14px;
   border-radius: var(--radius-lg);
@@ -7345,7 +7375,7 @@ body.is-status-dash-dragging {
 .outputs-task-panel,
 .tuning-task-panel {
   display: grid;
-  gap: 12px;
+  gap: var(--space-3);
 }
 
 .receiver-task-panel--stack,
@@ -7357,7 +7387,7 @@ body.is-status-dash-dragging {
 .tuning-control-grid {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 12px;
+  gap: var(--space-3);
 }
 
 .tuning-control-grid--compact {
@@ -7491,7 +7521,7 @@ body.is-status-dash-dragging {
 .tuning-axis-snapshot-grid {
   display: grid;
   grid-template-columns: repeat(3, minmax(0, 1fr));
-  gap: 12px;
+  gap: var(--space-3);
 }
 
 .tuning-axis-card,
@@ -7523,13 +7553,13 @@ body.is-status-dash-dragging {
   display: flex;
   flex-wrap: wrap;
   align-items: flex-end;
-  gap: 12px;
+  gap: var(--space-3);
   margin-bottom: 12px;
 }
 
 .filters-from-gyro__entry label {
   display: grid;
-  gap: 4px;
+  gap: var(--space-1);
 }
 
 .filters-from-gyro__entry input {
@@ -7539,7 +7569,7 @@ body.is-status-dash-dragging {
 .filters-from-gyro__hints {
   display: flex;
   flex-wrap: wrap;
-  gap: 8px;
+  gap: var(--space-2);
 }
 
 .filters-from-gyro__rows {
@@ -7589,7 +7619,7 @@ body.is-status-dash-dragging {
 .filter-notch-help .switch-exercise-controls {
   display: flex;
   flex-wrap: wrap;
-  gap: 8px;
+  gap: var(--space-2);
   justify-content: flex-start;
 }
 
@@ -7643,7 +7673,7 @@ body.is-status-dash-dragging {
 .tuning-curve-grid {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 12px;
+  gap: var(--space-3);
 }
 
 .receiver-inline-toggle {
@@ -7738,12 +7768,12 @@ body.is-status-dash-dragging {
 
 .tuning-master-slider-grid {
   display: grid;
-  gap: 12px;
+  gap: var(--space-3);
 }
 
 .tuning-master-slider {
   display: grid;
-  gap: 8px;
+  gap: var(--space-2);
   padding: 12px;
   border-radius: var(--radius-xl);
   background: rgba(var(--edge-rgb), 0.025);
@@ -7753,7 +7783,7 @@ body.is-status-dash-dragging {
 .tuning-master-slider__header {
   display: flex;
   justify-content: space-between;
-  gap: 12px;
+  gap: var(--space-3);
   align-items: flex-start;
 }
 
@@ -7787,7 +7817,7 @@ body.is-status-dash-dragging {
 .tuning-profile-browser {
   display: grid;
   grid-template-columns: minmax(240px, 0.88fr) minmax(0, 1.12fr);
-  gap: 12px;
+  gap: var(--space-3);
   align-items: start;
 }
 
@@ -7810,7 +7840,7 @@ body.is-status-dash-dragging {
   bottom: 16px;
   z-index: 3;
   grid-template-columns: minmax(0, 1fr) auto;
-  gap: 12px;
+  gap: var(--space-3);
   align-items: center;
   background: rgba(var(--fill-rgb), 0.98);
   box-shadow: 0 -10px 28px rgba(0, 0, 0, 0.26);
@@ -7825,7 +7855,7 @@ body.is-status-dash-dragging {
 .rc-range-axis-grid {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 12px;
+  gap: var(--space-3);
 }
 
 .rc-range-axis-card {
@@ -7850,7 +7880,7 @@ body.is-status-dash-dragging {
 .rc-range-axis-card__header {
   display: flex;
   justify-content: space-between;
-  gap: 12px;
+  gap: var(--space-3);
   align-items: center;
 }
 
@@ -7863,12 +7893,12 @@ body.is-status-dash-dragging {
 .rc-channel-grid {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 12px;
+  gap: var(--space-3);
 }
 
 .rc-channel-card {
   display: grid;
-  gap: 8px;
+  gap: var(--space-2);
   padding: 8px 10px;
   border-radius: var(--radius-md);
   border: 1px solid var(--border);
@@ -7891,7 +7921,7 @@ body.is-status-dash-dragging {
 .rc-channel-card__footer {
   display: flex;
   justify-content: space-between;
-  gap: 12px;
+  gap: var(--space-3);
   align-items: center;
 }
 
@@ -7940,7 +7970,7 @@ body.is-status-dash-dragging {
 .telemetry-metric-grid {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 12px;
+  gap: var(--space-3);
 }
 
 /* Condensed live battery readout — replaces the four big metric cards. */
@@ -7976,7 +8006,7 @@ body.is-status-dash-dragging {
 
 .telemetry-metric-card {
   display: grid;
-  gap: 4px;
+  gap: var(--space-1);
   padding: 8px 10px;
   border-radius: var(--radius-lg);
   border: 1px solid rgba(var(--edge-rgb), 0.035);
@@ -8004,12 +8034,12 @@ body.is-status-dash-dragging {
 .output-card-grid {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 12px;
+  gap: var(--space-3);
 }
 
 .output-card {
   display: grid;
-  gap: 8px;
+  gap: var(--space-2);
   padding: 8px 10px;
   border-radius: var(--radius-lg);
   border: 1px solid rgba(var(--edge-rgb), 0.035);
@@ -8035,7 +8065,7 @@ body.is-status-dash-dragging {
   display: flex;
   justify-content: space-between;
   align-items: flex-start;
-  gap: 12px;
+  gap: var(--space-3);
 }
 
 .output-card__header strong {
@@ -8069,7 +8099,7 @@ body.is-status-dash-dragging {
 
 .scoped-review-card {
   display: grid;
-  gap: 12px;
+  gap: var(--space-3);
   padding: 16px 16px 15px;
   border-radius: var(--radius-lg);
   border: 1px solid rgba(var(--edge-rgb), 0.04);
@@ -8082,7 +8112,7 @@ body.is-status-dash-dragging {
 
 .receiver-arm-switch__field {
   display: grid;
-  gap: 4px;
+  gap: var(--space-1);
   font-size: var(--text-md);
   color: var(--text-muted);
 }
@@ -8100,7 +8130,7 @@ body.is-status-dash-dragging {
 .receiver-arm-switch__checkbox {
   display: inline-flex;
   align-items: center;
-  gap: 8px;
+  gap: var(--space-2);
   font-size: var(--text-md);
   color: var(--text-muted);
   cursor: pointer;
@@ -8115,7 +8145,7 @@ body.is-status-dash-dragging {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 12px;
+  gap: var(--space-3);
 }
 
 .scoped-review-card__disclosure small {
@@ -8131,7 +8161,7 @@ body.is-status-dash-dragging {
 
 .scoped-draft-item {
   display: grid;
-  gap: 8px;
+  gap: var(--space-2);
   padding: 8px 10px;
   border-radius: var(--radius-lg);
   border: 1px solid rgba(var(--edge-rgb), 0.04);
@@ -8151,7 +8181,7 @@ body.is-status-dash-dragging {
   display: flex;
   justify-content: space-between;
   align-items: flex-start;
-  gap: 12px;
+  gap: var(--space-3);
 }
 
 .scoped-draft-item p,
@@ -8171,7 +8201,7 @@ body.is-status-dash-dragging {
 .scoped-editor-grid {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 12px;
+  gap: var(--space-3);
 }
 
 /* Power (Config ▸ Power) is a short surface — four battery fields — that was
@@ -8193,7 +8223,7 @@ body.is-status-dash-dragging {
 
 .preset-editor label {
   display: grid;
-  gap: 4px;
+  gap: var(--space-1);
   font-size: var(--text-md);
   color: var(--text-muted);
 }
@@ -8217,7 +8247,7 @@ body.is-status-dash-dragging {
   display: grid;
   grid-template-columns: minmax(0, 1fr) 120px auto;
   align-items: center;
-  gap: 8px;
+  gap: var(--space-2);
 }
 
 .preset-editor__row code {
@@ -8233,7 +8263,7 @@ body.is-status-dash-dragging {
 
 .preset-editor__actions {
   display: flex;
-  gap: 8px;
+  gap: var(--space-2);
 }
 
 /* A section hosting a whole panel spans the multicolumn flow instead of being
@@ -8300,13 +8330,13 @@ body.is-status-dash-dragging {
   display: flex;
   align-items: center;
   flex-wrap: wrap;
-  gap: 4px;
+  gap: var(--space-1);
   font-family: var(--font-data);
 }
 .ip-address-field__group {
   display: inline-flex;
   align-items: center;
-  gap: 4px;
+  gap: var(--space-1);
 }
 .ip-address-field__octet {
   width: 3.4em;
@@ -8320,7 +8350,7 @@ body.is-status-dash-dragging {
 .passthrough-list {
   display: flex;
   flex-direction: column;
-  gap: 8px;
+  gap: var(--space-2);
 }
 .passthrough-row {
   display: flex;
@@ -8341,7 +8371,7 @@ body.is-status-dash-dragging {
 .passthrough-row__endpoints {
   display: inline-flex;
   align-items: center;
-  gap: 8px;
+  gap: var(--space-2);
   flex-wrap: wrap;
 }
 .passthrough-row__link {
@@ -8350,7 +8380,7 @@ body.is-status-dash-dragging {
 }
 .passthrough-row__baud {
   display: inline-flex;
-  gap: 12px;
+  gap: var(--space-3);
   flex-wrap: wrap;
 }
 .passthrough-row__baud label {
@@ -8553,7 +8583,7 @@ body.is-status-dash-dragging {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 8px;
+  gap: var(--space-2);
   padding: 6px 8px;
   border: 1px solid var(--surface-400);
   border-radius: var(--radius-sm);
@@ -8592,7 +8622,7 @@ body.is-status-dash-dragging {
 .scoped-option-chips {
   display: flex;
   flex-wrap: wrap;
-  gap: 4px;
+  gap: var(--space-1);
 }
 
 .scoped-bitmask-bits--single {
@@ -8621,13 +8651,13 @@ body.is-status-dash-dragging {
 
 .scoped-bitmask-bit,
 .scoped-option-chip {
-  padding: 3px 8px;
-  border-radius: var(--radius-sm);
-  border: 1px solid var(--surface-400);
+  /* An option chip is a button the operator clicks, so it keeps sentence case
+     and the app's UI face rather than the label treatment. */
   background: transparent;
-  color: var(--text-muted, rgba(var(--edge-rgb), 0.55));
-  font: inherit;
-  font-size: 0.8em;
+  font-family: var(--font-ui);
+  font-weight: 400;
+  letter-spacing: normal;
+  text-transform: none;
   text-align: left;
   cursor: pointer;
 }
@@ -8658,7 +8688,7 @@ body.is-status-dash-dragging {
 .scoped-checkbox-option {
   display: grid;
   grid-template-columns: auto minmax(0, 1fr);
-  gap: 8px;
+  gap: var(--space-2);
   align-items: center;
   min-width: 0;
   /* Compact row, not a chunky bordered card. */
@@ -8747,7 +8777,7 @@ body.is-status-dash-dragging {
 
 .metadata-settings-section {
   display: grid;
-  gap: 12px;
+  gap: var(--space-3);
 }
 
 .metadata-settings-section + .metadata-settings-section {
@@ -8757,7 +8787,7 @@ body.is-status-dash-dragging {
 
 .metadata-settings-section__header {
   display: grid;
-  gap: 4px;
+  gap: var(--space-1);
 }
 
 .metadata-settings-section__header p {
@@ -8800,7 +8830,7 @@ details.metadata-settings-section:not([open]) > summary::after {
 .port-card-grid {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 12px;
+  gap: var(--space-3);
 }
 
 .ports-matrix {
@@ -8869,7 +8899,7 @@ details.metadata-settings-section:not([open]) > summary::after {
 
 .ports-matrix-row__cell {
   display: grid;
-  gap: 8px;
+  gap: var(--space-2);
   align-content: start;
   /* Grid items default to min-width:auto, so a nowrap pill could force the
      track wider than its minmax() and bleed into the next column. */
@@ -8915,7 +8945,7 @@ details.metadata-settings-section:not([open]) > summary::after {
 
 .ports-matrix-row__baud {
   display: grid;
-  gap: 8px;
+  gap: var(--space-2);
 }
 
 .ports-matrix-row__options {
@@ -8926,7 +8956,7 @@ details.metadata-settings-section:not([open]) > summary::after {
 .ports-matrix-row__options-header {
   display: flex;
   justify-content: space-between;
-  gap: 8px;
+  gap: var(--space-2);
   align-items: center;
 }
 
@@ -8949,7 +8979,7 @@ details.metadata-settings-section:not([open]) > summary::after {
 
 .ports-matrix-row__expanded {
   display: grid;
-  gap: 8px;
+  gap: var(--space-2);
   padding-top: 10px;
   border-top: 1px solid var(--surface-400);
 }
@@ -8972,7 +9002,7 @@ details.metadata-settings-section:not([open]) > summary::after {
   display: flex;
   justify-content: space-between;
   align-items: flex-start;
-  gap: 12px;
+  gap: var(--space-3);
 }
 
 .port-row__title {
@@ -9007,14 +9037,14 @@ details.metadata-settings-section:not([open]) > summary::after {
 
 .port-row__options {
   display: grid;
-  gap: 8px;
+  gap: var(--space-2);
 }
 
 .port-row__options-header {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 12px;
+  gap: var(--space-3);
 }
 
 .port-row__options-header strong {
@@ -9040,7 +9070,7 @@ details.metadata-settings-section:not([open]) > summary::after {
 
 .port-card {
   display: grid;
-  gap: 8px;
+  gap: var(--space-2);
   padding: 10px 12px;
   border-radius: var(--radius-md);
   border: 1px solid var(--border);
@@ -9051,7 +9081,7 @@ details.metadata-settings-section:not([open]) > summary::after {
   display: flex;
   justify-content: space-between;
   align-items: flex-start;
-  gap: 12px;
+  gap: var(--space-3);
 }
 
 .port-card__header strong {
@@ -9085,7 +9115,7 @@ details.metadata-settings-section:not([open]) > summary::after {
 
 .dronecan-peripherals__header {
   display: grid;
-  gap: 4px;
+  gap: var(--space-1);
 }
 
 .dronecan-peripherals__header strong {
@@ -9103,7 +9133,7 @@ details.metadata-settings-section:not([open]) > summary::after {
   display: flex;
   justify-content: space-between;
   align-items: baseline;
-  gap: 12px;
+  gap: var(--space-3);
   margin: 0;
   font-size: var(--text-sm);
 }
@@ -9126,7 +9156,7 @@ details.metadata-settings-section:not([open]) > summary::after {
    ArduPilot gap. */
 .rc-mixer-callout {
   display: flex;
-  gap: 12px;
+  gap: var(--space-3);
   align-items: flex-start;
   padding: 10px 12px;
   border-radius: var(--radius-md);
@@ -9156,13 +9186,13 @@ details.metadata-settings-section:not([open]) > summary::after {
   padding-top: 12px;
   border-top: 1px solid var(--border, #2a2f37);
   display: grid;
-  gap: 8px;
+  gap: var(--space-2);
 }
 .rc-mixer-logic__header {
   display: flex;
   align-items: flex-start;
   justify-content: space-between;
-  gap: 12px;
+  gap: var(--space-3);
 }
 .rc-mixer-logic__header small {
   display: block;
@@ -9184,7 +9214,7 @@ details.metadata-settings-section:not([open]) > summary::after {
   display: flex;
   flex-wrap: wrap;
   align-items: end;
-  gap: 8px;
+  gap: var(--space-2);
   padding: 8px;
   border: 1px solid var(--border, #2a2f37);
   border-radius: var(--radius-md);
@@ -9215,7 +9245,7 @@ details.metadata-settings-section:not([open]) > summary::after {
 .rc-mixer-vtx-level-note {
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: var(--space-2);
   font-size: var(--text-sm);
   color: var(--warning, #b8860b);
 }
@@ -9223,13 +9253,13 @@ details.metadata-settings-section:not([open]) > summary::after {
 /* AP_RC_Logic engine controls (shown when the firmware supports RCL_*). */
 .rc-mixer-engine {
   display: grid;
-  gap: 8px;
+  gap: var(--space-2);
   margin-bottom: 12px;
 }
 .rc-mixer-engine__toggle {
   display: inline-flex;
   align-items: center;
-  gap: 8px;
+  gap: var(--space-2);
   cursor: pointer;
   font-size: var(--text-lg);
 }
@@ -9371,7 +9401,7 @@ details.metadata-settings-section:not([open]) > summary::after {
 
 .rc-mixer-channel {
   display: grid;
-  gap: 4px;
+  gap: var(--space-1);
   padding: 6px 10px;
   border-radius: var(--radius-md);
   border: 1px solid var(--border);
@@ -9382,7 +9412,7 @@ details.metadata-settings-section:not([open]) > summary::after {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 8px;
+  gap: var(--space-2);
   flex-wrap: wrap;
 }
 
@@ -9432,7 +9462,7 @@ details.metadata-settings-section:not([open]) > summary::after {
 .rc-mixer-assignment__range,
 .rc-mixer-assignment__status {
   display: grid;
-  gap: 4px;
+  gap: var(--space-1);
   min-width: 0;
 }
 
@@ -9541,7 +9571,7 @@ details.metadata-settings-section:not([open]) > summary::after {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 16px;
+  gap: var(--space-4);
   flex-wrap: wrap;
   margin-bottom: 14px;
   padding: 12px 14px;
@@ -9576,7 +9606,7 @@ details.metadata-settings-section:not([open]) > summary::after {
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 8px;
+  gap: var(--space-2);
   margin-top: 6px;
 }
 .board-orientation-diagram__stage {
@@ -9757,7 +9787,7 @@ details.metadata-settings-section:not([open]) > summary::after {
 .can-bus-header__status {
   display: flex;
   flex-direction: column;
-  gap: 4px;
+  gap: var(--space-1);
 }
 
 .can-bus-header__status small {
@@ -9856,7 +9886,7 @@ details.metadata-settings-section:not([open]) > summary::after {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  gap: 12px;
+  gap: var(--space-3);
   flex-wrap: wrap;
 }
 
@@ -9870,7 +9900,7 @@ details.metadata-settings-section:not([open]) > summary::after {
 .can-bus-node__name-row {
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: var(--space-2);
 }
 
 .can-bus-node__name-row strong {
@@ -9929,7 +9959,7 @@ details.metadata-settings-section:not([open]) > summary::after {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  gap: 12px;
+  gap: var(--space-3);
   flex-wrap: wrap;
 }
 
@@ -9946,12 +9976,12 @@ details.metadata-settings-section:not([open]) > summary::after {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 12px;
+  gap: var(--space-3);
 }
 
 .can-bus-staged__buttons {
   display: flex;
-  gap: 8px;
+  gap: var(--space-2);
 }
 
 .can-bus-staged__list {
@@ -9963,7 +9993,7 @@ details.metadata-settings-section:not([open]) > summary::after {
 .can-bus-staged__list li {
   display: flex;
   align-items: center;
-  gap: 12px;
+  gap: var(--space-3);
   padding: 4px 0;
   border-top: 1px solid rgba(var(--edge-rgb), 0.06);
 }
@@ -10043,7 +10073,7 @@ details.metadata-settings-section:not([open]) > summary::after {
 .port-board-links {
   display: flex;
   flex-wrap: wrap;
-  gap: 8px;
+  gap: var(--space-2);
 }
 
 .port-board-links a {
@@ -10064,7 +10094,7 @@ details.metadata-settings-section:not([open]) > summary::after {
 
 .port-board-debug {
   display: grid;
-  gap: 8px;
+  gap: var(--space-2);
 }
 
 .port-board-debug summary {
@@ -10099,7 +10129,7 @@ details.metadata-settings-section:not([open]) > summary::after {
 
 .board-media-lightbox__frame {
   display: grid;
-  gap: 16px;
+  gap: var(--space-4);
   width: min(1040px, 100%);
   max-height: calc(100vh - 64px);
   padding: 20px;
@@ -10112,7 +10142,7 @@ details.metadata-settings-section:not([open]) > summary::after {
 .board-media-lightbox__header {
   display: flex;
   justify-content: space-between;
-  gap: 16px;
+  gap: var(--space-4);
   align-items: flex-start;
 }
 
@@ -10141,7 +10171,7 @@ details.metadata-settings-section:not([open]) > summary::after {
    (no lightbox chrome). Stacks the acks / tabs / panels / apply-bar. */
 .motor-reorder-inline {
   display: grid;
-  gap: 12px;
+  gap: var(--space-3);
 }
 
 /* Calm single-line status shown in place of the panel during an apply-and-reboot
@@ -10168,7 +10198,7 @@ details.metadata-settings-section:not([open]) > summary::after {
 .motor-reorder-lightbox__grid {
   display: grid;
   grid-template-columns: minmax(320px, 0.95fr) minmax(340px, 1.05fr);
-  gap: 16px;
+  gap: var(--space-4);
   align-items: start;
 }
 
@@ -10195,7 +10225,7 @@ details.metadata-settings-section:not([open]) > summary::after {
 .motor-reorder-lightbox__apply-bar {
   display: flex;
   flex-direction: column;
-  gap: 8px;
+  gap: var(--space-2);
   margin-top: 14px;
   padding-top: 14px;
   border-top: 1px solid var(--surface-400);
@@ -10210,40 +10240,61 @@ details.metadata-settings-section:not([open]) > summary::after {
  * a primary-tinted underline so it reads at a glance against the dialog
  * surround. */
 /* Superseded by .tab-strip — kept only for any stale markup. */
+/* The app's second tab implementation. It shared no property with .tab-strip:
+ * underline instead of outline, borderless, uppercase with tracking, its own
+ * padding. Same widget, drawn two ways, so it now borrows the real one. The
+ * lightbox keeps its own strip container (it sits inside a modal, not under a
+ * page title). */
 .motor-reorder-lightbox__tabs {
   display: inline-flex;
-  gap: 4px;
-  border-bottom: 1px solid var(--surface-400);
-  margin: 0 0 14px;
-  padding: 0;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin: 0 0 var(--space-3);
+  padding-bottom: var(--space-2);
+  border-bottom: 1px solid var(--border);
 }
 
 .motor-reorder-lightbox__tab {
-  padding: 8px 16px;
-  background: transparent;
-  border: none;
-  border-bottom: 2px solid transparent;
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+  padding: 8px 14px;
+  border: 2px solid var(--border);
+  border-radius: var(--radius-md);
+  background: color-mix(in srgb, var(--text) 4%, transparent);
   color: var(--text-muted);
   font: inherit;
-  font-size: var(--text-md);
-  letter-spacing: var(--tracking-label);
-  text-transform: uppercase;
+  font-weight: 600;
   cursor: pointer;
+  transition: border-color 120ms ease, background-color 120ms ease, color 120ms ease;
 }
 
 .motor-reorder-lightbox__tab:hover {
   color: var(--text);
+  border-color: color-mix(in srgb, var(--accent) 50%, var(--border));
+}
+
+.motor-reorder-lightbox__tab:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
 }
 
 .motor-reorder-lightbox__tab.is-active {
-  color: var(--text);
-  border-bottom-color: var(--primary-500);
+  color: var(--accent);
+  border-color: var(--accent);
+  background: color-mix(in srgb, var(--accent) 14%, transparent);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .motor-reorder-lightbox__tab {
+    transition: none;
+  }
 }
 
 .motor-reorder-lightbox__direction {
   display: grid;
   grid-template-columns: minmax(320px, 0.95fr) minmax(340px, 1.05fr);
-  gap: 16px;
+  gap: var(--space-4);
   align-items: start;
 }
 
@@ -10268,7 +10319,7 @@ details.metadata-settings-section:not([open]) > summary::after {
 .motor-reorder-autospin {
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: var(--space-2);
   margin-top: 8px;
   font-size: var(--text-md);
   color: var(--text-muted);
@@ -10289,7 +10340,7 @@ details.metadata-settings-section:not([open]) > summary::after {
 .motor-reorder-table__row {
   display: grid;
   grid-template-columns: 88px 96px minmax(0, 1fr);
-  gap: 12px;
+  gap: var(--space-3);
   align-items: center;
   padding: 12px 14px;
   background: rgba(var(--fill-rgb), 0.96);
@@ -10387,7 +10438,7 @@ details.metadata-settings-section:not([open]) > summary::after {
 }
 
 .telemetry-stack--ports .port-card {
-  gap: 12px;
+  gap: var(--space-3);
   border-radius: var(--radius-xl);
   border-width: 1px;
   border-color: rgba(var(--edge-rgb), 0.04);
@@ -10395,7 +10446,7 @@ details.metadata-settings-section:not([open]) > summary::after {
 }
 
 .telemetry-stack--ports .port-row {
-  gap: 12px;
+  gap: var(--space-3);
   border-radius: var(--radius-xl);
 }
 
@@ -10421,7 +10472,7 @@ details.metadata-settings-section:not([open]) > summary::after {
 }
 
 .telemetry-stack--outputs .orientation-card {
-  gap: 16px;
+  gap: var(--space-4);
 }
 
 .telemetry-stack--outputs .config-pills:first-of-type,
@@ -10432,7 +10483,7 @@ details.metadata-settings-section:not([open]) > summary::after {
 .snapshot-capture-row {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 12px;
+  gap: var(--space-3);
   align-items: start;
 }
 
@@ -10488,12 +10539,12 @@ details.metadata-settings-section:not([open]) > summary::after {
 .snapshot-library-grid {
   display: grid;
   grid-template-columns: repeat(3, minmax(0, 1fr));
-  gap: 12px;
+  gap: var(--space-3);
 }
 
 .snapshot-card {
   display: grid;
-  gap: 8px;
+  gap: var(--space-2);
   width: 100%;
   padding: 10px 12px;
   border-radius: var(--radius-md);
@@ -10520,7 +10571,7 @@ details.metadata-settings-section:not([open]) > summary::after {
   display: flex;
   justify-content: space-between;
   align-items: flex-start;
-  gap: 12px;
+  gap: var(--space-3);
 }
 
 .snapshot-card__header strong {
@@ -10550,7 +10601,7 @@ details.metadata-settings-section:not([open]) > summary::after {
 
 .snapshot-selected {
   display: grid;
-  gap: 16px;
+  gap: var(--space-4);
   padding: 18px;
   border-radius: var(--radius-xl);
   border: 1px solid var(--card-outline);
@@ -10588,31 +10639,14 @@ details.metadata-settings-section:not([open]) > summary::after {
   color: var(--text-muted);
 }
 
-.snapshots-page,
-.tuning-page {
-  --snapshots-font-ui:
-    "Inter",
-    "SF Pro Display",
-    "SF Pro Text",
-    "Segoe UI",
-    system-ui,
-    sans-serif;
-  --snapshots-font-mono:
-    "JetBrains Mono",
-    "SFMono-Regular",
-    "SF Mono",
-    Consolas,
-    monospace;
-}
-
 .snapshots-page {
-  font-family: var(--snapshots-font-ui);
+  font-family: var(--font-ui);
   position: relative;
   isolation: isolate;
 }
 
 .snapshots-page .telemetry-stack {
-  gap: 12px;
+  gap: var(--space-3);
 }
 
 .snapshots-page::before {
@@ -10651,7 +10685,7 @@ details.metadata-settings-section:not([open]) > summary::after {
 }
 
 .snapshots-page__stack {
-  gap: 16px;
+  gap: var(--space-4);
 }
 
 .snapshots-page__hero {
@@ -10702,7 +10736,7 @@ details.metadata-settings-section:not([open]) > summary::after {
 .snapshots-page__hero-metrics {
   display: grid;
   grid-template-columns: repeat(3, minmax(0, 1fr));
-  gap: 12px;
+  gap: var(--space-3);
   align-self: end;
 }
 
@@ -10787,19 +10821,9 @@ details.metadata-settings-section:not([open]) > summary::after {
 }
 
 .snapshots-counter-chip {
-  display: inline-flex;
-  align-items: center;
   justify-content: center;
-  min-height: 28px;
-  padding: 6px 10px;
-  border-radius: 999px;
   background: rgba(var(--edge-rgb), 0.055);
   color: rgba(var(--ink-rgb), 0.88);
-  font-family: var(--snapshots-font-mono);
-  font-size: var(--text-sm);
-  font-weight: 600;
-  letter-spacing: var(--tracking-label);
-  text-transform: uppercase;
 }
 
 .snapshots-counter-chip.is-success {
@@ -10857,7 +10881,7 @@ details.metadata-settings-section:not([open]) > summary::after {
 
 .snapshots-field {
   display: grid;
-  gap: 8px;
+  gap: var(--space-2);
   padding: 0;
   border: none;
   background: transparent;
@@ -10875,7 +10899,7 @@ details.metadata-settings-section:not([open]) > summary::after {
   font-weight: 600;
   letter-spacing: var(--tracking-label);
   text-transform: uppercase;
-  font-family: var(--snapshots-font-ui);
+  font-family: var(--font-ui);
 }
 
 .snapshots-page .snapshots-field input,
@@ -10944,7 +10968,7 @@ details.metadata-settings-section:not([open]) > summary::after {
 .snapshots-capture-actions,
 .provisioning-capture-actions {
   display: grid;
-  gap: 16px;
+  gap: var(--space-4);
   align-items: start;
 }
 
@@ -10975,7 +10999,7 @@ details.metadata-settings-section:not([open]) > summary::after {
 
 .snapshots-setting-row span {
   display: grid;
-  gap: 4px;
+  gap: var(--space-1);
 }
 
 .snapshots-setting-row strong {
@@ -11005,7 +11029,7 @@ details.metadata-settings-section:not([open]) > summary::after {
   border-radius: var(--radius-md);
   min-height: 28px;
   padding: 0 12px;
-  font-family: var(--snapshots-font-ui);
+  font-family: var(--font-ui);
   font-size: var(--text-md);
   font-weight: 600;
   letter-spacing: 0.01em;
@@ -11099,7 +11123,7 @@ details.metadata-settings-section:not([open]) > summary::after {
 
 .snapshots-metrics-grid {
   grid-template-columns: repeat(4, minmax(0, 1fr));
-  gap: 12px;
+  gap: var(--space-3);
 }
 
 .snapshots-metric-card {
@@ -11113,7 +11137,7 @@ details.metadata-settings-section:not([open]) > summary::after {
 
 .snapshots-metric-card span {
   color: rgba(var(--ink-rgb), 0.48);
-  font-family: var(--snapshots-font-ui);
+  font-family: var(--font-ui);
   font-size: var(--text-sm);
   font-weight: 600;
   letter-spacing: 0.1em;
@@ -11194,7 +11218,7 @@ details.metadata-settings-section:not([open]) > summary::after {
 
 .snapshots-page .snapshot-card__header strong {
   margin-bottom: 4px;
-  font-family: var(--snapshots-font-ui);
+  font-family: var(--font-ui);
   font-size: var(--text-lg);
   font-weight: 600;
   letter-spacing: -0.01em;
@@ -11202,7 +11226,7 @@ details.metadata-settings-section:not([open]) > summary::after {
 }
 
 .snapshots-page .snapshot-card__header small {
-  font-family: var(--snapshots-font-mono);
+  font-family: var(--font-data);
   font-size: var(--text-sm);
   letter-spacing: 0.02em;
 }
@@ -11218,7 +11242,7 @@ details.metadata-settings-section:not([open]) > summary::after {
 .snapshots-page .config-pills {
   display: flex;
   flex-wrap: wrap;
-  gap: 8px;
+  gap: var(--space-2);
 }
 
 .snapshots-page .config-pills span {
@@ -11243,7 +11267,7 @@ details.metadata-settings-section:not([open]) > summary::after {
 .snapshots-empty-state,
 .snapshots-detail-panel {
   display: grid;
-  gap: 12px;
+  gap: var(--space-3);
   padding: 14px 16px;
   border-radius: var(--radius-2xl);
   background: rgba(var(--edge-rgb), 0.024);
@@ -11313,7 +11337,7 @@ details.metadata-settings-section:not([open]) > summary::after {
   display: flex;
   align-items: flex-end;
   justify-content: space-between;
-  gap: 16px;
+  gap: var(--space-4);
   padding-top: 4px;
 }
 
@@ -11329,7 +11353,7 @@ details.metadata-settings-section:not([open]) > summary::after {
 .snapshots-compare-picker {
   display: flex;
   flex-direction: column;
-  gap: 4px;
+  gap: var(--space-1);
   margin: 4px 0 8px;
   padding: 8px 10px;
   border-radius: var(--radius-sm);
@@ -11375,7 +11399,7 @@ details.metadata-settings-section:not([open]) > summary::after {
 }
 
 .snapshots-page .parameter-diff-group {
-  gap: 12px;
+  gap: var(--space-3);
   padding: 18px 0;
   border: none;
   border-radius: 0;
@@ -11439,7 +11463,7 @@ details.metadata-settings-section:not([open]) > summary::after {
 }
 
 .snapshots-page .snapshot-restore-ack {
-  gap: 12px;
+  gap: var(--space-3);
   padding: 15px 16px;
   border-radius: var(--radius-2xl);
   background: rgba(var(--edge-rgb), 0.025);
@@ -11454,7 +11478,7 @@ details.metadata-settings-section:not([open]) > summary::after {
 
 .snapshots-page .provisioning-checklist {
   display: grid;
-  gap: 12px;
+  gap: var(--space-3);
   padding: 18px 18px 16px;
   border-radius: var(--radius-2xl);
   background: rgba(var(--edge-rgb), 0.024);
@@ -11510,7 +11534,7 @@ details.metadata-settings-section:not([open]) > summary::after {
 
 .preset-group-grid {
   display: grid;
-  gap: 16px;
+  gap: var(--space-4);
 }
 
 .preset-group {
@@ -11532,7 +11556,7 @@ details.metadata-settings-section:not([open]) > summary::after {
   display: flex;
   justify-content: space-between;
   align-items: flex-start;
-  gap: 12px;
+  gap: var(--space-3);
 }
 
 .preset-group__header strong {
@@ -11552,12 +11576,12 @@ details.metadata-settings-section:not([open]) > summary::after {
 .preset-card-grid {
   display: grid;
   grid-template-columns: repeat(3, minmax(0, 1fr));
-  gap: 12px;
+  gap: var(--space-3);
 }
 
 .preset-card {
   display: grid;
-  gap: 8px;
+  gap: var(--space-2);
   width: 100%;
   padding: 10px 12px;
   border-radius: var(--radius-md);
@@ -11584,7 +11608,7 @@ details.metadata-settings-section:not([open]) > summary::after {
   display: flex;
   justify-content: space-between;
   align-items: flex-start;
-  gap: 12px;
+  gap: var(--space-3);
 }
 
 .preset-card__header strong {
@@ -11609,7 +11633,7 @@ details.metadata-settings-section:not([open]) > summary::after {
 
 .preset-selected {
   display: grid;
-  gap: 16px;
+  gap: var(--space-4);
   padding: 18px;
   border-radius: var(--radius-xl);
   border: 1px solid var(--border);
@@ -11621,12 +11645,12 @@ details.metadata-settings-section:not([open]) > summary::after {
 .preset-selected__badges {
   display: flex;
   flex-wrap: wrap;
-  gap: 8px;
+  gap: var(--space-2);
 }
 
 .preset-notes {
   display: grid;
-  gap: 8px;
+  gap: var(--space-2);
 }
 
 .preset-notes strong {
@@ -11689,13 +11713,13 @@ details.metadata-settings-section:not([open]) > summary::after {
 .motor-test-grid {
   display: grid;
   grid-template-columns: repeat(3, minmax(0, 1fr));
-  gap: 12px;
+  gap: var(--space-3);
 }
 
 .motor-test-grid label,
 .motor-test-acknowledgments label {
   display: grid;
-  gap: 8px;
+  gap: var(--space-2);
 }
 
 .motor-test-grid span {
@@ -11780,7 +11804,7 @@ details.metadata-settings-section:not([open]) > summary::after {
 .status-entry {
   display: grid;
   grid-template-columns: 88px minmax(0, 1fr);
-  gap: 12px;
+  gap: var(--space-3);
   padding: 12px 14px;
   border-radius: var(--radius-lg);
   border: 1px solid var(--border);
@@ -11802,7 +11826,7 @@ details.metadata-settings-section:not([open]) > summary::after {
 .setup-grid {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 16px;
+  gap: var(--space-4);
 }
 
 .setup-card {
@@ -11814,12 +11838,12 @@ details.metadata-settings-section:not([open]) > summary::after {
 
 .guided-actions {
   display: grid;
-  gap: 12px;
+  gap: var(--space-3);
 }
 
 .guided-action-card {
   display: grid;
-  gap: 12px;
+  gap: var(--space-3);
   padding: 14px;
   border-radius: var(--radius-lg);
   border: 1px solid var(--border);
@@ -11830,7 +11854,7 @@ details.metadata-settings-section:not([open]) > summary::after {
   display: flex;
   justify-content: space-between;
   align-items: flex-start;
-  gap: 12px;
+  gap: var(--space-3);
 }
 
 .guided-action-summary {
@@ -11847,7 +11871,7 @@ details.metadata-settings-section:not([open]) > summary::after {
 .guided-action-log {
   display: flex;
   flex-wrap: wrap;
-  gap: 8px;
+  gap: var(--space-2);
 }
 
 .guided-action-log span {
@@ -11889,7 +11913,7 @@ details.metadata-settings-section:not([open]) > summary::after {
 .parameter-pills {
   display: flex;
   flex-wrap: wrap;
-  gap: 8px;
+  gap: var(--space-2);
   margin-bottom: 14px;
 }
 
@@ -11924,7 +11948,7 @@ details.metadata-settings-section:not([open]) > summary::after {
 
 .parameter-review {
   display: grid;
-  gap: 12px;
+  gap: var(--space-3);
   margin-bottom: 24px;
   padding: 12px 14px;
   border-radius: var(--radius-xl);
@@ -11936,7 +11960,7 @@ details.metadata-settings-section:not([open]) > summary::after {
   display: flex;
   align-items: flex-start;
   justify-content: space-between;
-  gap: 16px;
+  gap: var(--space-4);
 }
 
 .parameter-review__stats {
@@ -11974,7 +11998,7 @@ details.metadata-settings-section:not([open]) > summary::after {
 .parameter-review__notice {
   display: flex;
   align-items: flex-start;
-  gap: 12px;
+  gap: var(--space-3);
   padding: 14px 16px;
   border-radius: var(--radius-lg);
   border: 1px solid rgba(var(--edge-rgb), 0.04);
@@ -11996,7 +12020,7 @@ details.metadata-settings-section:not([open]) > summary::after {
 .parameter-follow-up {
   display: flex;
   align-items: flex-start;
-  gap: 12px;
+  gap: var(--space-3);
   padding: 14px 16px;
   border-radius: var(--radius-lg);
   border: 1px solid rgba(var(--edge-rgb), 0.04);
@@ -12017,7 +12041,7 @@ details.metadata-settings-section:not([open]) > summary::after {
   margin-left: auto;
   display: flex;
   flex-wrap: wrap;
-  gap: 8px;
+  gap: var(--space-2);
 }
 
 .parameter-backup-input {
@@ -12042,7 +12066,7 @@ details.metadata-settings-section:not([open]) > summary::after {
 .parameter-import-exclusions {
   display: inline-flex;
   align-items: center;
-  gap: 12px;
+  gap: var(--space-3);
   margin: 0;
   padding: 4px 12px 6px;
   border: 1px solid var(--border-subtle, rgba(var(--edge-rgb), 0.12));
@@ -12072,12 +12096,12 @@ details.metadata-settings-section:not([open]) > summary::after {
 
 .parameter-diff-grid {
   display: grid;
-  gap: 12px;
+  gap: var(--space-3);
 }
 
 .parameter-diff-group {
   display: grid;
-  gap: 12px;
+  gap: var(--space-3);
   padding: 16px;
   border-radius: var(--radius-xl);
   border: 1px solid var(--border);
@@ -12093,7 +12117,7 @@ details.metadata-settings-section:not([open]) > summary::after {
   display: flex;
   align-items: baseline;
   justify-content: space-between;
-  gap: 12px;
+  gap: var(--space-3);
   color: var(--text-muted);
   text-transform: uppercase;
   letter-spacing: var(--tracking-label);
@@ -12123,7 +12147,7 @@ details.metadata-settings-section:not([open]) > summary::after {
 .parameter-diff-item {
   display: grid;
   grid-template-columns: minmax(140px, 1fr) minmax(180px, 1fr) minmax(140px, 0.8fr) auto;
-  gap: 12px;
+  gap: var(--space-3);
   align-items: center;
   padding-top: 12px;
   border-top: 1px solid rgba(39, 49, 59, 0.72);
@@ -12137,7 +12161,7 @@ details.metadata-settings-section:not([open]) > summary::after {
 .parameter-diff-actions {
   display: flex;
   flex-wrap: wrap;
-  gap: 8px;
+  gap: var(--space-2);
   align-items: center;
   justify-content: flex-end;
   /* .parameter-diff-item is a grid, so the actions cell also has to place
@@ -12207,7 +12231,7 @@ details.metadata-settings-section:not([open]) > summary::after {
 
 .parameter-diff-bulk {
   display: flex;
-  gap: 12px;
+  gap: var(--space-3);
   align-items: center;
 }
 
@@ -12287,7 +12311,7 @@ details.metadata-settings-section:not([open]) > summary::after {
 .create-preset__field {
   display: flex;
   flex-direction: column;
-  gap: 4px;
+  gap: var(--space-1);
   font-size: var(--text-lg);
 }
 
@@ -12315,7 +12339,7 @@ details.metadata-settings-section:not([open]) > summary::after {
 .create-preset__question {
   display: flex;
   flex-direction: column;
-  gap: 4px;
+  gap: var(--space-1);
   padding: 10px;
   border: 1px solid var(--surface-400);
   border-radius: var(--radius-md);
@@ -12324,7 +12348,7 @@ details.metadata-settings-section:not([open]) > summary::after {
 
 .create-preset__question > label {
   display: flex;
-  gap: 8px;
+  gap: var(--space-2);
   align-items: flex-start;
   cursor: pointer;
 }
@@ -12348,7 +12372,7 @@ details.metadata-settings-section:not([open]) > summary::after {
 
 .create-preset__cells {
   display: inline-flex;
-  gap: 8px;
+  gap: var(--space-2);
   align-items: center;
   font-size: var(--text-md);
   color: var(--text-muted);
@@ -12361,7 +12385,7 @@ details.metadata-settings-section:not([open]) > summary::after {
 .create-preset__params > header {
   display: flex;
   flex-wrap: wrap;
-  gap: 8px;
+  gap: var(--space-2);
   align-items: baseline;
   justify-content: space-between;
   margin-bottom: 6px;
@@ -12379,7 +12403,7 @@ details.metadata-settings-section:not([open]) > summary::after {
 .create-preset__param {
   display: grid;
   grid-template-columns: minmax(0, 1.2fr) minmax(0, 1.4fr) minmax(0, 0.8fr) auto;
-  gap: 8px;
+  gap: var(--space-2);
   align-items: center;
   padding: 6px 10px;
   font-size: var(--text-md);
@@ -12397,7 +12421,7 @@ details.metadata-settings-section:not([open]) > summary::after {
 
 .create-preset__param-id {
   display: inline-flex;
-  gap: 4px;
+  gap: var(--space-1);
   align-items: center;
   min-width: 0;
 }
@@ -12427,7 +12451,7 @@ details.metadata-settings-section:not([open]) > summary::after {
 
 .preset-serial-remap > label {
   display: inline-flex;
-  gap: 8px;
+  gap: var(--space-2);
   align-items: center;
   font-size: var(--text-lg);
   color: var(--text-muted);
@@ -12560,7 +12584,7 @@ details.metadata-settings-section:not([open]) > summary::after {
 .parameter-option-list {
   display: flex;
   flex-wrap: wrap;
-  gap: 8px;
+  gap: var(--space-2);
 }
 
 .parameter-option-list span {
@@ -12652,7 +12676,7 @@ details.metadata-settings-section:not([open]) > summary::after {
 .parameter-detail__head {
   display: flex;
   align-items: baseline;
-  gap: 12px;
+  gap: var(--space-3);
   flex-wrap: wrap;
 }
 .parameter-detail__head strong {
@@ -12697,7 +12721,7 @@ details.metadata-settings-section:not([open]) > summary::after {
 .parameter-detail__value-row {
   display: flex;
   flex-wrap: wrap;
-  gap: 16px;
+  gap: var(--space-4);
   align-items: flex-end;
 }
 .parameter-detail__field {
@@ -12794,7 +12818,7 @@ details.metadata-settings-section:not([open]) > summary::after {
   display: flex;
   flex-wrap: wrap;
   align-items: center;
-  gap: 8px;
+  gap: var(--space-2);
 }
 
 .parameter-actions__idle {
@@ -12912,7 +12936,7 @@ details.metadata-settings-section:not([open]) > summary::after {
      chips overflowed the viewport. */
   .header-quad-status {
     padding: 5px 9px;
-    gap: 4px;
+    gap: var(--space-1);
   }
 
   .header-battery-icon {
@@ -13226,7 +13250,7 @@ details.metadata-settings-section:not([open]) > summary::after {
 
 .landing__hero {
   display: grid;
-  gap: 12px;
+  gap: var(--space-3);
   max-width: 760px;
 }
 
@@ -13240,7 +13264,7 @@ details.metadata-settings-section:not([open]) > summary::after {
 
 .landing__connect {
   display: grid;
-  gap: 12px;
+  gap: var(--space-3);
   padding: 14px 16px;
   border-radius: var(--radius-xl);
   border: 1px solid var(--border-accent);
@@ -13249,7 +13273,7 @@ details.metadata-settings-section:not([open]) > summary::after {
 
 .landing__connect-copy {
   display: grid;
-  gap: 4px;
+  gap: var(--space-1);
 }
 
 .landing__connect-copy h2 {
@@ -13267,7 +13291,7 @@ details.metadata-settings-section:not([open]) > summary::after {
 .landing__connect-form {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
-  gap: 12px;
+  gap: var(--space-3);
   align-items: end;
 }
 
@@ -13315,13 +13339,18 @@ details.metadata-settings-section:not([open]) > summary::after {
   border-color: var(--primary-500);
 }
 
+/* The commit colour is --primary-action (green): the header's Connect, Apply
+ * Config, Save OSD and Apply Port Changes all use it. This button was amber,
+ * so the landing screen showed the same verb -- Connect -- in two different
+ * colours at once, one in the card and one in the header. Amber stays what it
+ * is everywhere else: selection and accent, not commit. */
 .landing__connect-button {
   height: 32px;
-  padding: 0 16px;
+  padding: 0 var(--space-4);
   border-radius: var(--radius-md);
-  border: 1px solid var(--primary-500);
-  background: var(--primary-500);
-  color: var(--text-on-light);
+  border: 1px solid var(--primary-action-border);
+  background: linear-gradient(180deg, var(--primary-action), var(--primary-action-border));
+  color: #0a1308;
   font-size: var(--text-xl);
   font-weight: 600;
   letter-spacing: 0.02em;
@@ -13385,7 +13414,7 @@ details.metadata-settings-section:not([open]) > summary::after {
 .dfu-hex-flasher__activate {
   display: flex;
   flex-wrap: wrap;
-  gap: 8px;
+  gap: var(--space-2);
   margin: 0 0 12px;
 }
 .dfu-hex-flasher__help {
@@ -13402,7 +13431,7 @@ details.metadata-settings-section:not([open]) > summary::after {
   padding-left: 18px;
   display: flex;
   flex-direction: column;
-  gap: 4px;
+  gap: var(--space-1);
 }
 /* Three-step DFU progress: erase -> write -> verify, each with its own bar. */
 .dfu-hex-flasher__steps {
@@ -13441,7 +13470,7 @@ details.metadata-settings-section:not([open]) > summary::after {
 .dfu-hex-flasher__full-erase {
   display: flex;
   align-items: flex-start;
-  gap: 8px;
+  gap: var(--space-2);
   margin: 12px 0;
   font-size: var(--text-md);
   color: var(--text-muted);
@@ -13513,7 +13542,7 @@ details.metadata-settings-section:not([open]) > summary::after {
   flex: 1 1 auto;
   display: flex;
   flex-direction: column;
-  gap: 4px;
+  gap: var(--space-1);
   min-width: 0;
 }
 
@@ -13534,7 +13563,7 @@ details.metadata-settings-section:not([open]) > summary::after {
 .firmware-replug-prompt {
   display: flex;
   flex-direction: column;
-  gap: 8px;
+  gap: var(--space-2);
   margin: 14px 0;
   padding: 12px 14px;
   border: 1px solid var(--border);
@@ -13607,7 +13636,7 @@ details.metadata-settings-section:not([open]) > summary::after {
 .firmware-wizard__steps > li {
   display: flex;
   flex-direction: column;
-  gap: 8px;
+  gap: var(--space-2);
   padding: 12px 14px;
   border: 1px solid var(--border, #3d3d3d);
   border-radius: var(--radius-md);
@@ -13620,7 +13649,7 @@ details.metadata-settings-section:not([open]) > summary::after {
 
 .firmware-wizard__row {
   display: flex;
-  gap: 12px;
+  gap: var(--space-3);
   flex-wrap: wrap;
 }
 
@@ -13651,7 +13680,7 @@ details.metadata-settings-section:not([open]) > summary::after {
   display: flex;
   flex-direction: row;
   align-items: center;
-  gap: 8px;
+  gap: var(--space-2);
   margin: 8px 0;
   /* Plain inline confirm, not a heavy bordered field-card — it was reading as
      obnoxious for a single safety checkbox. */
@@ -13677,12 +13706,12 @@ details.metadata-settings-section:not([open]) > summary::after {
 
 .landing__section {
   display: grid;
-  gap: 16px;
+  gap: var(--space-4);
 }
 
 .landing__section-header {
   display: grid;
-  gap: 4px;
+  gap: var(--space-1);
 }
 
 .landing__section-header h2 {
@@ -13703,7 +13732,7 @@ details.metadata-settings-section:not([open]) > summary::after {
   padding: 0;
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-  gap: 12px;
+  gap: var(--space-3);
 }
 
 .landing__capability {
@@ -13795,7 +13824,7 @@ details.metadata-settings-section:not([open]) > summary::after {
 /* Modes view: read-only flight-mode slot table with live indicator. */
 .modes-stack {
   display: grid;
-  gap: 12px;
+  gap: var(--space-3);
 }
 
 .modes-status {
@@ -13810,7 +13839,7 @@ details.metadata-settings-section:not([open]) > summary::after {
   display: flex;
   flex-wrap: wrap;
   align-items: baseline;
-  column-gap: 8px;
+  column-gap: var(--space-2);
   row-gap: 1px;
   padding: 7px 12px;
   border-radius: var(--radius-md);
@@ -13980,7 +14009,7 @@ details.metadata-settings-section:not([open]) > summary::after {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 16px;
+  gap: var(--space-4);
   padding: 12px 16px;
   border-radius: var(--radius-md);
   border: 1px solid var(--card-outline);
@@ -14244,7 +14273,7 @@ details.metadata-settings-section:not([open]) > summary::after {
 
 .failsafe-placeholder {
   display: grid;
-  gap: 8px;
+  gap: var(--space-2);
   padding: var(--card-padding, 12px);
   border-radius: var(--radius-md);
   border: 1px dashed var(--surface-500);
@@ -14284,7 +14313,7 @@ details.metadata-settings-section:not([open]) > summary::after {
      few cards, so cap the width so 2-3 cards read as a calm flow rather than
      spreading thin across a wide screen. */
   columns: 360px 3;
-  column-gap: var(--space-3, 12px);
+  column-gap: var(--space-3);
   padding-right: 6px;
   max-width: 1180px;
 }
@@ -14292,7 +14321,7 @@ details.metadata-settings-section:not([open]) > summary::after {
 /* Category tab strip — reuses .tab-strip; a little breathing room + the
    unsaved-changes dot on a group you're not looking at. */
 .config-category-nav {
-  margin-bottom: var(--space-3, 12px);
+  margin-bottom: var(--space-3);
 }
 .config-category-nav__dot {
   display: inline-block;
@@ -14352,14 +14381,14 @@ details.metadata-settings-section:not([open]) > summary::after {
 
 .config-section {
   display: grid;
-  gap: var(--space-2, 8px);
+  gap: var(--space-2);
   padding: var(--card-padding, 12px);
   border-radius: var(--radius-md);
   border: 1px solid var(--surface-400);
   background: var(--surface-200);
   /* Multicolumn item: keep a card whole and space it from the next one. */
   break-inside: avoid;
-  margin-bottom: var(--space-3, 12px);
+  margin-bottom: var(--space-3);
 }
 
 .config-section--planned {
@@ -14398,13 +14427,13 @@ details.metadata-settings-section:not([open]) > summary::after {
 .config-section__values {
   margin: 0;
   display: grid;
-  gap: 4px;
+  gap: var(--space-1);
 }
 
 .config-section__value-row {
   display: grid;
   grid-template-columns: 1fr auto;
-  gap: 8px;
+  gap: var(--space-2);
   padding: 4px 0;
   border-bottom: 1px solid var(--surface-300);
   font-size: var(--text-md);
@@ -14440,7 +14469,7 @@ details.metadata-settings-section:not([open]) > summary::after {
 }
 
 .config-grid__footnote {
-  margin: var(--space-3, 12px) 0 0;
+  margin: var(--space-3) 0 0;
   color: var(--text-muted);
   font-size: var(--text-sm);
   line-height: 1.5;
@@ -14455,7 +14484,7 @@ details.metadata-settings-section:not([open]) > summary::after {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  gap: 12px;
+  gap: var(--space-3);
 }
 
 /* OSD custom-abbreviation (shorthand) editor — a small from→to table under the
@@ -14463,7 +14492,7 @@ details.metadata-settings-section:not([open]) > summary::after {
 .osd-shorthand {
   margin-top: 12px;
   display: grid;
-  gap: 8px;
+  gap: var(--space-2);
 }
 .osd-shorthand__header {
   display: flex;
@@ -14478,7 +14507,7 @@ details.metadata-settings-section:not([open]) > summary::after {
   display: grid;
   grid-template-columns: minmax(0, 1.4fr) auto minmax(0, 1fr) auto;
   align-items: center;
-  gap: 8px;
+  gap: var(--space-2);
 }
 .osd-shorthand__row input {
   min-width: 0;
@@ -14537,7 +14566,7 @@ details.metadata-settings-section:not([open]) > summary::after {
 }
 .osd-shorthand__actions {
   display: flex;
-  gap: 8px;
+  gap: var(--space-2);
   flex-wrap: wrap;
 }
 @media (max-width: 480px) {
@@ -14594,13 +14623,13 @@ details.bf-gui-box:not([open]) > summary::after {
   /* Preview column can shrink (its screen scales via aspect-ratio) so it
      never forces the layout wider than the content well. */
   grid-template-columns: minmax(0, 1.05fr) minmax(0, 0.95fr);
-  gap: var(--space-3, 12px);
+  gap: var(--space-3);
   align-items: start;
 }
 
 .osd-bf-menu {
   display: grid;
-  gap: var(--space-3, 12px);
+  gap: var(--space-3);
   align-content: start;
 }
 
@@ -14616,7 +14645,7 @@ details.bf-gui-box:not([open]) > summary::after {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  gap: 12px;
+  gap: var(--space-3);
 }
 
 .osd-bf-preview .bf-gui-box__titlebar small {
@@ -14641,7 +14670,7 @@ details.bf-gui-box:not([open]) > summary::after {
 
 .config-section__editors {
   display: grid;
-  gap: var(--space-2, 8px);
+  gap: var(--space-2);
 }
 
 .config-section__editors .scoped-editor-field {
@@ -14766,7 +14795,7 @@ details.bf-gui-box:not([open]) > summary::after {
 .config-section__missing-row {
   display: grid;
   grid-template-columns: 1fr auto;
-  gap: 4px;
+  gap: var(--space-1);
   padding: 6px 8px;
   border-radius: var(--radius-sm);
   border: 1px dashed var(--surface-400);
@@ -14794,8 +14823,8 @@ details.bf-gui-box:not([open]) > summary::after {
   display: flex;
   align-items: center;
   gap: 10px;
-  margin-top: var(--space-3, 12px);
-  padding-top: var(--space-3, 12px);
+  margin-top: var(--space-3);
+  padding-top: var(--space-3);
   border-top: 1px solid var(--surface-300);
   /* The grid is no longer internally scrolled, so pin the Apply/Revert bar to
      the bottom as the page scrolls — but ABOVE the fixed bottom status bar,
@@ -14803,7 +14832,7 @@ details.bf-gui-box:not([open]) > summary::after {
   position: sticky;
   bottom: var(--statusbar-height, 24px);
   background: var(--bg-panel, var(--surface-100));
-  padding-bottom: var(--space-2, 8px);
+  padding-bottom: var(--space-2);
   z-index: 3;
 }
 
@@ -14818,8 +14847,8 @@ details.bf-gui-box:not([open]) > summary::after {
 .firmware-wizard__quick-actions {
   display: flex;
   flex-wrap: wrap;
-  gap: 8px;
-  margin-bottom: var(--space-3, 12px);
+  gap: var(--space-2);
+  margin-bottom: var(--space-3);
 }
 
 .firmware-wizard__dfu-button,
@@ -14837,18 +14866,18 @@ details.bf-gui-box:not([open]) > summary::after {
 
 .files-browser {
   display: grid;
-  gap: var(--space-3, 12px);
+  gap: var(--space-3);
 }
 
 .vehicle-output-summary {
   display: grid;
-  gap: var(--space-3, 12px);
+  gap: var(--space-3);
 }
 
 .files-toolbar {
   display: flex;
   flex-wrap: wrap;
-  gap: var(--space-3, 12px);
+  gap: var(--space-3);
   justify-content: space-between;
   align-items: center;
 }
@@ -14918,13 +14947,13 @@ details.bf-gui-box:not([open]) > summary::after {
 
 .files-toolbar__actions {
   display: flex;
-  gap: 8px;
+  gap: var(--space-2);
 }
 
 .files-path {
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: var(--space-2);
   font-size: var(--text-md);
 }
 
@@ -15009,7 +15038,7 @@ details.bf-gui-box:not([open]) > summary::after {
   display: flex;
   justify-content: space-between;
   align-items: flex-start;
-  gap: 12px;
+  gap: var(--space-3);
 }
 
 .vehicle-output-summary__header strong {
@@ -15128,13 +15157,13 @@ details.bf-gui-box:not([open]) > summary::after {
 .bootloader-identity__rows {
   margin: 0;
   display: grid;
-  gap: 4px;
+  gap: var(--space-1);
 }
 
 .bootloader-identity__row {
   display: grid;
   grid-template-columns: minmax(0, 110px) minmax(0, 1fr);
-  gap: 8px;
+  gap: var(--space-2);
   align-items: baseline;
 }
 
@@ -15181,7 +15210,7 @@ details.bf-gui-box:not([open]) > summary::after {
 
 .filter-bank__routing {
   display: grid;
-  gap: 8px;
+  gap: var(--space-2);
   margin-top: 10px;
   padding: 10px 12px;
   border-radius: var(--radius-lg);
@@ -15206,7 +15235,7 @@ details.bf-gui-box:not([open]) > summary::after {
 
 .parameter-reference__row {
   display: grid;
-  gap: 4px;
+  gap: var(--space-1);
   padding: 8px 10px;
   border-radius: var(--radius-lg);
   border: 1px solid rgba(var(--edge-rgb), 0.05);
@@ -15218,7 +15247,7 @@ details.bf-gui-box:not([open]) > summary::after {
   display: flex;
   align-items: baseline;
   flex-wrap: wrap;
-  gap: 8px;
+  gap: var(--space-2);
   min-width: 0;
 }
 
@@ -15264,7 +15293,7 @@ details.bf-gui-box:not([open]) > summary::after {
 .guided-current-cal__steps {
   list-style: none;
   display: grid;
-  gap: 4px;
+  gap: var(--space-1);
   margin: 0;
   padding: 0;
 }
@@ -15285,7 +15314,7 @@ details.bf-gui-box:not([open]) > summary::after {
 .guided-current-cal__step-title {
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: var(--space-2);
   flex-wrap: wrap;
 }
 
@@ -15307,7 +15336,7 @@ details.bf-gui-box:not([open]) > summary::after {
 .guided-current-cal__step .scoped-editor-field {
   margin: 0;
   padding: 6px 8px;
-  gap: 4px;
+  gap: var(--space-1);
 }
 
 .guided-current-cal__step .scoped-editor-field span {
@@ -15357,7 +15386,7 @@ details.bf-gui-box:not([open]) > summary::after {
 .presets-share {
   display: flex;
   flex-wrap: wrap;
-  gap: 12px;
+  gap: var(--space-3);
   align-items: center;
   justify-content: space-between;
   padding: 12px 14px;
@@ -15376,7 +15405,7 @@ details.bf-gui-box:not([open]) > summary::after {
 .presets-erase {
   display: flex;
   flex-wrap: wrap;
-  gap: 12px;
+  gap: var(--space-3);
   align-items: center;
   justify-content: space-between;
   padding: 12px 14px;
@@ -15462,7 +15491,7 @@ details.bf-gui-box:not([open]) > summary::after {
 .osd-preview-screen-select {
   display: inline-flex;
   align-items: center;
-  gap: 8px;
+  gap: var(--space-2);
   margin-bottom: 8px;
 }
 .osd-preview-screen-select > span {
@@ -15499,7 +15528,7 @@ details.bf-gui-box:not([open]) > summary::after {
   display: grid;
   grid-template-columns: minmax(130px, 1.5fr) repeat(4, 46px);
   align-items: center;
-  column-gap: 4px;
+  column-gap: var(--space-1);
   padding: 2px 6px;
   border-radius: var(--radius-sm);
 }
@@ -15661,7 +15690,7 @@ details.bf-gui-box:not([open]) > summary::after {
 .receiver-stick-craft {
   display: flex;
   flex-direction: column;
-  gap: 4px;
+  gap: var(--space-1);
   margin-bottom: 10px;
 }
 .receiver-stick-craft small {
@@ -15677,7 +15706,7 @@ details.bf-gui-box:not([open]) > summary::after {
 .calibration-card {
   display: flex;
   flex-direction: column;
-  gap: 8px;
+  gap: var(--space-2);
   padding: 14px;
   border: 1px solid var(--border);
   border-radius: var(--radius-lg);
@@ -15687,7 +15716,7 @@ details.bf-gui-box:not([open]) > summary::after {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 8px;
+  gap: var(--space-2);
 }
 .calibration-card__blocked {
   font-size: var(--text-sm);
@@ -15706,7 +15735,7 @@ details.bf-gui-box:not([open]) > summary::after {
   display: flex;
   align-items: baseline;
   justify-content: space-between;
-  gap: 8px;
+  gap: var(--space-2);
 }
 .esc-rpm-readout__summary {
   margin: 4px 0 0 0;
@@ -15784,7 +15813,7 @@ details.bf-gui-box:not([open]) > summary::after {
 .calibration-card__reboot {
   display: flex;
   flex-direction: column;
-  gap: 8px;
+  gap: var(--space-2);
   margin-top: 2px;
   padding: 10px;
   border: 1px solid var(--border);
@@ -15803,7 +15832,7 @@ details.bf-gui-box:not([open]) > summary::after {
 .calibration-card__reboot-actions {
   display: flex;
   flex-wrap: wrap;
-  gap: 8px;
+  gap: var(--space-2);
 }
 .calibration-card__reboot-note {
   font-size: var(--text-sm);
@@ -15866,7 +15895,7 @@ details.bf-gui-box:not([open]) > summary::after {
 }
 .valt-manual__row {
   display: flex;
-  gap: 8px;
+  gap: var(--space-2);
   align-items: flex-end;
   flex-wrap: wrap;
 }
@@ -15927,7 +15956,7 @@ details.bf-gui-box:not([open]) > summary::after {
 .motor-reverse-toggle {
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: var(--space-2);
   padding: 6px 10px;
   border-radius: var(--radius-md);
   border: 1px solid transparent;
@@ -15973,7 +16002,7 @@ details.bf-gui-box:not([open]) > summary::after {
   border-radius: var(--radius-lg);
   background: rgba(var(--edge-rgb), 0.025);
   display: grid;
-  gap: 8px;
+  gap: var(--space-2);
 }
 .firmware-wizard__browse-header {
   display: grid;
@@ -15987,7 +16016,7 @@ details.bf-gui-box:not([open]) > summary::after {
   display: flex;
   flex-wrap: wrap;
   align-items: end;
-  gap: 8px;
+  gap: var(--space-2);
 }
 .firmware-wizard__browse-list {
   list-style: none;
@@ -16045,7 +16074,7 @@ details.bf-gui-box:not([open]) > summary::after {
 
   .parameter-review {
     padding: 10px;
-    gap: 8px;
+    gap: var(--space-2);
     margin-bottom: 12px;
   }
 
@@ -16072,7 +16101,7 @@ details.bf-gui-box:not([open]) > summary::after {
 .cal-location {
   display: flex;
   flex-direction: column;
-  gap: 12px;
+  gap: var(--space-3);
 }
 
 .cal-location__heading {
@@ -16089,7 +16118,7 @@ details.bf-gui-box:not([open]) > summary::after {
   border: 1px solid var(--border);
   background: var(--surface-200);
   color: var(--text-muted);
-  font-family: Georgia, "Times New Roman", serif;
+  font-family: var(--font-data);
   font-style: italic;
   font-weight: 700;
   line-height: 1;
@@ -16150,14 +16179,14 @@ details.bf-gui-box:not([open]) > summary::after {
 .cal-location__actions {
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: var(--space-2);
   flex-wrap: wrap;
 }
 
 .cal-location__frame {
   display: flex;
   flex-direction: column;
-  gap: 12px;
+  gap: var(--space-3);
   width: min(560px, 92vw);
   max-width: 92vw;
   padding: 16px;
@@ -16167,7 +16196,7 @@ details.bf-gui-box:not([open]) > summary::after {
   display: flex;
   align-items: flex-start;
   justify-content: space-between;
-  gap: 12px;
+  gap: var(--space-3);
 }
 
 .cal-location__modal-header strong {
@@ -16183,7 +16212,7 @@ details.bf-gui-box:not([open]) > summary::after {
 /* MAVLink / DroneCAN inspector tables. */
 .mavlink-inspector__controls {
   display: flex;
-  gap: 8px;
+  gap: var(--space-2);
   align-items: center;
 }
 .mavlink-inspector__filter {
@@ -16194,7 +16223,7 @@ details.bf-gui-box:not([open]) > summary::after {
   display: flex;
   flex-wrap: wrap;
   align-items: end;
-  gap: 8px;
+  gap: var(--space-2);
   padding: 8px 10px;
   border: 1px solid var(--surface-300);
   border-radius: var(--radius-md);
@@ -16211,7 +16240,7 @@ details.bf-gui-box:not([open]) > summary::after {
   display: flex;
   flex-wrap: wrap;
   align-items: center;
-  gap: 8px;
+  gap: var(--space-2);
   padding: 8px 10px;
   border: 1px solid var(--surface-300);
   border-radius: var(--radius-md);
@@ -16277,7 +16306,7 @@ details.bf-gui-box:not([open]) > summary::after {
 .mavlink-inspector__sent-row {
   display: grid;
   grid-template-columns: minmax(0, 1fr) auto auto auto;
-  gap: 12px;
+  gap: var(--space-3);
   padding: 4px 8px;
   align-items: center;
 }
@@ -16452,7 +16481,7 @@ button.mavlink-inspector__sent-row {
 }
 .mavlink-inspector__field-actions {
   display: inline-flex;
-  gap: 4px;
+  gap: var(--space-1);
   justify-content: flex-end;
 }
 .mavlink-inspector__field-copy,
@@ -16494,7 +16523,7 @@ button.mavlink-inspector__sent-row {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 8px;
+  gap: var(--space-2);
   margin-bottom: 4px;
 }
 .mavlink-inspector__plot-title {
@@ -16661,7 +16690,7 @@ button.mavlink-inspector__sent-row {
   display: flex;
   flex-wrap: wrap;
   align-items: center;
-  gap: 8px;
+  gap: var(--space-2);
 }
 .dronecan-inspector__node-actions {
   margin-top: 12px;
@@ -16674,7 +16703,7 @@ button.mavlink-inspector__sent-row {
   margin-top: 12px;
   display: flex;
   flex-direction: column;
-  gap: 8px;
+  gap: var(--space-2);
   padding: 12px;
   border: 1px solid var(--surface-300);
   border-radius: var(--radius-md);
@@ -16684,14 +16713,14 @@ button.mavlink-inspector__sent-row {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 8px;
+  gap: var(--space-2);
   font-size: var(--text-lg);
   font-weight: 600;
 }
 .dronecan-inspector__fwupdate-file {
   display: flex;
   flex-direction: column;
-  gap: 4px;
+  gap: var(--space-1);
   font-size: var(--text-md);
   color: var(--text-muted);
 }
@@ -16715,18 +16744,18 @@ button.mavlink-inspector__sent-row {
   padding: 0;
   display: flex;
   flex-direction: column;
-  gap: 4px;
+  gap: var(--space-1);
 }
 .dronecan-inspector__fwupdate-online-list li {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 8px;
+  gap: var(--space-2);
 }
 .dronecan-inspector__fwupdate-ack {
   display: flex;
   align-items: flex-start;
-  gap: 8px;
+  gap: var(--space-2);
   font-size: var(--text-md);
   line-height: 1.4;
   padding: 8px;
@@ -16791,7 +16820,7 @@ button.mavlink-inspector__sent-row {
 .dronecan-inspector__esc-row {
   display: grid;
   grid-template-columns: 1.2fr 0.8fr 0.9fr 0.9fr 0.8fr 0.7fr 0.7fr 0.8fr;
-  gap: 8px;
+  gap: var(--space-2);
   align-items: center;
   padding: 6px 12px;
   font-family: var(--font-data);
@@ -16823,7 +16852,7 @@ button.mavlink-inspector__sent-row {
   display: flex;
   align-items: center;
   flex-wrap: wrap;
-  gap: 8px;
+  gap: var(--space-2);
   margin: 0;
   color: var(--text-muted);
   line-height: 1.5;
@@ -16856,7 +16885,7 @@ button.mavlink-inspector__sent-row {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 8px;
+  gap: var(--space-2);
 }
 .lua-section-head h3 {
   margin: 0;
@@ -16886,7 +16915,7 @@ button.mavlink-inspector__sent-row {
 .lua-card-head {
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: var(--space-2);
   flex-wrap: wrap;
 }
 .lua-card-name {
@@ -16897,7 +16926,7 @@ button.mavlink-inspector__sent-row {
 .lua-card-actions {
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: var(--space-2);
   margin-left: auto;
 }
 
@@ -16933,7 +16962,7 @@ button.mavlink-inspector__sent-row {
 /* Full description + prerequisite list, tucked inside the InfoDot tip. */
 .lua-info-body {
   display: grid;
-  gap: 8px;
+  gap: var(--space-2);
 }
 .lua-info-prereqs {
   display: grid;
@@ -16994,7 +17023,7 @@ button.mavlink-inspector__sent-row {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 8px;
+  gap: var(--space-2);
   padding: 6px 0;
   border-bottom: 1px solid var(--border-subtle, var(--border));
 }
@@ -17016,7 +17045,7 @@ button.mavlink-inspector__sent-row {
 .ai-assistant {
   display: flex;
   flex-direction: column;
-  gap: 12px;
+  gap: var(--space-3);
 }
 .ai-assistant__settings-disclosure > summary {
   cursor: pointer;
@@ -17027,13 +17056,13 @@ button.mavlink-inspector__sent-row {
 .ai-assistant__settings-grid {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
-  gap: 12px;
+  gap: var(--space-3);
 }
 .ai-assistant__settings-grid label,
 .ai-assistant__remember {
   display: flex;
   flex-direction: column;
-  gap: 4px;
+  gap: var(--space-1);
   font-size: 0.82em;
   color: var(--text-muted);
 }
@@ -17044,7 +17073,7 @@ button.mavlink-inspector__sent-row {
 .ai-assistant__remember {
   flex-direction: row;
   align-items: flex-start;
-  gap: 8px;
+  gap: var(--space-2);
   margin-top: 12px;
   line-height: 1.45;
 }
@@ -17101,12 +17130,7 @@ button.mavlink-inspector__sent-row {
   margin-top: 8px;
 }
 .ai-assistant__tool-chip {
-  font-family: var(--font-data);
-  font-size: 0.75em;
-  padding: 2px 7px;
-  border-radius: 999px;
-  border: 1px solid var(--border-subtle, var(--border));
-  color: var(--text-muted);
+  border-color: var(--border-subtle, var(--border));
   background: var(--bg-panel-soft);
 }
 .ai-assistant__tool-chip--done {
@@ -17116,7 +17140,7 @@ button.mavlink-inspector__sent-row {
 .ai-assistant__composer {
   display: flex;
   flex-direction: column;
-  gap: 8px;
+  gap: var(--space-2);
 }
 .ai-assistant__composer textarea {
   width: 100%;
@@ -17126,7 +17150,7 @@ button.mavlink-inspector__sent-row {
 .ai-assistant__composer-actions {
   display: flex;
   justify-content: flex-end;
-  gap: 8px;
+  gap: var(--space-2);
 }
 .ai-assistant__hint {
   margin: 0;
@@ -17150,7 +17174,7 @@ button.mavlink-inspector__sent-row {
   display: flex;
   flex-wrap: wrap;
   align-items: baseline;
-  gap: 8px;
+  gap: var(--space-2);
 }
 .ai-assistant__proposal-summary {
   color: var(--text-muted);
@@ -17175,7 +17199,7 @@ button.mavlink-inspector__sent-row {
   flex-wrap: wrap;
   align-items: baseline;
   justify-content: space-between;
-  gap: 8px;
+  gap: var(--space-2);
 }
 .ai-assistant__proposal-row-head code {
   font-family: var(--font-data);
@@ -17204,7 +17228,7 @@ button.mavlink-inspector__sent-row {
 .ai-assistant__proposal-ack {
   display: flex;
   align-items: flex-start;
-  gap: 8px;
+  gap: var(--space-2);
   font-size: 0.82em;
   color: var(--text-muted);
   line-height: 1.45;
@@ -17215,7 +17239,7 @@ button.mavlink-inspector__sent-row {
 }
 .ai-assistant__proposal-actions {
   display: flex;
-  gap: 8px;
+  gap: var(--space-2);
 }
 
 /* AI Assistant — model picker (dropdown fetched from the provider). */
@@ -17248,7 +17272,7 @@ button.mavlink-inspector__sent-row {
 .log-tuning__upload {
   display: flex;
   align-items: center;
-  gap: 12px;
+  gap: var(--space-3);
   margin: 12px 0;
 }
 .log-tuning__file {
@@ -17262,14 +17286,14 @@ button.mavlink-inspector__sent-row {
 }
 .log-tuning__results {
   display: grid;
-  gap: 12px;
+  gap: var(--space-3);
   margin-top: 12px;
 }
 .log-tuning__warnings {
   margin: 0;
   padding-left: 18px;
   display: grid;
-  gap: 4px;
+  gap: var(--space-1);
   color: var(--warning);
   font-size: 0.85em;
 }
@@ -17280,7 +17304,7 @@ button.mavlink-inspector__sent-row {
 .log-tuning__metrics {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
-  gap: 8px;
+  gap: var(--space-2);
 }
 .log-tuning__metrics article {
   display: grid;
@@ -17316,17 +17340,17 @@ button.mavlink-inspector__sent-row {
 }
 .log-tuning__recs {
   display: grid;
-  gap: 8px;
+  gap: var(--space-2);
 }
 .log-tuning__recs-header {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 12px;
+  gap: var(--space-3);
 }
 .log-tuning__rec {
   display: grid;
-  gap: 4px;
+  gap: var(--space-1);
   padding: 10px 12px;
   border-radius: var(--radius-md);
   background: var(--bg-panel-muted);
@@ -17369,7 +17393,7 @@ button.mavlink-inspector__sent-row {
 /* Log Tuning per-axis gyro spectrum charts. */
 .log-tuning__spectra {
   display: grid;
-  gap: 8px;
+  gap: var(--space-2);
 }
 .log-tuning__spectrum {
   display: grid;
@@ -17413,7 +17437,7 @@ button.mavlink-inspector__sent-row {
 
 .log-tuning__advisories {
   display: grid;
-  gap: 8px;
+  gap: var(--space-2);
 }
 
 /* Stale-link banner: the values on screen came from a link that has dropped
@@ -17429,7 +17453,7 @@ button.mavlink-inspector__sent-row {
 .workspace-note--stale__headline {
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: var(--space-2);
 }
 
 .workspace-note--stale__headline strong {
@@ -17500,7 +17524,7 @@ button.mavlink-inspector__sent-row {
 .receiver-functions-row {
   display: grid;
   grid-template-columns: 92px minmax(0, 1fr);
-  gap: 12px;
+  gap: var(--space-3);
   align-items: center;
   padding: 6px 8px;
   border-radius: var(--radius-md);
@@ -17535,7 +17559,7 @@ button.mavlink-inspector__sent-row {
 .parameter-import-prompt {
   display: flex;
   flex-wrap: wrap;
-  gap: 12px;
+  gap: var(--space-3);
   align-items: center;
   justify-content: space-between;
   padding: 12px 14px;
@@ -17558,7 +17582,7 @@ button.mavlink-inspector__sent-row {
 .parameter-import-prompt__actions {
   display: flex;
   flex-wrap: wrap;
-  gap: 8px;
+  gap: var(--space-2);
 }
 
 /* "Reset to Defaults" on Parameters and Snapshots. Mirrors the Flash tab's
@@ -17623,7 +17647,7 @@ button.mavlink-inspector__sent-row {
 .parameter-detail__body {
   display: grid;
   grid-template-columns: minmax(0, 1.6fr) minmax(260px, 1fr);
-  gap: var(--space-3, 12px) 24px;
+  gap: var(--space-3) 24px;
   align-items: start;
 }
 
@@ -17670,7 +17694,7 @@ button.mavlink-inspector__sent-row {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 12px;
+  gap: var(--space-3);
   flex-wrap: wrap;
 }
 

--- a/apps/web/src/views/Osd.tsx
+++ b/apps/web/src/views/Osd.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef, useState } from 'react'
+import type { ReactNode } from 'react'
 
 import { Panel, StatusBadge, buttonStyle } from '@arduconfig/ui-kit'
 
@@ -169,6 +170,9 @@ export interface OsdElementMatrixRow {
 }
 
 export interface OsdViewProps {
+  /** The OSD/VTX switcher, rendered under the panel title like every other
+   *  view's tab strip. */
+  headerNav?: ReactNode
   linkPorts: readonly OsdLinkPort[]
   typeField: OsdSelectField | undefined
   channelField: OsdSelectField | undefined
@@ -236,6 +240,7 @@ function fieldStatusClass(draftStatusById: ScopedFieldDraftMap, paramId: string)
 
 export function OsdView(props: OsdViewProps) {
   const {
+    headerNav,
     linkPorts,
     typeField,
     channelField,
@@ -462,6 +467,10 @@ export function OsdView(props: OsdViewProps) {
         }
       >
         <div className="bf-tab-stack">
+          {/* The OSD/VTX switcher. It used to render above the page title while
+           *  every other view puts its tab strip under the title — same widget,
+           *  two structural positions. */}
+          {headerNav}
           {/* The "Previewing OSDn" dropdown used to live here, far from the
            *  preview canvas it actually drives. It's now docked into the
            *  Preview pane's titlebar (search "osd-preview-screen-select"). */}

--- a/apps/web/src/views/Vtx.tsx
+++ b/apps/web/src/views/Vtx.tsx
@@ -1,4 +1,5 @@
 import { useRef, useState } from 'react'
+import type { ReactNode } from 'react'
 import { Panel, StatusBadge, buttonStyle } from '@arduconfig/ui-kit'
 import type { ParameterState } from '@arduconfig/ardupilot-core'
 import {
@@ -24,6 +25,9 @@ export interface VtxField {
 }
 
 export interface VtxViewProps {
+  /** The OSD/VTX switcher, rendered under the panel title like every other
+   *  view's tab strip. */
+  headerNav?: ReactNode
   linkPorts: readonly VtxLinkPort[]
   enabledLabel: string
   enableField: VtxField | undefined
@@ -52,6 +56,7 @@ export interface VtxViewProps {
 
 export function VtxView(props: VtxViewProps) {
   const {
+    headerNav,
     vtxTable,
     linkPorts,
     enabledLabel,
@@ -101,6 +106,7 @@ export function VtxView(props: VtxViewProps) {
         subtitle="Use a dedicated VTX workflow while keeping the actual ArduPilot-backed controls visible and honest."
       >
         <div className="bf-tab-stack">
+          {headerNav}
           <div className="bf-note">
             <p>Assign the control UART in Ports first. This tab is for transmitter-facing behavior, not the serial-role assignment itself.</p>
             <p>

--- a/packages/ui-kit/src/index.tsx
+++ b/packages/ui-kit/src/index.tsx
@@ -72,14 +72,26 @@ export function StatusBadge({ tone, children }: PropsWithChildren<{ tone: 'neutr
         minHeight: 20,
         padding: '2px 8px',
         borderRadius: 999,
-        border: `1px solid ${color}48`,
+        // `${color}48` appended an alpha byte to a hex literal -- but every
+        // palette entry is a var() string, so the result was the invalid
+        // "var(--success, #7fb966)48" and both the border and the fill were
+        // dropped. Only the neutral tone survived, because it used a literal
+        // rgba(), which is why a toned badge read as bare coloured text beside
+        // a filled neutral one in the same tab strip. color-mix() composes with
+        // var() the way the app's stylesheet already does.
+        border: `1px solid color-mix(in srgb, ${color} 28%, transparent)`,
         color: tone === 'neutral' ? palette.text : color,
-        background: tone === 'neutral' ? 'rgba(255, 187, 0, 0.12)' : `${color}14`,
+        background:
+          tone === 'neutral'
+            ? 'rgba(var(--primary-rgb, 255, 187, 0), 0.12)'
+            : `color-mix(in srgb, ${color} 8%, transparent)`,
         fontSize: 10,
         fontWeight: 600,
         textTransform: 'uppercase',
-        letterSpacing: 0.06,
-        fontFamily: '"JetBrains Mono", "SFMono-Regular", "SF Mono", Consolas, monospace',
+        // A bare number is px in React, so this was 0.06px -- no tracking at
+        // all on an uppercase label.
+        letterSpacing: '0.08em',
+        fontFamily: 'var(--font-data, "JetBrains Mono", "SFMono-Regular", monospace)',
         lineHeight: 1.4
       }}
     >
@@ -98,7 +110,7 @@ export function buttonStyle(kind: 'primary' | 'secondary' | 'hero' = 'secondary'
       borderRadius: 8,
       fontWeight: 600,
       fontSize: 13,
-      letterSpacing: 0.01,
+      letterSpacing: 'normal',
       cursor: 'pointer'
     }
   }
@@ -116,7 +128,7 @@ export function buttonStyle(kind: 'primary' | 'secondary' | 'hero' = 'secondary'
     borderRadius: 8,
     fontWeight: 600,
     fontSize: 12,
-    letterSpacing: 0.01,
+    letterSpacing: 'normal',
     cursor: 'pointer'
   }
 }

--- a/tests/e2e/views.spec.ts
+++ b/tests/e2e/views.spec.ts
@@ -3384,7 +3384,16 @@ test.describe('OSD view preview', () => {
     // Nothing copied yet -> paste disabled.
     await expect(paste).toBeDisabled()
 
-    // Wait for OSD params to sync before copying (copy reads the live snapshot).
+    // Wait for the parameter table to finish, not just for one cell to tick.
+    //
+    // Copy reads every OSD1_*_EN/X/Y out of the live snapshot, and Paste stages
+    // a draft only where the pasted value differs from OSD2's live one -- so
+    // both screens have to be present. A single checked cell proves one
+    // parameter arrived; the rest can still be in flight, and then Paste stages
+    // nothing and Save OSD stays disabled. That was this test failing 2 runs in
+    // 3. The header summary reads "Params <n>" only once the sync completes.
+    await expect(page.getByTestId('session-parameter-summary'))
+      .toHaveText(/^(\d+ params|Params \d+)$/, { timeout: COMMAND_ACK_TIMEOUT })
     await expect(page.getByTestId('osd-cell-BAT_VOLT-1')).toBeChecked({ timeout: COMMAND_ACK_TIMEOUT })
 
     // Copy OSD1's layout, switch to OSD2, paste. The demo seeds different


### PR DESCRIPTION
A UI/UX consistency pass over `apps/web`, plus two real bugs it turned up.

`styles.css` already defined 148 design tokens across both themes. The drift
was not a missing system — it was 2,724 selectors across 429 component
namespaces that had each re-decided values the tokens already held.

## Two bugs, not taste

**`StatusBadge` lost its fill and border on every toned variant.** It composed
them as `` `${color}48` `` — appending an alpha byte to what it assumed was a hex
literal. Every palette entry is a `var()` string, so the result was the invalid
`"var(--success, #7fb966)48"` and both declarations were dropped. Only the
neutral tone rendered, because it alone used a literal `rgba()`. That is the
whole reason a tab strip showed two chip languages side by side.

**`letterSpacing: 0.06` is `0.06px` in React**, not `0.06em` — no tracking at
all on an uppercase label. `buttonStyle` had the same unit bug twice.

Also: six rules referenced `--font-mono` / `--mono`, neither of which is
defined, so they rendered in the browser's generic monospace instead of
JetBrains Mono; the header mark drew itself in a baked near-white and vanished
on the light theme; and native checkboxes/radios/ranges had `accent-color` set
in only four places, so they were platform blue throughout an amber UI.

## Commits

- **`08756cd`** — tokens. No visual change: every substitution is the value that
  was already there. 49 amber + 26 danger `rgba` literals to `--primary-rgb` /
  `--danger-rgb` (following the existing `--edge-rgb` pattern), 141 bare radii
  onto the five radius tokens, 532 font sizes onto a new `--text-*` scale, 131
  uppercase rules onto one `--tracking-label`. The `#e2123f` → `var(--danger)`
  substitution is a genuine light-theme fix, since `--danger` is `#cc1038` there.
- **`1cbe5fd`** — components. Five chip treatments share one geometry; the
  motor-reorder tabs adopt the real `.tab-strip`; the OSD/VTX switcher moved
  below the page title via a `ReactNode` slot, matching every other view;
  `.bf-toolbar` stopped floating over content and became the same pinned bar as
  Config, with the same lowercase counter; the theme toggle matches its header
  neighbours; the Wiki emoji is a letter mark; `guided-setup` and `calibration`
  no longer both read `APP`; the one serif is gone; the landing Connect is the
  same green as every other commit action.
- **`a5201e7`** — the OSD copy/paste e2e test. It was failing 2 runs in 3 on
  `main` and passing in isolation, which read as a timing flake. It was not: the
  gate proved less than the test needed. It waited on one checked cell, but Copy
  reads every `OSD1_*_EN/X/Y` and Paste diffs against OSD2's live values, so both
  screens must be synced. Now gated on `session-parameter-summary`, the same gate
  the sibling OSD specs already use.

## Left undone, deliberately

The ten section-heading classes are structurally different containers — flex
rows with an action, stacked title/subtitle grids, a small-caps group label.
Collapsing them into one primitive would be a worse lie than leaving them; their
spacing is on the scale instead.

336 gap values sit between the 4px steps (6, 10, 14, 18px), and 30 font sizes
are still `em`. Snapping either shifts layout by up to 2px everywhere, including
the 390px phone-overflow gate, and the `em` values' effective size depends on
parents I have not measured. Both want their own pass with visual verification
rather than riding along in a sweep.

## Validation

Rungs 1 and 3. ArduCopter byte-identical — web presentational only, no runtime,
protocol, or transport code.

- `npm run typecheck` — 0 errors
- `npm run test` — 957 pass, 0 fail, 9 skipped
- `npm run test:e2e` — 349 pass, 0 fail, 6 skipped (visual baselines)

Verified by hand in both themes at desktop width across Setup, Config, Ports,
Motors, Tuning and OSD.