### PR TITLE
fix(ui): Motors control sizing, and a Calibration row driven by one card

### DIFF
--- a/apps/web/src/motor-test-sliders.tsx
+++ b/apps/web/src/motor-test-sliders.tsx
@@ -59,11 +59,14 @@ const color = {
 
 /* ── geometry ── */
 
-// Default track height: 80, with the buttons beside the sliders rather than
-// under them to pay for it. The Motors column is tight -- a 200px track pushed
-// the rest of the test panel below the fold on a laptop -- but callers with
-// room (the spin-threshold dialog) pass their own.
-const TRACK_HEIGHT = 80
+// Default track height, for the compact Motors column: 62. The buttons sit
+// beside the sliders rather than under them to pay for it. This column is
+// tight -- a 200px track pushed the rest of the test panel below the fold on a
+// laptop -- and it is for quick per-motor checks, so fine granularity is not
+// its job. Callers with room and a reason pass their own: the spin-threshold
+// wizard uses 180, because easing up on a break-away point is exactly the case
+// that needs travel per step.
+const TRACK_HEIGHT = 58
 // Narrow tracks: this is a column beside the settings now, not a full-width
 // row, and 36px columns pushed the ALL tile off a 300px column at laptop
 // widths. The pointer handlers are on the tile, not the visible bar, so the
@@ -316,9 +319,14 @@ export function MotorTestSliders({
     display: 'flex',
     alignItems: 'center',
     gap: 4,
+    // Height matched to the Test/Stop buttons it stacks with. Left to its own
+    // intrinsic size it came out 21px against their 31 and read as a different
+    // class of control sitting in the same column.
+    height: 31,
+    boxSizing: 'border-box',
     border: `1px solid ${color.border}`,
     borderRadius: 5,
-    padding: '2px 6px',
+    padding: '0 6px',
     background: color.bgPanelMuted,
   }
 
@@ -419,7 +427,7 @@ export function MotorTestSliders({
         ) : null}
       </div>
 
-      <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
         {/* Typed entry alongside the drag. A slider is the fast way to find
             roughly the right throttle; it is a poor way to ask for exactly 7%,
             which is what a repeatable bench test needs. Both drive the same

--- a/apps/web/src/sections/CalibrationSection.tsx
+++ b/apps/web/src/sections/CalibrationSection.tsx
@@ -1400,15 +1400,15 @@ export function CalibrationSection(props: CalibrationSectionProps): ReactElement
                         </div>
                       ) : null}
                       {escCalUnsupported ? (
-                        <div className="parameter-follow-up parameter-follow-up--warning" data-testid="esc-cal-unsupported">
+                        <div
+                          className="parameter-follow-up parameter-follow-up--warning parameter-follow-up--stacked"
+                          data-testid="esc-cal-unsupported"
+                        >
                           <StatusBadge tone="neutral">not applicable</StatusBadge>
                           <p>
-                            ESC endpoint calibration only applies to PWM / OneShot ESCs. This vehicle's motor output is
-                            {' '}<strong>{escProtocolLabel}</strong> (<code>MOT_PWM_TYPE</code>)
-                            {escIsDShot
-                              ? ' — a digital protocol with no throttle endpoints to calibrate.'
-                              : ' — which does not use throttle-endpoint calibration.'}
-                            {' '}Change <code>MOT_PWM_TYPE</code> to a PWM/OneShot type in Motors if you truly need to calibrate analog ESCs.
+                            This vehicle runs <strong>{escProtocolLabel}</strong> (<code>MOT_PWM_TYPE</code>)
+                            {escIsDShot ? ', a digital protocol with no throttle endpoints.' : ', which has no throttle endpoints.'}
+                            {' '}Only PWM and OneShot ESCs need this.
                           </p>
                         </div>
                       ) : (

--- a/apps/web/src/sections/CalibrationSection.tsx
+++ b/apps/web/src/sections/CalibrationSection.tsx
@@ -1176,7 +1176,7 @@ export function CalibrationSection(props: CalibrationSectionProps): ReactElement
                               })()
                             }}
                           >
-                            Calibrate from measured current
+                            Calibrate from meter
                           </button>
                           </li>
                           </ol>

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -12100,6 +12100,17 @@ details.metadata-settings-section:not([open]) > summary::after {
   background: rgba(55, 41, 24, 0.3);
 }
 
+/* Badge above the text rather than beside it.
+ *
+ * The row layout works in a wide panel; in a single calibration column it left
+ * the paragraph about 100px wide and turned three sentences into a column of
+ * text taller than the card explaining it. Stacking gives the copy the full
+ * width it has. */
+.parameter-follow-up--stacked {
+  flex-direction: column;
+  gap: var(--space-2);
+}
+
 .parameter-follow-up p {
   margin: 0;
   color: var(--text);

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -15796,6 +15796,18 @@ details.bf-gui-box:not([open]) > summary::after {
   grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
   gap: 14px;
 }
+
+/* The battery-current card is a three-step procedure with its own inputs, and
+ * in a single column it ran to 1099px -- forcing every card sharing its row to
+ * that height and adding ~380px to the tab. Given two columns its content
+ * reflows to roughly half the height, which shortens the row rather than
+ * padding its neighbours out. Only where there is room for it: below three
+ * columns the grid is already stacking and a span would fill the width. */
+@media (min-width: 1100px) {
+  .calibration-grid > [data-testid='calibration-card-battery-current'] {
+    grid-column: span 2;
+  }
+}
 .calibration-card {
   display: flex;
   flex-direction: column;
@@ -15860,6 +15872,10 @@ details.bf-gui-box:not([open]) > summary::after {
 }
 .esc-rpm-readout__table tbody th small {
   margin-left: 4px;
+  /* Explicit, not the browser's 0.8em: the compact Motors column drops this
+     table to --text-xs, and 0.8em of that is 8px -- below --text-2xs, the
+     smallest size anything in the app is allowed to use. */
+  font-size: var(--text-2xs);
   font-weight: 400;
   color: var(--text-dim);
 }


### PR DESCRIPTION
UI/UX audit of the Motors and Calibration tabs, measured in the browser rather than eyeballed.

## Motors
- Typed **Throttle %** field was 21px in a column of 31px buttons and read as a different class of control. Matched to them.
- ESC RPM motor labels rendered at **8px** — below the smallest size used anywhere in the app — because `small` is 0.8em of a parent the compact column had already dropped to `--text-xs`.
- Slider tracks 80px → 58px. The live column had 8px of clearance at 1333×690 and the fixes above cost 25px. The spin wizard passes its own 180px track and is untouched.

## Calibration
- The battery-current card ran to 1099px in one column, forcing every card in its row to that height (thermal calibration: 267px of content in an 1099px box). Spanning it across two columns reflows it to 774px and shortens the row. **1705px → 1380px.** Gated above 1100px.
- "Calibrate from measured current" wrapped to three lines, making a 46px button among 29px ones → "Calibrate from meter".
- The ESC not-applicable notice put its badge beside its paragraph, leaving the copy ~100px wide and 154px tall. Badge stacked above, copy trimmed. Paragraph 99×154 → 197×86.

## Deliberately not changed
The `--space-*` tokens (4/8/12/16/24) are **not** what this stylesheet follows: 6px occurs 220 times and 10px 237, against 8px at 110 and 12px at 87. Snapping these two tabs to the token scale would make them inconsistent with the rest of the app.

Multi-column layout for the calibration grid was tried and reverted — it cut the tab to 1324px but left ragged columns and squeezed the ESC copy. `align-items: start` was also rejected: it right-sizes cards but the row still takes the tallest card's height, losing aligned bottoms for no height saving.

## Validation
typecheck, 964 node tests, 1048 vitest, full Playwright suite (353 passed, 6 skipped), and before/after geometry at 1333×690, 1600×900, 900×800, 390×844.

ArduCopter byte-identical: presentation only.
