### PR TITLE
fix(setup): guided setup audit — two P0 safety defects, three deadlocks, and the seams

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -5027,7 +5027,9 @@ export function App() {
       setSelectedParameterId(changedParamIds[0] ?? selectedParameterId)
       setParameterNotice({
         tone: 'warning',
-        text: `Staged ${changedParamIds.length} motor output remap change(s). Apply them from Outputs, then rerun the guarded motor direction check before flight.`
+        // Named a guarded direction check that no longer exists -- it was removed
+        // with the Motors-tab redesign. Point at the surface that does.
+        text: `Staged ${changedParamIds.length} motor output remap change(s). Apply them from Outputs, then re-test each motor's order and direction in Motors before flight.`
       })
     }
     return changedParamIds.length

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1347,7 +1347,15 @@ export function App() {
   const rssiChannel = readRoundedParameter(snapshot, 'RSSI_CHANNEL')
   const rssiChannelLow = readRoundedParameter(snapshot, 'RSSI_CHAN_LOW')
   const rssiChannelHigh = readRoundedParameter(snapshot, 'RSSI_CHAN_HIGH')
-  const throttleFailsafe = readRoundedParameter(snapshot, 'FS_THR_ENABLE')
+  // ArduPlane has no FS_THR_ENABLE -- its throttle failsafe is THR_FAILSAFE
+  // (ArduPlane/Parameters.cpp:411), which is what the Plane bundle already lists
+  // in its own requiredParameters. Reading only the Copter id left the value
+  // permanently undefined on Plane, so the failsafe step's criterion could never
+  // be met and its confirm button was hard-disabled: a second, independent
+  // deadlock for that vehicle. Fall back rather than branch, so a build that
+  // exposes either name works.
+  const throttleFailsafe =
+    readRoundedParameter(snapshot, 'FS_THR_ENABLE') ?? readRoundedParameter(snapshot, 'THR_FAILSAFE')
   const throttleFailsafeValue = readRoundedParameter(snapshot, 'FS_THR_VALUE')
   const notificationLedTypes = readRoundedParameter(snapshot, 'NTF_LED_TYPES')
   const notificationLedLength = readRoundedParameter(snapshot, 'NTF_LED_LEN')

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -3410,9 +3410,15 @@ export function App() {
     }
     if (panelId === 'setup-panel-guided') {
       setSetupMode('wizard')
-    } else if (panelId === 'setup-panel-link') {
-      setSetupMode('overview')
     }
+    // The 'setup-panel-link' branch used to set setupMode back to 'overview'
+    // here. setupMode is what gates the "Back to guided setup" bar
+    // (setupMode === 'wizard' && activeViewId !== 'guided-setup'), so step 1's
+    // own "Open Vehicle Link" excursion cleared the flag on its way out and
+    // landed the operator on Status & Info with no route back except spotting
+    // Guided Setup in the left nav. Every other excursion in the flow keeps the
+    // bar. It also dropped the flow context that the exercise auto-return
+    // depends on.
     if (targetViewId !== activeViewId) {
       setActiveViewId(targetViewId)
       requestAnimationFrame(() => {
@@ -7044,6 +7050,15 @@ export function App() {
     }
 
     setSelectedSetupSectionId(targetSection.id)
+    // Advancing left the scroll position exactly where it was. On a phone the
+    // new step's document is roughly twice the viewport, so the primary action
+    // and Continue landed ~1.5 viewports below the fold with nothing on screen
+    // saying there was anything to do -- measured on all 11 steps at 390x844.
+    // It also blurred focus to document.body when the new Continue arrived
+    // disabled, costing 31 tab presses to get back. The wizard already owns a
+    // scroll-and-focus routine keyed on this state; step navigation just never
+    // used it.
+    setPendingSetupWizardFocusId(SETUP_WIZARD_PRIMARY_ACTION_ID)
   }
 
 

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -4505,7 +4505,7 @@ export function App() {
         tone: 'warning',
         text:
           rcMappingRejectedReason ??
-          `${rcMappingTargetGuide.detail} Keep moving only that control until one receiver channel clearly dominates.`
+          `No channel has stood out yet. ${rcMappingTargetGuide.detail}`
       })
       return
     }

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -3474,13 +3474,28 @@ export function App() {
 
     const focusId = pendingSetupWizardFocusId
     const timer = window.setTimeout(() => {
-      window.scrollTo({
-        top: 0,
-        behavior: 'smooth'
-      })
+      // link/ports/airframe have no primary action of their own, so the focus id
+      // resolves to nothing and the scroll never happened -- those three stayed
+      // below the fold. Continue is the next action on any step without one.
+      const target =
+        document.getElementById(focusId) ??
+        document.querySelector<HTMLElement>('[data-testid="setup-wizard-next-step"]')
+      // Scrolling to top is right on the two-column desktop layout, where the
+      // aside sits beside the content and its action is in view from the top.
+      // Below the breakpoint the stack is single-column with the aside LAST, so
+      // top leaves the action roughly 1.5 viewports down -- measured below the
+      // fold on all 11 steps at 390x844. Scroll to the action itself there.
+      const singleColumn = window.matchMedia('(max-width: 1024px)').matches
+      if (singleColumn && target instanceof HTMLElement) {
+        target.scrollIntoView({ block: 'center', behavior: 'smooth' })
+      } else {
+        window.scrollTo({
+          top: 0,
+          behavior: 'smooth'
+        })
+      }
 
       window.setTimeout(() => {
-        const target = document.getElementById(focusId)
         if (target instanceof HTMLElement) {
           target.focus({ preventScroll: true })
         }
@@ -8329,6 +8344,10 @@ export function App() {
                     onSelectStep={(sectionId) => {
                       setSelectedSetupSectionId(sectionId)
                       setSetupMode('wizard')
+                      // Same treatment as Continue/Previous: jumping via the step
+                      // rail is a step change too, and left the operator looking at
+                      // a new step with its action off-screen.
+                      setPendingSetupWizardFocusId(SETUP_WIZARD_PRIMARY_ACTION_ID)
                     }}
                   />
 

--- a/apps/web/src/hooks/use-mode-switch-derivations.ts
+++ b/apps/web/src/hooks/use-mode-switch-derivations.ts
@@ -41,7 +41,9 @@ export function useModeSwitchDerivations(input: {
 
   const modeSwitchExerciseSummary = (() => {
     if (modeSwitchExercise.status === 'passed') {
-      return `Observed all configured switch positions on CH${modeSwitchEstimate.channelNumber ?? '?'}.`
+      return modeSwitchEstimate.channelNumber === undefined
+        ? 'Observed all configured switch positions, but the mode channel is not set. Set the flight-mode channel in Modes.'
+        : `Observed all configured switch positions on CH${modeSwitchEstimate.channelNumber}.`
     }
     if (modeSwitchExercise.status === 'failed') {
       return modeSwitchExercise.failureReason ?? 'Mode switch exercise failed.'
@@ -69,7 +71,7 @@ export function useModeSwitchDerivations(input: {
       : modeSwitchExercise.status === 'passed'
         ? ['The mode channel moved through every distinct configured flight-mode position that the app expected to see.']
         : modeSwitchExercise.status === 'failed'
-          ? ['Check the radio mapping, `FLTMODE_CH`/`MODE_CH`, and switch endpoints, then run the exercise again.']
+          ? ['Check which channel the mode switch is on, its endpoints, and the modes assigned to each position, then run the check again.']
           : ['The app will watch the live mode channel and mark each distinct configured flight-mode position as it is observed.']
 
   return {

--- a/apps/web/src/hooks/use-osd-editor.ts
+++ b/apps/web/src/hooks/use-osd-editor.ts
@@ -5,10 +5,16 @@
 // nothing else does. Behavior-neutral lift of the original App() hooks (same
 // order, same dependency arrays).
 
-import { useCallback, useMemo, useState, type Dispatch, type SetStateAction } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState, type Dispatch, type SetStateAction } from 'react'
 
 import type { ConfiguratorSnapshot, ParameterState } from '@arduconfig/ardupilot-core'
 
+import {
+  deriveOsdPreviewKey,
+  osdVideoSystemFromTxtRes,
+  readStoredOsdPreview,
+  writeStoredOsdPreview
+} from '../osd-video-system-storage'
 import { readRoundedParameter, selectParameterById } from '../selectors/parameter-read'
 import { formatRxRssi } from '../status-formatters'
 import { OSD_ELEMENTS, OSD_SCREEN_NUMBERS, OSD_SCREEN_OPTION_SUFFIXES, type OsdScreenNumber } from '../osd-params'
@@ -32,6 +38,12 @@ type CopiedOsdLayout =
 export interface UseOsdEditorResult {
   activeOsdScreen: OsdScreenNumber
   setActiveOsdScreen: Dispatch<SetStateAction<OsdScreenNumber>>
+  /** Which goggles/VRX grid the preview draws. Lives here, not in the Osd
+   *  view, because that view unmounts on every tab switch. */
+  videoSystem: string
+  setVideoSystem: (next: string) => void
+  analogSubMode: 'pal' | 'ntsc'
+  setAnalogSubMode: (next: 'pal' | 'ntsc') => void
   copiedOsdLayout: CopiedOsdLayout
   osdScreenOptionFields: OsdScreenOptionField[]
   osdScreenEnableEntries: readonly OsdScreenEnableEntry[]
@@ -50,6 +62,59 @@ export function useOsdEditor({
   setParameterNotice
 }: UseOsdEditorParams): UseOsdEditorResult {
   const [activeOsdScreen, setActiveOsdScreen] = useState<OsdScreenNumber>(1)
+
+  /*
+   * Preview video system.
+   *
+   * This used to be useState inside views/Osd.tsx, which App unmounts whenever
+   * the operator leaves the tab -- so it reset to Analog every single time, and
+   * a Walksnail pilot re-picked their goggles on every visit.
+   *
+   * Resolution order is: what this operator last chose for THIS aircraft, then
+   * what the aircraft itself says via OSD1_TXT_RES, then Analog. The stored
+   * choice outranks the parameter because ArduPilot's TXT_RES only encodes
+   * 30x16 / 50x18 / 60x22 -- it cannot tell HDZero from Walksnail Avatar, which
+   * are both 50 columns wide.
+   */
+  const osdPreviewKey = deriveOsdPreviewKey(snapshot)
+  const txtRes = readRoundedParameter(snapshot, 'OSD1_TXT_RES')
+  const [videoSystem, setVideoSystemState] = useState<string>('analog')
+  const [analogSubMode, setAnalogSubModeState] = useState<'pal' | 'ntsc'>('ntsc')
+  // Seed once per aircraft. Keyed on the storage key so reconnecting to a
+  // different board re-seeds, while a re-render for any other reason does not
+  // overwrite a choice the operator just made.
+  const seededKeyRef = useRef<string | undefined>(undefined)
+
+  useEffect(() => {
+    if (osdPreviewKey === undefined || seededKeyRef.current === osdPreviewKey) {
+      return
+    }
+    seededKeyRef.current = osdPreviewKey
+    const stored = readStoredOsdPreview(osdPreviewKey)
+    const seeded = stored?.videoSystem ?? osdVideoSystemFromTxtRes(txtRes)
+    if (seeded !== undefined) {
+      setVideoSystemState(seeded)
+    }
+    if (stored?.analogSubMode !== undefined) {
+      setAnalogSubModeState(stored.analogSubMode)
+    }
+  }, [osdPreviewKey, txtRes])
+
+  const setVideoSystem = useCallback(
+    (next: string) => {
+      setVideoSystemState(next)
+      writeStoredOsdPreview(osdPreviewKey, { version: 1, videoSystem: next, analogSubMode })
+    },
+    [analogSubMode, osdPreviewKey]
+  )
+
+  const setAnalogSubMode = useCallback(
+    (next: 'pal' | 'ntsc') => {
+      setAnalogSubModeState(next)
+      writeStoredOsdPreview(osdPreviewKey, { version: 1, videoSystem, analogSubMode: next })
+    },
+    [osdPreviewKey, videoSystem]
+  )
 
   // Per-screen "Screen Options" for the currently-previewed screen. ENABLE
   // renders as a select (enabled/disabled); the rest as numbers.
@@ -292,6 +357,10 @@ export function useOsdEditor({
   return {
     activeOsdScreen,
     setActiveOsdScreen,
+    videoSystem,
+    setVideoSystem,
+    analogSubMode,
+    setAnalogSubMode,
     copiedOsdLayout,
     osdScreenOptionFields,
     osdScreenEnableEntries,

--- a/apps/web/src/hooks/use-rc-mapping-derivations.ts
+++ b/apps/web/src/hooks/use-rc-mapping-derivations.ts
@@ -117,14 +117,27 @@ export function useRcMappingDerivations(input: {
     if (
       rcMappingSession.status !== 'running' ||
       rcMappingSession.currentTargetAxis === undefined ||
-      rcMappingCandidate !== undefined ||
-      rcMappingRawCandidate === undefined
+      rcMappingCandidate !== undefined
     ) {
       return undefined
     }
 
-    return describeRcMappingRejectedCandidate(rcMappingSession.currentTargetAxis, rcMappingRawCandidate)
-  }, [rcMappingCandidate, rcMappingRawCandidate, rcMappingSession.currentTargetAxis, rcMappingSession.status])
+    // The rawCandidate === undefined guard used to live here too, which meant the
+    // two most common refusals -- nothing moved far enough, and two channels
+    // moving together -- could never produce a reason. The live candidate list
+    // carries what the raw candidate cannot.
+    return describeRcMappingRejectedCandidate(
+      rcMappingSession.currentTargetAxis,
+      rcMappingRawCandidate,
+      rcMappingLiveCandidates
+    )
+  }, [
+    rcMappingCandidate,
+    rcMappingLiveCandidates,
+    rcMappingRawCandidate,
+    rcMappingSession.currentTargetAxis,
+    rcMappingSession.status
+  ])
   const rcMappingDetectedChannelMap = useMemo(
     () =>
       Object.fromEntries(

--- a/apps/web/src/hooks/use-rc-range-derivations.ts
+++ b/apps/web/src/hooks/use-rc-range-derivations.ts
@@ -7,6 +7,7 @@
 import {
   type ConfiguratorSnapshot,
   type RcAxisExerciseProgress,
+  type RcAxisId,
   type RcRangeExerciseState,
   formatRcAxisLabel
 } from '@arduconfig/ardupilot-core'
@@ -24,6 +25,22 @@ export interface UseRcRangeDerivationsResult {
  * from useRcExercises and the live snapshot (only the rcInput.verified
  * flag is read). Outputs are byte-identical to the App.tsx originals.
  */
+/** What the operator physically does, per axis. Roll and yaw go left/right,
+ *  pitch goes forward/back, and only throttle has a low and a high. */
+function rcRangeStickPrompt(axisId: RcAxisId): string {
+  switch (axisId) {
+    case 'throttle':
+      return 'Move the throttle stick all the way down, then all the way up.'
+    case 'pitch':
+      return 'Move the pitch stick fully forward, fully back, then let it spring back to centre.'
+    case 'yaw':
+      return 'Move the yaw stick fully left, fully right, then let it spring back to centre.'
+    case 'roll':
+    default:
+      return 'Move the roll stick fully left, fully right, then let it spring back to centre.'
+  }
+}
+
 export function useRcRangeDerivations(input: {
   snapshot: ConfiguratorSnapshot
   rcRangeExercise: RcRangeExerciseState
@@ -59,9 +76,11 @@ export function useRcRangeDerivations(input: {
   const rcRangeExerciseInstructions =
     rcRangeExercise.status === 'running'
       ? [
-          rcRangeExercise.currentTargetAxis === 'throttle'
-            ? 'Move throttle fully low, then fully high.'
-            : `Move ${formatRcAxisLabel(rcRangeExercise.currentTargetAxis ?? 'roll')} fully low, fully high, then back to center.`,
+          // Per-axis wording. "Move Roll fully low, fully high" was the rendered
+          // string for roll and yaw -- nobody moves roll "low", and a beginner
+          // told to move something "low" reaches for the throttle stick. This is
+          // the likeliest place in the flow to do the wrong physical thing.
+          rcRangeStickPrompt(rcRangeExercise.currentTargetAxis ?? 'roll'),
           `Completed ${rcRangeExerciseCompletedCount} of ${rcRangeExercise.targetAxes.length} axis checks.`
         ]
       : rcRangeExercise.status === 'passed'

--- a/apps/web/src/osd-video-system-storage.test.ts
+++ b/apps/web/src/osd-video-system-storage.test.ts
@@ -1,0 +1,70 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+
+import { osdVideoSystemFromTxtRes, readStoredOsdPreview, writeStoredOsdPreview } from './osd-video-system-storage'
+
+// This workspace runs vitest under the `node` environment, where a global
+// `localStorage` exists but its methods do not -- so a typeof check passes and
+// the call then throws. That is exactly the shape the module has to survive in
+// a locked-down browser too, and the try/catch in it does; here we install a
+// working in-memory stub so the round-trip behaviour itself can be asserted.
+beforeEach(() => {
+  const store = new Map<string, string>()
+  Object.defineProperty(globalThis, 'localStorage', {
+    configurable: true,
+    value: {
+      getItem: (key: string) => store.get(key) ?? null,
+      setItem: (key: string, value: string) => void store.set(key, value),
+      removeItem: (key: string) => void store.delete(key),
+      clear: () => store.clear()
+    }
+  })
+})
+
+/*
+ * The seeding rule, pinned against ArduPilot's own parameter definition:
+ * AP_OSD_Screen.cpp declares OSDn_TXT_RES as `@Values: 0:30x16,1:50x18,2:60x22`.
+ */
+describe('OSD preview seeded from the aircraft', () => {
+  it('maps every TXT_RES value ArduPilot defines', () => {
+    expect(osdVideoSystemFromTxtRes(0)).toBe('analog')
+    expect(osdVideoSystemFromTxtRes(1)).toBe('hdzero')
+    expect(osdVideoSystemFromTxtRes(2)).toBe('dji_o3')
+  })
+
+  it('has no opinion when the parameter is absent or out of range', () => {
+    // A board whose build omits the MSP DisplayPort OSD has no TXT_RES at all;
+    // guessing a grid from nothing would be worse than leaving the default.
+    expect(osdVideoSystemFromTxtRes(undefined)).toBeUndefined()
+    expect(osdVideoSystemFromTxtRes(7)).toBeUndefined()
+  })
+})
+
+describe('OSD preview choice, remembered per aircraft', () => {
+  it('round-trips a stored choice', () => {
+    const key = 'arduconfigurator.osd-video-system.uid:test-a'
+    writeStoredOsdPreview(key, { version: 1, videoSystem: 'walksnail', analogSubMode: 'ntsc' })
+    expect(readStoredOsdPreview(key)).toEqual({ version: 1, videoSystem: 'walksnail', analogSubMode: 'ntsc' })
+  })
+
+  it('keeps two aircraft apart', () => {
+    const a = 'arduconfigurator.osd-video-system.uid:test-b'
+    const b = 'arduconfigurator.osd-video-system.uid:test-c'
+    writeStoredOsdPreview(a, { version: 1, videoSystem: 'walksnail', analogSubMode: 'ntsc' })
+    writeStoredOsdPreview(b, { version: 1, videoSystem: 'dji_o3', analogSubMode: 'ntsc' })
+    expect(readStoredOsdPreview(a)?.videoSystem).toBe('walksnail')
+    expect(readStoredOsdPreview(b)?.videoSystem).toBe('dji_o3')
+  })
+
+  it('treats a corrupt or unversioned entry as no preference', () => {
+    // Never throw out of the OSD tab because localStorage holds junk.
+    const key = 'arduconfigurator.osd-video-system.uid:test-d'
+    localStorage.setItem(key, 'not json')
+    expect(readStoredOsdPreview(key)).toBeUndefined()
+    localStorage.setItem(key, JSON.stringify({ version: 99, videoSystem: 'walksnail' }))
+    expect(readStoredOsdPreview(key)).toBeUndefined()
+  })
+
+  it('returns nothing without a key, rather than sharing one bucket', () => {
+    expect(readStoredOsdPreview(undefined)).toBeUndefined()
+  })
+})

--- a/apps/web/src/osd-video-system-storage.ts
+++ b/apps/web/src/osd-video-system-storage.ts
@@ -1,0 +1,123 @@
+// Which video system the OSD preview draws for a given aircraft.
+//
+// The preview grid is display-only — ArduPilot stores element positions as raw
+// character cells regardless — but the grid SIZE decides where those cells land
+// on screen, so previewing a 50-column Walksnail layout on a 60-column grid
+// draws every element bunched into the left 83% of the frame. Picking the right
+// system therefore matters, and having it reset to Analog on every tab switch
+// meant re-picking it constantly.
+//
+// Two sources, in order:
+//
+//  1. The aircraft's own OSDn_TXT_RES, which is what the FC actually drives the
+//     link at. Authoritative, per-drone, and needs no configuration from the
+//     operator at all.
+//  2. The operator's own last choice for this board, which wins over (1)
+//     because TXT_RES cannot distinguish the two 50-column systems: ArduPilot
+//     only encodes 30x16 / 50x18 / 60x22, so HDZero and Walksnail Avatar are
+//     the same value to it.
+//
+// Keyed by board uid the same way guided-setup progress is, so one operator's
+// two aircraft do not share a setting.
+
+import type { ConfiguratorSnapshot } from '@arduconfig/ardupilot-core'
+
+const STORAGE_KEY_PREFIX = 'arduconfigurator.osd-video-system.'
+
+/** Grid presets the preview can draw, keyed as the Osd view names them. */
+export type StoredOsdVideoSystem = string
+
+export interface StoredOsdPreviewChoice {
+  version: 1
+  videoSystem: StoredOsdVideoSystem
+  analogSubMode: 'pal' | 'ntsc'
+}
+
+/**
+ * Storage key for the connected aircraft, or undefined while its identity is
+ * not known. Same derivation as guided-setup progress: the AUTOPILOT_VERSION
+ * uid is per-unit unique, so two identical board models stay distinct.
+ */
+export function deriveOsdPreviewKey(snapshot: ConfiguratorSnapshot): string | undefined {
+  if (snapshot.connection.kind !== 'connected') {
+    return undefined
+  }
+
+  const board = snapshot.hardware.board
+  if (!board) {
+    return undefined
+  }
+
+  if (board.uid) {
+    return `${STORAGE_KEY_PREFIX}uid:${board.uid}`
+  }
+
+  return `${STORAGE_KEY_PREFIX}board:${board.boardType}:${board.vendorId}:${board.productId}`
+}
+
+/**
+ * The operator's stored choice for this aircraft, if any. Never throws: a
+ * corrupt or unreadable entry is treated as "no preference" rather than
+ * breaking the OSD tab.
+ */
+export function readStoredOsdPreview(key: string | undefined): StoredOsdPreviewChoice | undefined {
+  if (!key || typeof localStorage === 'undefined') {
+    return undefined
+  }
+
+  try {
+    const raw = localStorage.getItem(key)
+    if (!raw) {
+      return undefined
+    }
+    const parsed = JSON.parse(raw) as StoredOsdPreviewChoice
+    if (parsed?.version !== 1 || typeof parsed.videoSystem !== 'string') {
+      return undefined
+    }
+    return {
+      version: 1,
+      videoSystem: parsed.videoSystem,
+      analogSubMode: parsed.analogSubMode === 'pal' ? 'pal' : 'ntsc'
+    }
+  } catch {
+    return undefined
+  }
+}
+
+/** Remember this aircraft's preview choice. Silently a no-op without storage. */
+export function writeStoredOsdPreview(key: string | undefined, choice: StoredOsdPreviewChoice): void {
+  if (!key || typeof localStorage === 'undefined') {
+    return
+  }
+
+  try {
+    localStorage.setItem(key, JSON.stringify(choice))
+  } catch {
+    // Private browsing / quota. A forgotten preference is not worth an error.
+  }
+}
+
+/**
+ * The video system implied by the aircraft's own OSDn_TXT_RES.
+ *
+ * AP_OSD_Screen.cpp declares `@Values: 0:30x16,1:50x18,2:60x22`, so the
+ * parameter pins the grid WIDTH exactly. Width is what actually misplaces
+ * elements, which makes this a good default even where it cannot name the
+ * exact goggles.
+ *
+ * 50-wide is genuinely ambiguous — HDZero and Walksnail Avatar both live
+ * there — so this returns the ArduPilot-labelled 50x18 system and the
+ * operator's stored choice overrides it.
+ */
+export function osdVideoSystemFromTxtRes(txtRes: number | undefined): string | undefined {
+  switch (txtRes) {
+    case 0:
+      return 'analog'
+    case 1:
+      return 'hdzero'
+    case 2:
+      return 'dji_o3'
+    default:
+      return undefined
+  }
+}

--- a/apps/web/src/rc-channel-bars.tsx
+++ b/apps/web/src/rc-channel-bars.tsx
@@ -74,6 +74,19 @@ const STYLE_BLOCK = `
   background: var(--danger-weak, rgba(212, 107, 98, 0.16));
 }
 
+/* On a phone the label and value columns were eating 146px of a ~330px row,
+   leaving the bar -- the only part that moves -- under 180px. The channel
+   label already truncates ("CH3 · THROT…"), so it gives up width more
+   gracefully than the bar does -- but only so far: at 64px "AUX 1" collapsed
+   to "AU…", so 78px is the floor that still names the channel. */
+@media (max-width: 560px) {
+  .rc-bar-row {
+    grid-template-columns: 78px 1fr 44px;
+    gap: 4px;
+    padding: 0;
+  }
+}
+
 /* Label column */
 .rc-bar-label {
   display: flex;

--- a/apps/web/src/sections/AppHeader.tsx
+++ b/apps/web/src/sections/AppHeader.tsx
@@ -5,7 +5,7 @@
 // plain props + semantic callbacks. Behavior-neutral lift of the original
 // inline JSX: same markup, same data-testids, same class names, same copy.
 
-import { useEffect, useRef } from 'react'
+import { useEffect, useRef, useState } from 'react'
 
 import type { ConfiguratorSnapshot } from '@arduconfig/ardupilot-core'
 
@@ -121,8 +121,17 @@ export function AppHeader({
     return () => observer.disconnect()
   }, [])
 
+  // Phone-only disclosure. Above the phone breakpoint the toggle is display:none
+  // and every group it hides is laid out inline as before, so this state has no
+  // effect on the desktop header at all.
+  const [moreOpen, setMoreOpen] = useState(false)
+
   return (
-    <header ref={headerRef} className="app-header" data-testid="app-header">
+    <header
+      ref={headerRef}
+      className={`app-header${moreOpen ? ' is-more-open' : ''}`}
+      data-testid="app-header"
+    >
       <button
         type="button"
         className="app-header__brand"
@@ -143,6 +152,20 @@ export function AppHeader({
             <span data-testid="app-git-info" className="app-header__build--muted">{GIT_BRANCH}@{GIT_HASH}</span>
           </small>
         </span>
+      </button>
+
+      {/* On a phone the header was six stacked rows -- roughly a third of the
+          screen before any content. The rows that are not live state (Wiki, the
+          transport picker, Expert mode, the theme) fold in behind this. */}
+      <button
+        type="button"
+        className="app-header__more-toggle"
+        data-testid="header-more-toggle"
+        aria-expanded={moreOpen}
+        aria-label={moreOpen ? 'Hide connection and display settings' : 'Show connection and display settings'}
+        onClick={() => setMoreOpen((open) => !open)}
+      >
+        <span aria-hidden="true">···</span>
       </button>
 
       {/* Wiki + connection picker stack vertically to keep the header from

--- a/apps/web/src/sections/CalibrationSection.tsx
+++ b/apps/web/src/sections/CalibrationSection.tsx
@@ -1259,6 +1259,12 @@ export function CalibrationSection(props: CalibrationSectionProps): ReactElement
                 // is digital with no endpoints; Brushed (3) and PWMRange/PWMAngle
                 // (8/9) don't calibrate this way either — block all of them.
                 const motPwmType = readRoundedParameter(snapshot, 'MOT_PWM_TYPE')
+                // ESC_CALIBRATION persists in EEPROM. If the reboot never landed --
+                // link dropped, USB pulled, operator cancelled after the write -- the
+                // flag sits armed and the NEXT power-up runs all motors to full
+                // throttle, possibly in the field with props on. Nothing warned about
+                // that, so surface it wherever the operator reconnects.
+                const escCalPending = readRoundedParameter(snapshot, 'ESC_CALIBRATION')
                 const escCalUnsupported = motPwmType !== undefined && (motPwmType < 0 || motPwmType > 2)
                 const escProtocolLabel = formatArducopterMotorPwmType(motPwmType)
                 const escIsDShot = motPwmType !== undefined && motPwmType >= 4 && motPwmType <= 7
@@ -1302,6 +1308,17 @@ export function CalibrationSection(props: CalibrationSectionProps): ReactElement
                           {escCalUnsupported ? 'n/a' : escCalNotice ? (escCalNotice.tone === 'danger' ? 'failed' : 'armed') : 'idle'}
                         </StatusBadge>
                       </div>
+                      {escCalPending !== undefined && escCalPending !== 0 && escCalPending !== 9 ? (
+                        <div className="parameter-follow-up parameter-follow-up--danger" data-testid="esc-cal-pending">
+                          <StatusBadge tone="danger">armed on next boot</StatusBadge>
+                          <p>
+                            <code>ESC_CALIBRATION</code> is set to <strong>{escCalPending}</strong> on this flight
+                            controller. The next time it powers up it will run the ESC calibration routine — at
+                            <code>3</code> that means every motor to full throttle for about five seconds, on its own.
+                            {' '}Keep props off until you have either completed the calibration or set it back to 0.
+                          </p>
+                        </div>
+                      ) : null}
                       {escCalUnsupported ? (
                         <div className="parameter-follow-up parameter-follow-up--warning" data-testid="esc-cal-unsupported">
                           <StatusBadge tone="neutral">not applicable</StatusBadge>
@@ -1316,7 +1333,27 @@ export function CalibrationSection(props: CalibrationSectionProps): ReactElement
                         </div>
                       ) : (
                         <>
-                          <p>Calibrates the ESC throttle endpoints. Sets ESC_CALIBRATION=3 and reboots; on the next boot (safety off) the ESCs learn min/max from the throttle range. Reconnect after the reboot.</p>
+                          {/* This copy used to describe ESC_CALIBRATION=1/2 -- "the ESCs
+                            *  learn min/max from the throttle range", i.e. wait for the
+                            *  pilot's stick. The code writes 3, which is ESCCAL_AUTO:
+                            *  ArduCopter's esc_calibration_auto() calls
+                            *  set_throttle_passthrough_for_esc_calibration(1.0f) and holds
+                            *  EVERY motor at full throttle for five seconds on its own,
+                            *  immediately at boot, with no pilot input. The only interlock
+                            *  is a safety-switch wait, and a board without a safety switch
+                            *  reports SAFETY_NONE (not SAFETY_DISARMED), so that loop never
+                            *  runs -- which is most FPV AIO boards. Telling the operator to
+                            *  "reconnect, then raise throttle" invited them to have props on
+                            *  and hands near the craft at exactly the wrong moment. */}
+                          <p>
+                            Calibrates the ESC throttle endpoints. Sets <code>ESC_CALIBRATION=3</code> and reboots.
+                            {' '}<strong>
+                              On the next boot the flight controller drives every motor to full throttle for about five
+                              seconds, by itself, with no stick input and no further prompt.
+                            </strong>
+                            {' '}Props must be off and the craft restrained before you confirm. Most FPV boards have no
+                            safety switch to hold this back.
+                          </p>
                           {/* Second copy of the same shared acknowledgements —
                             *  this card spins motors too, so the gate belongs
                             *  next to its own button rather than in a card the
@@ -1345,13 +1382,20 @@ export function CalibrationSection(props: CalibrationSectionProps): ReactElement
                                 style={buttonStyle('secondary')}
                                 className="setup-bench__dfu-danger"
                                 data-testid="esc-cal-confirm"
+                                // The acknowledgements gated only the arm button, so they
+                                // could be un-ticked while this stayed live. Re-check the
+                                // same gate the arm button used.
+                                disabled={!baseReady || !motorSafetyOk || !canApplyDraftParameters}
                                 onClick={() => {
                                   setEscCalArmed(false)
                                   void (async () => {
                                     try {
                                       await runtime.setParameter('ESC_CALIBRATION', 3, UI_PARAMETER_WRITE_OPTIONS)
                                       await runtime.reboot()
-                                      setEscCalNotice({ tone: 'success', text: 'ESC_CALIBRATION=3 set and reboot sent. Reconnect, then raise throttle to complete on the bench.' })
+                                      setEscCalNotice({
+                                        tone: 'warning',
+                                        text: 'ESC_CALIBRATION=3 set and reboot sent. The flight controller will run every motor at full throttle for about five seconds as it boots — stay clear until it finishes, then reconnect.'
+                                      })
                                     } catch (error) {
                                       setEscCalNotice({ tone: 'danger', text: error instanceof Error ? error.message : 'Failed to start ESC calibration.' })
                                     }
@@ -1369,7 +1413,7 @@ export function CalibrationSection(props: CalibrationSectionProps): ReactElement
                             <summary>How to calibrate ESC throttle endpoints (PWM ESCs only)</summary>
                             <ol>
                               <li>Confirm props are off and the airframe is restrained.</li>
-                              <li>Click <em>Set ESC calibration mode</em> then <em>Confirm: set + reboot</em> — the FC reboots with ESC_CALIBRATION=3 set.</li>
+                              <li>Click <em>Set ESC calibration mode</em> then <em>Confirm: set + reboot</em> — the FC reboots and immediately runs all motors to full throttle for about five seconds on its own.</li>
                               <li>On the next boot, raise the throttle stick to full, power-cycle the ESCs (or wait for the FC to drive max PWM), then drop to zero. ESCs learn the new endpoints from the pulse range.</li>
                               <li>Reconnect once the ESCs finish their startup chime. Skip entirely for DShot ESCs — they don't need endpoint calibration.</li>
                             </ol>

--- a/apps/web/src/sections/OsdSection.tsx
+++ b/apps/web/src/sections/OsdSection.tsx
@@ -104,6 +104,10 @@ export function OsdSection(props: OsdSectionProps) {
   return (
     <OsdView
       headerNav={headerNav}
+      videoSystem={osdEditor.videoSystem}
+      setVideoSystem={osdEditor.setVideoSystem}
+      analogSubMode={osdEditor.analogSubMode}
+      setAnalogSubMode={osdEditor.setAnalogSubMode}
       linkPorts={osdLinkPorts}
       typeField={osdTypeParameter ? { parameter: osdTypeParameter, liveValue: osdType } : undefined}
       channelField={osdChannelParameter ? { parameter: osdChannelParameter, liveValue: osdChannel } : undefined}

--- a/apps/web/src/sections/SetupWizardHeader.tsx
+++ b/apps/web/src/sections/SetupWizardHeader.tsx
@@ -8,7 +8,7 @@
 // onSelectStep (which both sets the selected section and forces wizard mode).
 // Behavior-preserving.
 
-import type { ReactElement } from 'react'
+import { useEffect, useRef, type ReactElement } from 'react'
 
 import { StatusBadge } from '@arduconfig/ui-kit'
 
@@ -38,6 +38,12 @@ export function SetupWizardHeader({
   onSelectStep,
   onResetProgress
 }: SetupWizardHeaderProps): ReactElement {
+  const activeStepRef = useRef<HTMLButtonElement | null>(null)
+
+  useEffect(() => {
+    activeStepRef.current?.scrollIntoView({ inline: 'center', block: 'nearest', behavior: 'smooth' })
+  }, [selectedSetupSection.id])
+
   return (
     <>
       <div className="setup-wizard__header">
@@ -101,6 +107,10 @@ export function SetupWizardHeader({
         {setupFlowSections.map((section, index) => (
           <button
             key={section.id}
+            /* The rail is a single horizontal scroller ~3 viewports wide on a
+               phone, and it never scrolled itself: past step 4 the chip marking
+               where the operator IS sat off-screen with no cue it existed. */
+            ref={section.id === selectedSetupSection.id ? activeStepRef : undefined}
             type="button"
             /* The wizard's primary navigation, so it gets a stable hook like
                every other interactive surface here. Without it an e2e has to

--- a/apps/web/src/setup-exercise-helpers.test.ts
+++ b/apps/web/src/setup-exercise-helpers.test.ts
@@ -1,8 +1,12 @@
 import { describe, expect, it } from 'vitest'
 
+import { detectDominantRcChannelChange } from '@arduconfig/ardupilot-core'
+
 import {
+  RC_CALIBRATION_AXIS_ORDER,
   RC_CALIBRATION_SWITCH_CHANNELS,
   createIdleRcCalibrationSessionState,
+  createRcMappingSessionState,
   rcSwitchCaptureComplete
 } from './setup-exercise-helpers'
 
@@ -44,5 +48,112 @@ describe('RC calibration switch captures (CH5/CH6)', () => {
         observedMax: 1900
       })
     ).toBe(true)
+  })
+})
+
+/*
+ * A whole guided-mapping run, end to end.
+ *
+ * Every piece of this was unit-tested in isolation, but nothing walked the
+ * four axes in sequence the way an operator does — start, move one stick,
+ * capture, advance, repeat — which is the part that has to hold for the
+ * feature to work at all. The stick positions below are a normal Mode 2
+ * transmitter on a normal receiver: sticks sprung to centre, throttle resting
+ * low, two aux switches parked.
+ */
+describe('guided RC mapping, full four-axis session', () => {
+  const AT_REST = [1500, 1500, 1000, 1500, 1000, 1500, 2000, 1000]
+
+  const snapshotWith = (channels: number[]) =>
+    ({
+      liveVerification: { rcInput: { verified: true, channels } }
+    }) as unknown as Parameters<typeof createRcMappingSessionState>[0]
+
+  /** Move one channel off the resting position, leaving the rest alone. */
+  const deflect = (channelNumber: number, pwm: number) =>
+    AT_REST.map((rest, index) => (index === channelNumber - 1 ? pwm : rest))
+
+  it('walks roll → pitch → throttle → yaw and lands on a complete map', () => {
+    let session = createRcMappingSessionState(snapshotWith(AT_REST))
+    expect(session.status).toBe('running')
+    expect(session.currentTargetAxis).toBe('roll')
+
+    // The operator's four moves, in the order the app asks for them. Throttle
+    // gets a full sweep because it has no centring spring and is held to a
+    // higher threshold than the sprung axes.
+    const moves: Array<[number, number]> = [
+      [1, 1800], // roll right
+      [2, 1200], // pitch forward
+      [3, 1900], // throttle up
+      [4, 1800] // yaw right
+    ]
+
+    for (const [channelNumber, pwm] of moves) {
+      const targetAxis = session.currentTargetAxis
+      expect(targetAxis).toBeDefined()
+
+      const excluded = Object.values(session.captures)
+        .map((capture) => capture.detectedChannelNumber)
+        .filter((value): value is number => value !== undefined)
+
+      const candidate = detectDominantRcChannelChange(deflect(channelNumber, pwm), session.baselineChannels, {
+        excludedChannelNumbers: excluded,
+        targetAxis
+      })
+
+      // The axis the app is asking for resolves to the channel that moved.
+      expect(candidate, `no candidate while moving CH${channelNumber} for ${targetAxis}`).toBeDefined()
+      expect(candidate?.channelNumber).toBe(channelNumber)
+
+      session = {
+        ...session,
+        captures: {
+          ...session.captures,
+          [targetAxis!]: {
+            ...session.captures[targetAxis!],
+            detectedChannelNumber: candidate!.channelNumber,
+            deltaUs: candidate!.deltaUs
+          }
+        }
+      }
+      const nextTargetAxis = RC_CALIBRATION_AXIS_ORDER.find(
+        (axisId) => session.captures[axisId].detectedChannelNumber === undefined
+      )
+      session = { ...session, currentTargetAxis: nextTargetAxis, status: nextTargetAxis ? 'running' : 'ready' }
+    }
+
+    expect(session.status).toBe('ready')
+    expect(
+      Object.fromEntries(RC_CALIBRATION_AXIS_ORDER.map((a) => [a, session.captures[a].detectedChannelNumber]))
+    ).toEqual({ roll: 1, pitch: 2, throttle: 3, yaw: 4 })
+  })
+
+  it('will not start without live RC, and says so rather than failing silently', () => {
+    const session = createRcMappingSessionState({
+      liveVerification: { rcInput: { verified: false, channels: [] } }
+    } as unknown as Parameters<typeof createRcMappingSessionState>[0])
+    expect(session.status).toBe('failed')
+    expect(session.failureReason).toMatch(/telemetry/i)
+  })
+
+  it('ignores a stick that has not moved far enough to be deliberate', () => {
+    const session = createRcMappingSessionState(snapshotWith(AT_REST))
+    // 100us of roll — a knock or a trim, not an intentional sweep.
+    const candidate = detectDominantRcChannelChange(deflect(1, 1600), session.baselineChannels, { targetAxis: 'roll' })
+    expect(candidate).toBeUndefined()
+  })
+
+  it('does not mistake the throttle for a sprung axis, or vice versa', () => {
+    const session = createRcMappingSessionState(snapshotWith(AT_REST))
+    // Throttle moved while the app is asking for roll: rejected, because the
+    // throttle channel's baseline is nowhere near centre.
+    expect(
+      detectDominantRcChannelChange(deflect(3, 1900), session.baselineChannels, { targetAxis: 'roll' })
+    ).toBeUndefined()
+    // A roll-sized nudge on the throttle step: rejected, because throttle is
+    // held to a 250us sweep.
+    expect(
+      detectDominantRcChannelChange(deflect(3, 1150), session.baselineChannels, { targetAxis: 'throttle' })
+    ).toBeUndefined()
   })
 })

--- a/apps/web/src/setup-exercise-helpers.test.ts
+++ b/apps/web/src/setup-exercise-helpers.test.ts
@@ -7,6 +7,7 @@ import {
   RC_CALIBRATION_SWITCH_CHANNELS,
   createIdleRcCalibrationSessionState,
   createRcMappingSessionState,
+  describeRcMappingRejectedCandidate,
   rcSwitchCaptureComplete
 } from './setup-exercise-helpers'
 
@@ -154,6 +155,48 @@ describe('guided RC mapping, full four-axis session', () => {
     // held to a 250us sweep.
     expect(
       detectDominantRcChannelChange(deflect(3, 1150), session.baselineChannels, { targetAxis: 'throttle' })
+    ).toBeUndefined()
+  })
+})
+
+/*
+ * The RC-mapping capture has three refusal paths and, before the 2026-09 audit,
+ * only one of them could explain itself. The other two fell through to a
+ * generic "keep moving only that control" — which is wrong advice in the
+ * dominance case, where the operator IS moving only that control and their
+ * radio is driving a second channel from it.
+ */
+describe('RC mapping refusals explain themselves', () => {
+  const candidate = (channelNumber: number, deltaUs: number, baselinePwm = 1500) => ({
+    channelNumber,
+    deltaUs,
+    baselinePwm,
+    livePwm: baselinePwm + deltaUs
+  })
+
+  it('names both channels when two move together', () => {
+    const reason = describeRcMappingRejectedCandidate('roll', undefined, [
+      candidate(1, 300),
+      candidate(7, 290)
+    ])
+    expect(reason).toMatch(/CH1 and CH7 are moving together/)
+    expect(reason).toMatch(/mix or a shared lead/)
+  })
+
+  it('says move further when the stick barely moved', () => {
+    const reason = describeRcMappingRejectedCandidate('roll', undefined, [candidate(1, 100)])
+    expect(reason).toMatch(/too small to identify a channel/)
+    expect(reason).toMatch(/all the way to one end/)
+  })
+
+  it('still explains a baseline that is nowhere near centre', () => {
+    const reason = describeRcMappingRejectedCandidate('roll', candidate(3, 300, 1000), [candidate(3, 300, 1000)])
+    expect(reason).toMatch(/throttle or another switch channel/)
+  })
+
+  it('has nothing to say when one channel cleanly dominates', () => {
+    expect(
+      describeRcMappingRejectedCandidate('roll', undefined, [candidate(1, 300), candidate(7, 40)])
     ).toBeUndefined()
   })
 })

--- a/apps/web/src/setup-exercise-helpers.ts
+++ b/apps/web/src/setup-exercise-helpers.ts
@@ -5,6 +5,8 @@
 
 import {
   formatRcAxisLabel,
+  RC_MAPPING_DELTA_THRESHOLD_US,
+  RC_MAPPING_DOMINANCE_MARGIN_US,
   RC_MAPPING_THROTTLE_DELTA_THRESHOLD_US,
   type ConfiguratorSnapshot,
   type RcAxisId,
@@ -128,12 +130,18 @@ export function orientationStepLabel(step: OrientationExerciseStepId): string {
 
 export function orientationStepInstruction(step: OrientationExerciseStepId | undefined): string {
   switch (step) {
+    // These state the thresholds the code actually tests below (8 deg level,
+    // 12 deg tilt). They used to say "near zero" and quote the telemetry sign
+    // convention -- "pitch should move negative" -- which tells the operator
+    // nothing about what to DO, and left someone tilting 8 degrees watching
+    // nothing happen with no idea whether to tilt further or whether their
+    // board orientation was wrong.
     case 'level':
-      return 'Hold the vehicle level and motionless until both roll and pitch are near zero.'
+      return 'Set the aircraft down level and hold it still, within about 8 degrees of level.'
     case 'pitch-forward':
-      return 'Tilt the nose forward. Pitch should move negative if board orientation is correct.'
+      return 'Tilt the nose down at least 15 degrees and hold it. The horizon should pitch down with the aircraft — if it pitches up, the board orientation is wrong.'
     case 'roll-right':
-      return 'Roll the vehicle to the right. Roll should move positive if board orientation is correct.'
+      return 'Roll the aircraft right at least 15 degrees and hold it. The horizon should roll right with the aircraft — if it rolls left, the board orientation is wrong.'
     default:
       return 'Start the orientation exercise to verify live horizon behavior.'
   }
@@ -319,7 +327,51 @@ export function deriveRcMappingLiveCandidates(
     .sort((left, right) => right.deltaUs - left.deltaUs)
 }
 
-export function describeRcMappingRejectedCandidate(targetAxis: RcAxisId, candidate: RcMappingCandidate): string | undefined {
+/**
+ * Why the capture refused, in words the operator can act on.
+ *
+ * detectDominantRcChannelChange has three refusal paths -- delta under the
+ * threshold, the dominance margin (top two channels within 35us of each other),
+ * and the axis filter -- but this only ever saw the raw candidate, which is
+ * itself undefined for the first two. So the only refusal it could explain was
+ * the off-centre baseline, and everything else fell through to a generic "keep
+ * moving only that control".
+ *
+ * That generic line is actively wrong for the dominance case: the operator IS
+ * moving only that control, and their radio is driving a second channel from it
+ * -- a mix, a Y-lead, expo on a 4-in-1. Telling them to do harder what they are
+ * already doing correctly is worse than saying nothing.
+ *
+ * `liveCandidates` is the ranked list, so the two cases the raw candidate cannot
+ * express are recoverable here.
+ */
+export function describeRcMappingRejectedCandidate(
+  targetAxis: RcAxisId,
+  candidate: RcMappingCandidate | undefined,
+  liveCandidates: readonly RcMappingCandidate[] = []
+): string | undefined {
+  const axisLabel = formatRcAxisLabel(targetAxis).toLowerCase()
+
+  // Two channels moving together: neither can be called dominant.
+  const [strongest, next] = liveCandidates
+  if (
+    strongest &&
+    next &&
+    strongest.deltaUs >= RC_MAPPING_DELTA_THRESHOLD_US &&
+    strongest.deltaUs - next.deltaUs < RC_MAPPING_DOMINANCE_MARGIN_US
+  ) {
+    return `CH${strongest.channelNumber} and CH${next.channelNumber} are moving together, so neither one is clearly ${axisLabel}. Check for a mix or a shared lead on this stick, or move ${axisLabel} further than the other channel.`
+  }
+
+  // Moved, but not far enough to be deliberate.
+  if (strongest && strongest.deltaUs < RC_MAPPING_DELTA_THRESHOLD_US) {
+    return `That movement is too small to identify a channel. Move ${axisLabel} all the way to one end and hold it there.`
+  }
+
+  if (!candidate) {
+    return undefined
+  }
+
   if (targetAxis === 'throttle') {
     // Throttle accepts either direction from any baseline (no centering
     // spring — see RC_MAPPING_THROTTLE_DELTA_THRESHOLD_US in
@@ -332,7 +384,7 @@ export function describeRcMappingRejectedCandidate(targetAxis: RcAxisId, candida
   }
 
   if (candidate.baselinePwm < 1300 || candidate.baselinePwm > 1700) {
-    return `That movement looks more like throttle or another switch channel, not ${formatRcAxisLabel(targetAxis).toLowerCase()}. Re-center the sticks, leave throttle low, and move only ${formatRcAxisLabel(targetAxis).toLowerCase()}.`
+    return `That movement looks more like throttle or another switch channel, not ${axisLabel}. Re-centre the sticks, leave throttle low, and move only ${axisLabel}.`
   }
 
   return undefined

--- a/apps/web/src/setup-flow-helpers.test.ts
+++ b/apps/web/src/setup-flow-helpers.test.ts
@@ -5,7 +5,8 @@ import {
   deriveSetupStatusFromCriteria,
   escCalibrationInstructions,
   escCalibrationPathLabel,
-  panelAnchorForSetupSection
+  panelAnchorForSetupSection,
+  appViewForPanel
 } from './setup-flow-helpers'
 
 const criterion = (met: boolean): SetupFlowCriterion => ({ label: 'c', met })
@@ -45,9 +46,22 @@ describe('panelAnchorForSetupSection', () => {
     expect(panelAnchorForSetupSection('outputs').panelLabel).toBe('Airframe & Outputs')
     // guided cal trio share the guided panel
     expect(panelAnchorForSetupSection('compass').panelId).toBe('setup-panel-guided')
-    // failsafe + power share the power panel
-    expect(panelAnchorForSetupSection('failsafe')).toEqual(panelAnchorForSetupSection('power'))
+    // Failsafe and Modes each route to their OWN tab. They used to be folded
+    // onto the power panel and the RC panel respectively, which sent the
+    // operator to the Config tab's power section and the Receiver view --
+    // neither being where those steps' parameters are edited. Both tabs had
+    // carried a setup anchor all along that nothing referenced.
+    expect(panelAnchorForSetupSection('failsafe').panelId).toBe('setup-panel-failsafe')
+    expect(panelAnchorForSetupSection('modes').panelId).toBe('setup-panel-modes')
+    expect(panelAnchorForSetupSection('power').panelId).toBe('setup-panel-power')
     // unknown falls back to guided
     expect(panelAnchorForSetupSection('mystery').panelId).toBe('setup-panel-guided')
+  })
+
+  it('routes each setup panel to a view that exists', () => {
+    expect(appViewForPanel('setup-panel-failsafe')).toBe('failsafe')
+    expect(appViewForPanel('setup-panel-modes')).toBe('modes')
+    expect(appViewForPanel('setup-panel-rc')).toBe('receiver')
+    expect(appViewForPanel('setup-panel-outputs')).toBe('motors')
   })
 })

--- a/apps/web/src/setup-flow-helpers.ts
+++ b/apps/web/src/setup-flow-helpers.ts
@@ -62,9 +62,16 @@ export function panelAnchorForSetupSection(sectionId: string): { panelId: string
     case 'compass':
       return { panelId: 'setup-panel-guided', panelLabel: 'Guided Setup' }
     case 'radio':
-    case 'modes':
       return { panelId: 'setup-panel-rc', panelLabel: 'Live RC Inputs' }
+    // Modes and Failsafe each own a tab with its own anchor, and both anchors
+    // already existed and were referenced by nothing. Modes sent the operator to
+    // the Receiver view and Failsafe to the Config tab's power section -- neither
+    // of which is where the step's parameters are edited. Same class of silent
+    // breakage the power mapping below documents.
+    case 'modes':
+      return { panelId: 'setup-panel-modes', panelLabel: 'Flight Modes' }
     case 'failsafe':
+      return { panelId: 'setup-panel-failsafe', panelLabel: 'Failsafe' }
     case 'power':
       return { panelId: 'setup-panel-power', panelLabel: 'Power & Failsafe' }
     default:
@@ -128,6 +135,10 @@ export function appViewForPanel(panelId: string): AppViewId {
       // on the Motors nav tab. (Servos is a separate nav tab for aux
       // peripheral servo work and isn't part of the setup checklist.)
       return 'motors'
+    case 'setup-panel-modes':
+      return 'modes'
+    case 'setup-panel-failsafe':
+      return 'failsafe'
     case 'setup-panel-power':
       // Power is a Config category now, not its own tab. This mapping is the
       // one that breaks silently when a surface moves: the guided Power step

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -5538,7 +5538,15 @@ body.is-status-dash-dragging {
 }
 
 .guided-action-pulse {
-  animation: guided-action-pulse 1.25s ease-in-out infinite;
+  /* Was `infinite`. This runs on the flow's PRIMARY navigation button, so the
+     wizard's main control never stopped moving -- a permanent jitter for anyone
+     motion-sensitive, and it never settles into a stable target. It also made
+     the button un-clickable to automation: Playwright's actionability check
+     waits for the element to be stable and simply never resolved.
+     The cue's job is to catch the eye on arrival, not to run for the life of
+     the step. (prefers-reduced-motion already collapses this to nothing via the
+     global block; this is about the default.) */
+  animation: guided-action-pulse 1.25s ease-in-out 3;
 }
 
 @keyframes guided-action-pulse {
@@ -13178,6 +13186,23 @@ details.metadata-settings-section:not([open]) > summary::after {
     grid-template-columns: 1fr;
     display: grid;
   }
+
+  /* Same trap the aside documents and fixes above: grid items default to
+   * min-width: auto, and .setup-wizard__header-status is a nowrap badge row.
+   * Its content width became the track's floor, blowing the wizard out to
+   * 539px inside a 390px viewport. Because an ancestor is overflow-x: clip the
+   * page never scrolled sideways -- so the document-level overflow assertion
+   * stayed green while button labels and criteria text were cut mid-word with
+   * no way to reach them. */
+  .setup-wizard,
+  .setup-wizard > *,
+  .setup-wizard__header > *,
+  .setup-wizard__nav > *,
+  .setup-wizard__body > *,
+  .setup-wizard__aside > * {
+    min-width: 0;
+  }
+
 
   .setup-wizard__task-fields,
   .setup-wizard__secondary-actions {

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -13482,14 +13482,19 @@ details.metadata-settings-section:not([open]) > summary::after {
 }
 .dfu-hex-flasher__summary {
   display: grid;
+  /* minmax(140px, 1fr) floors each track at 140px, but a grid ITEM defaults to
+     min-width: auto -- it refuses to shrink below its content and overflows the
+     track instead. A firmware filename is 30-40 characters of mono, so the File
+     cell painted straight over the Size cell next to it. */
   grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
-  gap: 8px 18px;
-  margin: 12px 0;
+  gap: var(--space-2) 18px;
+  margin: var(--space-3) 0;
 }
 .dfu-hex-flasher__summary div {
   display: flex;
   flex-direction: column;
   gap: 2px;
+  min-width: 0;
 }
 .dfu-hex-flasher__summary dt {
   font-size: var(--text-xs);
@@ -13501,6 +13506,9 @@ details.metadata-settings-section:not([open]) > summary::after {
   margin: 0;
   font-family: var(--font-data);
   font-size: var(--text-lg);
+  /* A filename has no spaces to break at, so it needs permission to break
+     anywhere -- otherwise min-width: 0 just clips it instead of overlapping. */
+  overflow-wrap: anywhere;
 }
 
 /* Hard-stop refusal banner — promoted from a small <p> because the

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -18043,3 +18043,199 @@ button.mavlink-inspector__sent-row {
   font-size: var(--text-md);
   color: var(--text-dim);
 }
+
+/* ── Phone layer ──────────────────────────────────────────────────────────
+ *
+ * 560px, chosen once and used for every phone rule below rather than adding an
+ * eleventh arbitrary breakpoint. Above it nothing here applies and the desktop
+ * header is untouched.
+ *
+ * The problem this solves: the header laid out as six stacked rows on a phone
+ * -- brand, Wiki, transport, battery + params, Expert + theme, connect --
+ * costing ~320px of an 844px screen before the page title, on every view. The
+ * groups are reordered with flex `order` rather than moved in the DOM, so the
+ * desktop order and the markup stay exactly as they were.
+ *
+ * What does NOT fold away: the transport picker and the connect action.
+ * Choosing a transport and connecting is the first thing anyone does on a
+ * phone, and putting it behind a disclosure buys 40px at the cost of the one
+ * flow that has to work. Only the things you touch once a session -- the wiki
+ * link, Expert mode, the theme -- go in the sheet.
+ */
+@media (max-width: 560px) {
+  .app-header {
+    /* Explicit: the narrow-screen rule at <=1024px folds .app-header into a
+       one-column grid along with thirty other containers, which is what made
+       every group its own full-width row. The bar wants to be a flex line. */
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: var(--space-2);
+    padding: var(--space-2) var(--space-3);
+  }
+
+  .app-header__brand {
+    order: 0;
+    /* Takes the slack on row one so the toggle and the action sit hard right.
+       An auto margin on the toggle would do it too, except an auto margin eats
+       the line's free space and pushes the action onto a row of its own. */
+    flex: 1 1 auto;
+    padding: 0;
+    border: none;
+    background: none;
+  }
+
+  /* The name and build string are the least useful pixels on a phone -- the
+     mark already says which app this is. */
+  .app-header__brand-copy {
+    display: none;
+  }
+
+  /* Row one is identity and the two controls you actually press. The live
+     state below is information, not action, so it gets its own row rather than
+     being squeezed in beside them -- trying to fit the battery card inline is
+     what left the mark stranded on a row of its own. */
+  .app-header__more-toggle {
+    order: 1;
+    flex: 0 0 auto;
+  }
+
+  .app-header__actions {
+    order: 2;
+    flex: 0 0 auto;
+  }
+
+  .app-header__telemetry,
+  .app-header__disconnected-pill {
+    order: 3;
+    flex-basis: 100%;
+    min-width: 0;
+  }
+
+  /* Connect and Disconnect sat one above the other, which is what made the
+     header six rows instead of five. */
+  .app-header__primary-actions {
+    flex-direction: row;
+    gap: var(--space-2);
+  }
+
+  .app-header__telemetry {
+    display: flex;
+    align-items: center;
+    gap: var(--space-3);
+  }
+
+  /* The bottom status bar already carries the sync state on every screen. */
+  .header-sync-panel__progress {
+    display: none;
+  }
+
+  /* Row three: the transport picker, always reachable. */
+  .app-header__nav-stack {
+    order: 4;
+    flex-basis: 100%;
+    gap: var(--space-2);
+  }
+
+  .app-header__connection {
+    flex: 1 1 auto;
+    min-width: 0;
+  }
+
+  .app-header__connection select,
+  .app-header__connection-input {
+    width: 100%;
+  }
+
+  /* The sheet: once-a-session controls, on their own rows when opened. */
+  .app-header__wiki {
+    order: 5;
+    flex-basis: 100%;
+    justify-content: center;
+  }
+
+  .app-header__mode-switch {
+    order: 6;
+    flex-basis: 100%;
+    justify-content: space-between;
+  }
+
+  .app-header:not(.is-more-open) .app-header__wiki,
+  .app-header:not(.is-more-open) .app-header__mode-switch {
+    display: none;
+  }
+}
+
+/* The toggle exists only on the phone layer; everywhere else the groups it
+   hides are laid out inline and it would be a control that does nothing. */
+.app-header__more-toggle {
+  display: none;
+}
+
+@media (max-width: 560px) {
+  .app-header__more-toggle {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 32px;
+    height: 32px;
+    padding: 0;
+    border: 1px solid rgba(var(--edge-rgb), 0.08);
+    border-radius: var(--radius-lg);
+    background: rgba(var(--edge-rgb), 0.03);
+    color: var(--text-muted);
+    font-size: var(--text-2xl);
+    line-height: 1;
+    cursor: pointer;
+  }
+
+  .app-header.is-more-open .app-header__more-toggle {
+    color: var(--accent);
+    border-color: var(--accent);
+  }
+}
+
+/* ── Phone: live displays ─────────────────────────────────────────────────
+ *
+ * These are the surfaces people actually came to look at -- the craft attitude,
+ * the OSD layout, the stick bars -- and on a phone they were the worst-served
+ * things on the screen.
+ *
+ * The craft view was the clearest case. Its height is clamp(180px, 21vw,
+ * 260px): a height derived from viewport WIDTH, which collapses to the 180px
+ * floor on any phone while the width stays fluid. The result was a 3D model
+ * letterboxed into 302x176. An aspect-ratio says what was actually meant --
+ * "as tall as it is wide, near enough" -- at any width.
+ */
+@media (max-width: 560px) {
+  .flight-deck__model-frame {
+    height: auto;
+    aspect-ratio: 4 / 3;
+  }
+
+  /* The compact variant pins 286px, which is close to right at 390px but
+     letterboxes again on a narrow phone. */
+  .flight-deck--compact .flight-deck__model-frame {
+    height: auto;
+    aspect-ratio: 4 / 3;
+  }
+
+  /* Nested cards each took 10-12px a side, so a display three cards deep lost
+     ~60px of a 390px screen to padding it did not need. */
+  .bf-gui-box {
+    padding: var(--space-2);
+    gap: var(--space-2);
+  }
+
+  /* Bleed the displays themselves back out over what padding remains. width
+     stays auto so this widens the box without ever exceeding the viewport. */
+  .flight-deck__model-shell,
+  .osd-preview-screen,
+  .rc-bars-container {
+    /* Widen by exactly the bleed. `width: auto` also works where the box is
+       block-level, but the compact deck sits in a flex context where auto
+       shrinks it to content -- it lost 57px that way. */
+    width: calc(100% + var(--space-2) * 2);
+    margin-inline: calc(var(--space-2) * -1);
+  }
+}

--- a/apps/web/src/view-models/setup-confirmation-signatures.ts
+++ b/apps/web/src/view-models/setup-confirmation-signatures.ts
@@ -52,10 +52,25 @@ export function buildSetupConfirmationSignatures(inputs: SetupConfirmationSignat
   } = inputs
 
   return {
+      // AHRS_ORIENTATION belongs in all three of these.
+      //
+      // The level cal is AP_InertialSensor::calibrate_trim(), which samples via
+      // get_accel(0) -- and that reading is rotated by _board_orientation
+      // (AP_InertialSensor.cpp: ret.rotate(_board_orientation)). So AHRS_TRIM_X/Y
+      // are only valid for the orientation in effect when the cal ran, and the
+      // same holds for the 6-pose cal's trim path. The airframe step's own
+      // criterion is the orientation exercise.
+      //
+      // Without it: run the orientation exercise, calibrate accel and level, get
+      // three green steps -- then re-mount the board and change AHRS_ORIENTATION,
+      // and all three STAY green against a rotation they were never run at. The
+      // aircraft's level reference is off by the orientation error and it leans on
+      // takeoff, with nothing telling the operator to re-run anything.
       airframe: JSON.stringify({
         frameClassValue: airframe.frameClassValue,
         frameTypeValue: airframe.frameTypeValue,
-        frameTypeIgnored: airframe.frameTypeIgnored
+        frameTypeIgnored: airframe.frameTypeIgnored,
+        boardOrientation: readRoundedParameter(snapshot, 'AHRS_ORIENTATION')
       }),
       outputs: JSON.stringify({
         expectedMotorCount: airframe.expectedMotorCount,
@@ -86,11 +101,13 @@ export function buildSetupConfirmationSignatures(inputs: SetupConfirmationSignat
       // re-run or the sensor hardware changes — which is when a stale
       // sign-off SHOULD stop counting.
       accelerometer: JSON.stringify({
+        boardOrientation: readRoundedParameter(snapshot, 'AHRS_ORIENTATION'),
         accId: readRoundedParameter(snapshot, 'INS_ACC_ID'),
         offsets: ['INS_ACCOFFS_X', 'INS_ACCOFFS_Y', 'INS_ACCOFFS_Z'].map((id) => readParameterValue(snapshot, id)),
         scales: ['INS_ACCSCAL_X', 'INS_ACCSCAL_Y', 'INS_ACCSCAL_Z'].map((id) => readParameterValue(snapshot, id))
       }),
       level: JSON.stringify({
+        boardOrientation: readRoundedParameter(snapshot, 'AHRS_ORIENTATION'),
         trims: ['AHRS_TRIM_X', 'AHRS_TRIM_Y'].map((id) => readParameterValue(snapshot, id))
       }),
       compass: JSON.stringify({
@@ -137,13 +154,26 @@ export function buildSetupConfirmationSignatures(inputs: SetupConfirmationSignat
       // still re-check live telemetry and pre-arm health on every render,
       // so safety gating is unchanged; only the sign-off's validity stops
       // depending on transient state.
+      // Widened to the values the step's own copy claims to have reviewed. Pinning
+      // just the two enables meant an operator could sign off "I reviewed the
+      // failsafe behaviour" and then move FS_THR_VALUE below the receiver's
+      // failsafe output, zero BATT_LOW_VOLT, or set the critical action to
+      // warn-only -- and the sign-off stayed valid and green. Every id here is
+      // already in the bundle's requiredParameters for this section.
       failsafe: JSON.stringify({
         throttleFailsafe,
-        batteryFailsafe
+        batteryFailsafe,
+        throttleFailsafeValue: readRoundedParameter(snapshot, 'FS_THR_VALUE'),
+        batteryCriticalAction: readRoundedParameter(snapshot, 'BATT_FS_CRT_ACT'),
+        batteryLowVoltage: readParameterValue(snapshot, 'BATT_LOW_VOLT'),
+        batteryCriticalVoltage: readParameterValue(snapshot, 'BATT_CRT_VOLT'),
+        batteryLowCapacity: readParameterValue(snapshot, 'BATT_LOW_MAH')
       }),
       power: JSON.stringify({
         batteryMonitor,
-        batteryCapacity
+        batteryCapacity,
+        armVoltage: readParameterValue(snapshot, 'BATT_ARM_VOLT'),
+        armCapacity: readParameterValue(snapshot, 'BATT_ARM_MAH')
       })
   }
 }

--- a/apps/web/src/view-models/setup-flow-deadlocks.test.ts
+++ b/apps/web/src/view-models/setup-flow-deadlocks.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest'
+
+import { deriveSetupStatusFromCriteria } from '../setup-flow-helpers'
+
+/*
+ * Regression tests for the three deadlocks found in the 2026-09 guided-setup
+ * audit. Each one made some step permanently unreachable, which froze every
+ * step behind it via the sequential lock pass.
+ */
+describe('guided setup deadlocks', () => {
+  it('a step with no criteria is never silently complete', () => {
+    // This is the mechanism behind the non-Copter deadlock: section ids the
+    // switch does not name fell through with criteria = [], and 'attention'
+    // can never satisfy the sequence. The guard stays -- what changed is that
+    // the default branch now BUILDS criteria instead of leaving them empty.
+    expect(deriveSetupStatusFromCriteria([])).toBe('attention')
+  })
+
+  it('a reviewed step with its parameters present completes', () => {
+    expect(
+      deriveSetupStatusFromCriteria([
+        { label: 'Every parameter this step covers is present', met: true },
+        { label: 'Operator reviewed sensors', met: true }
+      ])
+    ).toBe('complete')
+  })
+
+  it('a reviewed step with a missing parameter does not complete', () => {
+    expect(
+      deriveSetupStatusFromCriteria([
+        { label: 'Every parameter this step covers is present', met: false },
+        { label: 'Operator reviewed sensors', met: true }
+      ])
+    ).toBe('in-progress')
+  })
+})

--- a/apps/web/src/view-models/setup-flow-sections.ts
+++ b/apps/web/src/view-models/setup-flow-sections.ts
@@ -449,13 +449,20 @@ export function buildSetupFlowSections(inputs: SetupFlowSectionsInputs): SetupFl
                   met: !outputMapping.notes.some((note) => note.startsWith('Missing motor assignments:'))
                 },
                 {
-                  label: 'Operator reviewed the output map before any props-on activity',
+                  // Motor order and spin direction are ArduPilot's own mandatory
+                  // item 3, ahead of RC calibration, and they are the two bench
+                  // errors that most reliably flip a multirotor on its first
+                  // takeoff. The guided direction gate was dropped with the
+                  // Motors-tab redesign and this confirmation was left to cover
+                  // it -- but it only claimed the output MAP was reviewed, so an
+                  // operator could complete the wizard having never spun a motor.
+                  // The check itself lives in Motors (props-off gated, with the
+                  // mixer diagram and per-motor spin); this says what signing off
+                  // actually asserts. The signature below already pins the
+                  // SERVOn_FUNCTION map, so a remap voids it.
+                  label: 'Operator verified motor order and spin direction in Motors',
                   met: outputsConfirmation !== undefined
                 }
-                // (Motor-order/direction verification and the separate ESC-range
-                // confirmation gates were removed with the Motors-tab redesign —
-                // direction is now checked manually in Motors -> Test / Motor
-                // Setup, so the operator-review confirmation is the gate here.)
               ]
             : [
                 {
@@ -478,7 +485,7 @@ export function buildSetupFlowSections(inputs: SetupFlowSectionsInputs): SetupFl
           ].slice(0, 4)
           actions.unshift({
             kind: outputsConfirmation ? 'clear-confirmation' : 'confirm-step',
-            label: outputsConfirmation ? 'Clear Output Review' : 'Confirm Output Review',
+            label: outputsConfirmation ? 'Clear Motor Order & Direction Review' : 'Confirm Motor Order & Direction Verified',
             tone: 'secondary',
             sectionId: 'outputs',
             disabled: isCopterVehicle
@@ -1167,8 +1174,28 @@ export function buildSetupFlowSections(inputs: SetupFlowSectionsInputs): SetupFl
               met: powerConfirmation !== undefined
             },
             {
-              label: 'No active pre-arm safety issues are present',
-              met: snapshot.preArmStatus.healthy
+              // snapshot.preArmStatus.healthy falls back to "no latched issue text"
+              // when the live verdict is unusable -- and the live verdict is marked
+              // unusable precisely when ARMING_CHECK/ARMING_SKIPCHK has turned the
+              // checks off (GCS.cpp only sets `enabled` if get_enabled_checks()).
+              // So an aircraft with every check disabled reported "pre-arm clear"
+              // and completed the step. ArduPilot also sets the health bit
+              // unconditionally while armed, and it arms for the duration of a
+              // DO_MOTOR_TEST, so a reading taken around a motor test was a
+              // hardcoded pass too. Require a verdict the firmware is actually
+              // computing, and ignore it while armed.
+              label: 'Flight controller reports pre-arm checks passing',
+              met:
+                (snapshot.preArmStatus.liveCheck?.present === true &&
+                  snapshot.preArmStatus.liveCheck.enabled === true &&
+                  snapshot.vehicle?.armed !== true &&
+                  snapshot.preArmStatus.healthy) ||
+                // Pre-arm is routinely unhealthy on a bench indoors -- no GPS fix,
+                // no position estimate -- and this is the LAST step, so without an
+                // escape the wizard could never report complete however correct the
+                // aircraft was. The waiver below acknowledges rather than suppresses:
+                // it changes nothing on the vehicle, and pre-arm still blocks arming.
+                powerConfirmation?.outcome === 'already-done'
             }
           ]
           summary = snapshot.liveVerification.batteryTelemetry.verified
@@ -1202,6 +1229,15 @@ export function buildSetupFlowSections(inputs: SetupFlowSectionsInputs): SetupFl
             actionId: 'reboot-autopilot',
             disabled: busyAction !== undefined || !canRunGuidedAction(snapshot, 'reboot-autopilot')
           })
+          if (!powerConfirmation && !snapshot.preArmStatus.healthy) {
+            actions.push({
+              kind: 'confirm-step',
+              label: 'Pre-arm Blocked On The Bench — Acknowledge',
+              tone: 'secondary',
+              sectionId: 'power',
+              confirmationOutcome: 'already-done'
+            })
+          }
           actions.unshift({
             kind: powerConfirmation ? 'clear-confirmation' : 'confirm-step',
             label: powerConfirmation ? 'Clear Power Review' : 'Confirm Power Review',

--- a/apps/web/src/view-models/setup-flow-sections.ts
+++ b/apps/web/src/view-models/setup-flow-sections.ts
@@ -1261,7 +1261,7 @@ export function buildSetupFlowSections(inputs: SetupFlowSectionsInputs): SetupFl
           // operator a sign-off. That is a real gate rather than a stub: a section
           // is not complete until its required parameters are present and it has
           // been reviewed.
-          const declaredParams: string[] = section.definition.requiredParameters ?? []
+          const declaredParams: string[] = section.definition?.requiredParameters ?? []
           const missingParams = declaredParams.filter(
             (paramId: string) => readRoundedParameter(snapshot, paramId) === undefined
           )

--- a/apps/web/src/view-models/setup-flow-sections.ts
+++ b/apps/web/src/view-models/setup-flow-sections.ts
@@ -294,7 +294,7 @@ export function buildSetupFlowSections(inputs: SetupFlowSectionsInputs): SetupFl
             ...(isCopterVehicle
               ? [
                   {
-                    label: 'Frame class set to a valid value (FRAME_CLASS != 0)',
+                    label: 'A frame class is selected',
                     // FRAME_CLASS=0 IS a defined value, but it means "unset" /
                     // "Frame: UNSUPPORTED". The criterion needs to reflect the
                     // real signal (a chosen frame class), not just presence.
@@ -1119,7 +1119,9 @@ export function buildSetupFlowSections(inputs: SetupFlowSectionsInputs): SetupFl
               : modeSwitchExercise.status === 'running'
                 ? modeSwitchExerciseSummary
                 : modeSwitchEstimate.estimatedSlot !== undefined
-                  ? `Live mode switch detected on CH${modeSwitchEstimate.channelNumber ?? '?'}, but the full switch exercise still needs to pass.`
+                  ? modeSwitchEstimate.channelNumber === undefined
+                    ? 'A mode switch is moving, but the flight-mode channel is not set. Set it in Modes, then run the switch check.'
+                    : `Live mode switch detected on CH${modeSwitchEstimate.channelNumber}, but the full switch check still needs to pass.`
                   : 'Waiting for a configured live mode channel before starting the switch exercise.'
           detail =
             modeSwitchExercise.status === 'failed'

--- a/apps/web/src/view-models/setup-flow-sections.ts
+++ b/apps/web/src/view-models/setup-flow-sections.ts
@@ -10,6 +10,7 @@
 // descriptors are kind/actionId data dispatched later by handleSetupFlowAction,
 // so no handler closures move with it.
 
+import { resolveSetupConfirmationRecord } from './setup-confirmation-resolve'
 import {
   deriveAirframe,
   deriveCompassSetupAvailability,
@@ -128,14 +129,23 @@ export function buildSetupFlowSections(inputs: SetupFlowSectionsInputs): SetupFl
     rcRangeExerciseSummary
   } = inputs
 
+  // Delegates to the shared resolver rather than re-implementing the check.
+  //
+  // The local copy had no parameterSyncComplete leniency, and every wizard
+  // section went through it -- so the resolver, which exists precisely to hold
+  // confirmations valid while the table is still streaming, never ran for the
+  // wizard at all. Mid-sync every signature is a blob of undefineds, nothing
+  // matched, and all nine confirmations vanished at once: after any reboot,
+  // link drop, or F5 the flow snapped back to Airframe and yanked the operator
+  // off whatever step they were on because it had just become locked. It
+  // recovered when the sync finished, but the window is exactly when someone is
+  // watching.
   function getSetupConfirmationRecord(sectionId: string): SetupConfirmationRecord | undefined {
-    const record = setupConfirmations[sectionId]
-    const signature = setupConfirmationSignatures[sectionId]
-    if (!record || signature === undefined || record.signature !== signature) {
-      return undefined
-    }
-
-    return record
+    return resolveSetupConfirmationRecord({
+      record: setupConfirmations[sectionId],
+      signature: setupConfirmationSignatures[sectionId],
+      parameterSyncComplete: snapshot.parameterStats.status === 'complete'
+    })
   }
 
     const airframeConfirmation = getSetupConfirmationRecord('airframe')

--- a/apps/web/src/view-models/setup-flow-sections.ts
+++ b/apps/web/src/view-models/setup-flow-sections.ts
@@ -1012,29 +1012,44 @@ export function buildSetupFlowSections(inputs: SetupFlowSectionsInputs): SetupFl
         case 'failsafe':
           criteria = [
             {
-              label: 'Throttle failsafe setting is present',
-              met: throttleFailsafe !== undefined
+              // Presence, not value, used to satisfy these -- so FS_THR_ENABLE=0
+              // (disabled) and BATT_FS_LOW_ACT=0 ("warn only") ticked the boxes and
+              // the step rendered complete on an aircraft with no RC failsafe and no
+              // battery failsafe at all. Firmware's own FS_THR_VALUE sanity check
+              // (AP_Arming_Copter.cpp:209) only runs when the throttle failsafe is
+              // enabled, so nothing else would have told the operator either.
+              label: 'Throttle failsafe is enabled',
+              met: throttleFailsafe !== undefined && throttleFailsafe !== 0
             },
             {
-              label: 'Battery failsafe action is present',
-              met: batteryFailsafe !== undefined
+              label: 'Battery failsafe has an action, not just a warning',
+              met: batteryFailsafe !== undefined && batteryFailsafe !== 0
             },
             {
               label: 'Live RC link is verified during review',
               met: snapshot.liveVerification.rcInput.verified
             },
             {
+              // Battery telemetry needs SYS_STATUS voltage > 1000 mV, i.e. a real
+              // pack. On a bench board on USB with props off -- the posture this
+              // wizard exists for -- it never arrives. This was a hard criterion AND
+              // the confirm gate, and failsafe was the only step in the flow with no
+              // waiver, so modes and power (both AFTER it) stayed locked forever.
+              // Kept as evidence with an operator escape below.
               label: 'Live battery telemetry is verified during review',
-              met: snapshot.liveVerification.batteryTelemetry.verified
+              met: snapshot.liveVerification.batteryTelemetry.verified || failsafeConfirmation !== undefined
             },
             {
               label: 'Operator reviewed the configured failsafe behavior',
               met: failsafeConfirmation !== undefined
             }
           ]
+          // failsafeActionLabel resolves the enum labels off the parameter
+          // definition, so it needs whichever id this vehicle actually exposes --
+          // Copter/Rover/Sub use FS_THR_ENABLE, Plane uses THR_FAILSAFE.
           summary = `Throttle failsafe ${failsafeActionLabel(
             snapshot,
-            'FS_THR_ENABLE',
+            readRoundedParameter(snapshot, 'FS_THR_ENABLE') !== undefined ? 'FS_THR_ENABLE' : 'THR_FAILSAFE',
             throttleFailsafe,
             formatArducopterThrottleFailsafe
           )}, battery action ${failsafeActionLabel(
@@ -1057,12 +1072,17 @@ export function buildSetupFlowSections(inputs: SetupFlowSectionsInputs): SetupFl
             label: failsafeConfirmation ? 'Clear Failsafe Review' : 'Confirm Failsafe Review',
             tone: 'primary',
             sectionId: 'failsafe',
-            disabled:
-              throttleFailsafe === undefined ||
-              batteryFailsafe === undefined ||
-              !snapshot.liveVerification.rcInput.verified ||
-              !snapshot.liveVerification.batteryTelemetry.verified
+            disabled: throttleFailsafe === undefined || batteryFailsafe === undefined
           })
+          if (!failsafeConfirmation && !snapshot.liveVerification.batteryTelemetry.verified) {
+            actions.push({
+              kind: 'confirm-step',
+              label: 'No Pack Connected — Review On Battery Later',
+              tone: 'secondary',
+              sectionId: 'failsafe',
+              confirmationOutcome: 'already-done'
+            })
+          }
           break
         case 'modes': {
           // Modes previously had NO operator escape of any kind: the switch
@@ -1190,8 +1210,59 @@ export function buildSetupFlowSections(inputs: SetupFlowSectionsInputs): SetupFl
             disabled: batteryMonitor === undefined || batteryMonitor <= 0 || !snapshot.liveVerification.batteryTelemetry.verified
           })
           break
-        default:
+        default: {
+          // Every section id the switch does not name -- 'sensors', 'verify',
+          // 'drive', 'frame', 'controls' -- used to fall through with criteria = [],
+          // and deriveSetupStatusFromCriteria([]) returns 'attention'. The step
+          // could therefore never be complete, the sequential lock pass froze
+          // everything behind it, and it rendered with no criteria and nothing to
+          // click. Those ids are exactly the ones Plane, Rover and Sub declare, so
+          // every non-Copter vehicle deadlocked in its first three steps.
+          //
+          // Build criteria from what the bundle itself declares, then give the
+          // operator a sign-off. That is a real gate rather than a stub: a section
+          // is not complete until its required parameters are present and it has
+          // been reviewed.
+          const declaredParams: string[] = section.definition.requiredParameters ?? []
+          const missingParams = declaredParams.filter(
+            (paramId: string) => readRoundedParameter(snapshot, paramId) === undefined
+          )
+          const genericConfirmation = getSetupConfirmationRecord(section.id)
+          criteria = [
+            ...(declaredParams.length > 0
+              ? [
+                  {
+                    label: 'Every parameter this step covers is present',
+                    met: missingParams.length === 0
+                  }
+                ]
+              : []),
+            {
+              label: `Operator reviewed ${section.title.toLowerCase()}`,
+              met: genericConfirmation !== undefined
+            }
+          ]
+          summary = section.description
+          detail =
+            missingParams.length > 0
+              ? `${missingParams.length} of this step's parameters have not been reported by the flight controller: ${missingParams
+                  .slice(0, 4)
+                  .join(', ')}${missingParams.length > 4 ? '…' : ''}. Re-sync parameters, or check the firmware exposes them.`
+              : 'Review this step against the vehicle, then confirm to continue.'
+          evidence = [
+            declaredParams.length > 0
+              ? `${declaredParams.length - missingParams.length}/${declaredParams.length} parameters present`
+              : 'No parameters declared for this step',
+            `Review: ${genericConfirmation ? `confirmed at ${formatConfirmationTime(genericConfirmation.confirmedAtMs)}` : 'pending operator confirmation'}`
+          ]
+          actions.unshift({
+            kind: genericConfirmation ? 'clear-confirmation' : 'confirm-step',
+            label: genericConfirmation ? `Clear ${section.title} Review` : `Confirm ${section.title} Review`,
+            tone: 'primary',
+            sectionId: section.id
+          })
           break
+        }
       }
 
       const status = deriveSetupStatusFromCriteria(criteria)

--- a/apps/web/src/views/Osd.tsx
+++ b/apps/web/src/views/Osd.tsx
@@ -170,6 +170,11 @@ export interface OsdElementMatrixRow {
 }
 
 export interface OsdViewProps {
+  /** Preview grid selection, hoisted so it survives leaving the tab. */
+  videoSystem?: string
+  setVideoSystem: (next: string) => void
+  analogSubMode: 'pal' | 'ntsc'
+  setAnalogSubMode: (next: 'pal' | 'ntsc') => void
   /** The OSD/VTX switcher, rendered under the panel title like every other
    *  view's tab strip. */
   headerNav?: ReactNode
@@ -241,6 +246,10 @@ function fieldStatusClass(draftStatusById: ScopedFieldDraftMap, paramId: string)
 export function OsdView(props: OsdViewProps) {
   const {
     headerNav,
+    videoSystem: videoSystemProp,
+    setVideoSystem,
+    analogSubMode,
+    setAnalogSubMode,
     linkPorts,
     typeField,
     channelField,
@@ -288,8 +297,13 @@ export function OsdView(props: OsdViewProps) {
   // Default NTSC, not PAL — an arbitrary-but-deliberate choice away from the
   // old hardcoded PAL default (field feedback). Digital systems don't need a
   // sub-choice since each one only ever runs a single fixed grid.
-  const [videoSystem, setVideoSystem] = useState<OsdVideoSystem>('analog')
-  const [analogSubMode, setAnalogSubMode] = useState<'pal' | 'ntsc'>('ntsc')
+  // Owned by useOsdEditor (which lives in App and survives), not by this view
+  // -- this view unmounts on every tab switch, so state held here reset to
+  // Analog each time the operator came back.
+  const videoSystem: OsdVideoSystem =
+    videoSystemProp !== undefined && videoSystemProp in OSD_VIDEO_SYSTEMS
+      ? (videoSystemProp as OsdVideoSystem)
+      : 'analog'
   const analogLayout: OsdAnalogLayout = OSD_VIDEO_SYSTEMS[videoSystem].layout ?? analogSubMode
   const layout = OSD_ANALOG_LAYOUTS[analogLayout]
   const [draggingId, setDraggingId] = useState<string | undefined>(undefined)

--- a/packages/ardupilot-core/src/setup-exercises.ts
+++ b/packages/ardupilot-core/src/setup-exercises.ts
@@ -120,8 +120,10 @@ const RC_LOW_THRESHOLD = 0.15
 const RC_HIGH_THRESHOLD = 0.85
 const RC_CENTER_TOLERANCE_RATIO = 0.1
 const RC_CENTER_TOLERANCE_US = 45
-const RC_MAPPING_DELTA_THRESHOLD_US = 120
-const RC_MAPPING_DOMINANCE_MARGIN_US = 35
+// Exported so the rejection messaging can name the same numbers the detector
+// enforces. Duplicating them in the web layer is how they drift apart.
+export const RC_MAPPING_DELTA_THRESHOLD_US = 120
+export const RC_MAPPING_DOMINANCE_MARGIN_US = 35
 const RC_MAPPING_CENTER_BASELINE_MIN_US = 1300
 const RC_MAPPING_CENTER_BASELINE_MAX_US = 1700
 // Throttle has no centering spring, so its baseline can rest anywhere. The

--- a/packages/param-metadata/src/arducopter.ts
+++ b/packages/param-metadata/src/arducopter.ts
@@ -861,6 +861,10 @@ export const arducopterMetadata: FirmwareMetadataBundle = {
     },
     power: {
       id: 'power',
+      // Ordered before failsafe deliberately: failsafe review wants live battery
+      // telemetry, and BATT_MONITOR -- the thing that produces it -- is configured
+      // here. With power last, the step that fixed the problem sat behind the step
+      // that was blocked by it.
       label: 'Power',
       description: 'Battery sensing and power monitoring.',
       order: 10,
@@ -3984,23 +3988,6 @@ export const arducopterMetadata: FirmwareMetadataBundle = {
       requiredLiveSignals: ['rc-input'],
     },
     {
-      id: 'failsafe',
-      title: 'Failsafe',
-      description: 'Review throttle and battery failsafe behavior.',
-      requiredParameters: [
-        'FS_THR_ENABLE',
-        'FS_THR_VALUE',
-        'BATT_FS_VOLTSRC',
-        'BATT_LOW_VOLT',
-        'BATT_LOW_MAH',
-        'BATT_FS_LOW_ACT',
-        'BATT_CRT_VOLT',
-        'BATT_CRT_MAH',
-        'BATT_FS_CRT_ACT'
-      ],
-      requiredLiveSignals: ['rc-input', 'battery-telemetry'],
-    },
-    {
       id: 'modes',
       title: 'Flight Modes',
       description: 'Check the first three mapped flight modes.',
@@ -4019,6 +4006,23 @@ export const arducopterMetadata: FirmwareMetadataBundle = {
       requiredNonZeroParameters: ['BATT_MONITOR'],
       requiredLiveSignals: ['battery-telemetry'],
       actions: ['reboot-autopilot']
+    },
+    {
+      id: 'failsafe',
+      title: 'Failsafe',
+      description: 'Review throttle and battery failsafe behavior.',
+      requiredParameters: [
+        'FS_THR_ENABLE',
+        'FS_THR_VALUE',
+        'BATT_FS_VOLTSRC',
+        'BATT_LOW_VOLT',
+        'BATT_LOW_MAH',
+        'BATT_FS_LOW_ACT',
+        'BATT_CRT_VOLT',
+        'BATT_CRT_MAH',
+        'BATT_FS_CRT_ACT'
+      ],
+      requiredLiveSignals: ['rc-input', 'battery-telemetry'],
     }
   ]
 }

--- a/packages/param-metadata/src/arducopter.ts
+++ b/packages/param-metadata/src/arducopter.ts
@@ -957,7 +957,12 @@ export const arducopterMetadata: FirmwareMetadataBundle = {
         'Replaces most of the vehicle configuration. Review the diff before applying.',
         'Check the serial map matches your wiring: O3 on SERIAL4, receiver on SERIAL5.',
         'Tuned for 2S and the stock prop.',
-        'Calibrate accelerometer, level and compass on this board afterwards.'
+        'Calibrate accelerometer, level and compass on this board afterwards.',
+        // Any preset value that relaxes a safety check has to say so here. The
+        // shipped dump previously carried ARMING_SKIPCHK=1048062 (every check
+        // off) and both battery failsafe actions at "warn only" with no caution
+        // naming either.
+        'Sets battery failsafes for a 2S pack: RTL at 7.2 V, land at 7.0 V. Check these match your pack before flying.'
       ],
       compatibility: {
         frameClasses: [1]

--- a/packages/param-metadata/src/pavo-femto-o3-preset.ts
+++ b/packages/param-metadata/src/pavo-femto-o3-preset.ts
@@ -61,7 +61,13 @@ export const PAVO_FEMTO_O3_VALUES: readonly ParameterPresetValue[] = [
   { paramId: 'ARMING_OPTIONS', value: 0 },
   { paramId: 'ARMING_PEND_TIM', value: 5 },
   { paramId: 'ARMING_RUDDER', value: 2 },
-  { paramId: 'ARMING_SKIPCHK', value: 1048062 },
+  // Was 1048062 -- every skip bit ArduPilot defines, i.e. no pre-arm checks at
+  // all. That also makes get_enabled_checks() return 0, so the firmware stops
+  // reporting the pre-arm bit as enabled and the guided setup's "no pre-arm
+  // issues" criterion passes vacuously: applying the preset made the wizard
+  // look GREENER while removing the checks behind it. 0 is ArduPilot's own
+  // recommended value.
+  { paramId: 'ARMING_SKIPCHK', value: 0 },
   { paramId: 'ATC_ACC_P_MAX', value: 1100 },
   { paramId: 'ATC_ACC_R_MAX', value: 1100 },
   { paramId: 'ATC_ACC_Y_MAX', value: 270 },
@@ -152,8 +158,11 @@ export const PAVO_FEMTO_O3_VALUES: readonly ParameterPresetValue[] = [
   { paramId: 'BATT_CRT_MAH', value: 0 },
   { paramId: 'BATT_CRT_VOLT', value: 7 },
   { paramId: 'BATT_CURR_PIN', value: 11 },
-  { paramId: 'BATT_FS_CRT_ACT', value: 0 },
-  { paramId: 'BATT_FS_LOW_ACT', value: 0 },
+  { paramId: 'BATT_FS_CRT_ACT', value: 1 },
+  // Was 0 ("Warn only") -- BATT_LOW_VOLT/BATT_CRT_VOLT below were set but no
+  // action was attached to either, so a 2S pack could run flat with nothing but
+  // a message. These are ArduPilot's own defaults for the two actions.
+  { paramId: 'BATT_FS_LOW_ACT', value: 2 },
   { paramId: 'BATT_FS_VOLTSRC', value: 0 },
   { paramId: 'BATT_LOW_MAH', value: 0 },
   { paramId: 'BATT_LOW_TIMER', value: 10 },

--- a/tests/e2e/artifact-upload.spec.ts
+++ b/tests/e2e/artifact-upload.spec.ts
@@ -85,8 +85,22 @@ async function openParameters(page: Page): Promise<void> {
   await expect(page.getByTestId('session-parameter-summary')).toHaveText(/^(\d+ params|Params \d+)$/, {
     timeout: VEHICLE_CONNECT_TIMEOUT
   })
-  await page.getByTestId('product-mode-expert').check()
+  await enableExpertMode(page)
   await page.getByTestId('view-button-parameters').click()
+}
+
+/* Expert mode moved into the header's phone disclosure, so on a narrow viewport
+ * the sheet has to be opened before the toggle can be reached. Above the phone
+ * breakpoint the sheet button is display:none and this is a no-op, so the same
+ * call is correct at every width. */
+async function enableExpertMode(page: Page): Promise<void> {
+  const sheet = page.getByTestId('header-more-toggle')
+  // Idempotent: a test may call this more than once, and clicking an already
+  // open sheet closes it again.
+  if (await sheet.isVisible() && (await sheet.getAttribute('aria-expanded')) !== 'true') {
+    await sheet.click()
+  }
+  await page.getByTestId('product-mode-expert').check()
 }
 
 test.describe('Naming a configuration upload', () => {

--- a/tests/e2e/guided-setup.spec.ts
+++ b/tests/e2e/guided-setup.spec.ts
@@ -19,7 +19,12 @@ const VEHICLE_CONNECT_TIMEOUT = 30_000
 /** Every section the ArduCopter metadata defines, in flow order. */
 const SECTIONS = [
   'link', 'ports', 'airframe', 'outputs', 'accelerometer',
-  'level', 'compass', 'radio', 'failsafe', 'modes', 'power'
+  // Power moved ahead of Failsafe deliberately: the failsafe review wants live
+  // battery telemetry, and BATT_MONITOR -- the thing that produces it -- is
+  // configured in Power. With Power last, the step that fixed the problem sat
+  // behind the step blocked by it, and the wizard could not be completed on a
+  // bench board with no pack attached.
+  'level', 'compass', 'radio', 'modes', 'power', 'failsafe'
 ] as const
 
 async function openGuidedSetup(page: Page, shortcutSection?: string): Promise<void> {
@@ -103,7 +108,9 @@ test.describe('Guided setup flow', () => {
     await openGuidedSetup(page, 'link')
     await expect(page.getByRole('button', { name: /Previous Step/i })).toBeDisabled()
 
-    await openGuidedSetup(page, 'power')
+    // The last step is whatever SECTIONS says it is, so this keeps testing "the
+    // end of the flow" rather than one hardcoded step id.
+    await openGuidedSetup(page, SECTIONS[SECTIONS.length - 1])
     // Setup Complete stays gated until the step's own confirmation is given.
     await expect(page.getByRole('button', { name: /Setup Complete/i })).toBeDisabled()
   })

--- a/tests/e2e/param-group-presets.spec.ts
+++ b/tests/e2e/param-group-presets.spec.ts
@@ -18,8 +18,22 @@ async function connectAndOpenParameters(page: Page): Promise<void> {
   await expect(page.getByTestId('session-parameter-summary')).toHaveText(/^(\d+ params|Params \d+)$/, {
     timeout: VEHICLE_CONNECT_TIMEOUT
   })
-  await page.getByTestId('product-mode-expert').click()
+  await enableExpertMode(page)
   await page.getByTestId('view-button-parameters').click()
+}
+
+/* Expert mode moved into the header's phone disclosure, so on a narrow viewport
+ * the sheet has to be opened before the toggle can be reached. Above the phone
+ * breakpoint the sheet button is display:none and this is a no-op, so the same
+ * call is correct at every width. */
+async function enableExpertMode(page: Page): Promise<void> {
+  const sheet = page.getByTestId('header-more-toggle')
+  // Idempotent: a test may call this more than once, and clicking an already
+  // open sheet closes it again.
+  if (await sheet.isVisible() && (await sheet.getAttribute('aria-expanded')) !== 'true') {
+    await sheet.click()
+  }
+  await page.getByTestId('product-mode-expert').check()
 }
 
 test.describe('Parameter-group presets', () => {
@@ -243,7 +257,7 @@ test.describe('Parameter reference with no vehicle', () => {
   // true of the vehicle and false of the question being asked.
   async function openParametersDisconnected(page: Page): Promise<void> {
     await page.goto('/')
-    await page.getByTestId('product-mode-expert').check()
+    await enableExpertMode(page)
     await page.getByTestId('view-button-parameters').click()
   }
 

--- a/tests/e2e/views.spec.ts
+++ b/tests/e2e/views.spec.ts
@@ -3678,7 +3678,11 @@ test.describe('ArduPlane demo', () => {
     // was mapped/counted — a Plane could never complete the step.
     // (The Outputs *view* bench motor-verification controls are a
     // separate non-Copter gating concern, tracked as C5b.)
-    await expect(page.getByRole('button', { name: 'Confirm Output Review' })).toBeEnabled()
+    // Renamed: the criterion now asserts motor order and spin direction were
+    // verified, not merely that the output map was looked at. The guided
+    // direction gate was dropped with the Motors-tab redesign and this
+    // confirmation was left covering it while still only claiming a map review.
+    await expect(page.getByRole('button', { name: 'Confirm Motor Order & Direction Verified' })).toBeEnabled()
   })
 
   test('guided-setup evidence pills are allowed to wrap, so a long line cannot be clipped', async ({ page }) => {

--- a/tests/e2e/views.spec.ts
+++ b/tests/e2e/views.spec.ts
@@ -73,7 +73,7 @@ test.describe('Phone layout', () => {
     await page.getByTestId('transport-mode-select').selectOption('demo')
     await page.getByTestId('connect-button').click()
     await expect(page.getByTestId('session-vehicle-name')).toHaveText('ArduCopter', { timeout: VEHICLE_CONNECT_TIMEOUT })
-    await page.getByTestId('product-mode-expert').check()
+    await enableExpertMode(page)
     await page.getByTestId('view-button-parameters').click()
     await expect(page.locator('.parameter-editor__expert-note')).toBeHidden()
     await expect(page.getByTestId('export-parameter-backup')).toBeHidden()
@@ -150,6 +150,20 @@ test.describe('Desktop firmware browse', () => {
     await expect(page.getByTestId('firmware-vehicle')).toHaveValue('Plane')
   })
 })
+
+/* Expert mode moved into the header's phone disclosure, so on a narrow viewport
+ * the sheet has to be opened before the toggle can be reached. Above the phone
+ * breakpoint the sheet button is display:none and this is a no-op, so the same
+ * call is correct at every width. */
+async function enableExpertMode(page: Page): Promise<void> {
+  const sheet = page.getByTestId('header-more-toggle')
+  // Idempotent: a test may call this more than once, and clicking an already
+  // open sheet closes it again.
+  if (await sheet.isVisible() && (await sheet.getAttribute('aria-expanded')) !== 'true') {
+    await sheet.click()
+  }
+  await page.getByTestId('product-mode-expert').check()
+}
 
 async function connectViaHeader(page: Page): Promise<void> {
   await page.getByTestId('transport-mode-select').selectOption('demo')
@@ -290,7 +304,7 @@ test.describe('Parameters tab (expert-only)', () => {
     // Wait for the full param sync before counting rows — the table populates as
     // params stream in, so an early count races the sync (and empties out).
     await expectParameterSyncComplete(page)
-    await page.getByTestId('product-mode-expert').click()
+    await enableExpertMode(page)
     await page.getByTestId('view-button-parameters').click()
 
     const dataRows = page.locator('.parameter-row:not(.parameter-row--header)')
@@ -314,7 +328,7 @@ test.describe('Parameters tab (expert-only)', () => {
     // leaving the diff grid to hunt for.
     await page.goto('/')
     await connectViaHeader(page)
-    await page.getByTestId('product-mode-expert').click()
+    await enableExpertMode(page)
     await page.getByTestId('view-button-parameters').click()
 
     const search = page.getByTestId('parameter-search-input')
@@ -351,7 +365,7 @@ test.describe('Parameters tab (expert-only)', () => {
     await page.addStyleTag({ content: '* { overflow-anchor: none !important; }' })
     await connectViaHeader(page)
     await expectParameterSyncComplete(page)
-    await page.getByTestId('product-mode-expert').click()
+    await enableExpertMode(page)
     await page.getByTestId('view-button-parameters').click()
     await page.addStyleTag({ content: '* { overflow-anchor: none !important; }' })
 
@@ -393,7 +407,7 @@ test.describe('Parameters tab (expert-only)', () => {
     // stays as a muted "won't write" row until Discard.
     await page.goto('/')
     await connectViaHeader(page)
-    await page.getByTestId('product-mode-expert').click()
+    await enableExpertMode(page)
     await page.getByTestId('view-button-parameters').click()
     await page.getByTestId('parameter-search-input').fill('ANGLE_MAX')
 
@@ -413,7 +427,7 @@ test.describe('Parameters tab (expert-only)', () => {
   test('expanding a param row reveals its metadata, old name, enum meaning, and a type-or-pick editor', async ({ page }) => {
     await page.goto('/')
     await connectViaHeader(page)
-    await page.getByTestId('product-mode-expert').click()
+    await enableExpertMode(page)
     await page.getByTestId('view-button-parameters').click()
     await page.getByTestId('parameter-search-input').fill('GPS_TYPE')
 
@@ -449,7 +463,7 @@ test.describe('Parameters tab (expert-only)', () => {
     // hundreds of parameters.
     await page.goto('/')
     await connectViaHeader(page)
-    await page.getByTestId('product-mode-expert').click()
+    await enableExpertMode(page)
     await page.getByTestId('view-button-parameters').click()
     await expectParameterSyncComplete(page)
 
@@ -484,7 +498,7 @@ test.describe('Parameters tab (expert-only)', () => {
   test('a staged bitmask is editable bit by bit, and a draft matching live clears on re-sync', async ({ page }) => {
     await page.goto('/')
     await connectViaHeader(page)
-    await page.getByTestId('product-mode-expert').click()
+    await enableExpertMode(page)
     await page.getByTestId('view-button-parameters').click()
     await expectParameterSyncComplete(page)
 
@@ -514,7 +528,7 @@ test.describe('Parameters tab (expert-only)', () => {
   test('an import can be staged one row at a time instead of all at once', async ({ page }) => {
     await page.goto('/')
     await connectViaHeader(page)
-    await page.getByTestId('product-mode-expert').click()
+    await enableExpertMode(page)
     await page.getByTestId('view-button-parameters').click()
     await expectParameterSyncComplete(page)
 
@@ -554,7 +568,7 @@ test.describe('Parameters tab (expert-only)', () => {
     // before "Drop selected".
     await page.goto('/')
     await connectViaHeader(page)
-    await page.getByTestId('product-mode-expert').click()
+    await enableExpertMode(page)
     await page.getByTestId('view-button-parameters').click()
 
     // Stage two failsafe params so the group has more than one row.
@@ -583,7 +597,7 @@ test.describe('Parameters tab (expert-only)', () => {
     // enum meanings in front of them.
     await page.goto('/')
     await connectViaHeader(page)
-    await page.getByTestId('product-mode-expert').click()
+    await enableExpertMode(page)
     await page.getByTestId('view-button-parameters').click()
     await page.getByTestId('parameter-search-input').fill('GPS_TYPE')
 
@@ -603,7 +617,7 @@ test.describe('Parameters tab (expert-only)', () => {
     // ArduConfigurator JSON or a ground-station format from one control.
     await page.goto('/')
     await connectViaHeader(page)
-    await page.getByTestId('product-mode-expert').click()
+    await enableExpertMode(page)
     await page.getByTestId('view-button-parameters').click()
 
     // No separate legacy control anymore.
@@ -742,7 +756,7 @@ test.describe('CAN bus enable prompt', () => {
     await page.goto('/')
     await page.getByTestId('transport-mode-select').selectOption('demo')
     await page.getByTestId('connect-button').click()
-    await page.getByTestId('product-mode-expert').check()
+    await enableExpertMode(page)
     await page.getByTestId('view-button-can').click()
 
     const prompt = page.getByTestId('can-enable-prompt')
@@ -765,7 +779,7 @@ test.describe('Networking view (Expert + networking-capable FC)', () => {
     await expect(page.getByTestId('view-button-networking')).toHaveCount(0)
 
     // Expert mode: the tab appears because the demo Copter reports NET_ params.
-    await page.getByTestId('product-mode-expert').check()
+    await enableExpertMode(page)
     await expect(page.getByTestId('view-button-networking')).toBeVisible()
     await page.getByTestId('view-button-networking').click()
 
@@ -822,7 +836,7 @@ test.describe('Lua Scripts view (Expert + scripting-capable FC)', () => {
     await expect(page.getByTestId('view-button-lua')).toHaveCount(0)
 
     // Expert mode: the tab appears because the demo Copter reports SCR_ params.
-    await page.getByTestId('product-mode-expert').check()
+    await enableExpertMode(page)
     await expect(page.getByTestId('view-button-lua')).toBeVisible()
     await page.getByTestId('view-button-lua').click()
 
@@ -872,7 +886,7 @@ test.describe('AI Assistant view (Expert, offline mock provider)', () => {
     await expect(page.getByTestId('view-button-ai-assistant')).toHaveCount(0)
 
     // Expert mode: the tab appears (gated on Expert alone, no FC capability).
-    await page.getByTestId('product-mode-expert').check()
+    await enableExpertMode(page)
     await expect(page.getByTestId('view-button-ai-assistant')).toBeVisible()
     await page.getByTestId('view-button-ai-assistant').click()
     await expect(page.getByTestId('ai-assistant-view')).toBeVisible()
@@ -896,7 +910,7 @@ test.describe('AI Assistant view (Expert, offline mock provider)', () => {
     await expect(page.getByTestId('session-vehicle-name')).toHaveText('ArduCopter', { timeout: VEHICLE_CONNECT_TIMEOUT })
     await expectParameterSyncComplete(page)
 
-    await page.getByTestId('product-mode-expert').check()
+    await enableExpertMode(page)
     await page.getByTestId('view-button-ai-assistant').click()
     await expect(page.getByTestId('ai-assistant-view')).toBeVisible()
 
@@ -931,7 +945,7 @@ test.describe('AI Assistant view (Expert, offline mock provider)', () => {
     await expect(page.getByTestId('session-vehicle-name')).toHaveText('ArduCopter', { timeout: VEHICLE_CONNECT_TIMEOUT })
     await expectParameterSyncComplete(page)
 
-    await page.getByTestId('product-mode-expert').check()
+    await enableExpertMode(page)
     await page.getByTestId('view-button-ai-assistant').click()
     await expect(page.getByTestId('ai-assistant-view')).toBeVisible()
 
@@ -1237,7 +1251,7 @@ test.describe('Calibration tab — motor-spin (ESC)', () => {
     await page.goto('/')
     await connectViaHeader(page)
     // Raw parameter editing is an Expert surface, so the tab only exists here.
-    await page.getByTestId('product-mode-expert').check()
+    await enableExpertMode(page)
 
     for (const view of ['parameters', 'snapshots'] as const) {
       await openView(page, view)
@@ -1823,7 +1837,7 @@ test.describe('Flash view', () => {
     await page.setViewportSize({ width: 390, height: 844 })
     await page.goto('/')
     await connectViaHeader(page)
-    await page.getByTestId('product-mode-expert').click()
+    await enableExpertMode(page)
     await openView(page, 'flash')
 
     // Not shown until the operator arms the update: reading the images costs
@@ -2158,7 +2172,7 @@ test.describe('Config view', () => {
     await page.goto('/')
     await page.getByTestId('transport-mode-select').selectOption('demo')
     await page.getByTestId('connect-button').click()
-    await page.getByTestId('product-mode-expert').click()
+    await enableExpertMode(page)
 
     // Stage + apply a reboot-required change (bdshot stages SERVO_BLH_* params).
     await page.getByTestId('view-button-config').click()
@@ -2478,7 +2492,7 @@ test.describe('RC Mixer view', () => {
     await page.goto('/')
     await page.getByTestId('transport-mode-select').selectOption('demo')
     await page.getByTestId('connect-button').click()
-    await page.getByTestId('product-mode-expert').check()
+    await enableExpertMode(page)
     await page.getByTestId('view-button-rc-mixer').click()
 
     for (const channel of [1, 2, 3, 4]) {
@@ -2517,7 +2531,7 @@ test.describe('RC Mixer view', () => {
     await page.getByTestId('transport-mode-select').selectOption('demo-plane')
     await page.getByTestId('connect-button').click()
     await expect(page.getByTestId('session-vehicle-name')).toHaveText('ArduPlane', { timeout: VEHICLE_CONNECT_TIMEOUT })
-    await page.getByTestId('product-mode-expert').check()
+    await enableExpertMode(page)
     await page.getByTestId('view-button-rc-mixer').click()
 
     const channel5 = page.getByTestId('rc-mixer-channel-5')
@@ -2539,7 +2553,7 @@ test.describe('RC Mixer view', () => {
     await page.goto('/')
     await page.getByTestId('transport-mode-select').selectOption('demo')
     await page.getByTestId('connect-button').click()
-    await page.getByTestId('product-mode-expert').check()
+    await enableExpertMode(page)
     await page.getByTestId('view-button-rc-mixer').click()
 
     // Demo seeds a real, already-applied ArmDisarm assignment on channel 5.
@@ -4052,7 +4066,7 @@ test.describe('ArduPlane demo', () => {
     await expect(page.getByTestId('calibration-card-tcal')).toHaveCount(0)
 
     // Expert mode reveals the full card (demo seeds INS_TCALn_ENABLE = 0).
-    await page.getByTestId('product-mode-expert').check()
+    await enableExpertMode(page)
     const tcal = page.getByTestId('calibration-card-tcal')
     await expect(tcal).toBeVisible()
     await expect(tcal).toContainText('Thermal calibration')
@@ -4075,7 +4089,7 @@ test.describe('ArduPlane demo', () => {
 
     // Expert mode is not enough on its own. Signed out there is no card at all
     // -- not a locked one -- because the calibration is fit from a hover log.
-    await page.getByTestId('product-mode-expert').check()
+    await enableExpertMode(page)
     // Guard the guard: Expert really did take effect, so this cannot pass for
     // the wrong reason.
     await expect(page.getByTestId('calibration-card-tcal')).toBeVisible()
@@ -4104,7 +4118,7 @@ test.describe('ArduPlane demo', () => {
     await expect(page.getByTestId('session-vehicle-name')).toHaveText('ArduCopter', { timeout: VEHICLE_CONNECT_TIMEOUT })
 
     await openView(page, 'calibration')
-    await page.getByTestId('product-mode-expert').check()
+    await enableExpertMode(page)
     const valt = page.getByTestId('calibration-card-valt')
     await valt.scrollIntoViewIfNeeded()
     await expect(valt).toBeVisible()
@@ -4775,7 +4789,7 @@ test('Recent Notices: clear-all button and expert-mode search bar', async ({ pag
   await expect(page.getByTestId('setup-notices-clear-all')).toBeVisible({ timeout: 15_000 })
   // The notice search bar is expert-only.
   await expect(page.getByTestId('setup-notices-search')).toHaveCount(0)
-  await page.getByTestId('product-mode-expert').click()
+  await enableExpertMode(page)
   await expect(page.getByTestId('setup-notices-search')).toBeVisible()
 })
 
@@ -4867,7 +4881,7 @@ test('Recent Notices pops out into its own styled, live window', async ({ page, 
   await expect(popout.getByTestId('notices-popout-list')).toBeVisible()
   await expect(noticeRows.first()).toBeVisible({ timeout: 15_000 })
   await expect(popout.getByTestId('notices-popout-search')).toHaveCount(0)
-  await page.getByTestId('product-mode-expert').click()
+  await enableExpertMode(page)
   await expect(popout.getByTestId('notices-popout-search')).toBeVisible()
 
   // …and the filter typed in the window filters the window: a term nothing can
@@ -5060,7 +5074,7 @@ test.describe('Inspectors (expert-only)', () => {
     await expect(page.getByTestId('view-button-dronecan-inspector')).toHaveCount(0)
     await expect(page.getByTestId('view-button-can')).toBeVisible()
 
-    await page.getByTestId('product-mode-expert').check()
+    await enableExpertMode(page)
 
     // MAVLink inspector shows the live decoded message stream.
     await page.getByTestId('view-button-mavlink-inspector').click()
@@ -5105,7 +5119,7 @@ test.describe('Inspectors (expert-only)', () => {
     await page.goto('/')
     await page.getByTestId('transport-mode-select').selectOption('demo')
     await page.getByTestId('connect-button').click()
-    await page.getByTestId('product-mode-expert').check()
+    await enableExpertMode(page)
 
     await page.getByTestId('view-button-mavlink-inspector').click()
     await expect(page.getByTestId('mavlink-inspector-table')).toBeVisible({ timeout: 8000 })
@@ -5128,7 +5142,7 @@ test.describe('Inspectors (expert-only)', () => {
     await page.goto('/')
     await page.getByTestId('transport-mode-select').selectOption('demo')
     await page.getByTestId('connect-button').click()
-    await page.getByTestId('product-mode-expert').check()
+    await enableExpertMode(page)
 
     await page.getByTestId('view-button-mavlink-inspector').click()
     await expect(page.getByTestId('mavlink-inspector-table')).toBeVisible({ timeout: 8000 })
@@ -5160,7 +5174,7 @@ test.describe('Inspectors (expert-only)', () => {
     await page.goto('/')
     await page.getByTestId('transport-mode-select').selectOption('demo')
     await page.getByTestId('connect-button').click()
-    await page.getByTestId('product-mode-expert').check()
+    await enableExpertMode(page)
 
     await page.getByTestId('view-button-mavlink-inspector').click()
     await expect(page.getByTestId('mavlink-inspector-table')).toBeVisible({ timeout: 8000 })
@@ -5183,7 +5197,7 @@ test.describe('Inspectors (expert-only)', () => {
     await page.goto('/')
     await page.getByTestId('transport-mode-select').selectOption('demo')
     await page.getByTestId('connect-button').click()
-    await page.getByTestId('product-mode-expert').check()
+    await enableExpertMode(page)
 
     await page.getByTestId('view-button-mavlink-inspector').click()
     const mavTable = page.getByTestId('mavlink-inspector-table')
@@ -5210,7 +5224,7 @@ test.describe('Inspectors (expert-only)', () => {
     await page.goto('/')
     await page.getByTestId('transport-mode-select').selectOption('demo')
     await page.getByTestId('connect-button').click()
-    await page.getByTestId('product-mode-expert').check()
+    await enableExpertMode(page)
 
     // Expand the first decoded MAVLink row and reveal its copy affordance.
     await page.getByTestId('view-button-mavlink-inspector').click()
@@ -5241,7 +5255,7 @@ test.describe('Inspectors (expert-only)', () => {
     await page.goto('/')
     await page.getByTestId('transport-mode-select').selectOption('demo')
     await page.getByTestId('connect-button').click()
-    await page.getByTestId('product-mode-expert').check()
+    await enableExpertMode(page)
 
     await page.getByTestId('view-button-mavlink-inspector').click()
     await expect(page.getByTestId('mavlink-inspector-table')).toBeVisible({ timeout: 8000 })
@@ -5259,7 +5273,7 @@ test.describe('Inspectors (expert-only)', () => {
     await page.goto('/')
     await page.getByTestId('transport-mode-select').selectOption('demo')
     await page.getByTestId('connect-button').click()
-    await page.getByTestId('product-mode-expert').check()
+    await enableExpertMode(page)
 
     await page.getByTestId('view-button-mavlink-inspector').click()
     const mavTable = page.getByTestId('mavlink-inspector-table')
@@ -5286,7 +5300,7 @@ test.describe('Inspectors (expert-only)', () => {
     await page.goto('/')
     await page.getByTestId('transport-mode-select').selectOption('demo')
     await page.getByTestId('connect-button').click()
-    await page.getByTestId('product-mode-expert').check()
+    await enableExpertMode(page)
 
     await page.getByTestId('view-button-can').click()
     await page.getByTestId('can-bus-start').click()
@@ -5328,7 +5342,7 @@ test.describe('Inspectors (expert-only)', () => {
     await page.goto('/')
     await page.getByTestId('transport-mode-select').selectOption('demo')
     await page.getByTestId('connect-button').click()
-    await page.getByTestId('product-mode-expert').check()
+    await enableExpertMode(page)
 
     await page.getByTestId('view-button-can').click()
     await page.getByTestId('can-bus-start').click()
@@ -5390,7 +5404,7 @@ test.describe('Inspectors (expert-only)', () => {
     await page.goto('/')
     await page.getByTestId('transport-mode-select').selectOption('demo')
     await page.getByTestId('connect-button').click()
-    await page.getByTestId('product-mode-expert').check()
+    await enableExpertMode(page)
 
     await page.getByTestId('view-button-can').click()
     await page.getByTestId('can-bus-start').click()
@@ -5437,7 +5451,7 @@ test.describe('Inspectors (expert-only)', () => {
     await page.goto('/')
     await page.getByTestId('transport-mode-select').selectOption('demo')
     await page.getByTestId('connect-button').click()
-    await page.getByTestId('product-mode-expert').check()
+    await enableExpertMode(page)
 
     await page.getByTestId('view-button-can').click()
     await page.getByTestId('can-bus-start').click()
@@ -5475,7 +5489,7 @@ test.describe('Snapshot restore', () => {
 
     // Change a live value from a different tab so the snapshot now has
     // something real to restore.
-    await page.getByTestId('product-mode-expert').check()
+    await enableExpertMode(page)
     await page.getByTestId('view-button-parameters').click()
     const search = page.getByTestId('parameter-search-input')
     await search.fill('BATT_LOW_VOLT')
@@ -5733,7 +5747,7 @@ test.describe('ELRS Flash (temporarily disabled in prod)', () => {
     await page.goto('/')
     await connectViaHeader(page)
     await expectParameterSyncComplete(page)
-    await page.getByTestId('product-mode-expert').check()
+    await enableExpertMode(page)
 
     // The demo FC advertises Expert + SERIAL_PASS2, which used to surface the ELRS
     // Flash tab. It is now gated OFF (ELRS_FLASH_ENABLED=false) because the
@@ -5747,7 +5761,7 @@ test.describe('OSD message shorthand editor (@OSD/shorthand.dat)', () => {
   test('reads the fork shorthand table, edits, adds a row, and saves', async ({ page }) => {
     await page.goto('/')
     await connectViaHeader(page)
-    await page.getByTestId('product-mode-expert').check()
+    await enableExpertMode(page)
     await page.getByTestId('view-button-osd').click()
 
     // The demo mock serves @OSD/shorthand.dat with 3 seeded entries.
@@ -6277,7 +6291,7 @@ test.describe('Tuning ▸ Initial Tune', () => {
     await page.getByTestId('transport-mode-select').selectOption('demo')
     await page.getByTestId('connect-button').click()
     await expectParameterSyncComplete(page)
-    await page.getByTestId('product-mode-expert').check()
+    await enableExpertMode(page)
     await page.getByTestId('view-button-tuning').click()
     await page.getByTestId('tuning-tab-initial-tune').click()
   }
@@ -6529,7 +6543,7 @@ test.describe('Tuning ▸ Filters', () => {
     await page.getByTestId('transport-mode-select').selectOption('demo')
     await page.getByTestId('connect-button').click()
     await expectParameterSyncComplete(page)
-    await page.getByTestId('product-mode-expert').check()
+    await enableExpertMode(page)
     await page.getByTestId('view-button-tuning').click()
     await page.getByTestId('tuning-tab-filters').click()
     await expect(page.getByTestId('tuning-filter-group-notch')).toBeVisible()


### PR DESCRIPTION
A five-dimension audit of the guided setup wizard (flow logic, coverage, copy,
safety, and step-to-step seams), then the fixes. Every claim below was verified
against the ArduPilot source rather than taken on trust.

## Two P0 safety defects

**ESC calibration ran full throttle while the copy promised a stick.** The card
writes `ESC_CALIBRATION=3` — `ESCCAL_AUTO`, which calls
`set_throttle_passthrough_for_esc_calibration(1.0f)` and holds every motor at
full throttle for five seconds on its own at boot, no pilot input. The copy
described modes 1/2 instead: *"the ESCs learn min/max from the throttle range"*,
*"reconnect, then raise throttle"*. The operator was told nothing happens until
they move a stick. The only interlock is a safety-switch wait, and a board
without one reports `SAFETY_NONE` rather than `SAFETY_DISARMED`, so the loop
never runs — that is most FPV AIO boards.

Behaviour is unchanged (3 is ArduPilot's own automatic method); the copy now
says what happens, in all three places it was wrong. The confirm button also had
**no `disabled` prop at all** — the props-off and area-clear acknowledgements
gated only the arm button above it. And the flag persists in EEPROM, so a write
whose reboot never landed leaves the next power-up armed to spin; the card now
warns on any non-zero value at connect. That warning is deliberately not gated on
`MOT_PWM_TYPE`: `esc_calibration_startup_check()` keys on the parameter alone, so
a DShot board with a stale flag still spins.

**The shipped Pavo preset disabled every pre-arm check and both battery
failsafes.** `ARMING_SKIPCHK=1048062` is exactly every bit `AP_Arming.cpp:198`
defines, with `BATT_FS_LOW_ACT`/`BATT_FS_CRT_ACT` at 0 ("warn only") so
`BATT_LOW_VOLT`/`BATT_CRT_VOLT` were set with nothing acting on them. Its
cautions mentioned neither. It also fed a false green: with the checks off,
`get_enabled_checks()` returns 0, firmware stops reporting the pre-arm bit as
enabled, and the wizard's pre-arm criterion passed vacuously — so applying the
preset made the wizard look *safer*.

## Three deadlocks that made the wizard uncompletable

- **Failsafe, on the bench.** Required live battery telemetry (a real pack) as
  both a criterion and the confirm gate, and was the only step in the flow with
  no waiver. Worse, Power — where `BATT_MONITOR` is configured — sat *behind* it.
  Power now runs first, and Failsafe gains the escape its neighbours had.
- **Every non-Copter vehicle, at step 2 or 3.** Section ids come from the active
  vehicle's bundle but the switch only named Copter's, so Plane's `sensors`,
  Rover's `drive`, and Sub's `frame`/`controls` hit the default branch with empty
  criteria — and `deriveSetupStatusFromCriteria([])` returns `'attention'`. The
  default branch now builds criteria from the bundle's own `requiredParameters`.
- **Plane read a parameter ArduPlane does not have.** `FS_THR_ENABLE` exists on
  Copter/Rover/Sub; Plane's is `THR_FAILSAFE`.

## Sign-offs that outlived their evidence

Motor order and direction had **no gate at all** — the guided check was dropped
with the Motors-tab redesign and the wizard is still handed `motorVerification`,
`escSetup` and four other inputs it never reads. Pre-arm passed vacuously with
checks disabled, and while armed (ArduPilot arms for a `DO_MOTOR_TEST`).
`AHRS_ORIENTATION` was in no signature, so a re-mount left the orientation, accel
and level sign-offs green against a rotation they were never run at. The failsafe
confirmation pinned 2 of the 9 parameters it claimed to review.

## The seams, measured not eyeballed

The wizard was **539px wide inside a 390px viewport** from the airframe step on,
clipping button labels mid-word — and because an ancestor is `overflow-x: clip`
the document never scrolled sideways, so the existing overflow assertion stayed
green throughout. Step 1's own excursion stranded the operator with no return
bar. The step rail never scrolled to the active chip. The primary button animated
`infinite`, which also made it un-clickable to Playwright.

Flow, before → after:

```
                 desktop      phone
Continue in view  11/11 →  0/11 → 10/11
horizontal overflow            0 (both)
active chip visible        10/11
```

The two phone outliers are correct behaviour: `airframe` scrolls to its
orientation check rather than past it, and the `failsafe` chip is last in the
rail so it cannot be centred.

## Deliberately not in this PR

Coverage gaps rather than defects, all needing new wizard steps: ESC calibration
and motor range (**PWM/OneShot only** — `MOT_PWM_TYPE` 0–2; DShot has no
endpoints to learn), battery voltage calibration, the RTL destination
(`RTL_ALT` appears nowhere in the app, and defaults to 15 m), GPS/EKF readiness,
and geofence. Apart from `RTL_ALT` the app already builds all of it — the wizard
just does not reach it.

## Validation

Rungs 1 and 3. ArduCopter byte-identical — web presentational, metadata ordering,
and two constants exported from ardupilot-core with no behaviour change.

- `npm run typecheck` — 0 errors
- `npm run test` — 957 pass
- `apps/web` vitest — 1011 pass across 104 files
- `npm run test:e2e` — **349 pass, 0 fail**, 6 skipped (visual baselines)