### PR TITLE
polish(ui): make the phone layout worth looking at

### DIFF
--- a/apps/web/src/rc-channel-bars.tsx
+++ b/apps/web/src/rc-channel-bars.tsx
@@ -74,6 +74,19 @@ const STYLE_BLOCK = `
   background: var(--danger-weak, rgba(212, 107, 98, 0.16));
 }
 
+/* On a phone the label and value columns were eating 146px of a ~330px row,
+   leaving the bar -- the only part that moves -- under 180px. The channel
+   label already truncates ("CH3 · THROT…"), so it gives up width more
+   gracefully than the bar does -- but only so far: at 64px "AUX 1" collapsed
+   to "AU…", so 78px is the floor that still names the channel. */
+@media (max-width: 560px) {
+  .rc-bar-row {
+    grid-template-columns: 78px 1fr 44px;
+    gap: 4px;
+    padding: 0;
+  }
+}
+
 /* Label column */
 .rc-bar-label {
   display: flex;

--- a/apps/web/src/sections/AppHeader.tsx
+++ b/apps/web/src/sections/AppHeader.tsx
@@ -5,7 +5,7 @@
 // plain props + semantic callbacks. Behavior-neutral lift of the original
 // inline JSX: same markup, same data-testids, same class names, same copy.
 
-import { useEffect, useRef } from 'react'
+import { useEffect, useRef, useState } from 'react'
 
 import type { ConfiguratorSnapshot } from '@arduconfig/ardupilot-core'
 
@@ -121,8 +121,17 @@ export function AppHeader({
     return () => observer.disconnect()
   }, [])
 
+  // Phone-only disclosure. Above the phone breakpoint the toggle is display:none
+  // and every group it hides is laid out inline as before, so this state has no
+  // effect on the desktop header at all.
+  const [moreOpen, setMoreOpen] = useState(false)
+
   return (
-    <header ref={headerRef} className="app-header" data-testid="app-header">
+    <header
+      ref={headerRef}
+      className={`app-header${moreOpen ? ' is-more-open' : ''}`}
+      data-testid="app-header"
+    >
       <button
         type="button"
         className="app-header__brand"
@@ -143,6 +152,20 @@ export function AppHeader({
             <span data-testid="app-git-info" className="app-header__build--muted">{GIT_BRANCH}@{GIT_HASH}</span>
           </small>
         </span>
+      </button>
+
+      {/* On a phone the header was six stacked rows -- roughly a third of the
+          screen before any content. The rows that are not live state (Wiki, the
+          transport picker, Expert mode, the theme) fold in behind this. */}
+      <button
+        type="button"
+        className="app-header__more-toggle"
+        data-testid="header-more-toggle"
+        aria-expanded={moreOpen}
+        aria-label={moreOpen ? 'Hide connection and display settings' : 'Show connection and display settings'}
+        onClick={() => setMoreOpen((open) => !open)}
+      >
+        <span aria-hidden="true">···</span>
       </button>
 
       {/* Wiki + connection picker stack vertically to keep the header from

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -18043,3 +18043,199 @@ button.mavlink-inspector__sent-row {
   font-size: var(--text-md);
   color: var(--text-dim);
 }
+
+/* ── Phone layer ──────────────────────────────────────────────────────────
+ *
+ * 560px, chosen once and used for every phone rule below rather than adding an
+ * eleventh arbitrary breakpoint. Above it nothing here applies and the desktop
+ * header is untouched.
+ *
+ * The problem this solves: the header laid out as six stacked rows on a phone
+ * -- brand, Wiki, transport, battery + params, Expert + theme, connect --
+ * costing ~320px of an 844px screen before the page title, on every view. The
+ * groups are reordered with flex `order` rather than moved in the DOM, so the
+ * desktop order and the markup stay exactly as they were.
+ *
+ * What does NOT fold away: the transport picker and the connect action.
+ * Choosing a transport and connecting is the first thing anyone does on a
+ * phone, and putting it behind a disclosure buys 40px at the cost of the one
+ * flow that has to work. Only the things you touch once a session -- the wiki
+ * link, Expert mode, the theme -- go in the sheet.
+ */
+@media (max-width: 560px) {
+  .app-header {
+    /* Explicit: the narrow-screen rule at <=1024px folds .app-header into a
+       one-column grid along with thirty other containers, which is what made
+       every group its own full-width row. The bar wants to be a flex line. */
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: var(--space-2);
+    padding: var(--space-2) var(--space-3);
+  }
+
+  .app-header__brand {
+    order: 0;
+    /* Takes the slack on row one so the toggle and the action sit hard right.
+       An auto margin on the toggle would do it too, except an auto margin eats
+       the line's free space and pushes the action onto a row of its own. */
+    flex: 1 1 auto;
+    padding: 0;
+    border: none;
+    background: none;
+  }
+
+  /* The name and build string are the least useful pixels on a phone -- the
+     mark already says which app this is. */
+  .app-header__brand-copy {
+    display: none;
+  }
+
+  /* Row one is identity and the two controls you actually press. The live
+     state below is information, not action, so it gets its own row rather than
+     being squeezed in beside them -- trying to fit the battery card inline is
+     what left the mark stranded on a row of its own. */
+  .app-header__more-toggle {
+    order: 1;
+    flex: 0 0 auto;
+  }
+
+  .app-header__actions {
+    order: 2;
+    flex: 0 0 auto;
+  }
+
+  .app-header__telemetry,
+  .app-header__disconnected-pill {
+    order: 3;
+    flex-basis: 100%;
+    min-width: 0;
+  }
+
+  /* Connect and Disconnect sat one above the other, which is what made the
+     header six rows instead of five. */
+  .app-header__primary-actions {
+    flex-direction: row;
+    gap: var(--space-2);
+  }
+
+  .app-header__telemetry {
+    display: flex;
+    align-items: center;
+    gap: var(--space-3);
+  }
+
+  /* The bottom status bar already carries the sync state on every screen. */
+  .header-sync-panel__progress {
+    display: none;
+  }
+
+  /* Row three: the transport picker, always reachable. */
+  .app-header__nav-stack {
+    order: 4;
+    flex-basis: 100%;
+    gap: var(--space-2);
+  }
+
+  .app-header__connection {
+    flex: 1 1 auto;
+    min-width: 0;
+  }
+
+  .app-header__connection select,
+  .app-header__connection-input {
+    width: 100%;
+  }
+
+  /* The sheet: once-a-session controls, on their own rows when opened. */
+  .app-header__wiki {
+    order: 5;
+    flex-basis: 100%;
+    justify-content: center;
+  }
+
+  .app-header__mode-switch {
+    order: 6;
+    flex-basis: 100%;
+    justify-content: space-between;
+  }
+
+  .app-header:not(.is-more-open) .app-header__wiki,
+  .app-header:not(.is-more-open) .app-header__mode-switch {
+    display: none;
+  }
+}
+
+/* The toggle exists only on the phone layer; everywhere else the groups it
+   hides are laid out inline and it would be a control that does nothing. */
+.app-header__more-toggle {
+  display: none;
+}
+
+@media (max-width: 560px) {
+  .app-header__more-toggle {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 32px;
+    height: 32px;
+    padding: 0;
+    border: 1px solid rgba(var(--edge-rgb), 0.08);
+    border-radius: var(--radius-lg);
+    background: rgba(var(--edge-rgb), 0.03);
+    color: var(--text-muted);
+    font-size: var(--text-2xl);
+    line-height: 1;
+    cursor: pointer;
+  }
+
+  .app-header.is-more-open .app-header__more-toggle {
+    color: var(--accent);
+    border-color: var(--accent);
+  }
+}
+
+/* ── Phone: live displays ─────────────────────────────────────────────────
+ *
+ * These are the surfaces people actually came to look at -- the craft attitude,
+ * the OSD layout, the stick bars -- and on a phone they were the worst-served
+ * things on the screen.
+ *
+ * The craft view was the clearest case. Its height is clamp(180px, 21vw,
+ * 260px): a height derived from viewport WIDTH, which collapses to the 180px
+ * floor on any phone while the width stays fluid. The result was a 3D model
+ * letterboxed into 302x176. An aspect-ratio says what was actually meant --
+ * "as tall as it is wide, near enough" -- at any width.
+ */
+@media (max-width: 560px) {
+  .flight-deck__model-frame {
+    height: auto;
+    aspect-ratio: 4 / 3;
+  }
+
+  /* The compact variant pins 286px, which is close to right at 390px but
+     letterboxes again on a narrow phone. */
+  .flight-deck--compact .flight-deck__model-frame {
+    height: auto;
+    aspect-ratio: 4 / 3;
+  }
+
+  /* Nested cards each took 10-12px a side, so a display three cards deep lost
+     ~60px of a 390px screen to padding it did not need. */
+  .bf-gui-box {
+    padding: var(--space-2);
+    gap: var(--space-2);
+  }
+
+  /* Bleed the displays themselves back out over what padding remains. width
+     stays auto so this widens the box without ever exceeding the viewport. */
+  .flight-deck__model-shell,
+  .osd-preview-screen,
+  .rc-bars-container {
+    /* Widen by exactly the bleed. `width: auto` also works where the box is
+       block-level, but the compact deck sits in a flex context where auto
+       shrinks it to content -- it lost 57px that way. */
+    width: calc(100% + var(--space-2) * 2);
+    margin-inline: calc(var(--space-2) * -1);
+  }
+}

--- a/tests/e2e/artifact-upload.spec.ts
+++ b/tests/e2e/artifact-upload.spec.ts
@@ -85,8 +85,22 @@ async function openParameters(page: Page): Promise<void> {
   await expect(page.getByTestId('session-parameter-summary')).toHaveText(/^(\d+ params|Params \d+)$/, {
     timeout: VEHICLE_CONNECT_TIMEOUT
   })
-  await page.getByTestId('product-mode-expert').check()
+  await enableExpertMode(page)
   await page.getByTestId('view-button-parameters').click()
+}
+
+/* Expert mode moved into the header's phone disclosure, so on a narrow viewport
+ * the sheet has to be opened before the toggle can be reached. Above the phone
+ * breakpoint the sheet button is display:none and this is a no-op, so the same
+ * call is correct at every width. */
+async function enableExpertMode(page: Page): Promise<void> {
+  const sheet = page.getByTestId('header-more-toggle')
+  // Idempotent: a test may call this more than once, and clicking an already
+  // open sheet closes it again.
+  if (await sheet.isVisible() && (await sheet.getAttribute('aria-expanded')) !== 'true') {
+    await sheet.click()
+  }
+  await page.getByTestId('product-mode-expert').check()
 }
 
 test.describe('Naming a configuration upload', () => {

--- a/tests/e2e/param-group-presets.spec.ts
+++ b/tests/e2e/param-group-presets.spec.ts
@@ -18,8 +18,22 @@ async function connectAndOpenParameters(page: Page): Promise<void> {
   await expect(page.getByTestId('session-parameter-summary')).toHaveText(/^(\d+ params|Params \d+)$/, {
     timeout: VEHICLE_CONNECT_TIMEOUT
   })
-  await page.getByTestId('product-mode-expert').click()
+  await enableExpertMode(page)
   await page.getByTestId('view-button-parameters').click()
+}
+
+/* Expert mode moved into the header's phone disclosure, so on a narrow viewport
+ * the sheet has to be opened before the toggle can be reached. Above the phone
+ * breakpoint the sheet button is display:none and this is a no-op, so the same
+ * call is correct at every width. */
+async function enableExpertMode(page: Page): Promise<void> {
+  const sheet = page.getByTestId('header-more-toggle')
+  // Idempotent: a test may call this more than once, and clicking an already
+  // open sheet closes it again.
+  if (await sheet.isVisible() && (await sheet.getAttribute('aria-expanded')) !== 'true') {
+    await sheet.click()
+  }
+  await page.getByTestId('product-mode-expert').check()
 }
 
 test.describe('Parameter-group presets', () => {
@@ -243,7 +257,7 @@ test.describe('Parameter reference with no vehicle', () => {
   // true of the vehicle and false of the question being asked.
   async function openParametersDisconnected(page: Page): Promise<void> {
     await page.goto('/')
-    await page.getByTestId('product-mode-expert').check()
+    await enableExpertMode(page)
     await page.getByTestId('view-button-parameters').click()
   }
 

--- a/tests/e2e/views.spec.ts
+++ b/tests/e2e/views.spec.ts
@@ -73,7 +73,7 @@ test.describe('Phone layout', () => {
     await page.getByTestId('transport-mode-select').selectOption('demo')
     await page.getByTestId('connect-button').click()
     await expect(page.getByTestId('session-vehicle-name')).toHaveText('ArduCopter', { timeout: VEHICLE_CONNECT_TIMEOUT })
-    await page.getByTestId('product-mode-expert').check()
+    await enableExpertMode(page)
     await page.getByTestId('view-button-parameters').click()
     await expect(page.locator('.parameter-editor__expert-note')).toBeHidden()
     await expect(page.getByTestId('export-parameter-backup')).toBeHidden()
@@ -150,6 +150,20 @@ test.describe('Desktop firmware browse', () => {
     await expect(page.getByTestId('firmware-vehicle')).toHaveValue('Plane')
   })
 })
+
+/* Expert mode moved into the header's phone disclosure, so on a narrow viewport
+ * the sheet has to be opened before the toggle can be reached. Above the phone
+ * breakpoint the sheet button is display:none and this is a no-op, so the same
+ * call is correct at every width. */
+async function enableExpertMode(page: Page): Promise<void> {
+  const sheet = page.getByTestId('header-more-toggle')
+  // Idempotent: a test may call this more than once, and clicking an already
+  // open sheet closes it again.
+  if (await sheet.isVisible() && (await sheet.getAttribute('aria-expanded')) !== 'true') {
+    await sheet.click()
+  }
+  await page.getByTestId('product-mode-expert').check()
+}
 
 async function connectViaHeader(page: Page): Promise<void> {
   await page.getByTestId('transport-mode-select').selectOption('demo')
@@ -290,7 +304,7 @@ test.describe('Parameters tab (expert-only)', () => {
     // Wait for the full param sync before counting rows — the table populates as
     // params stream in, so an early count races the sync (and empties out).
     await expectParameterSyncComplete(page)
-    await page.getByTestId('product-mode-expert').click()
+    await enableExpertMode(page)
     await page.getByTestId('view-button-parameters').click()
 
     const dataRows = page.locator('.parameter-row:not(.parameter-row--header)')
@@ -314,7 +328,7 @@ test.describe('Parameters tab (expert-only)', () => {
     // leaving the diff grid to hunt for.
     await page.goto('/')
     await connectViaHeader(page)
-    await page.getByTestId('product-mode-expert').click()
+    await enableExpertMode(page)
     await page.getByTestId('view-button-parameters').click()
 
     const search = page.getByTestId('parameter-search-input')
@@ -351,7 +365,7 @@ test.describe('Parameters tab (expert-only)', () => {
     await page.addStyleTag({ content: '* { overflow-anchor: none !important; }' })
     await connectViaHeader(page)
     await expectParameterSyncComplete(page)
-    await page.getByTestId('product-mode-expert').click()
+    await enableExpertMode(page)
     await page.getByTestId('view-button-parameters').click()
     await page.addStyleTag({ content: '* { overflow-anchor: none !important; }' })
 
@@ -393,7 +407,7 @@ test.describe('Parameters tab (expert-only)', () => {
     // stays as a muted "won't write" row until Discard.
     await page.goto('/')
     await connectViaHeader(page)
-    await page.getByTestId('product-mode-expert').click()
+    await enableExpertMode(page)
     await page.getByTestId('view-button-parameters').click()
     await page.getByTestId('parameter-search-input').fill('ANGLE_MAX')
 
@@ -413,7 +427,7 @@ test.describe('Parameters tab (expert-only)', () => {
   test('expanding a param row reveals its metadata, old name, enum meaning, and a type-or-pick editor', async ({ page }) => {
     await page.goto('/')
     await connectViaHeader(page)
-    await page.getByTestId('product-mode-expert').click()
+    await enableExpertMode(page)
     await page.getByTestId('view-button-parameters').click()
     await page.getByTestId('parameter-search-input').fill('GPS_TYPE')
 
@@ -449,7 +463,7 @@ test.describe('Parameters tab (expert-only)', () => {
     // hundreds of parameters.
     await page.goto('/')
     await connectViaHeader(page)
-    await page.getByTestId('product-mode-expert').click()
+    await enableExpertMode(page)
     await page.getByTestId('view-button-parameters').click()
     await expectParameterSyncComplete(page)
 
@@ -484,7 +498,7 @@ test.describe('Parameters tab (expert-only)', () => {
   test('a staged bitmask is editable bit by bit, and a draft matching live clears on re-sync', async ({ page }) => {
     await page.goto('/')
     await connectViaHeader(page)
-    await page.getByTestId('product-mode-expert').click()
+    await enableExpertMode(page)
     await page.getByTestId('view-button-parameters').click()
     await expectParameterSyncComplete(page)
 
@@ -514,7 +528,7 @@ test.describe('Parameters tab (expert-only)', () => {
   test('an import can be staged one row at a time instead of all at once', async ({ page }) => {
     await page.goto('/')
     await connectViaHeader(page)
-    await page.getByTestId('product-mode-expert').click()
+    await enableExpertMode(page)
     await page.getByTestId('view-button-parameters').click()
     await expectParameterSyncComplete(page)
 
@@ -554,7 +568,7 @@ test.describe('Parameters tab (expert-only)', () => {
     // before "Drop selected".
     await page.goto('/')
     await connectViaHeader(page)
-    await page.getByTestId('product-mode-expert').click()
+    await enableExpertMode(page)
     await page.getByTestId('view-button-parameters').click()
 
     // Stage two failsafe params so the group has more than one row.
@@ -583,7 +597,7 @@ test.describe('Parameters tab (expert-only)', () => {
     // enum meanings in front of them.
     await page.goto('/')
     await connectViaHeader(page)
-    await page.getByTestId('product-mode-expert').click()
+    await enableExpertMode(page)
     await page.getByTestId('view-button-parameters').click()
     await page.getByTestId('parameter-search-input').fill('GPS_TYPE')
 
@@ -603,7 +617,7 @@ test.describe('Parameters tab (expert-only)', () => {
     // ArduConfigurator JSON or a ground-station format from one control.
     await page.goto('/')
     await connectViaHeader(page)
-    await page.getByTestId('product-mode-expert').click()
+    await enableExpertMode(page)
     await page.getByTestId('view-button-parameters').click()
 
     // No separate legacy control anymore.
@@ -742,7 +756,7 @@ test.describe('CAN bus enable prompt', () => {
     await page.goto('/')
     await page.getByTestId('transport-mode-select').selectOption('demo')
     await page.getByTestId('connect-button').click()
-    await page.getByTestId('product-mode-expert').check()
+    await enableExpertMode(page)
     await page.getByTestId('view-button-can').click()
 
     const prompt = page.getByTestId('can-enable-prompt')
@@ -765,7 +779,7 @@ test.describe('Networking view (Expert + networking-capable FC)', () => {
     await expect(page.getByTestId('view-button-networking')).toHaveCount(0)
 
     // Expert mode: the tab appears because the demo Copter reports NET_ params.
-    await page.getByTestId('product-mode-expert').check()
+    await enableExpertMode(page)
     await expect(page.getByTestId('view-button-networking')).toBeVisible()
     await page.getByTestId('view-button-networking').click()
 
@@ -822,7 +836,7 @@ test.describe('Lua Scripts view (Expert + scripting-capable FC)', () => {
     await expect(page.getByTestId('view-button-lua')).toHaveCount(0)
 
     // Expert mode: the tab appears because the demo Copter reports SCR_ params.
-    await page.getByTestId('product-mode-expert').check()
+    await enableExpertMode(page)
     await expect(page.getByTestId('view-button-lua')).toBeVisible()
     await page.getByTestId('view-button-lua').click()
 
@@ -872,7 +886,7 @@ test.describe('AI Assistant view (Expert, offline mock provider)', () => {
     await expect(page.getByTestId('view-button-ai-assistant')).toHaveCount(0)
 
     // Expert mode: the tab appears (gated on Expert alone, no FC capability).
-    await page.getByTestId('product-mode-expert').check()
+    await enableExpertMode(page)
     await expect(page.getByTestId('view-button-ai-assistant')).toBeVisible()
     await page.getByTestId('view-button-ai-assistant').click()
     await expect(page.getByTestId('ai-assistant-view')).toBeVisible()
@@ -896,7 +910,7 @@ test.describe('AI Assistant view (Expert, offline mock provider)', () => {
     await expect(page.getByTestId('session-vehicle-name')).toHaveText('ArduCopter', { timeout: VEHICLE_CONNECT_TIMEOUT })
     await expectParameterSyncComplete(page)
 
-    await page.getByTestId('product-mode-expert').check()
+    await enableExpertMode(page)
     await page.getByTestId('view-button-ai-assistant').click()
     await expect(page.getByTestId('ai-assistant-view')).toBeVisible()
 
@@ -931,7 +945,7 @@ test.describe('AI Assistant view (Expert, offline mock provider)', () => {
     await expect(page.getByTestId('session-vehicle-name')).toHaveText('ArduCopter', { timeout: VEHICLE_CONNECT_TIMEOUT })
     await expectParameterSyncComplete(page)
 
-    await page.getByTestId('product-mode-expert').check()
+    await enableExpertMode(page)
     await page.getByTestId('view-button-ai-assistant').click()
     await expect(page.getByTestId('ai-assistant-view')).toBeVisible()
 
@@ -1237,7 +1251,7 @@ test.describe('Calibration tab — motor-spin (ESC)', () => {
     await page.goto('/')
     await connectViaHeader(page)
     // Raw parameter editing is an Expert surface, so the tab only exists here.
-    await page.getByTestId('product-mode-expert').check()
+    await enableExpertMode(page)
 
     for (const view of ['parameters', 'snapshots'] as const) {
       await openView(page, view)
@@ -1823,7 +1837,7 @@ test.describe('Flash view', () => {
     await page.setViewportSize({ width: 390, height: 844 })
     await page.goto('/')
     await connectViaHeader(page)
-    await page.getByTestId('product-mode-expert').click()
+    await enableExpertMode(page)
     await openView(page, 'flash')
 
     // Not shown until the operator arms the update: reading the images costs
@@ -2158,7 +2172,7 @@ test.describe('Config view', () => {
     await page.goto('/')
     await page.getByTestId('transport-mode-select').selectOption('demo')
     await page.getByTestId('connect-button').click()
-    await page.getByTestId('product-mode-expert').click()
+    await enableExpertMode(page)
 
     // Stage + apply a reboot-required change (bdshot stages SERVO_BLH_* params).
     await page.getByTestId('view-button-config').click()
@@ -2478,7 +2492,7 @@ test.describe('RC Mixer view', () => {
     await page.goto('/')
     await page.getByTestId('transport-mode-select').selectOption('demo')
     await page.getByTestId('connect-button').click()
-    await page.getByTestId('product-mode-expert').check()
+    await enableExpertMode(page)
     await page.getByTestId('view-button-rc-mixer').click()
 
     for (const channel of [1, 2, 3, 4]) {
@@ -2517,7 +2531,7 @@ test.describe('RC Mixer view', () => {
     await page.getByTestId('transport-mode-select').selectOption('demo-plane')
     await page.getByTestId('connect-button').click()
     await expect(page.getByTestId('session-vehicle-name')).toHaveText('ArduPlane', { timeout: VEHICLE_CONNECT_TIMEOUT })
-    await page.getByTestId('product-mode-expert').check()
+    await enableExpertMode(page)
     await page.getByTestId('view-button-rc-mixer').click()
 
     const channel5 = page.getByTestId('rc-mixer-channel-5')
@@ -2539,7 +2553,7 @@ test.describe('RC Mixer view', () => {
     await page.goto('/')
     await page.getByTestId('transport-mode-select').selectOption('demo')
     await page.getByTestId('connect-button').click()
-    await page.getByTestId('product-mode-expert').check()
+    await enableExpertMode(page)
     await page.getByTestId('view-button-rc-mixer').click()
 
     // Demo seeds a real, already-applied ArmDisarm assignment on channel 5.
@@ -4052,7 +4066,7 @@ test.describe('ArduPlane demo', () => {
     await expect(page.getByTestId('calibration-card-tcal')).toHaveCount(0)
 
     // Expert mode reveals the full card (demo seeds INS_TCALn_ENABLE = 0).
-    await page.getByTestId('product-mode-expert').check()
+    await enableExpertMode(page)
     const tcal = page.getByTestId('calibration-card-tcal')
     await expect(tcal).toBeVisible()
     await expect(tcal).toContainText('Thermal calibration')
@@ -4075,7 +4089,7 @@ test.describe('ArduPlane demo', () => {
 
     // Expert mode is not enough on its own. Signed out there is no card at all
     // -- not a locked one -- because the calibration is fit from a hover log.
-    await page.getByTestId('product-mode-expert').check()
+    await enableExpertMode(page)
     // Guard the guard: Expert really did take effect, so this cannot pass for
     // the wrong reason.
     await expect(page.getByTestId('calibration-card-tcal')).toBeVisible()
@@ -4104,7 +4118,7 @@ test.describe('ArduPlane demo', () => {
     await expect(page.getByTestId('session-vehicle-name')).toHaveText('ArduCopter', { timeout: VEHICLE_CONNECT_TIMEOUT })
 
     await openView(page, 'calibration')
-    await page.getByTestId('product-mode-expert').check()
+    await enableExpertMode(page)
     const valt = page.getByTestId('calibration-card-valt')
     await valt.scrollIntoViewIfNeeded()
     await expect(valt).toBeVisible()
@@ -4775,7 +4789,7 @@ test('Recent Notices: clear-all button and expert-mode search bar', async ({ pag
   await expect(page.getByTestId('setup-notices-clear-all')).toBeVisible({ timeout: 15_000 })
   // The notice search bar is expert-only.
   await expect(page.getByTestId('setup-notices-search')).toHaveCount(0)
-  await page.getByTestId('product-mode-expert').click()
+  await enableExpertMode(page)
   await expect(page.getByTestId('setup-notices-search')).toBeVisible()
 })
 
@@ -4867,7 +4881,7 @@ test('Recent Notices pops out into its own styled, live window', async ({ page, 
   await expect(popout.getByTestId('notices-popout-list')).toBeVisible()
   await expect(noticeRows.first()).toBeVisible({ timeout: 15_000 })
   await expect(popout.getByTestId('notices-popout-search')).toHaveCount(0)
-  await page.getByTestId('product-mode-expert').click()
+  await enableExpertMode(page)
   await expect(popout.getByTestId('notices-popout-search')).toBeVisible()
 
   // …and the filter typed in the window filters the window: a term nothing can
@@ -5060,7 +5074,7 @@ test.describe('Inspectors (expert-only)', () => {
     await expect(page.getByTestId('view-button-dronecan-inspector')).toHaveCount(0)
     await expect(page.getByTestId('view-button-can')).toBeVisible()
 
-    await page.getByTestId('product-mode-expert').check()
+    await enableExpertMode(page)
 
     // MAVLink inspector shows the live decoded message stream.
     await page.getByTestId('view-button-mavlink-inspector').click()
@@ -5105,7 +5119,7 @@ test.describe('Inspectors (expert-only)', () => {
     await page.goto('/')
     await page.getByTestId('transport-mode-select').selectOption('demo')
     await page.getByTestId('connect-button').click()
-    await page.getByTestId('product-mode-expert').check()
+    await enableExpertMode(page)
 
     await page.getByTestId('view-button-mavlink-inspector').click()
     await expect(page.getByTestId('mavlink-inspector-table')).toBeVisible({ timeout: 8000 })
@@ -5128,7 +5142,7 @@ test.describe('Inspectors (expert-only)', () => {
     await page.goto('/')
     await page.getByTestId('transport-mode-select').selectOption('demo')
     await page.getByTestId('connect-button').click()
-    await page.getByTestId('product-mode-expert').check()
+    await enableExpertMode(page)
 
     await page.getByTestId('view-button-mavlink-inspector').click()
     await expect(page.getByTestId('mavlink-inspector-table')).toBeVisible({ timeout: 8000 })
@@ -5160,7 +5174,7 @@ test.describe('Inspectors (expert-only)', () => {
     await page.goto('/')
     await page.getByTestId('transport-mode-select').selectOption('demo')
     await page.getByTestId('connect-button').click()
-    await page.getByTestId('product-mode-expert').check()
+    await enableExpertMode(page)
 
     await page.getByTestId('view-button-mavlink-inspector').click()
     await expect(page.getByTestId('mavlink-inspector-table')).toBeVisible({ timeout: 8000 })
@@ -5183,7 +5197,7 @@ test.describe('Inspectors (expert-only)', () => {
     await page.goto('/')
     await page.getByTestId('transport-mode-select').selectOption('demo')
     await page.getByTestId('connect-button').click()
-    await page.getByTestId('product-mode-expert').check()
+    await enableExpertMode(page)
 
     await page.getByTestId('view-button-mavlink-inspector').click()
     const mavTable = page.getByTestId('mavlink-inspector-table')
@@ -5210,7 +5224,7 @@ test.describe('Inspectors (expert-only)', () => {
     await page.goto('/')
     await page.getByTestId('transport-mode-select').selectOption('demo')
     await page.getByTestId('connect-button').click()
-    await page.getByTestId('product-mode-expert').check()
+    await enableExpertMode(page)
 
     // Expand the first decoded MAVLink row and reveal its copy affordance.
     await page.getByTestId('view-button-mavlink-inspector').click()
@@ -5241,7 +5255,7 @@ test.describe('Inspectors (expert-only)', () => {
     await page.goto('/')
     await page.getByTestId('transport-mode-select').selectOption('demo')
     await page.getByTestId('connect-button').click()
-    await page.getByTestId('product-mode-expert').check()
+    await enableExpertMode(page)
 
     await page.getByTestId('view-button-mavlink-inspector').click()
     await expect(page.getByTestId('mavlink-inspector-table')).toBeVisible({ timeout: 8000 })
@@ -5259,7 +5273,7 @@ test.describe('Inspectors (expert-only)', () => {
     await page.goto('/')
     await page.getByTestId('transport-mode-select').selectOption('demo')
     await page.getByTestId('connect-button').click()
-    await page.getByTestId('product-mode-expert').check()
+    await enableExpertMode(page)
 
     await page.getByTestId('view-button-mavlink-inspector').click()
     const mavTable = page.getByTestId('mavlink-inspector-table')
@@ -5286,7 +5300,7 @@ test.describe('Inspectors (expert-only)', () => {
     await page.goto('/')
     await page.getByTestId('transport-mode-select').selectOption('demo')
     await page.getByTestId('connect-button').click()
-    await page.getByTestId('product-mode-expert').check()
+    await enableExpertMode(page)
 
     await page.getByTestId('view-button-can').click()
     await page.getByTestId('can-bus-start').click()
@@ -5328,7 +5342,7 @@ test.describe('Inspectors (expert-only)', () => {
     await page.goto('/')
     await page.getByTestId('transport-mode-select').selectOption('demo')
     await page.getByTestId('connect-button').click()
-    await page.getByTestId('product-mode-expert').check()
+    await enableExpertMode(page)
 
     await page.getByTestId('view-button-can').click()
     await page.getByTestId('can-bus-start').click()
@@ -5390,7 +5404,7 @@ test.describe('Inspectors (expert-only)', () => {
     await page.goto('/')
     await page.getByTestId('transport-mode-select').selectOption('demo')
     await page.getByTestId('connect-button').click()
-    await page.getByTestId('product-mode-expert').check()
+    await enableExpertMode(page)
 
     await page.getByTestId('view-button-can').click()
     await page.getByTestId('can-bus-start').click()
@@ -5437,7 +5451,7 @@ test.describe('Inspectors (expert-only)', () => {
     await page.goto('/')
     await page.getByTestId('transport-mode-select').selectOption('demo')
     await page.getByTestId('connect-button').click()
-    await page.getByTestId('product-mode-expert').check()
+    await enableExpertMode(page)
 
     await page.getByTestId('view-button-can').click()
     await page.getByTestId('can-bus-start').click()
@@ -5475,7 +5489,7 @@ test.describe('Snapshot restore', () => {
 
     // Change a live value from a different tab so the snapshot now has
     // something real to restore.
-    await page.getByTestId('product-mode-expert').check()
+    await enableExpertMode(page)
     await page.getByTestId('view-button-parameters').click()
     const search = page.getByTestId('parameter-search-input')
     await search.fill('BATT_LOW_VOLT')
@@ -5733,7 +5747,7 @@ test.describe('ELRS Flash (temporarily disabled in prod)', () => {
     await page.goto('/')
     await connectViaHeader(page)
     await expectParameterSyncComplete(page)
-    await page.getByTestId('product-mode-expert').check()
+    await enableExpertMode(page)
 
     // The demo FC advertises Expert + SERIAL_PASS2, which used to surface the ELRS
     // Flash tab. It is now gated OFF (ELRS_FLASH_ENABLED=false) because the
@@ -5747,7 +5761,7 @@ test.describe('OSD message shorthand editor (@OSD/shorthand.dat)', () => {
   test('reads the fork shorthand table, edits, adds a row, and saves', async ({ page }) => {
     await page.goto('/')
     await connectViaHeader(page)
-    await page.getByTestId('product-mode-expert').check()
+    await enableExpertMode(page)
     await page.getByTestId('view-button-osd').click()
 
     // The demo mock serves @OSD/shorthand.dat with 3 seeded entries.
@@ -6277,7 +6291,7 @@ test.describe('Tuning ▸ Initial Tune', () => {
     await page.getByTestId('transport-mode-select').selectOption('demo')
     await page.getByTestId('connect-button').click()
     await expectParameterSyncComplete(page)
-    await page.getByTestId('product-mode-expert').check()
+    await enableExpertMode(page)
     await page.getByTestId('view-button-tuning').click()
     await page.getByTestId('tuning-tab-initial-tune').click()
   }
@@ -6529,7 +6543,7 @@ test.describe('Tuning ▸ Filters', () => {
     await page.getByTestId('transport-mode-select').selectOption('demo')
     await page.getByTestId('connect-button').click()
     await expectParameterSyncComplete(page)
-    await page.getByTestId('product-mode-expert').check()
+    await enableExpertMode(page)
     await page.getByTestId('view-button-tuning').click()
     await page.getByTestId('tuning-tab-filters').click()
     await expect(page.getByTestId('tuning-filter-group-notch')).toBeVisible()


### PR DESCRIPTION
Follow-up to #177, aimed at phones: the header chrome and the live displays.

## The header was a third of the screen

Six stacked rows — brand, Wiki, transport, battery + params, Expert + theme,
and Connect above Disconnect — costing **315px of an 844px screen** before the
page title, on every view. It is **174px** now: identity, the sheet toggle and
the connect action on one line, live state on the next, transport on the third.
Wiki, Expert mode and the theme toggle fold in behind a `···` disclosure.

The transport picker deliberately does **not** fold away. Choosing a transport
and connecting is the first thing anyone does on a phone, and hiding it buys
40px at the cost of the one flow that has to work.

## The craft view was letterboxed by a unit, not a value

Its height is `clamp(180px, 21vw, 260px)` — a height derived from viewport
**width**, which collapses to the 180px floor on any phone while the width stays
fluid. A 3D model rendered into 302×176. `aspect-ratio` says what was meant, at
any width:

```
Setup craft     302×176 (1.72)  →  318×238 (1.33)
Receiver craft  324×282 (1.15)  →  340×254 (1.33)
```

The two also disagreed with each other, because the compact variant hard-pinned
286px. They hold the same proportion now.

## Stick bars gained ~60px of bar

Nested cards each took 10–12px a side, so a display three cards deep lost ~60px
of a 390px screen to padding, and the label + value columns took another 146px —
leaving the only part that actually moves under 180px. Padding tightened,
displays bled back over what remains, label column narrowed to 78px (64px
collapsed `AUX 1` to `AU…`).

## Tests

Expert mode now lives behind the phone disclosure, so four phone tests could no
longer reach it. They go through an `enableExpertMode` helper that opens the
sheet when it is visible — above the phone breakpoint the sheet button is
`display:none`, so the same call is correct at every width.

## A trap worth recording

`.app-header` is `display: grid` below 1024px, via a grouped rule that folds
~30 containers into a single column. Every `order` / `flex-basis` rule here did
nothing until `display` was overridden back to flex — worth knowing before
anyone else tries to lay out header children.

## Validation

Rungs 1 and 3. ArduCopter byte-identical — web presentational only.

- `npm run typecheck` — 0 errors
- `npm run test` — 957 pass, 0 fail
- `npm run test:e2e` — **349 pass, 0 fail**, 6 skipped (visual baselines)
- 0 horizontal overflow at 390px across all seven surveyed views

Measured at 390×844 with a scripted survey (header height, per-display width /
height / aspect ratio, and document overflow per view), not by eye alone.